### PR TITLE
SEC-1900: Fixed by removing dependency to equals method in SimpleGrantedAuthority

### DIFF
--- a/taglibs/src/main/java/org/springframework/security/taglibs/authz/AbstractAuthorizeTag.java
+++ b/taglibs/src/main/java/org/springframework/security/taglibs/authz/AbstractAuthorizeTag.java
@@ -132,9 +132,11 @@ public abstract class AbstractAuthorizeTag {
         final Collection<? extends GrantedAuthority> granted = getPrincipalAuthorities();
 
         if (hasTextAllGranted) {
-            if (!granted.containsAll(toAuthorities(getIfAllGranted()))) {
-                return false;
-            }
+            Set<String> grantedRoles = authoritiesToRoles(granted);
+            Set<String> requiredRoles = authoritiesToRoles(toAuthorities(getIfAllGranted()));
+            if (!grantedRoles.containsAll(requiredRoles)) { 
+                return false; 
+            } 
         }
 
         if (hasTextAnyGranted) {

--- a/taglibs/src/test/java/org/springframework/security/taglibs/authz/AuthorizeTagCustomGrantedAuthorityTests.java
+++ b/taglibs/src/test/java/org/springframework/security/taglibs/authz/AuthorizeTagCustomGrantedAuthorityTests.java
@@ -73,4 +73,28 @@ public class AuthorizeTagCustomGrantedAuthorityTests {
             assertTrue("expected", true);
         }
     }
+    
+    /**
+     * Tests that it is possible to use the authorize tag with any authorization
+     * object that implements GrantedAuthority.
+     * @throws JspException on tag failures (not supposed to happen in this test case)
+     */
+    @Test
+    public void testAuthorizeUsingGrantedAuthorities() throws JspException {
+        authorizeTag.setIfAnyGranted(null);
+        authorizeTag.setIfNotGranted(null);
+        authorizeTag.setIfAllGranted("ROLE_TEST");
+        List<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
+        authorities.add(new GrantedAuthority() {
+                    public String getAuthority() {
+                        return "ROLE_TEST";
+                    }
+                });
+        SecurityContextHolder.getContext().setAuthentication(new TestingAuthenticationToken("abc", "123", authorities));
+        int testResult = authorizeTag.doStartTag();
+        Assert.assertEquals("Not authorized even though having correct authorities.", 
+                Tag.EVAL_BODY_INCLUDE, testResult);
+        
+    }
+    
 }


### PR DESCRIPTION
Made the role comparision be performed on sets of (role) strings instead of comparing any given implementation of GrantedAuthority with SimpleGrantedAuthority. I.e. the ifAllGranted code is no longer dependent on the implementation of the equals method in SimpleGrantedAuthorization.
