### PR TITLE
SEC-1921: Fixes that SimpleGrantedAuthority can be compared with other GrantedAuthority impl.

### DIFF
--- a/core/src/main/java/org/springframework/security/core/authority/SimpleGrantedAuthority.java
+++ b/core/src/main/java/org/springframework/security/core/authority/SimpleGrantedAuthority.java
@@ -33,8 +33,8 @@ public final class SimpleGrantedAuthority implements GrantedAuthority {
             return true;
         }
 
-        if (obj instanceof SimpleGrantedAuthority) {
-            return role.equals(((SimpleGrantedAuthority) obj).role);
+        if (obj instanceof GrantedAuthority) {
+            return role.equals(((GrantedAuthority) obj).getAuthority());
         }
 
         return false;

--- a/core/src/test/java/org/springframework/security/core/authority/SimpleGrantedAuthorityTests.java
+++ b/core/src/test/java/org/springframework/security/core/authority/SimpleGrantedAuthorityTests.java
@@ -50,5 +50,17 @@ public class SimpleGrantedAuthorityTests {
         SimpleGrantedAuthority auth = new SimpleGrantedAuthority("TEST");
         assertEquals("TEST", auth.toString());
     }
+    
+    @Test
+    public void equalityWithGrantedAuthority() {
+        GrantedAuthority grantedAuthority = new GrantedAuthority() {
+            private static final long serialVersionUID = 1L;
+            public String getAuthority() {
+                return "ROLE_STATIC";
+            }
+        };
+        SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority("ROLE_STATIC");
+        Assert.assertTrue(simpleGrantedAuthority.equals(grantedAuthority));
+    }
 
 }


### PR DESCRIPTION
Fixes so that SimpleGrantedAuthority can be compared, using the equals method, with any GrantedAuthority implementation. Also adds a test checking that it is possible to use SimpleGrantedAuthority.equals in that way.
