### PR TITLE
Throw PasswordPolicyException not only when account is locked

### DIFF
--- a/ldap/src/main/java/org/springframework/security/ldap/ppolicy/PasswordPolicyAwareContextSource.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/ppolicy/PasswordPolicyAwareContextSource.java
@@ -58,10 +58,8 @@ public class PasswordPolicyAwareContextSource extends DefaultSpringSecurityConte
 
             LdapUtils.closeContext(ctx);
 
-            if (ctrl != null) {
-                if (ctrl.isLocked()) {
+            if (ctrl != null && ctrl.getErrorStatus()!=null) {
                     throw new PasswordPolicyException(ctrl.getErrorStatus());
-                }
             }
 
             throw LdapUtils.convertLdapException(ne);


### PR DESCRIPTION
With the original code spring-security-ldap throws PasswordPolicyException only when an account is locked. With this small change (tested against openldap), PasswordPolicyException are to be thrown when ErrorStatus is not null which covers most, if not all, ppolicy cases...
