### PR TITLE
Change default subjectDnRegex pattern in SubjectDnX509PrincipalExtractor to match CN at end of DN

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/preauth/x509/SubjectDnX509PrincipalExtractor.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/preauth/x509/SubjectDnX509PrincipalExtractor.java
@@ -17,7 +17,7 @@ import java.util.regex.Matcher;
  * Obtains the principal from a certificate using a regular expression match against the Subject (as returned by a call
  * to {@link X509Certificate#getSubjectDN()}).
  * <p>
- * The regular expression should contain a single group; for example the default expression "CN=(.?)," matches the
+ * The regular expression should contain a single group; for example the default expression "CN=(.*?)(?:,.*)*$" matches the
  * common name field. So "CN=Jimi Hendrix, OU=..." will give a user name of "Jimi Hendrix".
  * <p>
  * The matches are case insensitive. So "emailAddress=(.?)," will match "EMAILADDRESS=jimi@hendrix.org, CN=..." giving a

--- a/web/src/test/java/org/springframework/security/web/authentication/preauth/x509/SubjectDnX509PrincipalExtractorTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/preauth/x509/SubjectDnX509PrincipalExtractorTests.java
@@ -44,4 +44,10 @@ public class SubjectDnX509PrincipalExtractorTests {
         extractor.setSubjectDnRegex("shoeSize=(.*?),");
         extractor.extractPrincipal(X509TestUtils.buildTestCertificate());
     }
+
+    @Test
+    public void defaultCNPatternReturnsPrincipalAtEndOfDNString() throws Exception {
+        Object principal = extractor.extractPrincipal(X509TestUtils.buildTestCertificateWithCnAtEnd());
+        assertEquals("Duke", principal);
+    }
 }

--- a/web/src/test/java/org/springframework/security/web/authentication/preauth/x509/X509TestUtils.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/preauth/x509/X509TestUtils.java
@@ -98,4 +98,41 @@ public class X509TestUtils {
 
         return (X509Certificate) cf.generateCertificate(in);
     }
+
+    /**
+     * Builds an X.509 certificate with a subject DN where the CN field is at the end of the line.
+     * The actual DN line is:
+     * <pre>
+     *  L=Cupertino,C=US,ST=CA,OU=Java Software,O=Sun Microsystems\, Inc,CN=Duke
+     * </pre>
+     *
+     */
+    public static X509Certificate buildTestCertificateWithCnAtEnd() throws Exception {
+        String cert = "-----BEGIN CERTIFICATE-----\n" +
+                "MIIDjTCCAnWgAwIBAgIBATALBgkqhkiG9w0BAQswdTENMAsGA1UEAwwERHVrZTEe\n" +
+                "MBwGA1UECgwVU3VuIE1pY3Jvc3lzdGVtcywgSW5jMRYwFAYDVQQLDA1KYXZhIFNv\n" +
+                "ZnR3YXJlMQswCQYDVQQIDAJDQTELMAkGA1UEBhMCVVMxEjAQBgNVBAcMCUN1cGVy\n" +
+                "dGlubzAeFw0xMjA1MTgxNDQ4MzBaFw0xMzA1MTgxNDQ4MzBaMHUxDTALBgNVBAMM\n" +
+                "BER1a2UxHjAcBgNVBAoMFVN1biBNaWNyb3N5c3RlbXMsIEluYzEWMBQGA1UECwwN\n" +
+                "SmF2YSBTb2Z0d2FyZTELMAkGA1UECAwCQ0ExCzAJBgNVBAYTAlVTMRIwEAYDVQQH\n" +
+                "DAlDdXBlcnRpbm8wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDGLaCx\n" +
+                "Dy5oRJ/FelcoO/lAEApAhR4wxmUIu0guzN0Tx/cuWfyo4349NOxf5XfRcje37B//\n" +
+                "hyMwK1Q/pRhRYtZlK+O+9tNCAupekmSxEw9wNsRXNJ18QTTvQRPReXhG8gOiGmU2\n" +
+                "kpTVjpZURo/0WGuEyAWYzH99cQfUM92vIaGKq2fApNfwCULtFnAY9WPDZtwSZYhC\n" +
+                "qSAoy6B1I2A3i+G5Ep++eCa9PZKCZIPWJiC5+nMmzwCOnQqcZlorsrQ+M+I4GgE2\n" +
+                "Rryb/AeKoSPsrm4t0aWhFhKcuHpk3jfKhJhi5e+5bnY17pCoY9hx5EK3WqfKL/x1\n" +
+                "3HKsPpf/MieRWiAdAgMBAAGjKjAoMA4GA1UdDwEB/wQEAwIHgDAWBgNVHSUBAf8E\n" +
+                "DDAKBggrBgEFBQcDAjANBgkqhkiG9w0BAQsFAAOCAQEAdAtXZYCdb7JKzfwY7vEO\n" +
+                "9TOMyxxwxhxs+26urL2wQWqtRgHXopoi/GGSuZG5aPQcHWLoqZ1f7nZoWfKzJMKw\n" +
+                "MOvaw6wSSkmEoEvdek3s/bH6Gp0spnykqtb+kunGr/XFxyBhHmfdSroEgzspslFh\n" +
+                "Glqe/XfrQmFgPWd13GH8mqzSU1zc+0Ka7s68jcuNfz9ble5rT0IrdjRm5E64mVGk\n" +
+                "aJTAO5N87ks5JjkDHDJzcyYRcIpqBGotJtyZTjGpIeAG8xLGlkSsUg88iUOchI7s\n" +
+                "dOmse9mpgEjCb4kdZ0PnoxMFjsPR8AoGOz4A5vA19nKqWM8bxK9hqLGKsaiQpQg7\n" +
+                "bA==\n" +
+                "-----END CERTIFICATE-----\n";
+        ByteArrayInputStream in = new ByteArrayInputStream(cert.getBytes());
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+
+        return (X509Certificate) cf.generateCertificate(in);
+    }
 }


### PR DESCRIPTION
Changes subjectDnRegex default pattern from "CN=(._?)," to "CN=(._?)(?:,._)_$" to match a CN occurring anywhere in the subject DN field. Added unit test to show that this works and does not break existing unit tests.
