### PR TITLE
Allow LDAP BindAuthenticator to skip attribute retrieval or retrieve using manager context

### DIFF
--- a/ldap/src/integration-test/java/org/springframework/security/ldap/authentication/BindAuthenticatorTests.java
+++ b/ldap/src/integration-test/java/org/springframework/security/ldap/authentication/BindAuthenticatorTests.java
@@ -127,4 +127,20 @@ public class BindAuthenticatorTests extends AbstractLdapIntegrationTests {
         authenticator.setUserDnPatterns(new String[] {"cn={0},ou=people"});
         assertEquals("cn=Joe,ou=people", authenticator.getUserDns("Joe").get(0));
     }
+    
+    @Test
+    public void testRetrieveUserAttributes() {    	  
+        authenticator.setUserDnPatterns(new String[] {"uid={0},ou=people", "cn={0},ou=people"});        
+        DirContextOperations user = authenticator.authenticate(new UsernamePasswordAuthenticationToken("mouse, jerry", "jerryspassword"));
+        assertEquals("Mouse", user.getStringAttribute("sn"));        
+    }
+
+    @Test
+    public void testDoNotRetrieveUserAttributes() {    	  
+        authenticator.setUserDnPatterns(new String[] {"uid={0},ou=people", "cn={0},ou=people"});        
+        authenticator.setRetrieveUserAttributes(false);
+        DirContextOperations user = authenticator.authenticate(new UsernamePasswordAuthenticationToken("mouse, jerry", "jerryspassword"));
+        assertNull(user.getStringAttribute("sn"));        
+    }
+    
 }


### PR DESCRIPTION
This patch adds a couple of properties (retrieveUserAttributes and retrieveAttributesWithManagerContext) that provide more control over how BindAuthenticator retrieves user attributes. If retrieveUserAttributes is set to false no user attributes will be retrieved and if retrieveAttributesWithManagerContext is set to true, the attributes are retrieved with the manager context (contextSource property) as opposed to the context obtained from the user bind. 
I have seen [SEC-1510](https://jira.springsource.org/browse/SEC-1510) , and humbly ask that the 'Won't Fix' resolution be reconsidered. I have run in to multiple LDAP server configurations that throw errors when users attempt to access their own attributes, rendering the BindAuthenticator unusable even if you aren't interested in those attribute values at all. The suggested workaround on the jira issue (reimplement AuthenticationProvider) seems heavy-handed, throwing away the baby with the bathwater. I can understand the desire to keep the complexity down, but the way this patch is implemented preserves the default functionality (get user attribs, using the user context). Only someone who wanted to would need to set the additional properties. I think this situation is common enough in security-conscious enterprises that BindAuthenticator should at least allow configuration to prevent it from retrieving user attributes at all. 
