### PR TITLE
SEC-1940 publish event when AccountStatusException

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
@@ -160,6 +160,7 @@ public class ProviderManager implements AuthenticationManager, MessageSourceAwar
                     break;
                 }
             } catch (AccountStatusException e) {
+                eventPublisher.publishAuthenticationFailure(e, authentication);
                 prepareException(e, authentication);
                 // SEC-546: Avoid polling additional providers if auth failure is due to invalid account status
                 throw e;


### PR DESCRIPTION
Looks like the fix for SEC-546 stopped events being published in the case of an AccountStatusException. The fix for SEC-1940 is to publish the event before rethrowing the exception.
