### PR TITLE
SEC-2119: Add a 'form-parameter' attribute to <remember-me>

### DIFF
--- a/config/src/main/java/org/springframework/security/config/SecurityNamespaceHandler.java
+++ b/config/src/main/java/org/springframework/security/config/SecurityNamespaceHandler.java
@@ -1,4 +1,22 @@
+/*
+ * Copyright 2009-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.security.config;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -27,8 +45,6 @@ import org.springframework.security.core.SpringSecurityCoreVersion;
 import org.springframework.util.ClassUtils;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
-
-import java.util.*;
 
 /**
  * Parses elements from the "security" namespace (http://www.springframework.org/schema/security).
@@ -180,7 +196,7 @@ public final class SecurityNamespaceHandler implements NamespaceHandler {
 
     private boolean matchesVersionInternal(Element element) {
         String schemaLocation = element.getAttributeNS("http://www.w3.org/2001/XMLSchema-instance", "schemaLocation");
-        return schemaLocation.matches("(?m).*spring-security-3\\.1.*.xsd.*")
+        return schemaLocation.matches("(?m).*spring-security-3\\.2.*.xsd.*")
                  || schemaLocation.matches("(?m).*spring-security.xsd.*")
                  || !schemaLocation.matches("(?m).*spring-security.*");
     }

--- a/config/src/main/resources/META-INF/spring.schemas
+++ b/config/src/main/resources/META-INF/spring.schemas
@@ -1,4 +1,5 @@
-http\://www.springframework.org/schema/security/spring-security.xsd=org/springframework/security/config/spring-security-3.1.xsd
+http\://www.springframework.org/schema/security/spring-security.xsd=org/springframework/security/config/spring-security-3.2.xsd
+http\://www.springframework.org/schema/security/spring-security-3.2.xsd=org/springframework/security/config/spring-security-3.2.xsd
 http\://www.springframework.org/schema/security/spring-security-3.1.xsd=org/springframework/security/config/spring-security-3.1.xsd
 http\://www.springframework.org/schema/security/spring-security-3.0.3.xsd=org/springframework/security/config/spring-security-3.0.3.xsd
 http\://www.springframework.org/schema/security/spring-security-3.0.xsd=org/springframework/security/config/spring-security-3.0.xsd

--- a/config/src/main/resources/org/springframework/security/config/spring-security-3.2.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-3.2.xsd
@@ -1800,6 +1800,12 @@
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="form-parameter" type="xs:token">
+          <xs:annotation>
+              <xs:documentation>The name of the request parameter which toggles remember-me authentication. Defaults to '_spring_security_remember_me'.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
   </xs:attributeGroup>
   <xs:attributeGroup name="token-repository-ref">
       <xs:attribute name="token-repository-ref" use="required" type="xs:token">

--- a/config/src/test/groovy/org/springframework/security/config/http/RememberMeConfigTests.groovy
+++ b/config/src/test/groovy/org/springframework/security/config/http/RememberMeConfigTests.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.security.web.authentication.rememberme.TokenBasedReme
  *
  * @author Luke Taylor
  * @author Rob Winch
+ * @author Oliver Becker
  */
 class RememberMeConfigTests extends AbstractHttpConfigTests {
 
@@ -210,6 +211,27 @@ class RememberMeConfigTests extends AbstractHttpConfigTests {
 
         then: "Parses OK"
         notThrown BeanDefinitionParsingException
+    }
+
+    // SEC-2119
+    def 'Custom form-parameter is supported'() {
+        httpAutoConfig () {
+            'remember-me'('form-parameter': 'ourParam')
+        }
+
+        createAppContext(AUTH_PROVIDER_XML)
+        expect:
+        rememberMeServices().parameter == 'ourParam'
+    }
+
+    def 'form-parameter cannot be used together with services-ref'() {
+        when:
+        httpAutoConfig () {
+            'remember-me'('form-parameter': 'ourParam', 'services-ref': 'ourService')
+        }
+        createAppContext(AUTH_PROVIDER_XML)
+        then:
+        BeanDefinitionParsingException e = thrown()
     }
 
     def rememberMeServices() {

--- a/config/src/test/java/org/springframework/security/config/util/InMemoryXmlApplicationContext.java
+++ b/config/src/test/java/org/springframework/security/config/util/InMemoryXmlApplicationContext.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2009-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.security.config.util;
 
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -25,11 +40,11 @@ public class InMemoryXmlApplicationContext extends AbstractXmlApplicationContext
     Resource inMemoryXml;
 
     public InMemoryXmlApplicationContext(String xml) {
-        this(xml, "3.1", null);
+        this(xml, "3.2", null);
     }
 
     public InMemoryXmlApplicationContext(String xml, ApplicationContext parent) {
-        this(xml, "3.1", parent);
+        this(xml, "3.2", parent);
     }
 
     public InMemoryXmlApplicationContext(String xml, String secVersion, ApplicationContext parent) {

--- a/core/src/test/java/org/springframework/security/authentication/jaas/memory/InMemoryConfigurationTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/jaas/memory/InMemoryConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 the original author or authors.
+ * Copyright 2010-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/manual/src/docbook/appendix-namespace.xml
+++ b/docs/manual/src/docbook/appendix-namespace.xml
@@ -842,6 +842,11 @@
                         <classname>PersistentTokenBasedRememberMeServices</classname> will be used and configured with a
                         <classname>JdbcTokenRepositoryImpl</classname> instance. </para>
                 </section>
+                <section xml:id="nsa-remember-me-form-parameter">
+                    <title><literal>form-parameter</literal></title>
+                    <para>The name of the request parameter which toggles remember-me authentication. Defaults to "_spring_security_remember_me".
+                        Maps to the "parameter" property of <classname>AbstractRememberMeServices</classname>.</para>
+                </section>
                 <section xml:id="nsa-remember-me-key">
                     <title><literal>key</literal></title>
                     <para>Maps to the "key" property of


### PR DESCRIPTION
This change extends the namespace configuration of <remember-me>
with a 'form-parameter' attribute. The introduced attribute sets
the 'parameter' property of  AbstractRememberMeServices.

This enables overriding the default value of
'_spring_security_remember_me' using the namespace configuration.

Additional changes:
- Map the default schema location spring-security.xsd to the
  3.2 version (spring-security-3.2.xsd)

Issue: SEC-2119

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
