### PR TITLE
Update ldap/src/main/java/org/springframework/security/ldap/SpringSecuri...

### DIFF
--- a/ldap/src/main/java/org/springframework/security/ldap/SpringSecurityLdapTemplate.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/SpringSecurityLdapTemplate.java
@@ -52,14 +52,14 @@ import org.springframework.util.Assert;
  */
 public class SpringSecurityLdapTemplate extends LdapTemplate {
     //~ Static fields/initializers =====================================================================================
-    private static final Log logger = LogFactory.getLog(SpringSecurityLdapTemplate.class);
+    protected static final Log logger = LogFactory.getLog(SpringSecurityLdapTemplate.class);
 
     public static final String[] NO_ATTRS = new String[0];
 
     //~ Instance fields ================================================================================================
 
     /** Default search controls */
-    private SearchControls searchControls = new SearchControls();
+    protected SearchControls searchControls = new SearchControls();
 
     //~ Constructors ===================================================================================================
 


### PR DESCRIPTION
...tyLdapTemplate.java

making these fields protected help in easily overriding this class that provides lots of useful functionality otherwise. In my case i required a search method that would return dns for all entries that match the given search criteria. An incredibly versatile method will be one that takes in a contextMapper in addition to base , filter, params etc.
