### PR TITLE
Fixing spring and aspectj OSGi version ranges

### DIFF
--- a/gradle/javaprojects.gradle
+++ b/gradle/javaprojects.gradle
@@ -29,9 +29,9 @@ ext.powerMockDependencies = [
 
 ext.bundlorProperties = [
     version: version,
-    secRange: "[$version, 3.2.0)",
-    springRange: "[$springVersion, 3.2.0)",
-    aspectjRange: '[1.6.0, 1.7.0)',
+    secRange: "[$version, 3.3.0)",
+    springRange: "[$springVersion, 3.3.0)",
+    aspectjRange: '[1.6.0, 1.8.0)',
     casRange: '[3.1.1, 3.2.0)',
     cloggingRange: '[1.0.4, 2.0.0)',
     ehcacheRange: '[1.4.1, 2.5.0)',


### PR DESCRIPTION
Fixing spring and aspectj OSGi version ranges
spring: [3.2, 3.2) -> [3.2, 3.3)
spring-aspects 3.2.1 uses aspectj 1.7.1, therefore also bumping the apsectj range to "1.8)"
