### PR TITLE
SEC-2119: Add a 'parameter' to <remember-me>

### DIFF
--- a/config/src/main/java/org/springframework/security/config/http/RememberMeBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/http/RememberMeBeanDefinitionParser.java
@@ -49,7 +49,7 @@ class RememberMeBeanDefinitionParser implements BeanDefinitionParser {
     static final String ATT_SUCCESS_HANDLER_REF = "authentication-success-handler-ref";
     static final String ATT_TOKEN_VALIDITY = "token-validity-seconds";
     static final String ATT_SECURE_COOKIE = "use-secure-cookie";
-    static final String ATT_FORM_REMEMBERME_PARAMETER = "rememberme-parameter";
+    static final String ATT_FORM_REMEMBERME_PARAMETER = "remember-me-parameter";
 
     protected final Log logger = LogFactory.getLog(getClass());
     private final String key;

--- a/config/src/main/resources/org/springframework/security/config/spring-security-3.2.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-3.2.rnc
@@ -579,7 +579,7 @@ remember-me.attlist &=
     attribute authentication-success-handler-ref {xsd:token}?
 remember-me.attlist &=
     ## The name of the request parameter which toggles remember-me authentication. Defaults to '_spring_security_remember_me'.
-    attribute rememberme-parameter {xsd:token}?
+    attribute remember-me-parameter {xsd:token}?
 
 token-repository-ref =
     ## Reference to a PersistentTokenRepository bean for use with the persistent token remember-me implementation.

--- a/config/src/main/resources/org/springframework/security/config/spring-security-3.2.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-3.2.xsd
@@ -1801,7 +1801,7 @@
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="rememberme-parameter" type="xs:token">
+      <xs:attribute name="remember-me-parameter" type="xs:token">
          <xs:annotation>
             <xs:documentation>The name of the request parameter which toggles remember-me authentication. Defaults to
                 '_spring_security_remember_me'.

--- a/config/src/test/groovy/org/springframework/security/config/http/RememberMeConfigTests.groovy
+++ b/config/src/test/groovy/org/springframework/security/config/http/RememberMeConfigTests.groovy
@@ -214,7 +214,7 @@ class RememberMeConfigTests extends AbstractHttpConfigTests {
         notThrown BeanDefinitionParsingException
     }
 
-    def 'Default form-parameter is correct'() {
+    def 'Default remember-me-parameter is correct'() {
         httpAutoConfig () {
             'remember-me'()
         }
@@ -225,9 +225,9 @@ class RememberMeConfigTests extends AbstractHttpConfigTests {
     }
 
     // SEC-2119
-    def 'Custom form-parameter is supported'() {
+    def 'Custom remember-me-parameter is supported'() {
         httpAutoConfig () {
-            'remember-me'('rememberme-parameter': 'ourParam')
+            'remember-me'('remember-me-parameter': 'ourParam')
         }
 
         createAppContext(AUTH_PROVIDER_XML)
@@ -235,10 +235,10 @@ class RememberMeConfigTests extends AbstractHttpConfigTests {
         rememberMeServices().parameter == 'ourParam'
     }
 
-    def 'form-parameter cannot be used together with services-ref'() {
+    def 'remember-me-parameter cannot be used together with services-ref'() {
         when:
         httpAutoConfig () {
-            'remember-me'('rememberme-parameter': 'ourParam', 'services-ref': 'ourService')
+            'remember-me'('remember-me-parameter': 'ourParam', 'services-ref': 'ourService')
         }
         createAppContext(AUTH_PROVIDER_XML)
         then:

--- a/docs/manual/src/docbook/appendix-namespace.xml
+++ b/docs/manual/src/docbook/appendix-namespace.xml
@@ -842,8 +842,8 @@
                         <classname>PersistentTokenBasedRememberMeServices</classname> will be used and configured with a
                         <classname>JdbcTokenRepositoryImpl</classname> instance. </para>
                 </section>
-                <section xml:id="nsa-remember-me-rememberme-parameter">
-                    <title><literal>form-parameter</literal></title>
+                <section xml:id="nsa-remember-me-remember-me-parameter">
+                    <title><literal>remember-me-parameter</literal></title>
                     <para>The name of the request parameter which toggles remember-me authentication. Defaults to "_spring_security_remember_me".
                         Maps to the "parameter" property of <classname>AbstractRememberMeServices</classname>.</para>
                 </section>


### PR DESCRIPTION
This change extends pull request https://github.com/SpringSource/spring-security/pull/26 and its subsequent changes by renaming the attribute name 'rememberme-parameter' to 'remember-me-parameter'.

The spelling including the additional hyphen in 'remember-me-parameter' is more consistent
with the default spelling of the 'remember-me' functionality.

Issue: SEC-2119

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
