### PR TITLE
SEC-2002: Added events to notify of session ID change

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/session/SessionFixationProtectionEvent.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/session/SessionFixationProtectionEvent.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication.session;
+
+import org.springframework.security.authentication.event.AbstractAuthenticationEvent;
+import org.springframework.security.core.Authentication;
+import org.springframework.util.Assert;
+
+/**
+ * Indicates a session ID was changed for the purposes of session fixation protection.
+ *
+ * @author Nicholas Williams
+ * @since 3.2
+ * @see SessionFixationProtectionStrategy
+ */
+public class SessionFixationProtectionEvent extends AbstractAuthenticationEvent {
+    //~ Instance fields ================================================================================================
+
+    private final String oldSessionId;
+
+    private final String newSessionId;
+
+    //~ Constructors ===================================================================================================
+
+    /**
+     * Constructs a new session fixation protection event.
+     *
+     * @param authentication The authentication object
+     * @param oldSessionId The old session ID before it was changed
+     * @param newSessionId The new session ID after it was changed
+     */
+    public SessionFixationProtectionEvent(Authentication authentication, String oldSessionId, String newSessionId) {
+        super(authentication);
+        Assert.hasLength(oldSessionId);
+        Assert.hasLength(newSessionId);
+        this.oldSessionId = oldSessionId;
+        this.newSessionId = newSessionId;
+    }
+
+    //~ Methods ========================================================================================================
+
+    /**
+     * Getter for the session ID before it was changed.
+     *
+     * @return the old session ID.
+     */
+    public String getOldSessionId() {
+        return this.oldSessionId;
+    }
+
+    /**
+     * Getter for the session ID after it was changed.
+     *
+     * @return the new session ID.
+     */
+    public String getNewSessionId() {
+        return this.newSessionId;
+    }
+}

--- a/web/src/test/java/org/springframework/security/web/authentication/session/ConcurrentSessionControlStrategyTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/session/ConcurrentSessionControlStrategyTests.java
@@ -1,17 +1,36 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.security.web.authentication.session;
 
+import static org.junit.Assert.*;
 import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;
@@ -59,5 +78,29 @@ public class ConcurrentSessionControlStrategyTests {
 
         verify(sessionRegistry,times(0)).removeSessionInformation(anyString());
         verify(sessionRegistry).registerNewSession(not(eq(originalSessionId)), anyObject());
+    }
+
+    // SEC-2002
+    @Test
+    public void onAuthenticationChangeSessionWithEventPublisher() {
+        String originalSessionId = request.getSession().getId();
+
+        ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
+        strategy.setApplicationEventPublisher(eventPublisher);
+
+        strategy.onAuthentication(authentication, request, response);
+
+        verify(sessionRegistry,times(0)).removeSessionInformation(anyString());
+        verify(sessionRegistry).registerNewSession(not(eq(originalSessionId)), anyObject());
+
+        ArgumentCaptor<ApplicationEvent> eventArgumentCaptor = ArgumentCaptor.forClass(ApplicationEvent.class);
+        verify(eventPublisher).publishEvent(eventArgumentCaptor.capture());
+
+        assertNotNull(eventArgumentCaptor.getValue());
+        assertTrue(eventArgumentCaptor.getValue() instanceof SessionFixationProtectionEvent);
+        SessionFixationProtectionEvent event = (SessionFixationProtectionEvent)eventArgumentCaptor.getValue();
+        assertEquals(originalSessionId, event.getOldSessionId());
+        assertEquals(request.getSession().getId(), event.getNewSessionId());
+        assertSame(authentication, event.getAuthentication());
     }
 }

--- a/web/src/test/java/org/springframework/security/web/session/DefaultSessionAuthenticationStrategyTests.java
+++ b/web/src/test/java/org/springframework/security/web/session/DefaultSessionAuthenticationStrategyTests.java
@@ -1,17 +1,36 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.security.web.session;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.session.SessionFixationProtectionEvent;
 import org.springframework.security.web.authentication.session.SessionFixationProtectionStrategy;
-import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
 
 /**
  *
@@ -40,6 +59,38 @@ public class DefaultSessionAuthenticationStrategyTests {
         assertFalse(sessionId.equals(request.getSession().getId()));
     }
 
+    // SEC-2002
+    @Test
+    public void newSessionIsCreatedIfSessionAlreadyExistsWithEventPublisher() throws Exception {
+        SessionFixationProtectionStrategy strategy = new SessionFixationProtectionStrategy();
+        HttpServletRequest request = new MockHttpServletRequest();
+        HttpSession session = request.getSession();
+        session.setAttribute("blah", "blah");
+        session.setAttribute("SPRING_SECURITY_SAVED_REQUEST_KEY", "DefaultSavedRequest");
+        String oldSessionId = session.getId();
+
+        ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
+        strategy.setApplicationEventPublisher(eventPublisher);
+
+        Authentication mockAuthentication = mock(Authentication.class);
+
+        strategy.onAuthentication(mockAuthentication, request, new MockHttpServletResponse());
+
+        ArgumentCaptor<ApplicationEvent> eventArgumentCaptor = ArgumentCaptor.forClass(ApplicationEvent.class);
+        verify(eventPublisher).publishEvent(eventArgumentCaptor.capture());
+
+        assertFalse(oldSessionId.equals(request.getSession().getId()));
+        assertNotNull(request.getSession().getAttribute("blah"));
+        assertNotNull(request.getSession().getAttribute("SPRING_SECURITY_SAVED_REQUEST_KEY"));
+
+        assertNotNull(eventArgumentCaptor.getValue());
+        assertTrue(eventArgumentCaptor.getValue() instanceof SessionFixationProtectionEvent);
+        SessionFixationProtectionEvent event = (SessionFixationProtectionEvent)eventArgumentCaptor.getValue();
+        assertEquals(oldSessionId, event.getOldSessionId());
+        assertEquals(request.getSession().getId(), event.getNewSessionId());
+        assertSame(mockAuthentication, event.getAuthentication());
+    }
+
     // See SEC-1077
     @Test
     public void onlySavedRequestAttributeIsMigratedIfMigrateAttributesIsFalse() throws Exception {
@@ -54,6 +105,38 @@ public class DefaultSessionAuthenticationStrategyTests {
 
         assertNull(request.getSession().getAttribute("blah"));
         assertNotNull(request.getSession().getAttribute("SPRING_SECURITY_SAVED_REQUEST_KEY"));
+    }
+
+    // SEC-2002
+    @Test
+    public void onlySavedRequestAttributeIsMigratedIfMigrateAttributesIsFalseWithEventPublisher() throws Exception {
+        SessionFixationProtectionStrategy strategy = new SessionFixationProtectionStrategy();
+        strategy.setMigrateSessionAttributes(false);
+        HttpServletRequest request = new MockHttpServletRequest();
+        HttpSession session = request.getSession();
+        session.setAttribute("blah", "blah");
+        session.setAttribute("SPRING_SECURITY_SAVED_REQUEST_KEY", "DefaultSavedRequest");
+        String oldSessionId = session.getId();
+
+        ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
+        strategy.setApplicationEventPublisher(eventPublisher);
+
+        Authentication mockAuthentication = mock(Authentication.class);
+
+        strategy.onAuthentication(mockAuthentication, request, new MockHttpServletResponse());
+
+        ArgumentCaptor<ApplicationEvent> eventArgumentCaptor = ArgumentCaptor.forClass(ApplicationEvent.class);
+        verify(eventPublisher).publishEvent(eventArgumentCaptor.capture());
+
+        assertNull(request.getSession().getAttribute("blah"));
+        assertNotNull(request.getSession().getAttribute("SPRING_SECURITY_SAVED_REQUEST_KEY"));
+
+        assertNotNull(eventArgumentCaptor.getValue());
+        assertTrue(eventArgumentCaptor.getValue() instanceof SessionFixationProtectionEvent);
+        SessionFixationProtectionEvent event = (SessionFixationProtectionEvent)eventArgumentCaptor.getValue();
+        assertEquals(oldSessionId, event.getOldSessionId());
+        assertEquals(request.getSession().getId(), event.getNewSessionId());
+        assertSame(mockAuthentication, event.getAuthentication());
     }
 
     @Test


### PR DESCRIPTION
Session fixation protection, whether by clean new session or
migrated session, now publishes an event when a session is
migrated or its ID is changed. This enables application developers
to keep track of the session ID of a particular authentication
from the time the authentication is successful until the time
of logout. Previously this was not possible since session
migration changed the session ID and there was no way to
reliably detect that.

Revised changes per Rob Winch's suggestions. All of the events
have been consolidated into the one event, as requested. The
`ApplicationEventPublisher` in `SessionFixationProtectionStrategy` is
initialized to a `NullEventPublisher` now, as requested. The commit
is much simpler and more concise than previous commits. Instead
of changing existing unit tests, I only added new unit tests to test
my new behavior. The existing unit tests remain to demonstrate that
old behavior (without `ApplicationEventPublisher`) hasn't been
affected.

Apologies in advance that the imports for
`SessionFixationProtectionStrategy` have been reorganized. It
would seem that no two classes in SpringSecurity have their import
statements ordered/organized the same way. This makes it hard to
work in an IDE. I had to import new files, so my IDE was going to
reorder them. I set up my import settings so that my changes
would reorder the changes in only one file instead of all three that
I changed. That was the best I can get it. At least, the reorder
of imports improved the code. More consistency now.

Hopefully this pull request is much more satisfactory than
pull request #30, which can now be closed at your leisure.
