### PR TITLE
SEC-2177: Striping off all leading schemes

### DIFF
--- a/web/src/main/java/org/springframework/security/web/DefaultRedirectStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/DefaultRedirectStrategy.java
@@ -54,8 +54,9 @@ public class DefaultRedirectStrategy implements RedirectStrategy {
             return url;
         }
 
-        // Calculate the relative URL from the fully qualified URL, minus the scheme and base context.
-        url = url.substring(url.indexOf("://") + 3); // strip off scheme
+        // Calculate the relative URL from the fully qualified URL, minus the last
+        // occurrence of the scheme and base context.
+        url = url.substring(url.lastIndexOf("://") + 3); // strip off scheme
         url = url.substring(url.indexOf(contextPath) + contextPath.length());
 
         if (url.length() > 1 && url.charAt(0) == '/') {

--- a/web/src/test/java/org/springframework/security/web/DefaultRedirectStrategyTests.java
+++ b/web/src/test/java/org/springframework/security/web/DefaultRedirectStrategyTests.java
@@ -24,4 +24,17 @@ public class DefaultRedirectStrategyTests {
 
         assertEquals("remainder", response.getRedirectedUrl());
     }
+
+    @Test
+    public void contextRelativeUrlWithMultipleSchemesInHostnameIsHandledCorrectly() throws Exception {
+        DefaultRedirectStrategy rds = new DefaultRedirectStrategy();
+        rds.setContextRelative(true);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContextPath("/context");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        rds.sendRedirect(request, response, "http://http://context.blah.com/context/remainder");
+
+        assertEquals("remainder", response.getRedirectedUrl());
+    }
 }


### PR DESCRIPTION
Striping off all leading schemes in the DefaultRedirectStrategy, so it will be less vulnerable to open redirect phishing attacks.
This change is desired for our product, so either we'll copy source code and adjust ContextRelativeRedirectStrategy to our needs, or we’ll wait and use modified SpringSecurity’s component (which is obviously more preferable solution).
More details can be found at [SEC-2177](https://jira.spring.io/browse/SEC-2177) JIRA issue.

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
