### PR TITLE
SEC-2192: Create AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfiguration.java
@@ -40,6 +40,7 @@ import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.security.web.FilterInvocation;
 import org.springframework.security.web.access.WebInvocationPrivilegeEvaluator;
+import org.springframework.security.web.context.AbstractSecurityWebApplicationInitializer;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -55,6 +56,7 @@ import org.springframework.util.ClassUtils;
  * @see WebSecurity
  *
  * @author Rob Winch
+ * @author Keesun Baik
  * @since 3.2
  */
 @Configuration
@@ -66,7 +68,7 @@ public class WebSecurityConfiguration implements ImportAware, BeanClassLoaderAwa
     private ClassLoader beanClassLoader;
 
     @Bean
-    @DependsOn("springSecurityFilterChain")
+    @DependsOn(AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME)
     public SecurityExpressionHandler<FilterInvocation> webSecurityExpressionHandler() {
         return webSecurity.getExpressionHandler();
     }
@@ -76,7 +78,7 @@ public class WebSecurityConfiguration implements ImportAware, BeanClassLoaderAwa
      * @return
      * @throws Exception
      */
-    @Bean(name="springSecurityFilterChain")
+    @Bean(name=AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME)
     public Filter springSecurityFilterChain() throws Exception {
         boolean hasConfigurers = webSecurityConfigurers != null && !webSecurityConfigurers.isEmpty();
         if(!hasConfigurers) {
@@ -91,7 +93,7 @@ public class WebSecurityConfiguration implements ImportAware, BeanClassLoaderAwa
      * @throws Exception
      */
     @Bean
-    @DependsOn("springSecurityFilterChain")
+    @DependsOn(AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME)
     public WebInvocationPrivilegeEvaluator privilegeEvaluator() throws Exception {
         return webSecurity.getPrivilegeEvaluator();
     }

--- a/web/src/main/java/org/springframework/security/web/context/AbstractSecurityWebApplicationInitializer.java
+++ b/web/src/main/java/org/springframework/security/web/context/AbstractSecurityWebApplicationInitializer.java
@@ -66,10 +66,13 @@ import org.springframework.web.filter.DelegatingFilterProxy;
  * </p>
  *
  * @author Rob Winch
+ * @author Keesun Baik
  */
 public abstract class AbstractSecurityWebApplicationInitializer implements WebApplicationInitializer {
 
     private static final String SERVLET_CONTEXT_PREFIX = "org.springframework.web.servlet.FrameworkServlet.CONTEXT.";
+
+    public static final String DEFAULT_FILTER_NAME = "springSecurityFilterChain";
 
     /* (non-Javadoc)
      * @see org.springframework.web.WebApplicationInitializer#onStartup(javax.servlet.ServletContext)
@@ -100,7 +103,7 @@ public abstract class AbstractSecurityWebApplicationInitializer implements WebAp
      * @param servletContext the {@link ServletContext}
      */
     private void insertSpringSecurityFilterChain(ServletContext servletContext) {
-        String filterName = "springSecurityFilterChain";
+        String filterName = DEFAULT_FILTER_NAME;
         DelegatingFilterProxy springSecurityFilterChain = new DelegatingFilterProxy(filterName);
         String contextAttribute = getWebApplicationContextAttribute();
         if(contextAttribute != null) {

--- a/web/src/test/java/org/springframework/security/web/context/AbstractSecurityWebApplicationInitializerTest.java
+++ b/web/src/test/java/org/springframework/security/web/context/AbstractSecurityWebApplicationInitializerTest.java
@@ -1,0 +1,18 @@
+package org.springframework.security.web.context;
+
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Keesun Baik
+ */
+public class AbstractSecurityWebApplicationInitializerTest {
+
+    @Test
+    public void defaultFilterName() {
+        assertEquals(AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME, "springSecurityFilterChain");
+    }
+
+}


### PR DESCRIPTION
To reduce type error and to use more easily the 'springSecurityFilterChain' String, I've added a constant called DEFAULT_FILTER_NAME to the AbstractSecurityWebApplicationInitializer class.
