### PR TITLE
SEC-977: Add support for CAS gateway feature

### DIFF
--- a/cas/src/main/java/org/springframework/security/cas/authentication/TriggerCasGatewayException.java
+++ b/cas/src/main/java/org/springframework/security/cas/authentication/TriggerCasGatewayException.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.cas.authentication;
+
+import org.springframework.security.cas.web.CasAuthenticationEntryPoint;
+import org.springframework.security.core.AuthenticationException;
+
+/**
+ * Exception used to indicate the {@link CasAuthenticationEntryPoint} to make a CAS gateway authentication request.
+ *
+ * @author Michael Remond
+ *
+ */
+public class TriggerCasGatewayException extends
+        AuthenticationException {
+
+    //~ Constructors ===================================================================================================
+
+    /**
+     * Constructs an {@code InitiateCasGatewayAuthenticationException} with the specified message and no root cause.
+     *
+     * @param msg the detail message
+     */
+    public TriggerCasGatewayException(String msg) {
+        super(msg);
+    }
+
+    /**
+     * Constructs an {@code InitiateCasGatewayAuthenticationException} with the specified message and root cause.
+     *
+     * @param msg the detail message
+     * @param t the root cause
+     */
+    public TriggerCasGatewayException(String msg, Throwable t) {
+        super(msg, t);
+    }
+
+}

--- a/cas/src/main/java/org/springframework/security/cas/web/DefaultCasGatewayRequestMatcher.java
+++ b/cas/src/main/java/org/springframework/security/cas/web/DefaultCasGatewayRequestMatcher.java
@@ -1,0 +1,103 @@
+package org.springframework.security.cas.web;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.jasig.cas.client.authentication.DefaultGatewayResolverImpl;
+import org.jasig.cas.client.authentication.GatewayResolver;
+import org.springframework.security.cas.ServiceProperties;
+import org.springframework.security.cas.authentication.CasAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.util.RequestMatcher;
+import org.springframework.util.Assert;
+
+/**
+ * Default RequestMatcher implementation for the {@link TriggerCasGatewayFilter}.
+ * 
+ * This RequestMatcher returns <code>true</code> iff :
+ * <ul>
+ * <li>
+ * User is not already authenticated (see {@link #isAuthenticated})</li>
+ * <li>
+ * The request was not previously gatewayed</li>
+ * <li>
+ * The request matches additional criteria (see {@link #performGatewayAuthentication})</li>
+ * </ul>
+ * 
+ * Implementors can override this class to customize the authentication check and the gateway criteria.
+ * <p>
+ * The request is marked as "gatewayed" using the configured {@link GatewayResolver} to avoid infinite loop.
+ * 
+ * @author Michael Remond
+ * 
+ */
+public class DefaultCasGatewayRequestMatcher implements RequestMatcher {
+
+    // ~ Instance fields
+    // ================================================================================================
+
+    private ServiceProperties serviceProperties;
+
+    private GatewayResolver gatewayStorage = new DefaultGatewayResolverImpl();
+
+    // ~ Constructors
+    // ===================================================================================================
+
+    public DefaultCasGatewayRequestMatcher(ServiceProperties serviceProperties) {
+        Assert.notNull(serviceProperties, "serviceProperties cannot be null");
+        this.serviceProperties = serviceProperties;
+    }
+
+    public final boolean matches(HttpServletRequest request) {
+
+        // Test if we are already authenticated
+        if (isAuthenticated(request)) {
+            return false;
+        }
+
+        // Test if the request was already gatewayed to avoid infinite loop
+        final boolean wasGatewayed = this.gatewayStorage.hasGatewayedAlready(request, serviceProperties.getService());
+
+        if (wasGatewayed) {
+            return false;
+        }
+
+        // If request matches gateway criteria, we mark the request as gatewayed and return true to trigger a CAS
+        // gateway authentication
+        if (performGatewayAuthentication(request)) {
+            gatewayStorage.storeGatewayInformation(request, serviceProperties.getService());
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Test if the user is authenticated in Spring Security. Default implementation test if the user is CAS
+     * authenticated.
+     * 
+     * @param request
+     * @return true if the user is authenticated
+     */
+    protected boolean isAuthenticated(HttpServletRequest request) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication instanceof CasAuthenticationToken;
+    }
+
+    /**
+     * Method that determines if the current request triggers a CAS gateway authentication. Default implementation
+     * always returns <code>true</code>.
+     * 
+     * @param request
+     * @return true if the request must trigger a CAS gateway authentication
+     */
+    protected boolean performGatewayAuthentication(HttpServletRequest request) {
+        return true;
+    }
+
+    public void setGatewayStorage(GatewayResolver gatewayStorage) {
+        Assert.notNull(gatewayStorage, "gatewayStorage cannot be null");
+        this.gatewayStorage = gatewayStorage;
+    }
+
+}

--- a/cas/src/main/java/org/springframework/security/cas/web/TriggerCasGatewayFilter.java
+++ b/cas/src/main/java/org/springframework/security/cas/web/TriggerCasGatewayFilter.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2013-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.cas.web;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.cas.authentication.TriggerCasGatewayException;
+import org.springframework.security.web.util.RequestMatcher;
+import org.springframework.util.Assert;
+import org.springframework.web.filter.GenericFilterBean;
+
+/**
+ * Triggers a CAS gateway authentication attempt.
+ * <p>
+ * This filter must be placed after the <code>ExceptionTranslationFilter</code> in the filter chain in order to start
+ * the authentication process. Throws a {@link TriggerCasGatewayException} when the current request matches against the
+ * configured {@link RequestMatcher}.
+ * <p>
+ * The default implementation you can use is {@link DefaultCasGatewayRequestMatcher}.
+ * 
+ * @author Michael Remond
+ */
+public class TriggerCasGatewayFilter extends GenericFilterBean {
+
+    // ~ Instance fields
+    // ================================================================================================
+
+    private RequestMatcher requestMatcher;
+
+    // ~ Constructors
+    // ===================================================================================================
+
+    public TriggerCasGatewayFilter(RequestMatcher requestMatcher) {
+        Assert.notNull(requestMatcher, "requestMatcher cannot be null");
+        this.requestMatcher = requestMatcher;
+    }
+
+    public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException,
+            ServletException {
+
+        HttpServletRequest request = (HttpServletRequest) req;
+        HttpServletResponse response = (HttpServletResponse) res;
+
+        if (requestMatcher.matches(request)) {
+            throw new TriggerCasGatewayException("Try a CAS gateway authentication");
+        } else {
+            // Continue in the chain
+            chain.doFilter(request, response);
+        }
+
+    }
+
+    public void setRequestMatcher(RequestMatcher requestMatcher) {
+        this.requestMatcher = requestMatcher;
+    }
+
+}

--- a/cas/src/test/java/org/springframework/security/cas/web/CasAuthenticationEntryPointTests.java
+++ b/cas/src/test/java/org/springframework/security/cas/web/CasAuthenticationEntryPointTests.java
@@ -20,6 +20,7 @@ import junit.framework.TestCase;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.cas.ServiceProperties;
+import org.springframework.security.cas.authentication.TriggerCasGatewayException;
 import org.springframework.security.cas.web.CasAuthenticationEntryPoint;
 
 import java.net.URLEncoder;
@@ -106,6 +107,48 @@ public class CasAuthenticationEntryPointTests extends TestCase {
         ep.commence(request, response, null);
         assertEquals("https://cas/login?service="
             + URLEncoder.encode("https://mycompany.com/bigWebApp/j_spring_cas_security_check", "UTF-8") + "&renew=true",
+            response.getRedirectedUrl());
+    }
+
+    public void testNormalOperationWithRenewFalseAndGateway() throws Exception {
+        ServiceProperties sp = new ServiceProperties();
+        sp.setSendRenew(false);
+        sp.setService("https://mycompany.com/bigWebApp/j_spring_cas_security_check");
+
+        CasAuthenticationEntryPoint ep = new CasAuthenticationEntryPoint();
+        ep.setLoginUrl("https://cas/login");
+        ep.setServiceProperties(sp);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/some_path");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        ep.afterPropertiesSet();
+        ep.commence(request, response, new TriggerCasGatewayException(""));
+        assertEquals("https://cas/login?service="
+            + URLEncoder.encode("https://mycompany.com/bigWebApp/j_spring_cas_security_check", "UTF-8") + "&gateway=true",
+            response.getRedirectedUrl());
+    }
+
+    public void testNormalOperationWithRenewTrueAndGateway() throws Exception {
+        ServiceProperties sp = new ServiceProperties();
+        sp.setSendRenew(true);
+        sp.setService("https://mycompany.com/bigWebApp/j_spring_cas_security_check");
+
+        CasAuthenticationEntryPoint ep = new CasAuthenticationEntryPoint();
+        ep.setLoginUrl("https://cas/login");
+        ep.setServiceProperties(sp);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/some_path");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        ep.afterPropertiesSet();
+        ep.commence(request, response, new TriggerCasGatewayException(""));
+        assertEquals("https://cas/login?service="
+            + URLEncoder.encode("https://mycompany.com/bigWebApp/j_spring_cas_security_check", "UTF-8") + "&renew=true&gateway=true",
             response.getRedirectedUrl());
     }
 }

--- a/cas/src/test/java/org/springframework/security/cas/web/DefaultCasGatewayRequestMatcherTests.java
+++ b/cas/src/test/java/org/springframework/security/cas/web/DefaultCasGatewayRequestMatcherTests.java
@@ -1,0 +1,74 @@
+package org.springframework.security.cas.web;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+
+import junit.framework.Assert;
+
+import org.jasig.cas.client.authentication.DefaultGatewayResolverImpl;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.cas.ServiceProperties;
+import org.springframework.security.cas.authentication.CasAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class DefaultCasGatewayRequestMatcherTests {
+
+    @Test
+    public void testNullServiceProperties() throws Exception {
+        try {
+            new DefaultCasGatewayRequestMatcher(null);
+            fail("Should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            Assert.assertEquals("serviceProperties cannot be null", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void testNormalOperationWithNoSSOSession() throws IOException, ServletException {
+        ServiceProperties serviceProperties = new ServiceProperties();
+        serviceProperties.setService("http://localhost/j_spring_cas_security_check");
+        DefaultCasGatewayRequestMatcher rm = new DefaultCasGatewayRequestMatcher(serviceProperties);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/some_path");
+
+        // First request
+        Assert.assertTrue(rm.matches(request));
+        Assert.assertNotNull(request.getSession(false).getAttribute(DefaultGatewayResolverImpl.CONST_CAS_GATEWAY));
+        // Second request
+        Assert.assertFalse(rm.matches(request));
+        Assert.assertNull(request.getSession(false).getAttribute(DefaultGatewayResolverImpl.CONST_CAS_GATEWAY));
+    }
+
+    @Test
+    public void testGatewayWhenAlreadyCasAuthenticated() throws IOException, ServletException {
+        SecurityContextHolder.getContext().setAuthentication(mock(CasAuthenticationToken.class));
+
+        ServiceProperties serviceProperties = new ServiceProperties();
+        serviceProperties.setService("http://localhost/j_spring_cas_security_check");
+        DefaultCasGatewayRequestMatcher rm = new DefaultCasGatewayRequestMatcher(serviceProperties);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/some_path");
+
+        Assert.assertFalse(rm.matches(request));
+    }
+
+    @Test
+    public void testGatewayWithNoMatchingRequest() throws IOException, ServletException {
+        ServiceProperties serviceProperties = new ServiceProperties();
+        serviceProperties.setService("http://localhost/j_spring_cas_security_check");
+        DefaultCasGatewayRequestMatcher rm = new DefaultCasGatewayRequestMatcher(serviceProperties) {
+            @Override
+            protected boolean performGatewayAuthentication(HttpServletRequest request) {
+                return false;
+            }
+        };
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/some_path");
+
+        Assert.assertFalse(rm.matches(request));
+    }
+
+}

--- a/cas/src/test/java/org/springframework/security/cas/web/TriggerCasGatewayFilterTests.java
+++ b/cas/src/test/java/org/springframework/security/cas/web/TriggerCasGatewayFilterTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2013-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.cas.web;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.cas.authentication.TriggerCasGatewayException;
+import org.springframework.security.web.util.AnyRequestMatcher;
+import org.springframework.security.web.util.RequestMatcher;
+
+/**
+ * Tests {@link TriggerCasGatewayFilter}
+ * 
+ * @author Michael Remond
+ * 
+ */
+public class TriggerCasGatewayFilterTests {
+
+    @Test
+    public void testNullRequestMatcher() throws Exception {
+        try {
+            new TriggerCasGatewayFilter(null);
+            fail("Should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            Assert.assertEquals("requestMatcher cannot be null", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void testGatewayWithMatchingRequest() throws IOException, ServletException {
+        TriggerCasGatewayFilter filter = new TriggerCasGatewayFilter(new AnyRequestMatcher());
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/some_path");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        try {
+            filter.doFilter(request, response, chain);
+            fail("should have throw an AuthenticationException");
+        } catch (TriggerCasGatewayException expected) {
+            Assert.assertEquals("Try a CAS gateway authentication", expected.getMessage());
+        }
+        verifyZeroInteractions(chain);
+    }
+
+    @Test
+    public void testGatewayWithNoMatchingRequest() throws IOException, ServletException {
+        TriggerCasGatewayFilter filter = new TriggerCasGatewayFilter(new RequestMatcher() {
+            public boolean matches(HttpServletRequest request) {
+                return false;
+            }
+        });
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/some_path");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+        verify(chain).doFilter(request, response);
+    }
+
+}

--- a/cas/template.mf
+++ b/cas/template.mf
@@ -14,6 +14,7 @@ Import-Template:
  org.springframework.security.core.*;version="${secRange}",
  org.springframework.security.authentication.*;version="${secRange}",
  org.springframework.security.web.*;version="${secRange}",
+ org.springframework.web.filter.*;version="${springRange}",
  org.springframework.beans.factory;version="${springRange}",
  org.springframework.cache.*;version="${springRange}";resolution:=optional,
  org.springframework.context.*;version="${springRange}",


### PR DESCRIPTION
The opportunity and the implementation details of this new feature were discussed in Jira SEC-977.

The new filter TriggerCasGatewayAuthenticationFilter has been added to
call the CasAuthenticationEntryPoint when we want try a silent CAS
authentication (typically on a public page). The trigger criteria is
done with a requestMatcher instance.
The method unsuccessfulAuthentication has been overridden in
CasAuthenticationFilter in order to redirect to the saved url if there
was no SSO session (no service ticket sent from CAS).
To avoid infinite loop, we use the DefaultGatewayResolverImpl from Jasig
Cas Client.

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.