### PR TITLE
Fixing Javadoc for SessionFixationConfigurer#changeSessionId

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
@@ -242,14 +242,17 @@ public final class SessionManagementConfigurer<H extends HttpSecurityBuilder<H>>
         }
 
         /**
-         * Specifies that no session fixation protection should be enabled. This
-         * may be useful when utilizing other mechanisms for protecting against
-         * session fixation. For example, if application container session
-         * fixation protection is already in use. Otherwise, this option is not
-         * recommended.
+         * Specifies that the Servlet container-provided session fixation
+         * protection should be used. When a session authenticates, the
+         * Servlet 3.1 method {@code HttpServletRequest#changeSessionId()} is
+         * called to change the session ID and retain all session attributes.
+         * Using this option in a Servlet 3.0 or older container results in an
+         * {@link IllegalStateException}.
          *
          * @return the {@link SessionManagementConfigurer} for further
          *         customizations
+         * @throws IllegalStateException if the container is not Servlet 3.1 or
+         *         newer.
          */
         public SessionManagementConfigurer<H> changeSessionId() {
             setSessionFixationAuthenticationStrategy(new ChangeSessionIdAuthenticationStrategy());


### PR DESCRIPTION
The Javadoc for `SessionFixationConfigurer#changeSessionId()` was copied and pasted from `SessionFixationConfigurer#none()` and never updated. It is incorrect. This commit fixes that. It also adds a newline at the end of the file, which the file was missing, causing Git to complain.
