### PR TITLE
SEC-2302: Allow other filters to register in front of SpringSecurityFilterChain

### DIFF
--- a/web/src/main/java/org/springframework/security/web/context/AbstractSecurityWebApplicationInitializer.java
+++ b/web/src/main/java/org/springframework/security/web/context/AbstractSecurityWebApplicationInitializer.java
@@ -144,7 +144,7 @@ public abstract class AbstractSecurityWebApplicationInitializer implements WebAp
         if(contextAttribute != null) {
             springSecurityFilterChain.setContextAttribute(contextAttribute);
         }
-        registerFilter(servletContext, true, filterName, springSecurityFilterChain);
+        registerFilter(servletContext, false, filterName, springSecurityFilterChain);
     }
 
     /**


### PR DESCRIPTION
javax.servlet.FilterRegistration.Dynamic.addMappingForUrlPatterns(..., false, ...) locks the SpringSecurityFilterChain in front of later registered filters.

Please see https://github.com/bugix/spring-security-testcase for a testcase

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
