### PR TITLE
fix for invalid exception after calling setAuthenticated() even though constructor which takes a GrantedAuthority list is used

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/UsernamePasswordAuthenticationToken.java
+++ b/core/src/main/java/org/springframework/security/authentication/UsernamePasswordAuthenticationToken.java
@@ -84,9 +84,10 @@ public class UsernamePasswordAuthenticationToken extends AbstractAuthenticationT
     public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
         if (isAuthenticated && super.getAuthorities() == null) {
             super.setAuthenticated(false);
-
             throw new IllegalArgumentException(
                     "Cannot set this token to trusted - use constructor which takes a GrantedAuthority list instead");
+        } else if (!isAuthenticated) {
+            super.setAuthenticated(false);
         }
     }
 


### PR DESCRIPTION
Following code produces an exception with misleading exception message: 
ArrayList<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
Authentication customAuthentication = 
    new UsernamePasswordAuthenticationToken("ROLE_USER", authentication, authorities);
customAuthentication.setAuthenticated(true);

Following is the exception the code produces:

java.lang.IllegalArgumentException: Cannot set this token to trusted - use constructor which takes a GrantedAuthority list instead
    at org.springframework.security.authentication.UsernamePasswordAuthenticationToken.setAuthenticated(UsernamePasswordAuthenticationToken.java:87)
    at com.gamenism.server.auth.CustomAuthenticationProvider.authenticate(CustomAuthenticationProvider.java:45)
    at org.springframework.security.authentication.ProviderManager.authenticate(ProviderManager.java:156)
