### PR TITLE
Added RememberMeAuthenticationException constructor which keeps the root cause of the exception

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/rememberme/RememberMeAuthenticationException.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/rememberme/RememberMeAuthenticationException.java
@@ -3,11 +3,31 @@ package org.springframework.security.web.authentication.rememberme;
 import org.springframework.security.core.AuthenticationException;
 
 /**
+ * This exception is thrown when an {@link org.springframework.security.core.Authentication} exception occurs while
+ * using the remember-me authentication.
+ *
  * @author Luke Taylor
  */
 public class RememberMeAuthenticationException extends AuthenticationException {
 
-    public RememberMeAuthenticationException(String message) {
-        super(message);
+    //~ Constructors ===================================================================================================
+
+    /**
+     * Constructs a {@code RememberMeAuthenticationException} with the specified message and root cause.
+     *
+     * @param msg the detail message
+     * @param t the root cause
+     */
+    public RememberMeAuthenticationException(String msg, Throwable t) {
+        super(msg, t);
+    }
+
+    /**
+     * Constructs an {@code RememberMeAuthenticationException} with the specified message and no root cause.
+     *
+     * @param msg the detail message
+     */
+    public RememberMeAuthenticationException(String msg) {
+        super(msg);
     }
 }


### PR DESCRIPTION
- The main change is to add a new constructor which keeps the root cause of the exception (we don't all want to forget the root cause, in my case it is a DataAccessException and I would like to know about it. Besides, losing the root cause adds a Sonar violation)
- Added some documentation
- Copied the documentation style and the argument name from the root AuthenticationException class, so it is more consistent
