### PR TITLE
SEC-2387 - add ignored failing test case

### DIFF
--- a/ldap/ldap.gradle
+++ b/ldap/ldap.gradle
@@ -26,7 +26,7 @@ dependencies {
 }
 
 integrationTest {
-    include('**/ApacheDSServerIntegrationTests.class')
+    include('**/ApacheDSServerIntegrationTests.class', '**/ApacheDSEmbeddedLdifTests.class')
 //    exclude('**/OpenLDAPIntegrationTestSuite.class')
     maxParallelForks = 1
     systemProperties['apacheDSWorkDir'] = "${buildDir}/apacheDSWork"

--- a/ldap/src/integration-test/java/org/springframework/security/ldap/server/ApacheDSEmbeddedLdifTests.java
+++ b/ldap/src/integration-test/java/org/springframework/security/ldap/server/ApacheDSEmbeddedLdifTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.ldap.server;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.springframework.ldap.core.support.LdapContextSource;
+import org.springframework.security.ldap.SpringSecurityLdapTemplate;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests reproducing problems with loading structures from ldif on embedded ApacheDS server.
+ *
+ * @author Marcin Zajączkowski
+ */
+public class ApacheDSEmbeddedLdifTests {
+
+    private static final String LDAP_ROOT = "ou=ssattributes,dc=springframework,dc=org";
+    private static final int LDAP_PORT = 52389;
+
+    private ApacheDSContainer server;
+    private SpringSecurityLdapTemplate ldapTemplate;
+
+    @Before
+    public void setUp() throws Exception {
+        //TODO: InMemoryXmlApplicationContext would be useful here, but it is not visible
+        server = new ApacheDSContainer(LDAP_ROOT, "classpath:test-server-custom-attribute-types.ldif");
+        server.setPort(LDAP_PORT);
+        server.afterPropertiesSet();
+
+        ldapTemplate = new SpringSecurityLdapTemplate(createLdapContextSource());
+    }
+
+    private LdapContextSource createLdapContextSource() throws Exception {
+        LdapContextSource ldapContextSource = new LdapContextSource();
+        ldapContextSource.setUrl("ldap://localhost:" + LDAP_PORT);
+        ldapContextSource.setBase(LDAP_ROOT);
+        ldapContextSource.afterPropertiesSet();
+        return ldapContextSource;
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (server != null) {
+            server.destroy();
+        }
+    }
+
+    @Ignore //Not fixed yet
+    @Test   //SEC-2387
+    public void customAttributeTypesShouldBeProperlyCreatedWhenLoadedFromLdif() {
+        assertTrue(ldapTemplate.compare("uid=objectWithCustomAttribute1", "uid", "objectWithCustomAttribute1"));
+        assertTrue(ldapTemplate.compare("uid=objectWithCustomAttribute1", "customAttribute", "I am custom"));
+    }
+
+}

--- a/ldap/src/integration-test/resources/test-server-custom-attribute-types.ldif
+++ b/ldap/src/integration-test/resources/test-server-custom-attribute-types.ldif
@@ -1,0 +1,46 @@
+version: 1
+
+dn: cn=ssattributes, ou=schema
+objectclass: metaSchema
+objectclass: top
+cn: ssattributes
+
+dn: ou=attributetypes, cn=ssattributes, ou=schema
+objectclass: organizationalUnit
+objectclass: top
+ou: attributetypes
+
+dn: m-oid=1.3.6.1.4.1.18060.0.4.3.9.1, ou=attributetypes, cn=ssattributes, ou=schema
+objectclass: metaAttributeType
+objectclass: metaTop
+objectclass: top
+m-oid: 1.3.6.1.4.1.18060.0.4.3.9.1
+m-name: customAttribute
+m-syntax: 1.3.6.1.4.1.1466.115.121.1.15
+
+dn: ou=objectclasses, cn=ssattributes, ou=schema
+objectclass: organizationalUnit
+objectclass: top
+ou: objectclasses
+
+dn: m-oid=1.3.6.1.4.1.18060.0.4.3.10.1, ou=objectclasses, cn=ssattributes, ou=schema
+objectclass: metaObjectClass
+objectclass: metaTop
+objectclass: top
+m-oid: 1.3.6.1.4.1.18060.0.4.3.10.1
+m-name: customObject
+m-must: uid
+m-may: customAttribute
+
+dn: ou=ssattributes,dc=springframework,dc=org
+objectclass: top
+objectclass: extensibleObject
+objectclass: organizationalUnit
+ou: ssattributes
+
+dn: uid=objectWithCustomAttribute1, ou=ssattributes, dc=springframework, dc=org
+objectClass: top
+objectClass: extensibleObject
+objectClass: customObject
+uid: objectWithCustomAttribute1
+customAttribute: I am custom


### PR DESCRIPTION
A test case for SEC-2387 -  Interceptors breaks an ability to add custom attribute types from ldif on embedded LDAP server.

To see important warnings which can help resolve this issue a logging level for org.apache.directory should be lowered to (at least) WARN.

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.