### PR TITLE
SEC-2355: Add PATCH to intercept-url xsd

### DIFF
--- a/config/src/main/resources/org/springframework/security/config/spring-security-3.2.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-3.2.rnc
@@ -357,7 +357,7 @@ intercept-url.attlist &=
     attribute access {xsd:token}?
 intercept-url.attlist &=
     ## The HTTP Method for which the access configuration attributes should apply. If not specified, the attributes will apply to any method.
-    attribute method {"GET" | "DELETE" | "HEAD" | "OPTIONS" | "POST" | "PUT" | "TRACE"}?
+    attribute method {"GET" | "DELETE" | "HEAD" | "OPTIONS" | "POST" | "PUT" | "PATCH" | "TRACE"}?
 
 intercept-url.attlist &=
     ## The filter list for the path. Currently can be set to "none" to remove a path from having any filters applied. The full filter stack (consisting of all filters created by the namespace configuration, and any added using 'custom-filter'), will be applied to any other paths.

--- a/config/src/main/resources/org/springframework/security/config/spring-security-3.2.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-3.2.xsd
@@ -1248,6 +1248,7 @@
                <xs:enumeration value="OPTIONS"/>
                <xs:enumeration value="POST"/>
                <xs:enumeration value="PUT"/>
+               <xs:enumeration value="PATCH"/>
                <xs:enumeration value="TRACE"/>
             </xs:restriction>
          </xs:simpleType>


### PR DESCRIPTION
Fix for SEC-2355, adding the PATCH http method to the xsd for intercept-url

All integration tests pass, and the error disappears from Eclipse when I manually tell it to use the xsd from the file system. 
