### PR TITLE
SEC-2417: Add missing compile-time dependency on crypto module

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,6 +50,12 @@
   </repositories>
   <dependencies>
     <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-crypto</artifactId>
+      <version>3.2.0.CI-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>aopalliance</groupId>
       <artifactId>aopalliance</artifactId>
       <version>1.0</version>


### PR DESCRIPTION
The maven pom.xml files should declare all the dependencies necessary to build a given module, but the pom.xml for the core module does not declare a compile-time dependency on the crypto module.
