### PR TITLE
SEC-2418: Minor fix to toString method in LdapUserDetailsImpl

### DIFF
--- a/ldap/src/main/java/org/springframework/security/ldap/userdetails/LdapUserDetailsImpl.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/userdetails/LdapUserDetailsImpl.java
@@ -133,7 +133,7 @@ public class LdapUserDetailsImpl implements LdapUserDetails, PasswordPolicyData 
         sb.append("CredentialsNonExpired: ").append(this.credentialsNonExpired).append("; ");
         sb.append("AccountNonLocked: ").append(this.accountNonLocked).append("; ");
 
-        if (this.getAuthorities() != null) {
+        if (this.getAuthorities() != null && !this.getAuthorities().isEmpty()) {
             sb.append("Granted Authorities: ");
             boolean first = true;
 


### PR DESCRIPTION
The toString method does not print "Not granted any authorities" when the authorities collection is non-null but empty. This change fixes that.
