### PR TITLE
Make the PreFilter annotation support filtering of an immutable list.

### DIFF
--- a/core/src/main/java/org/springframework/security/access/expression/method/DefaultMethodSecurityExpressionHandler.java
+++ b/core/src/main/java/org/springframework/security/access/expression/method/DefaultMethodSecurityExpressionHandler.java
@@ -102,10 +102,7 @@ public class DefaultMethodSecurityExpressionHandler extends AbstractSecurityExpr
                 logger.debug("Retaining elements: " + retainList);
             }
 
-            collection.clear();
-            collection.addAll(retainList);
-
-            return filterTarget;
+            return retainList;
         }
 
         if (filterTarget.getClass().isArray()) {

--- a/core/src/main/java/org/springframework/security/access/expression/method/ExpressionBasedPreInvocationAdvice.java
+++ b/core/src/main/java/org/springframework/security/access/expression/method/ExpressionBasedPreInvocationAdvice.java
@@ -30,8 +30,8 @@ public class ExpressionBasedPreInvocationAdvice implements PreInvocationAuthoriz
 
         if (preFilter != null) {
             Object filterTarget = findFilterTarget(preAttr.getFilterTarget(), ctx, mi);
-
-            expressionHandler.filter(filterTarget, preFilter, ctx);
+            Object filterResult = expressionHandler.filter(filterTarget, preFilter, ctx);
+            replaceFirstMethodArgument(mi, filterResult);
         }
 
         if (preAuthorize == null) {
@@ -67,6 +67,14 @@ public class ExpressionBasedPreInvocationAdvice implements PreInvocationAuthoriz
         }
 
         return filterTarget;
+    }
+
+    private void replaceFirstMethodArgument(MethodInvocation mi, Object newFirstArgument) {
+        Object[] arguments = mi.getArguments();
+        if (arguments.length == 0) {
+            throw new IllegalArgumentException("Filter target had no argument to replace.");
+        }
+        arguments[0] = newFirstArgument;
     }
 
 


### PR DESCRIPTION
I'm working on a web application where I have a service method

```
@PreFilter("@securityAccessRightsBean.doesHaveDeleteRights(filterObject)")
public List<String> removeObjects(List<String> objectIds) {
    // impl here
}
```

and a controller that handles special flow for single objects, result ing in the use of the java.lang utility method

```
Collections.singletonList(singleObjectId)
```

which eventually becomes the `filterObject`. However, that results in an `UnsupportedOperationException`, due to the `filterObject` being mutated. I vote to support filtering immutable lists (see that added unit test) with this pull request.

Note I only ran the core modules unit tests.
