### PR TITLE
SEC-1869 additions: SuccessHandler and FailureHandler for pre-auth filter implementation

### DIFF
--- a/web/src/test/java/org/springframework/security/web/authentication/preauth/AbstractPreAuthenticatedProcessingFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/preauth/AbstractPreAuthenticatedProcessingFilterTests.java
@@ -20,7 +20,9 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 
 public class AbstractPreAuthenticatedProcessingFilterTests {
@@ -153,6 +155,44 @@ public class AbstractPreAuthenticatedProcessingFilterTests {
 
         verify(successHandler, times(1)).onAuthenticationSuccess(request, response, authentication);
         assertEquals(authentication, SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    // SEC-1869
+    @Test
+    public void nullFailureHandlerDoesntHarm() throws Exception {
+        MockHttpServletRequest request = createMockAuthenticationRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AuthenticationException authExc = new PreAuthenticatedCredentialsNotFoundException("foo!");
+
+        filter.setAuthenticationFailureHandler(null);
+
+        // be sure that this doesn't fail even though authenticationFailureHandler is null
+        filter.unsuccessfulAuthentication(request, response, authExc);
+
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    // SEC-1869
+    @Test
+    public void failureHandlerIsInvoked() throws Exception {
+        MockHttpServletRequest request = createMockAuthenticationRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AuthenticationFailureHandler failureHandler = mock(AuthenticationFailureHandler.class);
+
+        // mock an AuthenticationManager that always throws an exception
+        PreAuthenticatedCredentialsNotFoundException authExc = new PreAuthenticatedCredentialsNotFoundException("");
+        AuthenticationManager am = mock(AuthenticationManager.class);
+        when(am.authenticate(any(Authentication.class))).thenThrow(authExc);
+
+        filter.setAuthenticationManager(am);
+        filter.setAuthenticationFailureHandler(failureHandler);
+        filter.afterPropertiesSet();
+
+        filter.doFilter(request, response, mock(FilterChain.class));
+
+        // check that this exception causes the failure handler to be called. The exception as such
+        // is not propagated, but the failure handler receives it to act on it if needed.
+        verify(failureHandler, times(1)).onAuthenticationFailure(request, response, authExc);
     }
 
     private MockHttpServletRequest createMockAuthenticationRequest() {


### PR DESCRIPTION
This is a solution I want to suggest to address the issue described in https://jira.springsource.org/browse/SEC-1869

The point is that the documentation states that AuthenticationSuccessHandlers and AuthenticationFailureHandlers can be used to react to (un)successful authentication events. As these handlers receive request and response objects via their signature, they are more powerful than reacting to AuthenticationEvents.

<quote from documentation, PDF section 9.4>
The destination following a successful authentication or an authentication failure is controlled by the AuthenticationSuccessHandler and  AuthenticationFailureHandler strategy interfaces, respectively.
</quote>

This pull request adds support for both handlers types to pre-authenticated filter implementations by amending AbstractPreAuthenticatedProcessingFilter.

If that patch needs some more work to be ready for inclusion, pls let me know.

I have submitted the CLA in 2011 already, in the context of SEC-1793.