### PR TITLE
Remove double ALLOW-FROM from X-Frame-Options header.

### DIFF
--- a/web/src/main/java/org/springframework/security/web/header/writers/frameoptions/AbstractRequestParameterAllowFromStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/header/writers/frameoptions/AbstractRequestParameterAllowFromStrategy.java
@@ -30,7 +30,7 @@ abstract class AbstractRequestParameterAllowFromStrategy implements AllowFromStr
             log.debug("Supplied origin '"+allowFromOrigin+"'");
         }
         if (StringUtils.hasText(allowFromOrigin) && allowed(allowFromOrigin)) {
-            return "ALLOW-FROM " + allowFromOrigin;
+            return allowFromOrigin;
         } else {
             return "DENY";
         }


### PR DESCRIPTION
The interface documentation for getAllowFromValue states: Gets the value for ALLOW-FROM excluding the ALLOW-FROM.
