### PR TITLE
Update AbstractLdapAuthenticationProvider.java

### DIFF
--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/AbstractLdapAuthenticationProvider.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/AbstractLdapAuthenticationProvider.java
@@ -83,7 +83,7 @@ public abstract class AbstractLdapAuthenticationProvider implements Authenticati
 
         UsernamePasswordAuthenticationToken result = new UsernamePasswordAuthenticationToken(user, password,
                 authoritiesMapper.mapAuthorities(user.getAuthorities()));
-        result.setDetails(authentication.getDetails());
+        result.setDetails(user);
 
         return result;
     }


### PR DESCRIPTION
I think this is the way it should be. Otherwise the `UserDetails` obtained in `authenticate()` using the `userDetailsContextMapper` won't be accessible from the created `Authentication` object.
