### PR TITLE
SEC-2560: change the login page to default

### DIFF
--- a/samples/openid-jc/src/main/java/org/springframework/security/samples/config/SecurityConfig.java
+++ b/samples/openid-jc/src/main/java/org/springframework/security/samples/config/SecurityConfig.java
@@ -17,8 +17,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .anyRequest().authenticated()
                 .and()
             .openidLogin()
-                .loginPage("/login")
-                .permitAll()
                 .authenticationUserDetailsService(new CustomUserDetailsService())
                 .attributeExchange("https://www.google.com/.*")
                     .attribute("email")


### PR DESCRIPTION
as SecurityConfig class refer to /login page which does not exist,
I delete this configuration and let sample use default openid login page.

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
