### PR TITLE
Update Spring IO plugin configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath("org.springframework.build.gradle:propdeps-plugin:0.0.6")
         classpath("org.springframework.build.gradle:bundlor-plugin:0.1.2")
-        classpath("org.springframework.build.gradle:springio-platform-plugin:0.0.2.RELEASE")
+        classpath("org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE")
         classpath("org.gradle.api.plugins:gradle-tomcat-plugin:0.9.8")
         classpath('me.champeau.gradle:gradle-javadoc-hotfix-plugin:0.1')
         classpath('org.asciidoctor:asciidoctor-gradle-plugin:0.7.0')
@@ -101,7 +101,18 @@ configure(javaProjects) {
 configure(coreModuleProjects) {
     apply plugin: 'bundlor'
     apply plugin: 'emma'
-    apply plugin: 'springio-platform'
+    
+    if (project.hasProperty('platformVersion')) {
+        apply plugin: 'spring-io'
+
+        repositories {
+            maven { url "https://repo.spring.io/libs-snapshot" }
+        }
+
+        dependencies {
+            springIoVersions "io.spring.platform:platform-versions:${platformVersion}@properties"
+        }
+    }
 
     bundlor.doFirst {
         def templateText = file("template.mf").text


### PR DESCRIPTION
- Upgrade to 0.0.3.RELEASE of the plugin
- Declare a dependency in the springIoVersions configuration on the
  Platform’s platform-versions artifact. An external property is used to
  provide the version of this artifact. This means that the build script
  does not need to refer to a snapshot artifact (the only version
  available at the time of writing) and also breaks a circular
  dependency between Spring Security (a project that’s part of the
  Platform) and the Platform itself.
- The plugin is applied and the libs-snapshot repository is added only
  if the external property is specified. This removes the possibility
  of a release or milestone being shipped with a snapshot dependency
  (unless the release build is performed with -PplatformVersion=foo).
