### PR TITLE
SEC-1947: Make DefaultRedirectStrategy more extensible 

### DIFF
--- a/web/src/main/java/org/springframework/security/web/DefaultRedirectStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/DefaultRedirectStrategy.java
@@ -57,7 +57,7 @@ public class DefaultRedirectStrategy implements RedirectStrategy {
 		response.sendRedirect(redirectUrl);
 	}
 
-	private String calculateRedirectUrl(String contextPath, String url) {
+	protected String calculateRedirectUrl(String contextPath, String url) {
 		if (!UrlUtils.isAbsoluteUrl(url)) {
 			if (contextRelative) {
 				return url;

--- a/web/src/main/java/org/springframework/security/web/DefaultRedirectStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/DefaultRedirectStrategy.java
@@ -35,7 +35,7 @@ public class DefaultRedirectStrategy implements RedirectStrategy {
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
-	private boolean contextRelative;
+	protected boolean contextRelative;
 
 	/**
 	 * Redirects the response to the supplied URL.


### PR DESCRIPTION
The DefaultRedirectStrategy should be extensible to allow custom implementations (e.g. for AJAX handling or special relative URLs).
JIRAs: SEC-1947, SEC-1765

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.