### PR TITLE
Trivial logging fix in saveContext method in HttpSessionSecurityContextRepository

### DIFF
--- a/web/src/main/java/org/springframework/security/web/context/HttpSessionSecurityContextRepository.java
+++ b/web/src/main/java/org/springframework/security/web/context/HttpSessionSecurityContextRepository.java
@@ -324,7 +324,7 @@ public class HttpSessionSecurityContextRepository implements SecurityContextRepo
                     httpSession.setAttribute(springSecurityContextKey, context);
 
                     if (logger.isDebugEnabled()) {
-                        logger.debug("SecurityContext stored to HttpSession: '" + context + "'");
+                        logger.debug("SecurityContext '" + context + "' stored to HttpSession: '" + httpSession);
                     }
                 }
             }


### PR DESCRIPTION
I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.

I've added this log as when you have some session management issues (I had the case with Jetty), so you can check that sessions are the same between requests.