### PR TITLE
DefaultSpringSecurityContextSource does not work with spring-ldap-2.0.0

### DIFF
--- a/ldap/src/main/java/org/springframework/security/ldap/DefaultSpringSecurityContextSource.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/DefaultSpringSecurityContextSource.java
@@ -72,7 +72,7 @@ public class DefaultSpringSecurityContextSource extends LdapContextSource {
             public void setupEnvironment(Hashtable env, String dn, String password) {
                 super.setupEnvironment(env, dn, password);
                 // Remove the pooling flag unless we are authenticating as the 'manager' user.
-                if (!userDn.equals(dn) && env.containsKey(SUN_LDAP_POOLING_FLAG)) {
+                if (!getUserDn().equals(dn) && env.containsKey(SUN_LDAP_POOLING_FLAG)) {
                     logger.debug("Removing pooling flag for user " + dn);
                     env.remove(SUN_LDAP_POOLING_FLAG);
                 }


### PR DESCRIPTION
Spring LDAP as of version 2.0.0 made userDn field private which DefaultSpringSecurityContextSource used directly. Because of this webapps that had spring-security-3.2.x and spring-ldap-2.0.0 failed to deploy/initialize beans. This does not happen with spring-ldap-1.3.2 which has this field not private.

spring-ldap-2.0.2 created a workaround for this bug andmade userDn field protected and marked it as deprecated  with suggestion to use a getter method getUserDn().
