### PR TITLE
SEC-2071: Allow to provide a root DN different from the domain

### DIFF
--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/ad/ActiveDirectoryLdapAuthenticationProvider.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/ad/ActiveDirectoryLdapAuthenticationProvider.java
@@ -108,6 +108,18 @@ public final class ActiveDirectoryLdapAuthenticationProvider extends AbstractLda
 //    }
 
     /**
+     * @param rootDn the root DN (may be null or empty)
+     * @param domain the domain name (may be null or empty)
+     * @param url an LDAP url (or multiple URLs)
+     */
+    public ActiveDirectoryLdapAuthenticationProvider(String rootDn, String domain, String url) {
+        Assert.isTrue(StringUtils.hasText(url), "Url cannot be empty");
+        this.domain = StringUtils.hasText(domain) ? domain.toLowerCase() : null;
+        this.rootDn = StringUtils.hasText(rootDn) ? rootDn.toLowerCase() : null;
+        this.url = url;
+    }
+
+    /**
      * @param domain the domain name (may be null or empty)
      * @param url an LDAP url (or multiple URLs)
      */


### PR DESCRIPTION
This is an improvement to the current implementation to provide flexibility when the root DN doesn't match the domain and/or the userPrincipalName.