### PR TITLE
Provide a ClassLoader to be used to load LDIF files

### DIFF
--- a/ldap/src/main/java/org/springframework/security/ldap/server/ApacheDSContainer.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/server/ApacheDSContainer.java
@@ -260,7 +260,7 @@ public class ApacheDSContainer implements InitializingBean, DisposableBean, Life
                 ldifFile = ldifs[0].getURI().toString();
             }
             logger.info("Loading LDIF file: " + ldifFile);
-            LdifFileLoader loader = new LdifFileLoader(service.getAdminSession(), ldifFile);
+            LdifFileLoader loader = new LdifFileLoader(service.getAdminSession(), new File(ldifFile), null, getClass().getClassLoader());
             loader.execute();
         } else {
             throw new IllegalArgumentException("More than one LDIF resource found with the supplied pattern:" + ldifResources+ " Got " + Arrays.toString(ldifs));


### PR DESCRIPTION
Prior to this change, ApacheDSContainer created a LdifFileLoader
without a ClassLoader. This limited its ability to load LDIF files
and causes a problem with an executable war in Spring Boot. See [1]
for details.

ApacheDSContainer now initialises LdifFileLoader with a ClassLoader.
This allows it to locate LDIF files packaged in WEB-INF/classes in
the case of an executable war file. The executable jar case was not
affected by this problem as, in that case, the LDIF file is pacakaged
in the root of the jar and is accessible via getSystemResourceAsStream

[1] https://github.com/spring-projects/spring-boot/issues/1550
