### PR TITLE
HeaderWriterFilter rejects empty header writers list 

### DIFF
--- a/web/src/main/java/org/springframework/security/web/header/HeaderWriterFilter.java
+++ b/web/src/main/java/org/springframework/security/web/header/HeaderWriterFilter.java
@@ -44,7 +44,7 @@ public class HeaderWriterFilter extends OncePerRequestFilter {
      * @param headerWriters the {@link HeaderWriter} instances to write out headers to the {@link HttpServletResponse}.
      */
     public HeaderWriterFilter(List<HeaderWriter> headerWriters) {
-        Assert.notEmpty(headerWriters, "headerWriters cannot be null");
+        Assert.notNull(headerWriters, "headerWriters cannot be null");
         this.headerWriters = headerWriters;
     }
 


### PR DESCRIPTION
HeaderWriterFilter rejects empty header writers list with message 'headerWriters cannot be null'.
So the check doesn't match the message. 
