### PR TITLE
Prevent premature container initialization in WebSecurityConfiguration.

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfiguration.java
@@ -74,7 +74,7 @@ public class WebSecurityConfiguration implements ImportAware, BeanClassLoaderAwa
     private ClassLoader beanClassLoader;
 
     @Bean
-    public DelegatingApplicationListener delegatingApplicationListener() {
+    public static DelegatingApplicationListener delegatingApplicationListener() {
         return new DelegatingApplicationListener();
     }
 


### PR DESCRIPTION
Changed the bean definition method for the DelegatingApplicationListener
to be static to avoid the need to instantiate the configuration class which
caused further premature initializations to satisfy the dependencies 
expressed in setFilterChainProxySecurityConfigurer(…).

Issue: SEC-2773.
