### PR TITLE
SEC-2800 Documentation typo in class name

### DIFF
--- a/docs/manual/src/docs/asciidoc/index.adoc
+++ b/docs/manual/src/docs/asciidoc/index.adoc
@@ -3672,8 +3672,8 @@ public class WebSecurityConfig extends
     http
       // ...
       .headers()
-        .addHeaderWriter(new StaticHeaderWriter("X-Content-Security-Policy","default-src 'self'"))
-        .addHeaderWriter(new StaticHeaderWriter("X-WebKit-CSP","default-src 'self'"));
+        .addHeaderWriter(new StaticHeadersWriter("X-Content-Security-Policy","default-src 'self'"))
+        .addHeaderWriter(new StaticHeadersWriter("X-WebKit-CSP","default-src 'self'"));
   }
 }
 ----


### PR DESCRIPTION
In the section 15.2.1_Static Headers of the spring security documentation, the class name StaticHeadersWriter was written without the “s” as StaticHeaderWriter which does not exist.

https://jira.spring.io/browse/SEC-2800
