### PR TITLE
SEC-2819

### DIFF
--- a/messaging/src/main/java/org/springframework/security/messaging/util/matcher/SimpDestinationMessageMatcher.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/util/matcher/SimpDestinationMessageMatcher.java
@@ -88,7 +88,7 @@ public final class SimpDestinationMessageMatcher implements MessageMatcher<Objec
      * @param pathMatcher the {@link PathMatcher} to use.
      */
     public SimpDestinationMessageMatcher(String pattern, SimpMessageType type) {
-        this(pattern, null, new AntPathMatcher());
+        this(pattern, type, new AntPathMatcher());
     }
 
     /**
@@ -116,4 +116,10 @@ public final class SimpDestinationMessageMatcher implements MessageMatcher<Objec
         String destination = SimpMessageHeaderAccessor.getDestination(message.getHeaders());
         return destination != null && matcher.match(pattern, destination);
     }
+
+
+    public MessageMatcher<Object> getMessageTypeMatcher() {
+        return messageTypeMatcher;
+    }
+
 }

--- a/messaging/src/main/java/org/springframework/security/messaging/util/matcher/SimpMessageTypeMatcher.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/util/matcher/SimpMessageTypeMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -19,7 +19,9 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessageType;
+import org.springframework.messaging.support.GenericMessage;
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 
 /**
  * A {@link MessageMatcher} that matches if the provided {@link Message} has a
@@ -50,4 +52,24 @@ public class SimpMessageTypeMatcher implements MessageMatcher<Object> {
 
         return typeToMatch == messageType;
     }
+
+
+
+    @Override
+    public boolean equals(Object other) {
+	if (this == other) {
+		return true;
+	}
+	if (!(other instanceof SimpMessageTypeMatcher)) {
+		return false;
+	}
+	SimpMessageTypeMatcher otherMatcher = (SimpMessageTypeMatcher) other;
+	return ObjectUtils.nullSafeEquals(this.typeToMatch, otherMatcher.typeToMatch);
+
+    }
+
+	public int hashCode() {
+		// Using nullSafeHashCode for proper array hashCode handling
+		return ObjectUtils.nullSafeHashCode(this.typeToMatch);
+	}
 }

--- a/messaging/src/test/java/org/springframework/security/messaging/util/matcher/SimpDestinationMessageMatcherTests.java
+++ b/messaging/src/test/java/org/springframework/security/messaging/util/matcher/SimpDestinationMessageMatcherTests.java
@@ -15,13 +15,13 @@
  */
 package org.springframework.security.messaging.util.matcher;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessageType;
 import org.springframework.messaging.support.MessageBuilder;
-
-import static org.fest.assertions.Assertions.assertThat;
 
 
 public class SimpDestinationMessageMatcherTests {
@@ -99,5 +99,14 @@ public class SimpDestinationMessageMatcherTests {
         assertThat(matcher.matches(messageBuilder.build())).isTrue();
     }
 
+    @Test
+    public void typeConstructorParameterIsTransmitted() throws Exception {
+        matcher = new SimpDestinationMessageMatcher("/match", SimpMessageType.MESSAGE);
+
+        MessageMatcher<Object> expectedTypeMatcher = new SimpMessageTypeMatcher(SimpMessageType.MESSAGE);
+
+	assertThat(matcher.getMessageTypeMatcher()).isEqualTo(expectedTypeMatcher);
+
+    }
 
 }


### PR DESCRIPTION
SEC-2819
SimpDestinationMessageMatcher(String pattern, SimpMessageType type) never passes type param to this() constructor

