### PR TITLE
SEC-2825 MessageMatcher hierarchy should provide RequestMatcher like composites

### DIFF
--- a/messaging/src/main/java/org/springframework/security/messaging/util/matcher/AbstractMessageMatcherComposite.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/util/matcher/AbstractMessageMatcherComposite.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.springframework.security.messaging.util.matcher;
+
+import static java.util.Arrays.asList;
+import static org.apache.commons.logging.LogFactory.getLog;
+import static org.springframework.util.Assert.notEmpty;
+
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+
+/**
+ * Abstract {@link MessageMatcher} containing multiple {@link MessageMatcher}
+ *
+ * @since 4.0
+ */
+public abstract class AbstractMessageMatcherComposite<T> implements MessageMatcher<T> {
+    private final Log logger = getLog(getClass());
+
+    private final List<MessageMatcher<T>> messageMatchers;
+
+    /**
+     * Creates a new instance
+     *
+     * @param messageMatchers the {@link MessageMatcher} instances to try
+     */
+    public AbstractMessageMatcherComposite(List<MessageMatcher<T>> messageMatchers) {
+        notEmpty(messageMatchers, "messageMatchers must contain a value");
+        if (messageMatchers.contains(null)) {
+            throw new IllegalArgumentException("messageMatchers cannot contain null values");
+        }
+        this.messageMatchers = messageMatchers;
+
+    }
+
+    /**
+     * Creates a new instance
+     *
+     * @param messageMatchers the {@link MessageMatcher} instances to try
+     */
+    @SafeVarargs
+    public AbstractMessageMatcherComposite(MessageMatcher<T>... messagetMatchers) {
+        this(asList(messagetMatchers));
+    }
+
+    public List<MessageMatcher<T>> getMessageMatchers() {
+        return messageMatchers;
+    }
+
+    public Log getLogger() {
+        return logger;
+    }
+    @Override
+    public String toString() {
+        return getClass().getSimpleName()+ "[messageMatchers=" + messageMatchers + "]";
+    }
+}

--- a/messaging/src/main/java/org/springframework/security/messaging/util/matcher/AndMessageMatcher.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/util/matcher/AndMessageMatcher.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.springframework.security.messaging.util.matcher;
+
+import java.util.List;
+
+import org.springframework.messaging.Message;
+
+/**
+ * {@link MessageMatcher} that will return true if all of the passed in {@link MessageMatcher} instances match.
+ *
+ * @since 4.0
+ */
+public class AndMessageMatcher<T> extends AbstractMessageMatcherComposite<T> {
+    /**
+     * Creates a new instance
+     *
+     * @param messageMatchers the {@link MessageMatcher} instances to try
+     */
+    public AndMessageMatcher(List<MessageMatcher<T>> messageMatchers) {
+        super(messageMatchers);
+    }
+
+    /**
+     * Creates a new instance
+     *
+     * @param messageMatchers the {@link MessageMatcher} instances to try
+     */
+    @SafeVarargs
+    public AndMessageMatcher(MessageMatcher<T>... messagetMatchers) {
+        super(messagetMatchers);
+
+    }
+
+    @Override
+    public boolean matches(Message<? extends T> message) {
+        for (MessageMatcher<T> matcher : getMessageMatchers()) {
+            if (getLogger().isDebugEnabled()) {
+                getLogger().debug("Trying to match using " + matcher);
+            }
+            if (!matcher.matches(message)) {
+                getLogger().debug("Did not match");
+                return false;
+            }
+        }
+        getLogger().debug("All messagetMatchers returned true");
+        return true;
+    }
+}

--- a/messaging/src/main/java/org/springframework/security/messaging/util/matcher/OrMessageMatcher.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/util/matcher/OrMessageMatcher.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.springframework.security.messaging.util.matcher;
+
+import java.util.List;
+
+import org.springframework.messaging.Message;
+
+/**
+ * {@link MessageMatcher} that will return true if any of the passed in {@link MessageMatcher} instances match.
+ *
+ * @since 4.0
+ */
+public class OrMessageMatcher<T> extends AbstractMessageMatcherComposite<T> {
+    /**
+     * Creates a new instance
+     *
+     * @param messageMatchers the {@link MessageMatcher} instances to try
+     */
+    public OrMessageMatcher(List<MessageMatcher<T>> messageMatchers) {
+        super(messageMatchers);
+    }
+
+    /**
+     * Creates a new instance
+     *
+     * @param messageMatchers the {@link MessageMatcher} instances to try
+     */
+    @SafeVarargs
+    public OrMessageMatcher(MessageMatcher<T>... messagetMatchers) {
+        super(messagetMatchers);
+
+    }
+
+    @Override
+    public boolean matches(Message<? extends T> message) {
+        for (MessageMatcher<T> matcher : getMessageMatchers()) {
+            if (getLogger().isDebugEnabled()) {
+                getLogger().debug("Trying to match using " + matcher);
+            }
+            if (matcher.matches(message)) {
+                getLogger().debug("matched");
+                return true;
+            }
+        }
+        getLogger().debug("No matches found");
+        return false;
+    }
+}

--- a/messaging/src/test/java/org/springframework/security/messaging/util/matcher/AndMessageMatcherTest.java
+++ b/messaging/src/test/java/org/springframework/security/messaging/util/matcher/AndMessageMatcherTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.springframework.security.messaging.util.matcher;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.messaging.Message;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AndMessageMatcherTest {
+    @Mock
+    private MessageMatcher<Object> delegate;
+
+    @Mock
+    private MessageMatcher<Object> delegate2;
+
+    @Mock
+    private Message<Object> message;
+
+    private MessageMatcher<Object> matcher;
+
+    @Test(expected = NullPointerException.class)
+    public void constructorNullArray() {
+        new AndMessageMatcher<Object>((MessageMatcher<Object>[]) null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorArrayContainsNull() {
+        new AndMessageMatcher<Object>((MessageMatcher<Object>)null);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorEmptyArray() {
+        new AndMessageMatcher<Object>((MessageMatcher<Object>[])new MessageMatcher[0]);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorNullList() {
+        new AndMessageMatcher<Object>((List<MessageMatcher<Object>>) null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorListContainsNull() {
+        new AndMessageMatcher<Object>(Arrays.asList((MessageMatcher<Object>)null));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorEmptyList() {
+        new AndMessageMatcher<Object>(Collections.<MessageMatcher<Object>>emptyList());
+    }
+
+    @Test
+    public void matchesSingleTrue() {
+        when(delegate.matches(message)).thenReturn(true);
+        matcher = new AndMessageMatcher<Object>(delegate);
+
+        assertThat(matcher.matches(message)).isTrue();
+    }
+
+    @Test
+    public void matchesMultiTrue() {
+        when(delegate.matches(message)).thenReturn(true);
+        when(delegate2.matches(message)).thenReturn(true);
+        matcher = new AndMessageMatcher<Object>(delegate, delegate2);
+
+        assertThat(matcher.matches(message)).isTrue();
+    }
+
+
+    @Test
+    public void matchesSingleFalse() {
+        when(delegate.matches(message)).thenReturn(false);
+        matcher = new AndMessageMatcher<Object>(delegate);
+
+        assertThat(matcher.matches(message)).isFalse();
+    }
+
+    @Test
+    public void matchesMultiBothFalse() {
+        when(delegate.matches(message)).thenReturn(false);
+        when(delegate2.matches(message)).thenReturn(false);
+        matcher = new AndMessageMatcher<Object>(delegate, delegate2);
+
+        assertThat(matcher.matches(message)).isFalse();
+    }
+
+    @Test
+    public void matchesMultiSingleFalse() {
+        when(delegate.matches(message)).thenReturn(true);
+        when(delegate2.matches(message)).thenReturn(false);
+        matcher = new AndMessageMatcher<Object>(delegate, delegate2);
+
+        assertThat(matcher.matches(message)).isFalse();
+    }
+}
+

--- a/messaging/src/test/java/org/springframework/security/messaging/util/matcher/OrMessageMatcherTest.java
+++ b/messaging/src/test/java/org/springframework/security/messaging/util/matcher/OrMessageMatcherTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.springframework.security.messaging.util.matcher;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.messaging.Message;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OrMessageMatcherTest {
+    @Mock
+    private MessageMatcher<Object> delegate;
+
+    @Mock
+    private MessageMatcher<Object> delegate2;
+
+    @Mock
+    private Message<Object> message;
+
+    private MessageMatcher<Object> matcher;
+
+    @Test(expected = NullPointerException.class)
+    public void constructorNullArray() {
+        new OrMessageMatcher<Object>((MessageMatcher<Object>[]) null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorArrayContainsNull() {
+        new OrMessageMatcher<Object>((MessageMatcher<Object>)null);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorEmptyArray() {
+        new OrMessageMatcher<Object>((MessageMatcher<Object>[])new MessageMatcher[0]);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorNullList() {
+        new OrMessageMatcher<Object>((List<MessageMatcher<Object>>) null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorListContainsNull() {
+        new OrMessageMatcher<Object>(Arrays.asList((MessageMatcher<Object>)null));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorEmptyList() {
+        new OrMessageMatcher<Object>(Collections.<MessageMatcher<Object>>emptyList());
+    }
+
+    @Test
+    public void matchesSingleTrue() {
+        when(delegate.matches(message)).thenReturn(true);
+        matcher = new OrMessageMatcher<Object>(delegate);
+
+        assertThat(matcher.matches(message)).isTrue();
+    }
+
+    @Test
+    public void matchesMultiTrue() {
+        when(delegate.matches(message)).thenReturn(true);
+        when(delegate2.matches(message)).thenReturn(true);
+        matcher = new OrMessageMatcher<Object>(delegate, delegate2);
+
+        assertThat(matcher.matches(message)).isTrue();
+    }
+
+
+    @Test
+    public void matchesSingleFalse() {
+        when(delegate.matches(message)).thenReturn(false);
+        matcher = new OrMessageMatcher<Object>(delegate);
+
+        assertThat(matcher.matches(message)).isFalse();
+    }
+
+    @Test
+    public void matchesMultiBothFalse() {
+        when(delegate.matches(message)).thenReturn(false);
+        when(delegate2.matches(message)).thenReturn(false);
+        matcher = new OrMessageMatcher<Object>(delegate, delegate2);
+
+        assertThat(matcher.matches(message)).isFalse();
+    }
+
+    @Test
+    public void matchesMultiSingleFalse() {
+        when(delegate.matches(message)).thenReturn(true);
+        when(delegate2.matches(message)).thenReturn(false);
+        matcher = new OrMessageMatcher<Object>(delegate, delegate2);
+
+        assertThat(matcher.matches(message)).isTrue();
+    }
+}
+


### PR DESCRIPTION
Like And and Or Matchers

I work on a project where we write dynamic security access rules using
MessageMatchers. We implemented our own AndMessageMatcher and
OrMessageMatcher. I'd like to give them to spring-security-messaging.