### PR TITLE
SEC-2836: If token not present into request generate the InvalidCsrfTokenException always

### DIFF
--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,7 +106,7 @@ public final class CsrfFilter extends OncePerRequestFilter {
 				logger.debug("Invalid CSRF token found for "
 						+ UrlUtils.buildFullRequestUrl(request));
 			}
-			if (missingToken) {
+			if(actualToken != null && missingToken) {
 				accessDeniedHandler.handle(request, response,
 						new MissingCsrfTokenException(actualToken));
 			}


### PR DESCRIPTION
I modified that if token not present into request generate the `InvalidCsrfTokenException` always.
Please review and merge this pull-request, if possible.

https://jira.spring.io/browse/SEC-2836

I have signed and agree to the terms of the Spring Individual Contributor License Agreement.