### PR TITLE
Introduced new AbstractUsernamePasswordAuthenticationFilter

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/AbstractUsernamePasswordAuthenticationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/AbstractUsernamePasswordAuthenticationFilter.java
@@ -1,0 +1,97 @@
+/* Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication;
+
+
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.util.Assert;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+
+/**
+ * Abstract authentication filter for username/password based authentication requests.
+ * <p>
+ * Subclasses should implement how to actually retrieve the username and password from the incoming request.
+ * This can e.g. be a form submission, request headers or a json payload.
+ * <p>
+ * This filter by default responds to the URL {@code /login}.
+ *
+ * @author Ben Alex
+ * @author Colin Sampaleanu
+ * @author Luke Taylor
+ * @author Marcel Overdijk
+ * @since 4.0
+ */
+public abstract class AbstractUsernamePasswordAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+
+    private boolean postOnly = true;
+
+    public AbstractUsernamePasswordAuthenticationFilter() {
+        super(new AntPathRequestMatcher("/login", "POST"));
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        if (postOnly && !request.getMethod().equals("POST")) {
+            throw new AuthenticationServiceException("Authentication method not supported: " + request.getMethod());
+        }
+
+        UsernamePasswordAuthenticationToken authRequest = obtainUsernamePasswordAuthenticationToken(request);
+
+        // Allow subclasses to set the "details" property
+        setDetails(request, authRequest);
+
+        return this.getAuthenticationManager().authenticate(authRequest);
+    }
+
+    /**
+     * Subclasses must implement this to obtain the username and password from the request, and return them
+     * as a <tt>UsernamePasswordAuthenticationToken</tt> used for the authentication request.
+     *
+     * @param request the request to retrieve the username and password from
+     * @return the <code>UsernamePasswordAuthenticationToken</code> that will be used for the authentication request
+     */
+    protected abstract UsernamePasswordAuthenticationToken obtainUsernamePasswordAuthenticationToken(HttpServletRequest request);
+
+    /**
+     * Provided so that subclasses may configure what is put into the authentication request's details
+     * property.
+     *
+     * @param request that an authentication request is being created for
+     * @param authRequest the authentication request object that should have its details set
+     */
+    protected void setDetails(HttpServletRequest request, UsernamePasswordAuthenticationToken authRequest) {
+        authRequest.setDetails(authenticationDetailsSource.buildDetails(request));
+    }
+
+    /**
+     * Defines whether only HTTP POST requests will be allowed by this filter.
+     * If set to true, and an authentication request is received which is not a POST request, an exception will
+     * be raised immediately and authentication will not be attempted. The <tt>unsuccessfulAuthentication()</tt> method
+     * will be called as if handling a failed authentication.
+     * <p>
+     * Defaults to <tt>true</tt> but may be overridden by subclasses.
+     */
+    public void setPostOnly(boolean postOnly) {
+        this.postOnly = postOnly;
+    }
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/UsernamePasswordAuthenticationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/UsernamePasswordAuthenticationFilter.java
@@ -44,9 +44,10 @@ import org.springframework.util.Assert;
  * @author Ben Alex
  * @author Colin Sampaleanu
  * @author Luke Taylor
+ * @author Marcel Overdijk
  * @since 3.0
  */
-public class UsernamePasswordAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+public class UsernamePasswordAuthenticationFilter extends AbstractUsernamePasswordAuthenticationFilter {
     //~ Static fields/initializers =====================================================================================
 
     public static final String SPRING_SECURITY_FORM_USERNAME_KEY = "username";
@@ -54,21 +55,11 @@ public class UsernamePasswordAuthenticationFilter extends AbstractAuthentication
 
     private String usernameParameter = SPRING_SECURITY_FORM_USERNAME_KEY;
     private String passwordParameter = SPRING_SECURITY_FORM_PASSWORD_KEY;
-    private boolean postOnly = true;
-
-    //~ Constructors ===================================================================================================
-
-    public UsernamePasswordAuthenticationFilter() {
-        super(new AntPathRequestMatcher("/login","POST"));
-    }
 
     //~ Methods ========================================================================================================
 
-    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
-        if (postOnly && !request.getMethod().equals("POST")) {
-            throw new AuthenticationServiceException("Authentication method not supported: " + request.getMethod());
-        }
-
+    @Override
+    protected UsernamePasswordAuthenticationToken obtainUsernamePasswordAuthenticationToken(HttpServletRequest request) {
         String username = obtainUsername(request);
         String password = obtainPassword(request);
 
@@ -82,12 +73,7 @@ public class UsernamePasswordAuthenticationFilter extends AbstractAuthentication
 
         username = username.trim();
 
-        UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(username, password);
-
-        // Allow subclasses to set the "details" property
-        setDetails(request, authRequest);
-
-        return this.getAuthenticationManager().authenticate(authRequest);
+        return new UsernamePasswordAuthenticationToken(username, password);
     }
 
     /**
@@ -119,17 +105,6 @@ public class UsernamePasswordAuthenticationFilter extends AbstractAuthentication
     }
 
     /**
-     * Provided so that subclasses may configure what is put into the authentication request's details
-     * property.
-     *
-     * @param request that an authentication request is being created for
-     * @param authRequest the authentication request object that should have its details set
-     */
-    protected void setDetails(HttpServletRequest request, UsernamePasswordAuthenticationToken authRequest) {
-        authRequest.setDetails(authenticationDetailsSource.buildDetails(request));
-    }
-
-    /**
      * Sets the parameter name which will be used to obtain the username from the login request.
      *
      * @param usernameParameter the parameter name. Defaults to "username".
@@ -147,18 +122,6 @@ public class UsernamePasswordAuthenticationFilter extends AbstractAuthentication
     public void setPasswordParameter(String passwordParameter) {
         Assert.hasText(passwordParameter, "Password parameter must not be empty or null");
         this.passwordParameter = passwordParameter;
-    }
-
-    /**
-     * Defines whether only HTTP POST requests will be allowed by this filter.
-     * If set to true, and an authentication request is received which is not a POST request, an exception will
-     * be raised immediately and authentication will not be attempted. The <tt>unsuccessfulAuthentication()</tt> method
-     * will be called as if handling a failed authentication.
-     * <p>
-     * Defaults to <tt>true</tt> but may be overridden by subclasses.
-     */
-    public void setPostOnly(boolean postOnly) {
-        this.postOnly = postOnly;
     }
 
     public final String getUsernameParameter() {


### PR DESCRIPTION
I've created a new AbstractUsernamePasswordAuthenticationFilter.
AbstractUsernamePasswordAuthenticationFilter allows more easily custom username/password based authentication scenario's.
Implmenetors can e.g. use form submission data, request headers or a json payload.

The existing UsernamePasswordAuthenticationFilter is now extending this new  AbstractUsernamePasswordAuthenticationFilter, but API wise it's unchanged and supports exactly what it does now.

So what this AbstractUsernamePasswordAuthenticationFilter provides for me at the end is an easy way to create my custom JsonUsernamePasswordAuthenticationFilter.

What do you think?