### PR TITLE
Adds "challenge" property to BasicAuthenticationEntryPoint

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HttpBasicConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HttpBasicConfigurer.java
@@ -35,9 +35,10 @@ import org.springframework.security.web.authentication.DelegatingAuthenticationE
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
-import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestHeaderRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.util.Assert;
 import org.springframework.web.accept.ContentNegotiationStrategy;
 import org.springframework.web.accept.HeaderContentNegotiationStrategy;
 
@@ -109,6 +110,22 @@ public final class HttpBasicConfigurer<B extends HttpSecurityBuilder<B>> extends
     public HttpBasicConfigurer<B> realmName(String realmName) throws Exception {
         basicAuthEntryPoint.setRealmName(realmName);
         basicAuthEntryPoint.afterPropertiesSet();
+        return this;
+    }
+
+    /**
+     * Allows easily changing the challenge (default "Basic"), but leaving the remaining 
+     * defaults in place. If {@link #authenticationEntryPoint(AuthenticationEntryPoint)} 
+     * has been invoked, invoking this method will result in an error.
+     *
+     * @param challenge
+     *            the HTTP Basic realm to use
+     * @return {@link HttpBasicConfigurer} for additional customization
+     * @throws Exception
+     */
+    public HttpBasicConfigurer<B> challenge(String challenge) throws Exception {
+    	Assert.hasText(challenge, "Basic auth challenge must have text");
+        basicAuthEntryPoint.setChallenge(challenge);
         return this;
     }
 

--- a/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationEntryPoint.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationEntryPoint.java
@@ -42,17 +42,23 @@ public class BasicAuthenticationEntryPoint implements AuthenticationEntryPoint, 
 
     private String realmName;
 
-    private String challenge = "Basic";
+    private String challenge = "Basic realm=\"%\"";
+
+	private String header;
 
     //~ Methods ========================================================================================================
 
     public void afterPropertiesSet() throws Exception {
-        Assert.hasText(realmName, "realmName must be specified");
+       Assert.hasText(realmName, "realmName must be specified");
+       Assert.hasText(challenge, "challenge must be specified");
     }
 
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
             throws IOException, ServletException {
-        response.addHeader("WWW-Authenticate", challenge + " realm=\"" + realmName + "\"");
+    	if (header==null) {
+    		header = challenge.replace("%", realmName);
+    	}
+        response.addHeader("WWW-Authenticate", header);
         response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authException.getMessage());
     }
 

--- a/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationEntryPoint.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationEntryPoint.java
@@ -42,6 +42,8 @@ public class BasicAuthenticationEntryPoint implements AuthenticationEntryPoint, 
 
     private String realmName;
 
+    private String challenge = "Basic";
+
     //~ Methods ========================================================================================================
 
     public void afterPropertiesSet() throws Exception {
@@ -50,7 +52,7 @@ public class BasicAuthenticationEntryPoint implements AuthenticationEntryPoint, 
 
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
             throws IOException, ServletException {
-        response.addHeader("WWW-Authenticate", "Basic realm=\"" + realmName + "\"");
+        response.addHeader("WWW-Authenticate", challenge + " realm=\"" + realmName + "\"");
         response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authException.getMessage());
     }
 
@@ -61,5 +63,13 @@ public class BasicAuthenticationEntryPoint implements AuthenticationEntryPoint, 
     public void setRealmName(String realmName) {
         this.realmName = realmName;
     }
+
+	public String getChallenge() {
+		return challenge;
+	}
+
+	public void setChallenge(String challenge) {
+		this.challenge = challenge;
+	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/authentication/www/BasicAuthenticationEntryPointTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/www/BasicAuthenticationEntryPointTests.java
@@ -93,7 +93,7 @@ public class BasicAuthenticationEntryPointTests extends TestCase {
         BasicAuthenticationEntryPoint ep = new BasicAuthenticationEntryPoint();
 
         ep.setRealmName("hello");
-        ep.setChallenge("Auth");
+        ep.setChallenge("Auth realm=\"%\"");
 
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setRequestURI("/some_path");

--- a/web/src/test/java/org/springframework/security/web/authentication/www/BasicAuthenticationEntryPointTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/www/BasicAuthenticationEntryPointTests.java
@@ -63,7 +63,9 @@ public class BasicAuthenticationEntryPointTests extends TestCase {
     public void testGettersSetters() {
         BasicAuthenticationEntryPoint ep = new BasicAuthenticationEntryPoint();
         ep.setRealmName("realm");
+        ep.setChallenge("Foo");
         assertEquals("realm", ep.getRealmName());
+        assertEquals("Foo", ep.getChallenge());
     }
 
     public void testNormalOperation() throws Exception {
@@ -85,5 +87,27 @@ public class BasicAuthenticationEntryPointTests extends TestCase {
         assertEquals(msg, response.getErrorMessage());
 
         assertEquals("Basic realm=\"hello\"", response.getHeader("WWW-Authenticate"));
+    }
+
+    public void testNormalOperationWithChallenge() throws Exception {
+        BasicAuthenticationEntryPoint ep = new BasicAuthenticationEntryPoint();
+
+        ep.setRealmName("hello");
+        ep.setChallenge("Auth");
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/some_path");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        //ep.afterPropertiesSet();
+
+        String msg = "These are the jokes kid";
+        ep.commence(request, response, new DisabledException(msg));
+
+        assertEquals(401, response.getStatus());
+        assertEquals(msg, response.getErrorMessage());
+
+        assertEquals("Auth realm=\"hello\"", response.getHeader("WWW-Authenticate"));
     }
 }


### PR DESCRIPTION
This provides useful additional flexibility if you want a
WWW-Authenticate header but don't want the "Basic" challenge
(e.g. to prevent a browser from popping up a dialog).

See https://jira.spring.io/browse/SEC-2803