### PR TITLE
Add cookie support to CsrfFilter

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurer.java
@@ -76,8 +76,6 @@ public final class CsrfConfigurer<H extends HttpSecurityBuilder<H>> extends Abst
     private CsrfTokenRepository csrfTokenRepository = new HttpSessionCsrfTokenRepository();
     private RequestMatcher requireCsrfProtectionMatcher = CsrfFilter.DEFAULT_CSRF_MATCHER;
     private List<RequestMatcher> ignoredCsrfProtectionMatchers = new ArrayList<RequestMatcher>();
-	private String cookieName;
-	private String cookiePath;
 
     /**
      * Creates a new instance
@@ -128,8 +126,11 @@ public final class CsrfConfigurer<H extends HttpSecurityBuilder<H>> extends Abst
      */
     public CsrfConfigurer<H> cookie(String cookieName, String cookiePath) {
 		Assert.notNull(cookieName, "cookieName cannot be null");
-        this.cookieName = cookieName;
-        this.cookiePath = cookiePath;
+        if (csrfTokenRepository instanceof HttpSessionCsrfTokenRepository) {
+        	HttpSessionCsrfTokenRepository httpRepository = (HttpSessionCsrfTokenRepository) csrfTokenRepository;
+        	httpRepository.setCookieName(cookieName);
+        	httpRepository.setCookiePath(cookiePath);
+        }
         return this;
     }
 
@@ -207,8 +208,6 @@ public final class CsrfConfigurer<H extends HttpSecurityBuilder<H>> extends Abst
         if(sessionConfigurer != null) {
             sessionConfigurer.addSessionAuthenticationStrategy(new CsrfAuthenticationStrategy(csrfTokenRepository));
         }
-        filter.setCookieName(cookieName);
-        filter.setCookiePath(cookiePath);
         filter = postProcess(filter);
         http.addFilter(filter);
     }

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurer.java
@@ -76,12 +76,61 @@ public final class CsrfConfigurer<H extends HttpSecurityBuilder<H>> extends Abst
     private CsrfTokenRepository csrfTokenRepository = new HttpSessionCsrfTokenRepository();
     private RequestMatcher requireCsrfProtectionMatcher = CsrfFilter.DEFAULT_CSRF_MATCHER;
     private List<RequestMatcher> ignoredCsrfProtectionMatchers = new ArrayList<RequestMatcher>();
+	private String cookieName;
+	private String cookiePath;
 
     /**
      * Creates a new instance
      * @see HttpSecurity#csrf()
      */
     public CsrfConfigurer() {
+    }
+
+    /**
+     * Specify the header name to use in the default {@link CsrfTokenRepository}. The default 
+     * is "X-CSRF-TOKEN", but it is common in front end frameworks to send other values (e.g.
+     * "X-XSRF-TOKEN").
+     *
+     * @param headerName the header name to use
+     * @return the {@link CsrfConfigurer} for further customizations
+     */
+    public CsrfConfigurer<H> headerName(String headerName) {
+        Assert.notNull(headerName, "headerName cannot be null");
+        if (csrfTokenRepository instanceof HttpSessionCsrfTokenRepository) {
+        	HttpSessionCsrfTokenRepository httpRepository = (HttpSessionCsrfTokenRepository) csrfTokenRepository;
+        	httpRepository.setHeaderName(headerName);
+        }
+        return this;
+    }
+
+    /**
+     * Specify the cookie name to use when sending a cookie containing the CSRF token. The default 
+     * is null (meaning send no cookie), but it is common in front end frameworks to expect other 
+     * values (e.g. "XSRF-TOKEN").
+     *
+     * @param cookieName the cookie name to use
+     * @return the {@link CsrfConfigurer} for further customizations
+     */
+    public CsrfConfigurer<H> cookie(String cookieName) {
+        return this.cookie(cookieName, null);
+    }
+
+
+    /**
+     * Specify the cookie name and path to use when sending a cookie containing the CSRF token. 
+     * The default is null (meaning send no cookie), but it is common in front end frameworks 
+     * to expect other values (e.g. "XSRF-TOKEN").
+     *
+     * @param cookieName the cookie name to use
+     * @param cookiePath the cookie path to send
+     * @return the {@link CsrfConfigurer} for further customizations
+     * @see CsrfConfigurer#cookie(String)
+     */
+    public CsrfConfigurer<H> cookie(String cookieName, String cookiePath) {
+		Assert.notNull(cookieName, "cookieName cannot be null");
+        this.cookieName = cookieName;
+        this.cookiePath = cookiePath;
+        return this;
     }
 
     /**
@@ -158,6 +207,8 @@ public final class CsrfConfigurer<H extends HttpSecurityBuilder<H>> extends Abst
         if(sessionConfigurer != null) {
             sessionConfigurer.addSessionAuthenticationStrategy(new CsrfAuthenticationStrategy(csrfTokenRepository));
         }
+        filter.setCookieName(cookieName);
+        filter.setCookiePath(cookiePath);
         filter = postProcess(filter);
         http.addFilter(filter);
     }

--- a/config/src/test/groovy/org/springframework/security/config/annotation/web/configurers/CsrfConfigurerTests.groovy
+++ b/config/src/test/groovy/org/springframework/security/config/annotation/web/configurers/CsrfConfigurerTests.groovy
@@ -65,7 +65,7 @@ class CsrfConfigurerTests extends BaseSpringSpec {
             'OPTIONS'  | HttpServletResponse.SC_OK
     }
 
-    def "csrf default creates CsrfRequestDataValueProcessor"() {
+	 def "csrf default creates CsrfRequestDataValueProcessor"() {
         when:
             loadConfig(CsrfAppliedDefaultConfig)
         then:

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
@@ -20,6 +20,7 @@ import java.util.regex.Pattern;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -28,10 +29,11 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.access.AccessDeniedHandlerImpl;
-import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.security.web.util.UrlUtils;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.WebUtils;
 
 /**
  * <p>
@@ -66,6 +68,8 @@ public final class CsrfFilter extends OncePerRequestFilter {
     private final CsrfTokenRepository tokenRepository;
     private RequestMatcher requireCsrfProtectionMatcher = new DefaultRequiresCsrfMatcher();
     private AccessDeniedHandler accessDeniedHandler = new AccessDeniedHandlerImpl();
+    private String cookieName;
+    private String cookiePath;
 
     public CsrfFilter(CsrfTokenRepository csrfTokenRepository) {
         Assert.notNull(csrfTokenRepository, "csrfTokenRepository cannot be null");
@@ -84,6 +88,20 @@ public final class CsrfFilter extends OncePerRequestFilter {
         if(missingToken) {
             CsrfToken generatedToken = tokenRepository.generateToken(request);
             csrfToken = new SaveOnAccessCsrfToken(tokenRepository, request, response, generatedToken);
+            if (cookieName!=null) {
+            	Cookie cookie = WebUtils.getCookie(request, cookieName);
+				String token = csrfToken.getToken();
+				if (cookie==null || token!=null && !token.equals(cookie.getValue())) {
+					cookie = new Cookie(cookieName, token);
+					if (cookiePath==null) {
+						String path = request.getContextPath();
+						cookie.setPath(path.equals("") ? "/" : path);
+					} else {
+						cookie.setPath(cookiePath);
+					}
+					response.addCookie(cookie);
+				}
+            }
         }
         request.setAttribute(CsrfToken.class.getName(), csrfToken);
         request.setAttribute(csrfToken.getParameterName(), csrfToken);
@@ -146,6 +164,28 @@ public final class CsrfFilter extends OncePerRequestFilter {
         Assert.notNull(accessDeniedHandler, "accessDeniedHandler cannot be null");
         this.accessDeniedHandler = accessDeniedHandler;
     }
+    
+    /**
+     * The name of a cookie to send containing the CSRF token value. Some client-side
+     * frameworks use this mechanism to find the value of the token, and then send it
+     * back as a header if it is set.
+     * 
+	 * @param cookieName the cookie name to set (default null, meaning not to send
+	 * a cookie at all)
+	 */
+	public void setCookieName(String cookieName) {
+		this.cookieName = cookieName;
+	}
+	
+	/**
+	 * The path to send in a cookie (if {@link #setCookieName(String) cookieName} is set). 
+	 * If unset the path will be set to the context path of the request.
+	 *  
+	 * @param cookiePath the cookie path to set (e.g. "/"), default null.
+	 */
+	public void setCookiePath(String cookiePath) {
+		this.cookiePath = cookiePath;
+	}
 
     @SuppressWarnings("serial")
     private static final class SaveOnAccessCsrfToken implements CsrfToken {

--- a/web/src/test/java/org/springframework/security/web/csrf/CsrfFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CsrfFilterTests.java
@@ -294,6 +294,27 @@ public class CsrfFilterTests {
     }
 
     @Test
+    public void doFilterIsCsrfRequestGenerateCookie() throws ServletException,
+            IOException {
+    	filter.setCookieName("XSRF-TOKEN");
+        when(requestMatcher.matches(request)).thenReturn(true);
+        when(tokenRepository.generateToken(request))
+                .thenReturn(token);
+        request.setParameter(token.getParameterName(), token.getToken());
+
+        filter.doFilter(request, response, filterChain);
+
+        assertToken(request.getAttribute(token.getParameterName())).isEqualTo(
+                token);
+        assertToken(request.getAttribute(CsrfToken.class.getName())).isEqualTo(
+                token);
+
+        verify(filterChain).doFilter(request, response);
+        verifyZeroInteractions(deniedHandler);
+        assertThat(response.getCookie("XSRF-TOKEN").getValue()).isEqualTo(token.getToken());
+    }
+
+    @Test
     public void doFilterDefaultRequireCsrfProtectionMatcherAllowedMethods()
             throws ServletException, IOException {
         filter = new CsrfFilter(tokenRepository);

--- a/web/src/test/java/org/springframework/security/web/csrf/CsrfFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CsrfFilterTests.java
@@ -294,27 +294,6 @@ public class CsrfFilterTests {
     }
 
     @Test
-    public void doFilterIsCsrfRequestGenerateCookie() throws ServletException,
-            IOException {
-    	filter.setCookieName("XSRF-TOKEN");
-        when(requestMatcher.matches(request)).thenReturn(true);
-        when(tokenRepository.generateToken(request))
-                .thenReturn(token);
-        request.setParameter(token.getParameterName(), token.getToken());
-
-        filter.doFilter(request, response, filterChain);
-
-        assertToken(request.getAttribute(token.getParameterName())).isEqualTo(
-                token);
-        assertToken(request.getAttribute(CsrfToken.class.getName())).isEqualTo(
-                token);
-
-        verify(filterChain).doFilter(request, response);
-        verifyZeroInteractions(deniedHandler);
-        assertThat(response.getCookie("XSRF-TOKEN").getValue()).isEqualTo(token.getToken());
-    }
-
-    @Test
     public void doFilterDefaultRequireCsrfProtectionMatcherAllowedMethods()
             throws ServletException, IOException {
         filter = new CsrfFilter(tokenRepository);


### PR DESCRIPTION
User can specify the cookie name (and optionally path) in the
CsrfFilter via the CsrfConfigurer, e.g. .cookie("XSRF-TOKEN")
for AngularJS.

See https://jira.spring.io/browse/SEC-2891