### PR TITLE
Spring 4 should be allowed in bundle dependencies

### DIFF
--- a/gradle/javaprojects.gradle
+++ b/gradle/javaprojects.gradle
@@ -72,7 +72,7 @@ ext.apachedsDependencies = [
 ext.bundlorProperties = [
     version: version,
     secRange: "[$version, 3.3.0)",
-    springRange: "[$springVersion, 3.3.0)",
+    springRange: "[$springVersion, 4.1.0)",
     aspectjRange: '[1.6.0, 1.8.0)',
     casRange: '[3.1.1, 3.2.0)',
     cloggingRange: '[1.0.4, 2.0.0)',


### PR DESCRIPTION
According to the JIRA release notes for Spring Security 3.2, it should have compatibility with Spring Framework 4.0. However, the springRange variable limits OSGi bundle compatibility to Spring Framework 3.2. The variable should be changed to allow compatibility with Spring Framework 4.0.

See:
https://jira.spring.io/browse/SEC-2350
https://jira.spring.io/browse/SEC-2385
https://jira.spring.io/browse/SEC-2434

I cannot find documentation about whether Spring Framework 4.1 is also considered to be compatible with Spring Security 3.2 but this is also a possibility.