### PR TITLE
Allow setting alwaysRemember from RememberMeConfigurer

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/RememberMeConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/RememberMeConfigurer.java
@@ -84,6 +84,7 @@ public final class RememberMeConfigurer<H extends HttpSecurityBuilder<H>> extend
     private UserDetailsService userDetailsService;
     private Integer tokenValiditySeconds;
     private Boolean useSecureCookie;
+    private Boolean alwaysRemember;
 
     /**
      * Creates a new instance
@@ -104,7 +105,7 @@ public final class RememberMeConfigurer<H extends HttpSecurityBuilder<H>> extend
     }
 
     /**
-     *Whether the cookie should be flagged as secure or not. Secure cookies can only be sent over an HTTPS connection
+     * Whether the cookie should be flagged as secure or not. Secure cookies can only be sent over an HTTPS connection
      * and thus cannot be accidentally submitted over HTTP where they could be intercepted.
      * <p>
      * By default the cookie will be secure if the request is secure. If you only want to use remember-me over
@@ -116,6 +117,20 @@ public final class RememberMeConfigurer<H extends HttpSecurityBuilder<H>> extend
      */
     public RememberMeConfigurer<H> useSecureCookie(boolean useSecureCookie) {
         this.useSecureCookie = useSecureCookie;
+        return this;
+    }
+
+    /**
+     * Whether the cookie should always be created even if the remember-me parameter is not set.
+     * <p>
+     * By default this will be set to {@code false}.
+     *
+     * @param alwaysRemember set to {@code true} to always trigger remember me, {@code false} to use the remember-me parameter.
+     * @return the {@link RememberMeConfigurer} for further customization
+     * @see AbstractRememberMeServices#setAlwaysRemember(boolean)
+     */
+    public RememberMeConfigurer<H> alwaysRemember(boolean alwaysRemember) {
+        this.alwaysRemember = alwaysRemember;
         return this;
     }
 
@@ -277,6 +292,9 @@ public final class RememberMeConfigurer<H extends HttpSecurityBuilder<H>> extend
         }
         if (useSecureCookie != null) {
             tokenRememberMeServices.setUseSecureCookie(useSecureCookie);
+        }
+        if (alwaysRemember != null) {
+            tokenRememberMeServices.setAlwaysRemember(alwaysRemember);
         }
         tokenRememberMeServices.afterPropertiesSet();
         logoutHandler = tokenRememberMeServices;


### PR DESCRIPTION
Using the remember me functionality together with spring social is a bit painful, since there is no easy way to send the remember-me parameter.

By allowing setting alwaysRemember via the fluent api, it will work out of the box.

```java
@Override
protected void configure(HttpSecurity http) throws Exception {
	http
		.authorizeRequests()
			.antMatchers("/auth/**", "/password/**").permitAll()
			.antMatchers("/oauth/**").authenticated()
			.antMatchers("/**").hasRole("USER")
			.anyRequest().authenticated()
		.and()
		.formLogin()
			.permitAll()
		.and()
		.logout()
			.permitAll()
		.and()
		.rememberMe()
			.alwaysRemember(true)
		.and()
		.apply(new SpringSocialConfigurer());
}
```