### PR TITLE
SEC-2903: Expire a session via the SessionRegistry

### DIFF
--- a/core/src/main/java/org/springframework/security/core/session/SessionRegistry.java
+++ b/core/src/main/java/org/springframework/security/core/session/SessionRegistry.java
@@ -21,6 +21,7 @@ import java.util.List;
  * Maintains a registry of <code>SessionInformation</code> instances.
  *
  * @author Ben Alex
+ * @author Kazuki Shimizu
  */
 public interface SessionRegistry {
     //~ Methods ========================================================================================================
@@ -59,8 +60,23 @@ public interface SessionRegistry {
      * Silently returns if the given <code>sessionId</code> cannot be found or the session is marked to expire.
      *
      * @param sessionId for which to update the date and time of the last request (should never be <code>null</code>)
+     * @deprecated Please use the {@link #refreshLastRequest(SessionInformation)} instead of.
      */
+    @Deprecated
     void refreshLastRequest(String sessionId);
+
+    /**
+     * Refresh the last request time on session.
+     *
+     * @param sessionInformation session information (should never be <code>null</code>)
+     */
+    void refreshLastRequest(SessionInformation sessionInformation);
+
+    /**
+     * Update to the expired status.
+     * @param sessionInformation session information (should never be <code>null</code>)
+     */
+    void expireSession(SessionInformation sessionInformation);
 
     /**
      * Registers a new session for the specified principal. The newly registered session will not be marked for

--- a/core/src/main/java/org/springframework/security/core/session/SessionRegistryImpl.java
+++ b/core/src/main/java/org/springframework/security/core/session/SessionRegistryImpl.java
@@ -36,6 +36,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
  *
  * @author Ben Alex
  * @author Luke Taylor
+ * @author Kazuki Shimizu
  */
 public class SessionRegistryImpl implements SessionRegistry, ApplicationListener<SessionDestroyedEvent> {
 
@@ -89,14 +90,25 @@ public class SessionRegistryImpl implements SessionRegistry, ApplicationListener
         removeSessionInformation(sessionId);
     }
 
+    @Deprecated
     public void refreshLastRequest(String sessionId) {
         Assert.hasText(sessionId, "SessionId required as per interface contract");
 
         SessionInformation info = getSessionInformation(sessionId);
 
         if (info != null) {
-            info.refreshLastRequest();
+            refreshLastRequest(info);
         }
+    }
+
+    public void refreshLastRequest(SessionInformation sessionInformation) {
+        Assert.notNull(sessionInformation, "sessionInformation required as per interface contract");
+        sessionInformation.refreshLastRequest();
+    }
+
+    public void expireSession(SessionInformation sessionInformation) {
+        Assert.notNull(sessionInformation, "sessionInformation required as per interface contract");
+        sessionInformation.expireNow();
     }
 
     public void registerNewSession(String sessionId, Object principal) {

--- a/core/src/test/java/org/springframework/security/core/session/SessionInformationTests.java
+++ b/core/src/test/java/org/springframework/security/core/session/SessionInformationTests.java
@@ -15,21 +15,23 @@
 
 package org.springframework.security.core.session;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 import java.util.Date;
 
-import org.springframework.security.core.session.SessionInformation;
+import static org.junit.Assert.*;
 
 
 /**
  * Tests {@link SessionInformation}.
  *
  * @author Ben Alex
+ * @author Kazuki Shimizu
  */
-public class SessionInformationTests extends TestCase {
+public class SessionInformationTests {
     //~ Methods ========================================================================================================
 
+    @Test
     public void testObject() throws Exception {
         Object principal = "Some principal object";
         String sessionId = "1234567890";
@@ -39,11 +41,14 @@ public class SessionInformationTests extends TestCase {
         assertEquals(principal, info.getPrincipal());
         assertEquals(sessionId, info.getSessionId());
         assertEquals(currentDate, info.getLastRequest());
+        assertFalse(info.isExpired());
 
         Thread.sleep(10);
 
         info.refreshLastRequest();
+        info.expireNow();
 
         assertTrue(info.getLastRequest().after(currentDate));
+        assertTrue(info.isExpired());
     }
 }

--- a/web/src/main/java/org/springframework/security/web/authentication/session/ConcurrentSessionControlAuthenticationStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/session/ConcurrentSessionControlAuthenticationStrategy.java
@@ -49,6 +49,7 @@ import org.springframework.util.Assert;
  *
  * @author Luke Taylor
  * @author Rob Winch
+ * @author Kazuki Shimizu
  * @since 3.2
  */
 public class ConcurrentSessionControlAuthenticationStrategy implements MessageSourceAware, SessionAuthenticationStrategy {
@@ -141,8 +142,7 @@ public class ConcurrentSessionControlAuthenticationStrategy implements MessageSo
                 leastRecentlyUsed = session;
             }
         }
-
-        leastRecentlyUsed.expireNow();
+        sessionRegistry.expireSession(leastRecentlyUsed);
     }
 
     /**

--- a/web/src/main/java/org/springframework/security/web/session/ConcurrentSessionFilter.java
+++ b/web/src/main/java/org/springframework/security/web/session/ConcurrentSessionFilter.java
@@ -42,7 +42,7 @@ import org.springframework.web.filter.GenericFilterBean;
  * Filter required by concurrent session handling package.
  * <p>
  * This filter performs two functions. First, it calls
- * {@link org.springframework.security.core.session.SessionRegistry#refreshLastRequest(String)} for each request
+ * {@link org.springframework.security.core.session.SessionRegistry#refreshLastRequest(SessionInformation)} for each request
  * so that registered sessions always have a correct "last update" date/time. Second, it retrieves a
  * {@link org.springframework.security.core.session.SessionInformation} from the <code>SessionRegistry</code>
  * for each request and checks if the session has been marked as expired.
@@ -53,6 +53,7 @@ import org.springframework.web.filter.GenericFilterBean;
  * {@link org.springframework.security.web.session.HttpSessionEventPublisher} registered in <code>web.xml</code>.</p>
  *
  * @author Ben Alex
+ * @author Kazuki Shimizu
  */
 public class ConcurrentSessionFilter extends GenericFilterBean {
     //~ Instance fields ================================================================================================
@@ -114,7 +115,7 @@ public class ConcurrentSessionFilter extends GenericFilterBean {
                     return;
                 } else {
                     // Non-expired - update last request date/time
-                    sessionRegistry.refreshLastRequest(info.getSessionId());
+                    sessionRegistry.refreshLastRequest(info);
                 }
             }
         }


### PR DESCRIPTION
* Add SessionRegistry#expireSession(SessionInformation).
* Add SessionRegistry#refreshLastRequest(SessionInformation).
* Deprecate SessionRegistry#refreshLastRequest(String)

Added the refreshLastRequest(SessionInformation) for having a consistent method signature.

For details see [SEC-2903](https://jira.spring.io/browse/SEC-2903).
Please review this PR.

I have signed and agree to the terms of the Spring Individual Contributor License Agreement.


