### PR TITLE
SEC-2910: Add the invalidSessionDetectionMatcher

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ import org.springframework.security.web.session.ConcurrentSessionFilter;
 import org.springframework.security.web.session.InvalidSessionStrategy;
 import org.springframework.security.web.session.SessionManagementFilter;
 import org.springframework.security.web.session.SimpleRedirectInvalidSessionStrategy;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
 
 /**
@@ -85,6 +86,7 @@ import org.springframework.util.Assert;
  * </ul>
  *
  * @author Rob Winch
+ * @author Kazuki Shimizu
  * @since 3.2
  * @see SessionManagementFilter
  * @see ConcurrentSessionFilter
@@ -103,6 +105,7 @@ public final class SessionManagementConfigurer<H extends HttpSecurityBuilder<H>>
 	private SessionCreationPolicy sessionPolicy = SessionCreationPolicy.IF_REQUIRED;
 	private boolean enableSessionUrlRewriting;
 	private String invalidSessionUrl;
+	private RequestMatcher invalidSessionRequestMatcher;
 	private String sessionAuthenticationErrorUrl;
 
 	/**
@@ -123,6 +126,23 @@ public final class SessionManagementConfigurer<H extends HttpSecurityBuilder<H>>
 	 */
 	public SessionManagementConfigurer<H> invalidSessionUrl(String invalidSessionUrl) {
 		this.invalidSessionUrl = invalidSessionUrl;
+		return this;
+	}
+
+	/**
+	 * Sets the {@link RequestMatcher} to customize target URLs of detecting a invalid session.
+	 * Setting this attribute will be inject to the {@link SessionManagementFilter#invalidSessionDetectionMatcher}.
+	 * <p>
+	 * This attribute is valid only when set the {@link #invalidSessionUrl(String)}.
+	 * Default setting set the {@link RequestMatcher} to detect a invalid session for all requests.
+	 * </p>
+	 *
+	 * @param invalidSessionRequestMatcher the {@link RequestMatcher} to detect invalid session
+	 * @return the {@link SessionManagementConfigurer} for further customization
+	 * @since 4.0.1
+	 */
+	public SessionManagementConfigurer<H> invalidSessionRequestMatcher(RequestMatcher invalidSessionRequestMatcher){
+		this.invalidSessionRequestMatcher = invalidSessionRequestMatcher;
 		return this;
 	}
 
@@ -404,6 +424,9 @@ public final class SessionManagementConfigurer<H extends HttpSecurityBuilder<H>>
 		if (invalidSessionUrl != null) {
 			sessionManagementFilter
 					.setInvalidSessionStrategy(getInvalidSessionStrategy());
+			if (invalidSessionRequestMatcher != null) {
+					sessionManagementFilter.setInvalidSessionDetectionMatcher(invalidSessionRequestMatcher);
+			}
 		}
 		AuthenticationTrustResolver trustResolver = http
 				.getSharedObject(AuthenticationTrustResolver.class);

--- a/config/src/main/java/org/springframework/security/config/http/HttpConfigurationBuilder.java
+++ b/config/src/main/java/org/springframework/security/config/http/HttpConfigurationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,6 +83,7 @@ import org.w3c.dom.Element;
  *
  * @author Luke Taylor
  * @author Rob Winch
+ * @author Kazuki Shimizu
  * @since 3.0
  */
 class HttpConfigurationBuilder {
@@ -94,6 +95,7 @@ class HttpConfigurationBuilder {
 	private static final String OPT_CHANGE_SESSION_ID = "changeSessionId";
 
 	private static final String ATT_INVALID_SESSION_URL = "invalid-session-url";
+	private static final String ATT_INVALID_SESSION_REQUEST_MATCHER_REF = "invalid-session-request-matcher-ref";
 	private static final String ATT_SESSION_AUTH_STRATEGY_REF = "session-authentication-strategy-ref";
 	private static final String ATT_SESSION_AUTH_ERROR_URL = "session-authentication-error-url";
 	private static final String ATT_SECURITY_CONTEXT_REPOSITORY = "security-context-repository-ref";
@@ -287,6 +289,7 @@ class HttpConfigurationBuilder {
 
 		String sessionFixationAttribute = null;
 		String invalidSessionUrl = null;
+		String invalidSessionRequestMatcherRef = null;
 		String sessionAuthStratRef = null;
 		String errorUrl = null;
 
@@ -302,6 +305,7 @@ class HttpConfigurationBuilder {
 			sessionFixationAttribute = sessionMgmtElt
 					.getAttribute(ATT_SESSION_FIXATION_PROTECTION);
 			invalidSessionUrl = sessionMgmtElt.getAttribute(ATT_INVALID_SESSION_URL);
+			invalidSessionRequestMatcherRef = sessionMgmtElt.getAttribute(ATT_INVALID_SESSION_REQUEST_MATCHER_REF);
 			sessionAuthStratRef = sessionMgmtElt
 					.getAttribute(ATT_SESSION_AUTH_STRATEGY_REF);
 			errorUrl = sessionMgmtElt.getAttribute(ATT_SESSION_AUTH_ERROR_URL);
@@ -442,6 +446,9 @@ class HttpConfigurationBuilder {
 			invalidSessionBldr.addConstructorArgValue(invalidSessionUrl);
 			invalidSession = invalidSessionBldr.getBeanDefinition();
 			sessionMgmtFilter.addPropertyValue("invalidSessionStrategy", invalidSession);
+			if(StringUtils.hasText(invalidSessionRequestMatcherRef)) {
+				sessionMgmtFilter.addPropertyReference("invalidSessionDetectionMatcher", invalidSessionRequestMatcherRef);
+			}
 		}
 
 		sessionMgmtFilter.addConstructorArgReference(sessionAuthStratRef);

--- a/config/src/main/resources/org/springframework/security/config/spring-security-4.0.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-4.0.rnc
@@ -527,6 +527,9 @@ session-management.attlist &=
 	## The URL to which a user will be redirected if they submit an invalid session indentifier. Typically used to detect session timeouts.
 	attribute invalid-session-url {xsd:token}?
 session-management.attlist &=
+	## Sets the RequestMatcher to customize target URLs of detecting a invalid session. Setting this attribute will be inject to the SessionManagementFilter#invalidSessionDetectionMatcher field. This attribute is valid only when set the invalid-session-url. Default setting set the RequestMatcher to detect a invalid session for all requests.
+	attribute invalid-session-request-matcher-ref {xsd:token}?
+session-management.attlist &=
 	## Allows injection of the SessionAuthenticationStrategy instance used by the SessionManagementFilter
 	attribute session-authentication-strategy-ref {xsd:token}?
 session-management.attlist &=

--- a/config/src/main/resources/org/springframework/security/config/spring-security-4.0.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-4.0.xsd
@@ -1705,6 +1705,15 @@
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="invalid-session-request-matcher-ref" type="xs:token">
+          <xs:annotation>
+              <xs:documentation>Sets the RequestMatcher to customize target URLs of detecting a invalid session.
+                  Setting this attribute will be inject to the SessionManagementFilter#invalidSessionDetectionMatcher field.
+                  This attribute is valid only when set the invalid-session-url.
+                  Default setting set the RequestMatcher to detect a invalid session for all requests.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
       <xs:attribute name="session-authentication-strategy-ref" type="xs:token">
          <xs:annotation>
             <xs:documentation>Allows injection of the SessionAuthenticationStrategy instance used by the

--- a/config/src/test/groovy/org/springframework/security/config/http/SessionManagementConfigTests.groovy
+++ b/config/src/test/groovy/org/springframework/security/config/http/SessionManagementConfigTests.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,14 @@
  */
 package org.springframework.security.config.http
 
+import org.springframework.security.web.util.matcher.RequestMatcher
+
 import static org.junit.Assert.assertSame
 import static org.mockito.Mockito.*
 
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
-import org.mockito.Mockito
 import org.springframework.mock.web.MockFilterChain
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
@@ -41,7 +42,6 @@ import org.springframework.security.web.authentication.logout.CookieClearingLogo
 import org.springframework.security.web.authentication.logout.LogoutFilter
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler
 import org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationFilter
-import org.springframework.security.web.authentication.session.SessionAuthenticationException
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy
 import org.springframework.security.web.context.NullSecurityContextRepository
 import org.springframework.security.web.context.SaveContextOnUpdateOrErrorResponseWrapper
@@ -55,6 +55,7 @@ import org.springframework.security.web.session.SessionManagementFilter
  *
  * @author Luke Taylor
  * @author Rob Winch
+ * @author Kazuki Shimizu
  */
 class SessionManagementConfigTests extends AbstractHttpConfigTests {
 
@@ -427,6 +428,23 @@ class SessionManagementConfigTests extends AbstractHttpConfigTests {
 		expect:
 		filter instanceof SessionManagementFilter
 		filter.invalidSessionStrategy.destinationUrl == '/timeoutUrl'
+	}
+
+	def sessionManagementFilterInvalidSessionDetectionRequestMatcherSet() {
+		httpAutoConfig {
+			'session-management'(
+					'invalid-session-url': '/timeoutUrl',
+					'invalid-session-request-matcher-ref':'matcher')
+        }
+		mockBean(RequestMatcher, 'matcher')
+		createAppContext()
+		RequestMatcher matcher = appContext.getBean("matcher",RequestMatcher)
+
+		def filter = getFilters("/someurl")[11]
+
+		expect:
+		filter instanceof SessionManagementFilter
+		filter.invalidSessionDetectionMatcher == matcher
 	}
 
 }

--- a/web/src/main/java/org/springframework/security/web/session/SessionManagementFilter.java
+++ b/web/src/main/java/org/springframework/security/web/session/SessionManagementFilter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.security.web.session;
 
 import java.io.IOException;
@@ -19,6 +34,7 @@ import org.springframework.security.web.authentication.session.SessionAuthentica
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 import org.springframework.security.web.authentication.session.SessionFixationProtectionStrategy;
 import org.springframework.security.web.context.SecurityContextRepository;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
 import org.springframework.web.filter.GenericFilterBean;
 
@@ -30,6 +46,7 @@ import org.springframework.web.filter.GenericFilterBean;
  *
  * @author Martin Algesten
  * @author Luke Taylor
+ * @author Kazuki Shimizu
  * @since 2.0
  */
 public class SessionManagementFilter extends GenericFilterBean {
@@ -46,6 +63,11 @@ public class SessionManagementFilter extends GenericFilterBean {
 	private AuthenticationTrustResolver trustResolver = new AuthenticationTrustResolverImpl();
 	private InvalidSessionStrategy invalidSessionStrategy = null;
 	private AuthenticationFailureHandler failureHandler = new SimpleUrlAuthenticationFailureHandler();
+	private RequestMatcher invalidSessionDetectionMatcher = new RequestMatcher() {
+		public boolean matches(HttpServletRequest request) {
+			return true;
+		}
+	};
 
 	public SessionManagementFilter(SecurityContextRepository securityContextRepository) {
 		this(securityContextRepository, new SessionFixationProtectionStrategy());
@@ -110,9 +132,9 @@ public class SessionManagementFilter extends GenericFilterBean {
 								+ request.getRequestedSessionId() + " is invalid.");
 					}
 
-					if (invalidSessionStrategy != null) {
-						invalidSessionStrategy
-								.onInvalidSessionDetected(request, response);
+					if (invalidSessionStrategy != null &&
+							invalidSessionDetectionMatcher.matches(request)) {
+						invalidSessionStrategy.onInvalidSessionDetected(request, response);
 						return;
 					}
 				}
@@ -158,4 +180,20 @@ public class SessionManagementFilter extends GenericFilterBean {
 		Assert.notNull(trustResolver, "trustResolver cannot be null");
 		this.trustResolver = trustResolver;
 	}
+
+	/**
+	 * Sets the {@link RequestMatcher} to customize target URLs of detecting a invalid session.
+	 * <p>
+	 * This attribute is valid only when set the {@link InvalidSessionStrategy}.
+	 * Default setting set the {@link RequestMatcher} to detect a invalid session for all requests.
+	 * </p>
+	 *
+	 * @param invalidSessionDetectionMatcher the {@link RequestMatcher} to detect invalid session (cannot be null)
+	 * @since 4.0.1
+	 */
+	public void setInvalidSessionDetectionMatcher(RequestMatcher invalidSessionDetectionMatcher) {
+		Assert.notNull(invalidSessionDetectionMatcher, "invalidSessionDetectionMatcher cannot be null");
+		this.invalidSessionDetectionMatcher = invalidSessionDetectionMatcher;
+	}
+
 }


### PR DESCRIPTION
invalidSessionDetectionMatcher is property to customize target URLs
of detecting a invalid session.

Please review this PR.
I have signed and agree to the terms of the Spring Individual Contributor License Agreement.

https://jira.spring.io/browse/SEC-2910
