### PR TITLE
SEC-2743: Add rememberCookieName() to RememberMeConfigurer

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/RememberMeConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/RememberMeConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -177,6 +177,18 @@ public final class RememberMeConfigurer<H extends HttpSecurityBuilder<H>> extend
 	 */
 	public RememberMeConfigurer<H> rememberMeParameter(String rememberMeParameter) {
 		this.rememberMeParameter = rememberMeParameter;
+		return this;
+	}
+
+	/**
+	 * The Cookie parameter used to indicate to remember the user at time of login.
+	 *
+	 * @param rememberMeCookieName the HTTP parameter used to indicate to remember the user
+	 * @return the {@link RememberMeConfigurer} for further customization
+	 * @since 4.1
+	 */
+	public RememberMeConfigurer<H> rememberMeCookieName(String rememberMeCookieName) {
+		this.rememberMeCookieName = rememberMeCookieName;
 		return this;
 	}
 

--- a/config/src/test/groovy/org/springframework/security/config/annotation/web/configurers/NamespaceRememberMeTests.groovy
+++ b/config/src/test/groovy/org/springframework/security/config/annotation/web/configurers/NamespaceRememberMeTests.groovy
@@ -271,6 +271,24 @@ public class NamespaceRememberMeTests extends BaseSpringSpec {
     }
 
     @Configuration
+    static class RememberMeCookieNameConfig extends BaseWebConfig {
+        protected void configure(HttpSecurity http) throws Exception {
+            http
+                .formLogin()
+                    .and()
+                .rememberMe()
+                    .rememberMeCookieName("rememberMe")
+        }
+    }
+
+    def "http/remember-me@remember-me-cookie-name"() {
+        when: "use custom rememberMeCookieName"
+            loadConfig(RememberMeCookieNameConfig)
+        then: "custom rememberMeCookieName will be used"
+            findFilter(RememberMeAuthenticationFilter).rememberMeServices.cookieName == "rememberMe"
+    }
+
+    @Configuration
     static class UseSecureCookieConfig extends BaseWebConfig {
         protected void configure(HttpSecurity http) throws Exception {
             http


### PR DESCRIPTION
This one allows

```java
http
   .rememberMe()
       .rememberCookieName("customName")
```

This reduce the requirement of a custom rememberMeService only for changing the default cookie name.

This is my first PR.. did I made it right?