### PR TITLE
Update HttpSecurity.java logout() sample code

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
@@ -691,7 +691,7 @@ public final class HttpSecurity extends
 	 * 		http.authorizeRequests().antMatchers(&quot;/**&quot;).hasRole(&quot;USER&quot;).and().formLogin()
 	 * 				.and()
 	 * 				// sample logout customization
-	 * 				.logout().logout().deleteCookies(&quot;remove&quot;).invalidateHttpSession(false)
+	 * 				.logout().deleteCookies(&quot;remove&quot;).invalidateHttpSession(false)
 	 * 				.logoutUrl(&quot;/custom-logout&quot;).logoutSuccessUrl(&quot;/logout-success&quot;);
 	 * 	}
 	 * 


### PR DESCRIPTION
Removed error provoking extra logout() from example code in documentation for HttpSecurity.java