### PR TITLE
Add missing jstl dependency

### DIFF
--- a/samples/gae-xml/gae.gradle
+++ b/samples/gae-xml/gae.gradle
@@ -31,6 +31,7 @@ dependencies {
 			"org.springframework:spring-context:$springVersion",
 			"org.springframework:spring-context-support:$springVersion",
 			"com.google.appengine:appengine-api-1.0-sdk:$gaeVersion",
+			jstlDependencies,
 			'javax.validation:validation-api:1.0.0.GA',
 			'org.hibernate:hibernate-validator:4.2.0.Final',
 			"org.slf4j:slf4j-api:$slf4jVersion"


### PR DESCRIPTION
register.jsp uses jstl, but no jstl dependencies are imported.