### PR TITLE
Improve error message when using the wrong xsd schema.

### DIFF
--- a/config/src/main/java/org/springframework/security/config/SecurityNamespaceHandler.java
+++ b/config/src/main/java/org/springframework/security/config/SecurityNamespaceHandler.java
@@ -85,8 +85,8 @@ public final class SecurityNamespaceHandler implements NamespaceHandler {
 	public BeanDefinition parse(Element element, ParserContext pc) {
 		if (!namespaceMatchesVersion(element)) {
 			pc.getReaderContext()
-					.fatal("You cannot use a spring-security-2.0.xsd or spring-security-3.0.xsd or spring-security-3.1.xsd schema "
-							+ "with Spring Security 3.2. Please update your schema declarations to the 3.2 schema.",
+					.fatal("You cannot use a spring-security-2.0.xsd or spring-security-3.0.xsd or spring-security-3.1.xsd schema or spring-security-3.2.xsd schema "
+							+ "with Spring Security 4.0. Please update your schema declarations to the 4.0 schema.",
 							element);
 		}
 		String name = pc.getDelegate().getLocalName(element);


### PR DESCRIPTION
When using the wrong xsd schema < 4.0 a message was shown that the schema needed to be version 3.2.

In reality this schema had to be version 4.0.