### PR TITLE
Update Spring Security to be compatible with Spring Framework 4.2

### DIFF
--- a/acl/src/main/java/org/springframework/security/acls/jdbc/JdbcMutableAclService.java
+++ b/acl/src/main/java/org/springframework/security/acls/jdbc/JdbcMutableAclService.java
@@ -192,7 +192,7 @@ public class JdbcMutableAclService extends JdbcAclService implements MutableAclS
 			jdbcTemplate.update(insertClass, type);
 			Assert.isTrue(TransactionSynchronizationManager.isSynchronizationActive(),
 					"Transaction must be running");
-			return new Long(jdbcTemplate.queryForLong(classIdentityQuery));
+			return jdbcTemplate.queryForObject(classIdentityQuery, Long.class);
 		}
 
 		return null;
@@ -252,7 +252,7 @@ public class JdbcMutableAclService extends JdbcAclService implements MutableAclS
 			jdbcTemplate.update(insertSid, Boolean.valueOf(sidIsPrincipal), sidName);
 			Assert.isTrue(TransactionSynchronizationManager.isSynchronizationActive(),
 					"Transaction must be running");
-			return new Long(jdbcTemplate.queryForLong(sidIdentityQuery));
+			return jdbcTemplate.queryForObject(sidIdentityQuery, Long.class);
 		}
 
 		return null;
@@ -332,8 +332,8 @@ public class JdbcMutableAclService extends JdbcAclService implements MutableAclS
 	 */
 	protected Long retrieveObjectIdentityPrimaryKey(ObjectIdentity oid) {
 		try {
-			return new Long(jdbcTemplate.queryForLong(selectObjectIdentityPrimaryKey,
-					oid.getType(), oid.getIdentifier()));
+			return jdbcTemplate.queryForObject(selectObjectIdentityPrimaryKey, Long.class,
+					oid.getType(), oid.getIdentifier());
 		}
 		catch (DataAccessException notFound) {
 			return null;

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 
 	ext.releaseBuild = version.endsWith('RELEASE')
 	ext.snapshotBuild = version.endsWith('SNAPSHOT')
-	ext.springVersion = '4.1.6.RELEASE'
+	ext.springVersion = '4.2.0.RC2'
 	ext.springLdapVersion = '2.0.2.RELEASE'
 
 	group = 'org.springframework.security'

--- a/config/src/test/groovy/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfigurationTests.groovy
+++ b/config/src/test/groovy/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfigurationTests.groovy
@@ -44,6 +44,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent
 import org.springframework.security.config.annotation.BaseSpringSpec
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
+import org.springframework.security.config.method.TestPermissionEvaluator;
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.authority.AuthorityUtils
 import org.springframework.security.core.context.SecurityContextHolder
@@ -250,7 +251,7 @@ public class GlobalMethodSecurityConfigurationTests extends BaseSpringSpec {
 
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	public static class MultiPermissionEvaluatorConfig extends GlobalMethodSecurityConfiguration {
-		static PermissionEvaluator PE
+		static PermissionEvaluator PE = new TestPermissionEvaluator()
 
 		@Override
 		protected void configure(AuthenticationManagerBuilder auth) throws Exception {

--- a/core/src/main/java/org/springframework/security/provisioning/JdbcUserDetailsManager.java
+++ b/core/src/main/java/org/springframework/security/provisioning/JdbcUserDetailsManager.java
@@ -375,7 +375,7 @@ public class JdbcUserDetailsManager extends JdbcDaoImpl implements UserDetailsMa
 	}
 
 	private int findGroupId(String group) {
-		return getJdbcTemplate().queryForInt(findGroupIdSql, group);
+		return getJdbcTemplate().queryForObject(findGroupIdSql, int.class, group);
 	}
 
 	public void setAuthenticationManager(AuthenticationManager authenticationManager) {

--- a/core/src/test/java/org/springframework/security/provisioning/JdbcUserDetailsManagerTests.java
+++ b/core/src/test/java/org/springframework/security/provisioning/JdbcUserDetailsManagerTests.java
@@ -250,7 +250,8 @@ public class JdbcUserDetailsManagerTests {
 
 		assertEquals(
 				0,
-				template.queryForInt("select id from groups where group_name = 'GROUP_X'"));
+				(int) template.queryForObject("select id from groups where group_name = 'GROUP_X'",
+						int.class));
 	}
 
 	@Test

--- a/samples/dms-xml/src/main/java/sample/dms/DocumentDaoImpl.java
+++ b/samples/dms-xml/src/main/java/sample/dms/DocumentDaoImpl.java
@@ -30,7 +30,7 @@ public class DocumentDaoImpl extends JdbcDaoSupport implements DocumentDao {
 	private Long obtainPrimaryKey() {
 		Assert.isTrue(TransactionSynchronizationManager.isSynchronizationActive(),
 				"Transaction must be running");
-		return new Long(getJdbcTemplate().queryForLong(SELECT_IDENTITY));
+		return getJdbcTemplate().queryForObject(SELECT_IDENTITY, Long.class);
 	}
 
 	public void create(AbstractElement element) {

--- a/samples/dms-xml/src/test/java/DmsIntegrationTests.java
+++ b/samples/dms-xml/src/test/java/DmsIntegrationTests.java
@@ -40,8 +40,8 @@ public class DmsIntegrationTests extends AbstractTransactionalJUnit4SpringContex
 
 	@Test
 	public void testBasePopulation() {
-		assertEquals(9, jdbcTemplate.queryForInt("select count(id) from DIRECTORY"));
-		assertEquals(90, jdbcTemplate.queryForInt("select count(id) from FILE"));
+		assertEquals(9, jdbcTemplate.queryForObject("select count(id) from DIRECTORY", int.class));
+		assertEquals(90, jdbcTemplate.queryForObject("select count(id) from FILE", int.class));
 		assertEquals(3, documentDao.findElements(Directory.ROOT_DIRECTORY).length);
 	}
 

--- a/samples/dms-xml/src/test/java/SecureDmsIntegrationTests.java
+++ b/samples/dms-xml/src/test/java/SecureDmsIntegrationTests.java
@@ -15,18 +15,23 @@ public class SecureDmsIntegrationTests extends DmsIntegrationTests {
 
 	@Test
 	public void testBasePopulation() {
-		assertEquals(9, jdbcTemplate.queryForInt("select count(id) from DIRECTORY"));
-		assertEquals(90, jdbcTemplate.queryForInt("select count(id) from FILE"));
-		assertEquals(4, jdbcTemplate.queryForInt("select count(id) from ACL_SID")); // 3
-																					// users
-																					// + 1
-																					// role
-		assertEquals(2, jdbcTemplate.queryForInt("select count(id) from ACL_CLASS")); // Directory
-																						// and
-																						// File
+		assertEquals(9,
+				jdbcTemplate.queryForObject("select count(id) from DIRECTORY", int.class));
+		assertEquals(90,
+				jdbcTemplate.queryForObject("select count(id) from FILE", int.class));
+		assertEquals(4,
+				jdbcTemplate.queryForObject("select count(id) from ACL_SID", int.class));	// 3
+																							// users
+																							// + 1
+																							// role
+		assertEquals(2,
+				jdbcTemplate.queryForObject("select count(id) from ACL_CLASS", int.class)); // Directory
+																							// and
+																							// File
 		assertEquals(100,
-				jdbcTemplate.queryForInt("select count(id) from ACL_OBJECT_IDENTITY"));
-		assertEquals(115, jdbcTemplate.queryForInt("select count(id) from ACL_ENTRY"));
+				jdbcTemplate.queryForObject("select count(id) from ACL_OBJECT_IDENTITY", int.class));
+		assertEquals(115,
+				jdbcTemplate.queryForObject("select count(id) from ACL_ENTRY", int.class));
 	}
 
 	public void testMarissaRetrieval() {

--- a/web/src/main/java/org/springframework/security/web/authentication/session/AbstractSessionFixationProtectionStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/session/AbstractSessionFixationProtectionStrategy.java
@@ -149,6 +149,9 @@ abstract class AbstractSessionFixationProtectionStrategy implements
 	protected static final class NullEventPublisher implements ApplicationEventPublisher {
 		public void publishEvent(ApplicationEvent event) {
 		}
+
+		public void publishEvent(Object event) {
+		}
 	}
 
 }


### PR DESCRIPTION
These changes should _not_ be merged as-is. They hopefully provide a good starting point for updating Spring Security to be compatible with Spring Framework 4.2, while also retaining compatibility with 4.1. Notably, the code currently compiled against 4.2.0.RC2 which is almost certainly wrong, but provides an easy way to test the changes. Furthermore, there are a handful of tests failures that I lack the Spring Security expertise to address. As I said, hopefully these changes prove to be a useful starting point.

Change summary:

 - Replace usage of `JdbcTemplate.queryForInt` and `JdbcTemplate.queryForLong` with `JdbcTemplate.queryForObject`. `queryForInt` and `queryForLong` have been removed in 4.2.
 - Initialize `PE` to a non-null value. Without this change the tests fail with an NPE when trying to order the `PermissionEvaluator` beans
 - Implement the new `publishEvent(Object object)` on `ApplicationEventPublisher` in `NullEventPublisher`