### PR TITLE
Upgrade to a version of Powermock that’s compatible with JUnit 4.12

### DIFF
--- a/gradle/javaprojects.gradle
+++ b/gradle/javaprojects.gradle
@@ -28,7 +28,7 @@ ext.jettyVersion = '6.1.26'
 ext.jstlVersion = '1.2.1'
 ext.junitVersion = '4.11'
 ext.logbackVersion = '1.1.2'
-ext.powerMockVersion = '1.6.0'
+ext.powerMockVersion = '1.6.2'
 ext.seleniumVersion = '2.44.0'
 ext.servletApiVersion = '3.0.1'
 ext.slf4jVersion = '1.7.7'
@@ -149,7 +149,7 @@ dependencies {
 	optional "commons-logging:commons-logging:$commonsLoggingVersion"
 
 	testCompile "junit:junit:$junitVersion",
-			'org.mockito:mockito-core:1.9.5',
+			'org.mockito:mockito-core:1.10.19',
 			"org.springframework:spring-test:$springVersion",
 			'org.easytesting:fest-assert:1.4'
 


### PR DESCRIPTION
The PR upgrades to Powermock 1.6.2 which is compatible with JUnit 4.12. It also upgrades Mockito as Powermock 1.6.2 is incompatible with the version of Mockito that was being used. 1.10.19 is the version used by Powermock 1.6.2.