### PR TITLE
SEC-3056 - Fix JavaDoc errors.

### DIFF
--- a/acl/src/main/java/org/springframework/security/acls/AclEntryVoter.java
+++ b/acl/src/main/java/org/springframework/security/acls/AclEntryVoter.java
@@ -83,14 +83,14 @@ import org.springframework.util.StringUtils;
  * Alternatively, you could have used a common superclass or interface for the
  * {@link #processDomainObjectClass} if both <code>BankAccount</code> and
  * <code>Customer</code> had common parents.
- * </p>
+ *
  * <p>
  * If the principal does not have sufficient permissions, the voter will vote to deny
  * access.
- * </p>
+ *
  * <p>
  * All comparisons and prefixes are case sensitive.
- * </p>
+ *
  *
  * @author Ben Alex
  */

--- a/config/src/main/java/org/springframework/security/config/annotation/SecurityConfigurerAdapter.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/SecurityConfigurerAdapter.java
@@ -58,7 +58,7 @@ public abstract class SecurityConfigurerAdapter<O, B extends SecurityBuilder<O>>
 	 * Gets the {@link SecurityBuilder}. Cannot be null.
 	 *
 	 * @return the {@link SecurityBuilder}
-	 * @throw {@link IllegalStateException} if {@link SecurityBuilder} is null
+	 * @throws IllegalStateException if {@link SecurityBuilder} is null
 	 */
 	protected final B getBuilder() {
 		if (securityBuilder == null) {

--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/ProviderManagerBuilder.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/ProviderManagerBuilder.java
@@ -36,9 +36,10 @@ public interface ProviderManagerBuilder<B extends ProviderManagerBuilder<B>> ext
 	 * customizations must be done externally and the {@link ProviderManagerBuilder} is
 	 * returned immediately.
 	 *
+	 * Note that an Exception is thrown if an error occurs when adding the {@link AuthenticationProvider}.
+	 *
 	 * @return a {@link ProviderManagerBuilder} to allow further authentication to be
 	 * provided to the {@link ProviderManagerBuilder}
-	 * @throws Exception if an error occurs when adding the {@link AuthenticationProvider}
 	 */
 	B authenticationProvider(AuthenticationProvider authenticationProvider);
 }

--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/builders/AuthenticationManagerBuilder.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/builders/AuthenticationManagerBuilder.java
@@ -61,7 +61,7 @@ public class AuthenticationManagerBuilder
 
 	/**
 	 * Creates a new instance
-	 * @param the {@link ObjectPostProcessor} instance to use.
+	 * @param objectPostProcessor the {@link ObjectPostProcessor} instance to use.
 	 */
 	public AuthenticationManagerBuilder(ObjectPostProcessor<Object> objectPostProcessor) {
 		super(objectPostProcessor, true);
@@ -196,7 +196,6 @@ public class AuthenticationManagerBuilder
 	 * <p>
 	 * This method <b>does NOT</b> ensure that a {@link UserDetailsService} is available
 	 * for the {@link #getDefaultUserDetailsService()} method.
-	 * </p>
 	 *
 	 * @return a {@link LdapAuthenticationProviderConfigurer} to allow customization of
 	 * the LDAP authentication
@@ -216,11 +215,11 @@ public class AuthenticationManagerBuilder
 	 * <p>
 	 * This method <b>does NOT</b> ensure that the {@link UserDetailsService} is available
 	 * for the {@link #getDefaultUserDetailsService()} method.
-	 * </p>
+	 *
+	 * Note that an {@link Exception} might be thrown if an error occurs when adding the {@link AuthenticationProvider}.
 	 *
 	 * @return a {@link AuthenticationManagerBuilder} to allow further authentication to
 	 * be provided to the {@link AuthenticationManagerBuilder}
-	 * @throws Exception if an error occurs when adding the {@link AuthenticationProvider}
 	 */
 	public AuthenticationManagerBuilder authenticationProvider(
 			AuthenticationProvider authenticationProvider) {

--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/provisioning/InMemoryUserDetailsManagerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/provisioning/InMemoryUserDetailsManagerConfigurer.java
@@ -27,7 +27,7 @@ import org.springframework.security.provisioning.InMemoryUserDetailsManager;
  * to have in memory authentication. It also allows easily adding users to the in memory
  * authentication.
  *
- * @param <B> the type of the {@link SecurityBuilder} that is being configured
+ * @param <B> the type of the {@link ProviderManagerBuilder} that is being configured
  *
  * @author Rob Winch
  * @since 3.2

--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/provisioning/JdbcUserDetailsManagerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/provisioning/JdbcUserDetailsManagerConfigurer.java
@@ -38,7 +38,6 @@ import org.springframework.security.provisioning.JdbcUserDetailsManager;
  * <p>
  * The only required method is the {@link #dataSource(javax.sql.DataSource)} all other
  * methods have reasonable defaults.
- * </p>
  *
  * @param <B> the type of the {@link ProviderManagerBuilder} that is being configured
  *
@@ -82,7 +81,7 @@ public class JdbcUserDetailsManagerConfigurer<B extends ProviderManagerBuilder<B
 	 * </code>
 	 * @param query The query to use for selecting the username, password, and if the user
 	 * is enabled by username. Must contain a single parameter for the username.
-	 * @return The {@link JdbcUserDetailsManagerRegistry} used for additional
+	 * @return The {@link JdbcUserDetailsManagerConfigurer} used for additional
 	 * customizations
 	 * @throws Exception
 	 */
@@ -102,7 +101,7 @@ public class JdbcUserDetailsManagerConfigurer<B extends ProviderManagerBuilder<B
 	 *
 	 * @param query The query to use for selecting the username, authority by username.
 	 * Must contain a single parameter for the username.
-	 * @return The {@link JdbcUserDetailsManagerRegistry} used for additional
+	 * @return The {@link JdbcUserDetailsManagerConfigurer} used for additional
 	 * customizations
 	 * @throws Exception
 	 */
@@ -126,7 +125,7 @@ public class JdbcUserDetailsManagerConfigurer<B extends ProviderManagerBuilder<B
 	 *
 	 * @param query The query to use for selecting the authorities by group. Must contain
 	 * a single parameter for the username.
-	 * @return The {@link JdbcUserDetailsManagerRegistry} used for additional
+	 * @return The {@link JdbcUserDetailsManagerConfigurer} used for additional
 	 * customizations
 	 * @throws Exception
 	 */
@@ -181,7 +180,7 @@ public class JdbcUserDetailsManagerConfigurer<B extends ProviderManagerBuilder<B
 	/**
 	 * Populates the default schema that allows users and authorities to be stored.
 	 *
-	 * @return The {@link JdbcUserDetailsManagerRegistry} used for additional
+	 * @return The {@link JdbcUserDetailsManagerConfigurer} used for additional
 	 * customizations
 	 */
 	public JdbcUserDetailsManagerConfigurer<B> withDefaultSchema() {

--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/provisioning/UserDetailsManagerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/provisioning/UserDetailsManagerConfigurer.java
@@ -80,9 +80,6 @@ public class UserDetailsManagerConfigurer<B extends ProviderManagerBuilder<B>, C
 	/**
 	 * Builds the user to be added. At minimum the username, password, and authorities
 	 * should provided. The remaining attributes have reasonable defaults.
-	 *
-	 * @param <T> the type of {@link UserDetailsManagerConfigurer} to return for chaining
-	 * methods.
 	 */
 	public class UserDetailsBuilder {
 		private String username;
@@ -103,11 +100,10 @@ public class UserDetailsManagerConfigurer<B extends ProviderManagerBuilder<B>, C
 		}
 
 		/**
-		 * Returns the {@link UserDetailsManagerRegistry} for method chaining (i.e. to add
+		 * Returns the {@link UserDetailsManagerConfigurer} for method chaining (i.e. to add
 		 * another user)
 		 *
-		 * @return the {@link UserDetailsManagerRegistry} for method chaining (i.e. to add
-		 * another user)
+		 * @return the {@link UserDetailsManagerConfigurer} for method chaining
 		 */
 		public C and() {
 			return builder;

--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/userdetails/UserDetailsServiceConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/userdetails/UserDetailsServiceConfigurer.java
@@ -27,8 +27,8 @@ import org.springframework.security.core.userdetails.UserDetailsService;
  * @author Rob Winch
  * @since 3.2
  *
- * @param <B> the type of the {@link SecurityBuilder}
- * @param <C> the {@link SecurityConfigurer} (or this)
+ * @param <B> the type of the {@link ProviderManagerBuilder}
+ * @param <C> the {@link UserDetailsServiceConfigurer} (or this)
  * @param <U> the type of UserDetailsService being used to allow for returning the
  * concrete UserDetailsService.
  */

--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/EnableGlobalMethodSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/EnableGlobalMethodSecurity.java
@@ -29,9 +29,8 @@ import org.springframework.security.config.annotation.configuration.ObjectPostPr
 
 /**
  * <p>
- * Enables Spring Security global method security similar to the <global-method-security>
+ * Enables Spring Security global method security similar to the &lt;global-method-security&gt;
  * xml support.
- * </p>
  *
  * <p>
  * More advanced configurations may wish to extend

--- a/config/src/main/java/org/springframework/security/config/annotation/web/HttpSecurityBuilder.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/HttpSecurityBuilder.java
@@ -142,11 +142,11 @@ public interface HttpSecurityBuilder<H extends HttpSecurityBuilder<H>> extends
 	 * <li>{@link LogoutFilter}</li>
 	 * <li>{@link X509AuthenticationFilter}</li>
 	 * <li>{@link AbstractPreAuthenticatedProcessingFilter}</li>
-	 * <li>{@link org.springframework.security.cas.web.CasAuthenticationFilter}</li>
+	 * <li><a href="{@docRoot}/org/springframework/security/cas/web/CasAuthenticationFilter.html">CasAuthenticationFilter</a></li>
 	 * <li>{@link UsernamePasswordAuthenticationFilter}</li>
 	 * <li>{@link ConcurrentSessionFilter}</li>
 	 * <li>{@link OpenIDAuthenticationFilter}</li>
-	 * <li>{@link DefaultLoginPageGeneratingFilter}</li>
+	 * <li>{@link org.springframework.security.web.authentication.ui.DefaultLoginPageGeneratingFilter}</li>
 	 * <li>{@link ConcurrentSessionFilter}</li>
 	 * <li>{@link DigestAuthenticationFilter}</li>
 	 * <li>{@link BasicAuthenticationFilter}</li>

--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
@@ -71,7 +71,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
 
 /**
- * A {@link HttpSecurity} is similar to Spring Security's XML <http> element in the
+ * A {@link HttpSecurity} is similar to Spring Security's XML &lt;http&gt; element in the
  * namespace configuration. It allows configuring web based security for specific http
  * requests. By default it will be applied to all requests, but can be restricted using
  * {@link #requestMatcher(RequestMatcher)} or other similar methods.
@@ -283,7 +283,7 @@ public final class HttpSecurity extends
 	 *
 	 * @return
 	 * @throws Exception
-	 * @see {@link HeadersConfigurer}
+	 * @see HeadersConfigurer
 	 */
 	public HeadersConfigurer<HttpSecurity> headers() throws Exception {
 		return getOrApply(new HeadersConfigurer<HttpSecurity>());
@@ -326,8 +326,8 @@ public final class HttpSecurity extends
 	 *
 	 * <pre>
 	 * &lt;listener&gt;
-	 *      &ltlistener-class&gt;org.springframework.security.web.session.HttpSessionEventPublisher&lt;/listener-class&gt;
-	 * &lt/listener>
+	 *      &lt;listener-class&gt;org.springframework.security.web.session.HttpSessionEventPublisher&lt;/listener-class&gt;
+	 * &lt;/listener&gt;
 	 * </pre>
 	 *
 	 * Alternatively,
@@ -378,7 +378,7 @@ public final class HttpSecurity extends
 	 *
 	 * @return the {@link PortMapperConfigurer} for further customizations
 	 * @throws Exception
-	 * @see {@link #requiresChannel()}
+	 * @see #requiresChannel()
 	 */
 	public PortMapperConfigurer<HttpSecurity> portMapper() throws Exception {
 		return getOrApply(new PortMapperConfigurer<HttpSecurity>());
@@ -716,7 +716,7 @@ public final class HttpSecurity extends
 	 * {@link org.springframework.security.authentication.AnonymousAuthenticationToken}
 	 * and contain the role "ROLE_ANONYMOUS".
 	 *
-	 * <h2>Example Configuration</h2
+	 * <h2>Example Configuration</h2>
 	 *
 	 * The following configuration demonstrates how to specify that anonymous users should
 	 * contain the role "ROLE_ANON" instead.
@@ -906,6 +906,10 @@ public final class HttpSecurity extends
 	 */
 	public HttpBasicConfigurer<HttpSecurity> httpBasic() throws Exception {
 		return getOrApply(new HttpBasicConfigurer<HttpSecurity>());
+	}
+
+	public <C> void setSharedObject(Class<C> sharedType, C object) {
+		super.setSharedObject(sharedType, object);
 	}
 
 	@Override

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configuration/WebMvcSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configuration/WebMvcSecurityConfiguration.java
@@ -29,7 +29,7 @@ import java.util.List;
 /**
  * Used to add a {@link RequestDataValueProcessor} for Spring MVC and Spring Security CSRF
  * integration. This configuration is added whenever {@link EnableWebMvc} is added by
- * {@link SpringWebMvcImportSelector} and the DispatcherServlet is present on the
+ * <a href="{@docRoot}/org/springframework/security/config/annotation/web/configuration/SpringWebMvcImportSelector.html">SpringWebMvcImportSelector</a> and the DispatcherServlet is present on the
  * classpath. It also adds the {@link AuthenticationPrincipalArgumentResolver} as a
  * {@link HandlerMethodArgumentResolver}.
  *

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurerAdapter.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurerAdapter.java
@@ -262,7 +262,7 @@ public abstract class WebSecurityConfigurerAdapter implements
 	 * {@link #userDetailsService()} instead
 	 * @return
 	 * @throws Exception
-	 * @see {@link #userDetailsService()}
+	 * @see #userDetailsService()
 	 */
 	public UserDetailsService userDetailsServiceBean() throws Exception {
 		AuthenticationManagerBuilder globalAuthBuilder = context
@@ -273,7 +273,7 @@ public abstract class WebSecurityConfigurerAdapter implements
 
 	/**
 	 * Allows modifying and accessing the {@link UserDetailsService} from
-	 * {@link #userDetailsServiceBean()()} without interacting with the
+	 * {@link #userDetailsServiceBean()} without interacting with the
 	 * {@link ApplicationContext}. Developers should override this method when changing
 	 * the instance of {@link #userDetailsServiceBean()}.
 	 *

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/AbstractAuthenticationFilterConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/AbstractAuthenticationFilterConfigurer.java
@@ -178,8 +178,8 @@ public abstract class AbstractAuthenticationFilterConfigurer<B extends HttpSecur
 	}
 
 	/**
-	 * Ensures the urls for {@link #failureUrl(String)} and
-	 * {@link #authenticationUrls(String)} are granted access to any user.
+	 * Ensures the urls for {@link #failureUrl(String)} as well as for the {@link HttpSecurityBuilder}, the
+	 * {@link #getLoginPage} and {@link #getLoginProcessingUrl} are granted access to any user.
 	 *
 	 * @param permitAll true to grant access to the URLs false to skip this step
 	 * @return the {@link FormLoginConfigurer} for additional customization

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/AbstractInterceptUrlConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/AbstractInterceptUrlConfigurer.java
@@ -51,7 +51,7 @@ import org.springframework.security.web.access.intercept.FilterSecurityIntercept
  *
  * <ul>
  * <li>
- * {@link org.springframework.security.config.annotation.web.builders.HttpSecurity#getAuthenticationManager()}
+ * {@link AuthenticationManager}
  * </li>
  * </ul>
  *
@@ -115,7 +115,7 @@ abstract class AbstractInterceptUrlConfigurer<C extends AbstractInterceptUrlConf
 
 		/**
 		 * Allows setting the {@link AccessDecisionManager}. If none is provided, a
-		 * default {@l AccessDecisionManager} is created.
+		 * default {@link AccessDecisionManager} is created.
 		 *
 		 * @param accessDecisionManager the {@link AccessDecisionManager} to use
 		 * @return the {@link AbstractInterceptUrlConfigurer} for further customization
@@ -162,7 +162,7 @@ abstract class AbstractInterceptUrlConfigurer<C extends AbstractInterceptUrlConf
 
 	/**
 	 * If currently null, creates a default {@link AccessDecisionManager} using
-	 * {@link #createDefaultAccessDecisionManager()}. Otherwise returns the
+	 * {@link #createDefaultAccessDecisionManager(HttpSecurityBuilder)}. Otherwise returns the
 	 * {@link AccessDecisionManager}.
 	 *
 	 * @param http the builder to use

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ExceptionHandlingConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ExceptionHandlingConfigurer.java
@@ -84,7 +84,7 @@ public final class ExceptionHandlingConfigurer<H extends HttpSecurityBuilder<H>>
 	 * @param accessDeniedUrl the URL to the access denied page (i.e. /errors/401)
 	 * @return the {@link ExceptionHandlingConfigurer} for further customization
 	 * @see AccessDeniedHandlerImpl
-	 * @see {@link #accessDeniedHandler(org.springframework.security.web.access.AccessDeniedHandler)}
+	 * @see #accessDeniedHandler(org.springframework.security.web.access.AccessDeniedHandler)
 	 */
 	public ExceptionHandlingConfigurer<H> accessDeniedPage(String accessDeniedUrl) {
 		AccessDeniedHandlerImpl accessDeniedHandler = new AccessDeniedHandlerImpl();

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ExpressionUrlAuthorizationConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ExpressionUrlAuthorizationConfigurer.java
@@ -70,7 +70,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Rob Winch
  * @since 3.2
- * @see {@link org.springframework.security.config.annotation.web.builders.HttpSecurity#authorizeRequests()}
+ * @see org.springframework.security.config.annotation.web.builders.HttpSecurity#authorizeRequests()
  */
 public final class ExpressionUrlAuthorizationConfigurer<H extends HttpSecurityBuilder<H>>
 		extends
@@ -339,7 +339,7 @@ public final class ExpressionUrlAuthorizationConfigurer<H extends HttpSecurityBu
 		 *
 		 * @return the {@link ExpressionUrlAuthorizationConfigurer} for further
 		 * customization
-		 * @see {@link RememberMeConfigurer}
+		 * @see RememberMeConfigurer
 		 */
 		public ExpressionInterceptUrlRegistry rememberMe() {
 			return access(rememberMe);
@@ -371,7 +371,7 @@ public final class ExpressionUrlAuthorizationConfigurer<H extends HttpSecurityBu
 		 *
 		 * @return the {@link ExpressionUrlAuthorizationConfigurer} for further
 		 * customization
-		 * @see {@link RememberMeConfigurer}
+		 * @see RememberMeConfigurer
 		 */
 		public ExpressionInterceptUrlRegistry fullyAuthenticated() {
 			return access(fullyAuthenticated);

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/FormLoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/FormLoginConfigurer.java
@@ -53,7 +53,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
  * The following shared objects are used:
  *
  * <ul>
- * <li>{@link AuthenticationManager}</li>
+ * <li>{@link org.springframework.security.authentication.AuthenticationManager}</li>
  * <li>{@link RememberMeServices} - is optionally used. See {@link RememberMeConfigurer}</li>
  * <li>{@link SessionAuthenticationStrategy} - is optionally used. See
  * {@link SessionManagementConfigurer}</li>

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HeadersConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HeadersConfigurer.java
@@ -186,7 +186,7 @@ public class HeadersConfigurer<H extends HttpSecurityBuilder<H>> extends
 		 * X-XSS-Protection: 1
 		 * </pre>
 		 *
-		 * or if {@link #setBlock(boolean)} is true
+		 * or if {@link XXssProtectionHeaderWriter#setBlock(boolean)} of the given {@link XXssProtectionHeaderWriter} is true
 		 *
 		 *
 		 * <pre>

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HttpBasicConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HttpBasicConfigurer.java
@@ -83,7 +83,7 @@ public final class HttpBasicConfigurer<B extends HttpSecurityBuilder<B>> extends
 	/**
 	 * Creates a new instance
 	 * @throws Exception
-	 * @see {@link HttpSecurity#httpBasic()}
+	 * @see HttpSecurity#httpBasic()
 	 */
 	public HttpBasicConfigurer() throws Exception {
 		realmName(DEFAULT_REALM);

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/JeeConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/JeeConfigurer.java
@@ -187,7 +187,7 @@ public final class JeeConfigurer<H extends HttpSecurityBuilder<H>> extends
 	 * Populates a {@link PreAuthenticatedAuthenticationProvider} into
 	 * {@link HttpSecurity#authenticationProvider(org.springframework.security.authentication.AuthenticationProvider)}
 	 * and a {@link Http403ForbiddenEntryPoint} into
-	 * {@link HttpSecurity#authenticationEntryPoint(org.springframework.security.web.AuthenticationEntryPoint)}
+	 * {@link HttpSecurityBuilder#setSharedObject(Class, Object)}
 	 *
 	 * @see org.springframework.security.config.annotation.SecurityConfigurerAdapter#init(org.springframework.security.config.annotation.SecurityBuilder)
 	 */

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/LogoutConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/LogoutConfigurer.java
@@ -35,7 +35,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 
 /**
  * Adds logout support. Other {@link SecurityConfigurer} instances may invoke
- * {@link #addLogoutHandler(LogoutHandler)} in the {@link #init(HttpSecurity)} phase.
+ * {@link #addLogoutHandler(LogoutHandler)} in the {@link #init(HttpSecurityBuilder)} phase.
  *
  * <h2>Security Filters</h2>
  *

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/openid/OpenIDLoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/openid/OpenIDLoginConfigurer.java
@@ -199,7 +199,7 @@ public final class OpenIDLoginConfigurer<H extends HttpSecurityBuilder<H>>
 	 * {@link HttpServletRequest} matches this URL the {@link OpenIDAuthenticationFilter}
 	 * will attempt to authenticate the request. The default is "/login/openid".
 	 *
-	 * @param loginUrl the URL used to perform authentication
+	 * @param loginProcessingUrl the URL used to perform authentication
 	 * @return the {@link OpenIDLoginConfigurer} for additional customization
 	 */
 	public OpenIDLoginConfigurer<H> loginProcessingUrl(String loginProcessingUrl) {

--- a/config/src/main/java/org/springframework/security/config/annotation/web/messaging/MessageSecurityMetadataSourceRegistry.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/messaging/MessageSecurityMetadataSourceRegistry.java
@@ -105,7 +105,7 @@ public class MessageSecurityMetadataSourceRegistry {
 	 * {@link MessageSecurityMetadataSourceRegistry#simpDestPathMatcher(PathMatcher)} .
 	 *
 	 * @return the {@link Constraint} that is associated to the {@link MessageMatcher}
-	 * @see {@link MessageSecurityMetadataSourceRegistry#simpDestPathMatcher(PathMatcher)}
+	 * @see MessageSecurityMetadataSourceRegistry#simpDestPathMatcher(PathMatcher)
 	 */
 	public Constraint simpDestMatchers(String... patterns) {
 		return simpDestMatchers(null, patterns);
@@ -122,7 +122,7 @@ public class MessageSecurityMetadataSourceRegistry {
 	 * {@link MessageSecurityMetadataSourceRegistry#simpDestPathMatcher(PathMatcher)}.
 	 *
 	 * @return the {@link Constraint} that is associated to the {@link MessageMatcher}
-	 * @see {@link MessageSecurityMetadataSourceRegistry#simpDestPathMatcher(PathMatcher)}
+	 * @see MessageSecurityMetadataSourceRegistry#simpDestPathMatcher(PathMatcher)
 	 */
 	public Constraint simpMessageDestMatchers(String... patterns) {
 		return simpDestMatchers(SimpMessageType.MESSAGE, patterns);
@@ -139,7 +139,7 @@ public class MessageSecurityMetadataSourceRegistry {
 	 * {@link MessageSecurityMetadataSourceRegistry#simpDestPathMatcher(PathMatcher)}.
 	 *
 	 * @return the {@link Constraint} that is associated to the {@link MessageMatcher}
-	 * @see {@link MessageSecurityMetadataSourceRegistry#simpDestPathMatcher(PathMatcher)}
+	 * @see MessageSecurityMetadataSourceRegistry#simpDestPathMatcher(PathMatcher)
 	 */
 	public Constraint simpSubscribeDestMatchers(String... patterns) {
 		return simpDestMatchers(SimpMessageType.SUBSCRIBE, patterns);
@@ -353,7 +353,7 @@ public class MessageSecurityMetadataSourceRegistry {
 		 *
 		 * @return the {@link MessageSecurityMetadataSourceRegistry} for further
 		 * customization
-		 * @see {@link RememberMeConfigurer}
+		 * @see RememberMeConfigurer
 		 */
 		public MessageSecurityMetadataSourceRegistry rememberMe() {
 			return access(rememberMe);
@@ -385,7 +385,7 @@ public class MessageSecurityMetadataSourceRegistry {
 		 *
 		 * @return the {@link MessageSecurityMetadataSourceRegistry} for further
 		 * customization
-		 * @see {@link RememberMeConfigurer}
+		 * @see RememberMeConfigurer
 		 */
 		public MessageSecurityMetadataSourceRegistry fullyAuthenticated() {
 			return access(fullyAuthenticated);

--- a/config/src/main/java/org/springframework/security/config/annotation/web/servlet/configuration/WebMvcSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/servlet/configuration/WebMvcSecurityConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.web.servlet.support.RequestDataValueProcessor;
 /**
  * Used to add a {@link RequestDataValueProcessor} for Spring MVC and Spring Security CSRF
  * integration. This configuration is added whenever {@link EnableWebMvc} is added by
- * {@link SpringWebMvcImportSelector} and the DispatcherServlet is present on the
+ * <a href="{@docRoot}/org/springframework/security/config/annotation/web/configuration/SpringWebMvcImportSelector.html">SpringWebMvcImportSelector</a> and the DispatcherServlet is present on the
  * classpath. It also adds the {@link AuthenticationPrincipalArgumentResolver} as a
  * {@link HandlerMethodArgumentResolver}.
  *

--- a/config/src/main/java/org/springframework/security/config/authentication/PasswordEncoderParser.java
+++ b/config/src/main/java/org/springframework/security/config/authentication/PasswordEncoderParser.java
@@ -25,7 +25,7 @@ import org.springframework.util.xml.DomUtils;
 import org.w3c.dom.Element;
 
 /**
- * Stateful parser for the <password-encoder> element.
+ * Stateful parser for the &lt;password-encoder&gt; element.
  *
  * Will produce a PasswordEncoder and (optionally) a SaltSource.
  *

--- a/core/src/main/java/org/springframework/security/access/expression/SecurityExpressionOperations.java
+++ b/core/src/main/java/org/springframework/security/access/expression/SecurityExpressionOperations.java
@@ -45,7 +45,7 @@ public interface SecurityExpressionOperations {
 	 * is converted may depend on the implementation settings.
 	 * </p>
 	 *
-	 * @param authority the authority to test (i.e. "USER")
+	 * @param role the authority to test (i.e. "USER")
 	 * @return true if the authority is found, else false
 	 */
 	boolean hasRole(String role);
@@ -62,7 +62,7 @@ public interface SecurityExpressionOperations {
 	 * is converted may depend on the implementation settings.
 	 * </p>
 	 *
-	 * @param authorities the authorities to test (i.e. "USER", "ADMIN")
+	 * @param roles the authorities to test (i.e. "USER", "ADMIN")
 	 * @return true if any of the authorities is found, else false
 	 */
 	boolean hasAnyRole(String... roles);

--- a/core/src/main/java/org/springframework/security/access/expression/method/DefaultMethodSecurityExpressionHandler.java
+++ b/core/src/main/java/org/springframework/security/access/expression/method/DefaultMethodSecurityExpressionHandler.java
@@ -195,8 +195,8 @@ public class DefaultMethodSecurityExpressionHandler extends
 
 	/**
 	 * <p>
-	 * Sets the default prefix to be added to {@link #hasAnyRole(String...)} or
-	 * {@link #hasRole(String)}. For example, if hasRole("ADMIN") or hasRole("ROLE_ADMIN")
+	 * Sets the default prefix to be added to {@link org.springframework.security.access.expression.SecurityExpressionRoot#hasAnyRole(String...)} or
+	 * {@link org.springframework.security.access.expression.SecurityExpressionRoot#hasRole(String)}. For example, if hasRole("ADMIN") or hasRole("ROLE_ADMIN")
 	 * is passed in, then the role ROLE_ADMIN will be used when the defaultRolePrefix is
 	 * "ROLE_" (default).
 	 * </p>

--- a/core/src/main/java/org/springframework/security/access/hierarchicalroles/RoleHierarchy.java
+++ b/core/src/main/java/org/springframework/security/access/hierarchicalroles/RoleHierarchy.java
@@ -32,7 +32,7 @@ public interface RoleHierarchy {
 	 * that are (transitively) reachable from them in the role hierarchy.
 	 * <p>
 	 * Example:<br>
-	 * Role hierarchy: ROLE_A > ROLE_B and ROLE_B > ROLE_C.<br>
+	 * Role hierarchy: ROLE_A &gt; ROLE_B and ROLE_B &gt; ROLE_C.<br>
 	 * Directly assigned authority: ROLE_A.<br>
 	 * Reachable authorities: ROLE_A, ROLE_B, ROLE_C.
 	 *

--- a/core/src/main/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImpl.java
+++ b/core/src/main/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImpl.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
 /**
  * <p>
  * This class defines a role hierarchy for use with the UserDetailsServiceWrapper.
- * </p>
+ *
  * <p>
  * Here is an example configuration of a role hierarchy (hint: read the "&gt;" sign as
  * "includes"):
@@ -41,19 +41,18 @@ import java.util.regex.Pattern;
  *             &lt;/value&gt;
  *         &lt;/property&gt;
  * </pre>
- * 
- * </p>
+ *
  * <p>
  * Explanation of the above:<br>
  * In effect every user with ROLE_A also has ROLE_B, ROLE_AUTHENTICATED and
  * ROLE_UNAUTHENTICATED;<br>
  * every user with ROLE_B also has ROLE_AUTHENTICATED and ROLE_UNAUTHENTICATED;<br>
  * every user with ROLE_AUTHENTICATED also has ROLE_UNAUTHENTICATED.
- * </p>
+ *
  * <p>
  * Hierarchical Roles will dramatically shorten your access rules (and also make the
  * access rules much more elegant).
- * </p>
+ *
  * <p>
  * Consider this access rule for Spring Security's RoleVoter (background: every user that
  * is authenticated should be able to log out):<br>
@@ -62,10 +61,8 @@ import java.util.regex.Pattern;
  * /logout.html=ROLE_AUTHENTICATED<br>
  * In addition to shorter rules this will also make your access rules more readable and
  * your intentions clearer.
- * </p>
  *
  * @author Michael Mayr
- *
  */
 public class RoleHierarchyImpl implements RoleHierarchy {
 

--- a/core/src/main/java/org/springframework/security/access/intercept/package-info.java
+++ b/core/src/main/java/org/springframework/security/access/intercept/package-info.java
@@ -8,7 +8,7 @@
  * security facilities provided for it by Spring Security.
  * For example, one secure object would be <code>MethodInvocation</code>,
  * whilst another would be HTTP
- * {@link org.springframework.security.web.FilterInvocation}. Note these are
+ * {@code org.springframework.security.web.FilterInvocation}. Note these are
  * infrastructure objects and their design allows them to represent a large
  * variety of actual resources that might need to be secured, such as business
  * objects or HTTP request URLs.

--- a/core/src/main/java/org/springframework/security/access/method/MapBasedMethodSecurityMetadataSource.java
+++ b/core/src/main/java/org/springframework/security/access/method/MapBasedMethodSecurityMetadataSource.java
@@ -107,7 +107,7 @@ public class MapBasedMethodSecurityMetadataSource extends
 
 	/**
 	 * Add configuration attributes for a secure method. Method names can end or start
-	 * with <code>&#42</code> for matching multiple methods.
+	 * with <code>*</code> for matching multiple methods.
 	 *
 	 * @param name type and method name, separated by a dot
 	 * @param attr the security attributes associated with the method
@@ -131,7 +131,7 @@ public class MapBasedMethodSecurityMetadataSource extends
 
 	/**
 	 * Add configuration attributes for a secure method. Mapped method names can end or
-	 * start with <code>&#42</code> for matching multiple methods.
+	 * start with <code>*</code> for matching multiple methods.
 	 *
 	 * @param javaType target interface or class the security configuration attribute
 	 * applies to

--- a/core/src/main/java/org/springframework/security/access/vote/AbstractAccessDecisionManager.java
+++ b/core/src/main/java/org/springframework/security/access/vote/AbstractAccessDecisionManager.java
@@ -33,11 +33,11 @@ import org.springframework.util.Assert;
 
 /**
  * Abstract implementation of {@link AccessDecisionManager}.
- * <p/>
+ *
+ * <p>
  * Handles configuration of a bean context defined list of {@link AccessDecisionVoter}s
  * and the access control behaviour if all voters abstain from voting (defaults to deny
  * access).
- * </p>
  */
 public abstract class AbstractAccessDecisionManager implements AccessDecisionManager,
 		InitializingBean, MessageSourceAware {
@@ -101,10 +101,9 @@ public abstract class AbstractAccessDecisionManager implements AccessDecisionMan
 	/**
 	 * Iterates through all <code>AccessDecisionVoter</code>s and ensures each can support
 	 * the presented class.
-	 * <p/>
+	 * <p>
 	 * If one or more voters cannot support the presented class, <code>false</code> is
 	 * returned.
-	 * </p>
 	 *
 	 * @param clazz the type of secured object being presented
 	 * @return true if this type is supported

--- a/core/src/main/java/org/springframework/security/authentication/encoding/ShaPasswordEncoder.java
+++ b/core/src/main/java/org/springframework/security/authentication/encoding/ShaPasswordEncoder.java
@@ -24,7 +24,7 @@ package org.springframework.security.authentication.encoding;
  * </p>
  * <p>
  * As SHA is a one-way hash, the salt can contain any characters. The default strength for
- * the SHA encoding is SHA-1. If you wish to use higher strengths use the argumented
+ * the SHA encoding is SHA-1. If you wish to use higher strengths use the parametrised
  * constructor. {@link #ShaPasswordEncoder(int strength)}
  * </p>
  * <p>
@@ -32,7 +32,7 @@ package org.springframework.security.authentication.encoding;
  * 
  * <pre>
  * &lt;bean id="passwordEncoder" class="org.springframework.security.authentication.encoding.ShaPasswordEncoder"&gt;
- *     &lt;constructor-arg value="256"/>
+ *     &lt;constructor-arg value="256"/&gt;
  * &lt;/bean&gt;
  * </pre>
  *

--- a/core/src/main/java/org/springframework/security/authentication/jaas/AbstractJaasAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/jaas/AbstractJaasAuthenticationProvider.java
@@ -51,7 +51,7 @@ import org.springframework.util.ObjectUtils;
  * This <code>AuthenticationProvider</code> is capable of validating
  * {@link org.springframework.security.authentication.UsernamePasswordAuthenticationToken}
  * requests contain the correct username and password.
- * </p>
+ *
  * <p>
  * This implementation is backed by a <a
  * href="http://java.sun.com/j2se/1.5.0/docs/guide/security/jaas/JAASRefGuide.html"
@@ -68,7 +68,7 @@ import org.springframework.util.ObjectUtils;
  * in the ApplicationContext. When the LoginContext calls the internal CallbackHandler,
  * control is passed to each {@link JaasAuthenticationCallbackHandler} for each Callback
  * passed.
- * </p>
+ *
  * <p>
  * {@link JaasAuthenticationCallbackHandler}s are passed to the
  * AbstractJaasAuthenticationProvider through the
@@ -84,8 +84,7 @@ import org.springframework.util.ObjectUtils;
  *  &lt;/list&gt;
  * &lt;/property&gt;
  * </pre>
- * 
- * </p>
+ *
  * <p>
  * After calling LoginContext.login(), the AbstractJaasAuthenticationProvider will
  * retrieve the returned Principals from the Subject
@@ -95,7 +94,7 @@ import org.springframework.util.ObjectUtils;
  * Authorization a role, it returns that role name from it's
  * {@link AuthorityGranter#grant(java.security.Principal)} method. The returned role will
  * be applied to the Authorization object as a {@link GrantedAuthority}.
- * </p>
+ *
  * <p>
  * AuthorityGranters are configured in spring xml as follows...
  * 

--- a/core/src/main/java/org/springframework/security/authentication/jaas/JaasAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/jaas/JaasAuthenticationProvider.java
@@ -61,8 +61,7 @@ import java.security.Security;
  *   &lt;value&gt;/WEB-INF/login.conf&lt;/value&gt;
  * &lt;/property&gt;
  * </pre>
- * 
- * </p>
+ *
  * <p>
  * The loginContextName should coincide with a given index in the loginConfig specifed.
  * The loginConfig file used in the JUnit tests appears as the following...
@@ -80,7 +79,6 @@ import java.security.Security;
  *  &lt;property name="loginContextName"&gt; &lt;value&gt;JAASTest&lt;/value&gt; &lt;/property&gt;
  * </pre>
  * 
- * </p>
  * <p>
  * When using JAAS login modules as the authentication source, sometimes the <a href=
  * "http://java.sun.com/j2se/1.5.0/docs/api/javax/security/auth/login/LoginContext.html"
@@ -91,7 +89,7 @@ import java.security.Security;
  * in the ApplicationContext. When the LoginContext calls the internal CallbackHandler,
  * control is passed to each {@link JaasAuthenticationCallbackHandler} for each Callback
  * passed.
- * </p>
+ *
  * <p>
  * {@link JaasAuthenticationCallbackHandler}s are passed to the JaasAuthenticationProvider
  * through the
@@ -108,7 +106,6 @@ import java.security.Security;
  * &lt;/property&gt;
  * </pre>
  * 
- * </p>
  * <p>
  * After calling LoginContext.login(), the JaasAuthenticationProvider will retrieve the
  * returned Principals from the Subject (LoginContext.getSubject().getPrincipals). Each
@@ -130,10 +127,9 @@ import java.security.Security;
  * </pre>
  * 
  * A configuration note: The JaasAuthenticationProvider uses the security properites
- * &quote;login.config.url.X&quote; to configure jaas. If you would like to customize the
+ * "login.config.url.X" to configure jaas. If you would like to customize the
  * way Jaas gets configured, create a subclass of this and override the
  * {@link #configureJaas(Resource)} method.
- * </p>
  *
  * @author Ray Krueger
  * @author Rob Winch

--- a/core/src/main/java/org/springframework/security/concurrent/DelegatingSecurityContextExecutorService.java
+++ b/core/src/main/java/org/springframework/security/concurrent/DelegatingSecurityContextExecutorService.java
@@ -55,7 +55,7 @@ public class DelegatingSecurityContextExecutorService extends
 	 * Creates a new {@link DelegatingSecurityContextExecutorService} that uses the
 	 * current {@link SecurityContext} from the {@link SecurityContextHolder}.
 	 *
-	 * @param delegateTaskExecutor the {@link TaskExecutor} to delegate to. Cannot be
+	 * @param delegate the {@link ExecutorService} to delegate to. Cannot be
 	 * null.
 	 */
 	public DelegatingSecurityContextExecutorService(ExecutorService delegate) {

--- a/core/src/main/java/org/springframework/security/concurrent/DelegatingSecurityContextRunnable.java
+++ b/core/src/main/java/org/springframework/security/concurrent/DelegatingSecurityContextRunnable.java
@@ -70,13 +70,13 @@ public final class DelegatingSecurityContextRunnable implements Runnable {
 	}
 
 	/**
-	 * Determines if the SecurityContext should be transfered if {@link #call()}
+	 * Determines if the SecurityContext should be transfered if {@link #run()}
 	 * is invoked on the same {@link Thread} the
 	 * {@link DelegatingSecurityContextCallable} was created on.
 	 *
 	 * @param enableOnOriginalThread
 	 *            if false (default), will only transfer the
-	 *            {@link SecurityContext} if {@link #call()} is invoked on a
+	 *            {@link SecurityContext} if {@link #run()} is invoked on a
 	 *            different {@link Thread} than the
 	 *            {@link DelegatingSecurityContextCallable} was created on.
 	 * @since 4.0.2

--- a/core/src/main/java/org/springframework/security/concurrent/DelegatingSecurityContextScheduledExecutorService.java
+++ b/core/src/main/java/org/springframework/security/concurrent/DelegatingSecurityContextScheduledExecutorService.java
@@ -51,7 +51,7 @@ public final class DelegatingSecurityContextScheduledExecutorService extends
 	 * Creates a new {@link DelegatingSecurityContextScheduledExecutorService} that uses
 	 * the current {@link SecurityContext} from the {@link SecurityContextHolder}.
 	 *
-	 * @param delegateTaskExecutor the {@link TaskExecutor} to delegate to. Cannot be
+	 * @param delegate the {@link ScheduledExecutorService} to delegate to. Cannot be
 	 * null.
 	 */
 	public DelegatingSecurityContextScheduledExecutorService(

--- a/core/src/main/java/org/springframework/security/core/annotation/AuthenticationPrincipal.java
+++ b/core/src/main/java/org/springframework/security/core/annotation/AuthenticationPrincipal.java
@@ -30,7 +30,9 @@ import org.springframework.security.core.Authentication;
  * @author Rob Winch
  * @since 4.0
  *
- * @see org.springframework.security.messaging.context.AuthenticationPrincipalArgumentResolver
+ *  See: <a href="{@docRoot}/org/springframework/security/messaging/context/AuthenticationPrincipalArgumentResolver.html">
+ *  AuthenticationPrincipalArgumentResolver
+ *  </a>
  */
 @Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/src/main/java/org/springframework/security/core/parameters/AnnotationParameterNameDiscoverer.java
+++ b/core/src/main/java/org/springframework/security/core/parameters/AnnotationParameterNameDiscoverer.java
@@ -40,7 +40,7 @@ import org.springframework.util.ReflectionUtils;
  * <pre>
  * import org.springframework.security.access.method.P;
  * 
- * @PostAuthorize("#to == returnObject.to")
+ * {@code @PostAuthorize("#to == returnObject.to")}
  * public Message findMessageByTo(@P("to") String to);
  * </pre>
  *
@@ -70,7 +70,7 @@ import org.springframework.util.ReflectionUtils;
  * <pre>
  * import org.springframework.security.access.method.P;
  * 
- * @PostAuthorize("#to == returnObject.to")
+ * {@code @PostAuthorize("#to == returnObject.to")}
  * public Message findMessageByToAndFrom(@P("to") User to, User from);
  * </pre>
  *

--- a/core/src/main/java/org/springframework/security/core/session/SessionRegistryImpl.java
+++ b/core/src/main/java/org/springframework/security/core/session/SessionRegistryImpl.java
@@ -32,9 +32,8 @@ import java.util.concurrent.CopyOnWriteArraySet;
  * SessionDestroyedEvent}s published in the Spring application context.
  * <p>
  * For this class to function correctly in a web application, it is important that you
- * register an {@link org.springframework.security.web.session.HttpSessionEventPublisher
- * HttpSessionEventPublisher} in the <tt>web.xml</tt> file so that this class is notified
- * of sessions that expire.
+ * register an <a href="{@docRoot}/org/springframework/security/web/session/HttpSessionEventPublisher.html">HttpSessionEventPublisher</a>
+ * in the <tt>web.xml</tt> file so that this class is notified of sessions that expire.
  *
  * @author Ben Alex
  * @author Luke Taylor

--- a/core/src/main/java/org/springframework/security/core/token/KeyBasedPersistenceTokenService.java
+++ b/core/src/main/java/org/springframework/security/core/token/KeyBasedPersistenceTokenService.java
@@ -145,7 +145,7 @@ public class KeyBasedPersistenceTokenService implements TokenService, Initializi
 	}
 
 	/**
-	 * @param pseudoRandomNumberBytes changes the number of bytes issued (must be >= 0;
+	 * @param pseudoRandomNumberBytes changes the number of bytes issued (must be &gt;= 0;
 	 * defaults to 256)
 	 */
 	public void setPseudoRandomNumberBytes(int pseudoRandomNumberBytes) {

--- a/core/src/main/java/org/springframework/security/core/token/TokenService.java
+++ b/core/src/main/java/org/springframework/security/core/token/TokenService.java
@@ -38,7 +38,7 @@ public interface TokenService {
 	Token allocateToken(String extendedInformation);
 
 	/**
-	 * Permits verification the <{@link Token#getKey()} was issued by this
+	 * Permits verification the {@link Token#getKey()} was issued by this
 	 * <code>TokenService</code> and reconstructs the corresponding <code>Token</code>.
 	 *
 	 * @param key as obtained from {@link Token#getKey()} and created by this

--- a/core/src/main/java/org/springframework/security/core/userdetails/jdbc/JdbcDaoImpl.java
+++ b/core/src/main/java/org/springframework/security/core/userdetails/jdbc/JdbcDaoImpl.java
@@ -47,7 +47,7 @@ import org.springframework.util.Assert;
  *
  * This table contains the login name, password and enabled status of the user.
  *
- * <table>
+ * <table summary="The Users Table">
  * <tr>
  * <th>Column</th>
  * </tr>
@@ -64,7 +64,7 @@ import org.springframework.util.Assert;
  *
  * <h4>The Authorities Table</h4>
  *
- * <table>
+ * <table summary="The Authorities Table">
  * <tr>
  * <th>Column</th>
  * </tr>

--- a/core/src/main/java/org/springframework/security/core/userdetails/memory/UserAttribute.java
+++ b/core/src/main/java/org/springframework/security/core/userdetails/memory/UserAttribute.java
@@ -23,7 +23,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 /**
- * Used by {@link InMemoryDaoImpl} to temporarily store the attributes associated with a
+ * Used by {@link org.springframework.security.provisioning.InMemoryUserDetailsManager} to temporarily store the attributes associated with a
  * user.
  *
  * @author Ben Alex
@@ -50,7 +50,7 @@ public class UserAttribute {
 	/**
 	 * Set all authorities for this user.
 	 *
-	 * @param authorities {@link List} &lt;{@link GrantedAuthority}>
+	 * @param authorities {@link List} &lt;{@link GrantedAuthority}&gt;
 	 * @since 1.1
 	 */
 	public void setAuthorities(List<GrantedAuthority> authorities) {
@@ -61,7 +61,7 @@ public class UserAttribute {
 	 * Set all authorities for this user from String values. It will create the necessary
 	 * {@link GrantedAuthority} objects.
 	 *
-	 * @param authoritiesAsStrings {@link List} &lt;{@link String}>
+	 * @param authoritiesAsStrings {@link List} &lt;{@link String}&gt;
 	 * @since 1.1
 	 */
 	public void setAuthoritiesAsString(List<String> authoritiesAsStrings) {

--- a/core/src/main/java/org/springframework/security/task/DelegatingSecurityContextTaskExecutor.java
+++ b/core/src/main/java/org/springframework/security/task/DelegatingSecurityContextTaskExecutor.java
@@ -45,7 +45,7 @@ public class DelegatingSecurityContextTaskExecutor extends
 	 * Creates a new {@link DelegatingSecurityContextTaskExecutor} that uses the current
 	 * {@link SecurityContext} from the {@link SecurityContextHolder}.
 	 *
-	 * @param delegateTaskExecutor the {@link TaskExecutor} to delegate to. Cannot be
+	 * @param delegate the {@link TaskExecutor} to delegate to. Cannot be
 	 * null.
 	 */
 	public DelegatingSecurityContextTaskExecutor(TaskExecutor delegate) {

--- a/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCrypt.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCrypt.java
@@ -31,25 +31,25 @@ import java.security.SecureRandom;
  * with a random salt, like this:
  * <p>
  * <code>
- * String pw_hash = BCrypt.hashpw(plain_password, BCrypt.gensalt()); <br />
+ * String pw_hash = BCrypt.hashpw(plain_password, BCrypt.gensalt()); <br>
  * </code>
  * <p>
  * To check whether a plaintext password matches one that has been hashed previously, use
  * the checkpw method:
  * <p>
  * <code>
- * if (BCrypt.checkpw(candidate_password, stored_hash))<br />
- * &nbsp;&nbsp;&nbsp;&nbsp;System.out.println("It matches");<br />
- * else<br />
- * &nbsp;&nbsp;&nbsp;&nbsp;System.out.println("It does not match");<br />
+ * if (BCrypt.checkpw(candidate_password, stored_hash))<br>
+ * &nbsp;&nbsp;&nbsp;&nbsp;System.out.println("It matches");<br>
+ * else<br>
+ * &nbsp;&nbsp;&nbsp;&nbsp;System.out.println("It does not match");<br>
  * </code>
  * <p>
  * The gensalt() method takes an optional parameter (log_rounds) that determines the
  * computational complexity of the hashing:
  * <p>
  * <code>
- * String strong_salt = BCrypt.gensalt(10)<br />
- * String stronger_salt = BCrypt.gensalt(12)<br />
+ * String strong_salt = BCrypt.gensalt(10)<br>
+ * String stronger_salt = BCrypt.gensalt(12)<br>
  * </code>
  * <p>
  * The amount of work increases exponentially (2**log_rounds), so each increment is twice

--- a/data/src/main/java/org/springframework/security/data/repository/query/SecurityEvaluationContextExtension.java
+++ b/data/src/main/java/org/springframework/security/data/repository/query/SecurityEvaluationContextExtension.java
@@ -29,41 +29,39 @@ import java.util.Map;
  * <p>
  * By defining this object as a Bean, Spring Security is exposed as SpEL expressions for
  * creating Spring Data queries.
- * </p>
  *
  * <p>
  * With Java based configuration, we can define the bean using the following:
- * </p>
  *
  * <p>
  * For example, if you return a UserDetails that extends the following User object:
- * </p>
  *
  * <pre>
- * @Entity
+ * &#064;Entity
  * public class User {
- *     @GeneratedValue(strategy = GenerationType.AUTO)
- *     @Id
+ *     &#064;GeneratedValue(strategy = GenerationType.AUTO)
+ *     &#064;Id
  *     private Long id;
  * 
  *     ...
+ * }
  * </pre>
  *
  * <p>
  * And you have a Message object that looks like the following:
- * </p>
  *
  * <pre>
- * @Entity
+ * &#064;Entity
  * public class Message {
- *     @Id
- *     @GeneratedValue(strategy = GenerationType.AUTO)
+ *     &#064;Id
+ *     &#064;GeneratedValue(strategy = GenerationType.AUTO)
  *     private Long id;
  * 
- *     @OneToOne
+ *     &#064;OneToOne
  *     private User to;
  * 
  *     ...
+ * }
  * </pre>
  *
  * You can use the following {@code Query} annotation to search for only messages that are

--- a/ldap/src/main/java/org/springframework/security/ldap/DefaultSpringSecurityContextSource.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/DefaultSpringSecurityContextSource.java
@@ -40,7 +40,7 @@ public class DefaultSpringSecurityContextSource extends LdapContextSource {
 	 * you want to use more than one server for fail-over, rather use the
 	 * {@link #DefaultSpringSecurityContextSource(List, String)} constructor.
 	 *
-	 * @param providerUrl an LDAP URL of the form <code>ldap://localhost:389/base_dn<code>
+	 * @param providerUrl an LDAP URL of the form <code>ldap://localhost:389/base_dn</code>
 	 */
 	public DefaultSpringSecurityContextSource(String providerUrl) {
 		Assert.hasLength(providerUrl, "An LDAP connection URL must be supplied.");

--- a/ldap/src/main/java/org/springframework/security/ldap/search/LdapUserSearch.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/search/LdapUserSearch.java
@@ -22,8 +22,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
  * Obtains a user's information from the LDAP directory given a login name.
  * <p>
  * May be optionally used to configure the LDAP authentication implementation when a more
- * sophisticated approach is required than just using a simple username->DN mapping.
- * </p>
+ * sophisticated approach is required than just using a simple username-&gt;DN mapping.
  *
  * @author Luke Taylor
  */

--- a/ldap/src/main/java/org/springframework/security/ldap/userdetails/DefaultLdapAuthoritiesPopulator.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/userdetails/DefaultLdapAuthoritiesPopulator.java
@@ -75,15 +75,15 @@ import java.util.Set;
  *
  * <pre>
  * &lt;bean id="ldapAuthoritiesPopulator"
- *       class="org.springframework.security.ldap.userdetails.DefaultLdapAuthoritiesPopulator">
- *   &lt;constructor-arg ref="contextSource"/>
- *   &lt;constructor-arg value="ou=groups"/>
- *   &lt;property name="groupRoleAttribute" value="ou"/>
- * &lt;!-- the following properties are shown with their default values -->
- *   &lt;property name="searchSubtree" value="false"/>
- *   &lt;property name="rolePrefix" value="ROLE_"/>
- *   &lt;property name="convertToUpperCase" value="true"/>
- * &lt;/bean>
+ *       class="org.springframework.security.ldap.userdetails.DefaultLdapAuthoritiesPopulator"&gt;
+ *   &lt;constructor-arg ref="contextSource"/&gt;
+ *   &lt;constructor-arg value="ou=groups"/&gt;
+ *   &lt;property name="groupRoleAttribute" value="ou"/&gt;
+ * &lt;!-- the following properties are shown with their default values --&gt;
+ *   &lt;property name="searchSubtree" value="false"/&gt;
+ *   &lt;property name="rolePrefix" value="ROLE_"/&gt;
+ *   &lt;property name="convertToUpperCase" value="true"/&gt;
+ * &lt;/bean&gt;
  * </pre>
  *
  * A search for roles for user "uid=ben,ou=people,dc=springframework,dc=org" would return
@@ -292,7 +292,7 @@ public class DefaultLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
 
 	/**
 	 * Sets the prefix which will be prepended to the values loaded from the directory.
-	 * Defaults to "ROLE_" for compatibility with <tt>RoleVoter/tt>.
+	 * Defaults to "ROLE_" for compatibility with <tt>RoleVoter</tt>.
 	 */
 	public void setRolePrefix(String rolePrefix) {
 		Assert.notNull(rolePrefix, "rolePrefix must not be null");
@@ -326,7 +326,7 @@ public class DefaultLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
 	 * Returns the current LDAP template. Method available so that classes extending this
 	 * can override the template used
 	 * @return the LDAP template
-	 * @see {@link org.springframework.security.ldap.SpringSecurityLdapTemplate}
+	 * @see org.springframework.security.ldap.SpringSecurityLdapTemplate
 	 */
 	protected SpringSecurityLdapTemplate getLdapTemplate() {
 		return ldapTemplate;
@@ -336,7 +336,7 @@ public class DefaultLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
 	 * Returns the attribute name of the LDAP attribute that will be mapped to the role
 	 * name Method available so that classes extending this can override
 	 * @return the attribute name used for role mapping
-	 * @see {@link #setGroupRoleAttribute(String)}
+	 * @see #setGroupRoleAttribute(String)
 	 */
 	protected final String getGroupRoleAttribute() {
 		return groupRoleAttribute;
@@ -346,7 +346,7 @@ public class DefaultLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
 	 * Returns the search filter configured for this populator Method available so that
 	 * classes extending this can override
 	 * @return the search filter
-	 * @see {@link #setGroupSearchFilter(String)}
+	 * @see #setGroupSearchFilter(String)
 	 */
 	protected final String getGroupSearchFilter() {
 		return groupSearchFilter;
@@ -356,7 +356,7 @@ public class DefaultLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
 	 * Returns the role prefix used by this populator Method available so that classes
 	 * extending this can override
 	 * @return the role prefix
-	 * @see {@link #setRolePrefix(String)}
+	 * @see #setRolePrefix(String)
 	 */
 	protected final String getRolePrefix() {
 		return rolePrefix;
@@ -366,7 +366,7 @@ public class DefaultLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
 	 * Returns true if role names are converted to uppercase Method available so that
 	 * classes extending this can override
 	 * @return true if role names are converted to uppercase.
-	 * @see {@link #setConvertToUpperCase(boolean)}
+	 * @see #setConvertToUpperCase(boolean)
 	 */
 	protected final boolean isConvertToUpperCase() {
 		return convertToUpperCase;
@@ -376,7 +376,7 @@ public class DefaultLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
 	 * Returns the default role Method available so that classes extending this can
 	 * override
 	 * @return the default role used
-	 * @see {@link #setDefaultRole(String)}
+	 * @see #setDefaultRole(String)
 	 */
 	private GrantedAuthority getDefaultRole() {
 		return defaultRole;

--- a/ldap/src/main/java/org/springframework/security/ldap/userdetails/NestedLdapAuthoritiesPopulator.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/userdetails/NestedLdapAuthoritiesPopulator.java
@@ -110,9 +110,6 @@ import java.util.*;
  *  ou: jdeveloper
  *  member: uid=scaladude,ou=people,dc=springframework,dc=org *
  * </pre>
- * 
- * </pre>
- * </p>
  *
  * @author Filip Hanik
  */

--- a/messaging/src/main/java/org/springframework/security/messaging/access/expression/ExpressionBasedMessageSecurityMetadataSourceFactory.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/access/expression/ExpressionBasedMessageSecurityMetadataSourceFactory.java
@@ -45,7 +45,7 @@ public final class ExpressionBasedMessageSecurityMetadataSourceFactory {
 	 * For example:
 	 *
 	 * <pre>
-	 *     LinkedHashMap<MessageMatcher<?> matcherToExpression = new LinkedHashMap<MessageMatcher<Object>();
+	 *     LinkedHashMap&lt;MessageMatcher&lt;?&gt;,String&gt; matcherToExpression = new LinkedHashMap&lt;MessageMatcher&lt;Object&gt;,String&gt;();
 	 *     matcherToExpression.put(new SimDestinationMessageMatcher("/public/**"), "permitAll");
 	 *     matcherToExpression.put(new SimDestinationMessageMatcher("/admin/**"), "hasRole('ROLE_ADMIN')");
 	 *     matcherToExpression.put(new SimDestinationMessageMatcher("/**"), "authenticated");
@@ -57,11 +57,9 @@ public final class ExpressionBasedMessageSecurityMetadataSourceFactory {
 	 * If our destination is "/public/hello", it would match on "/public/**" and on "/**".
 	 * However, only "/public/**" would be used since it is the first entry. That means
 	 * that a destination of "/public/hello" will be mapped to "permitAll".
-	 * </p>
 	 *
 	 * <p>
 	 * For a complete listing of expressions see {@link MessageSecurityExpressionRoot}
-	 * </p>
 	 *
 	 * @param matcherToExpression an ordered mapping of {@link MessageMatcher} to Strings
 	 * that are turned into an Expression using
@@ -81,7 +79,7 @@ public final class ExpressionBasedMessageSecurityMetadataSourceFactory {
 	 * For example:
 	 *
 	 * <pre>
-	 *     LinkedHashMap<MessageMatcher<?> matcherToExpression = new LinkedHashMap<MessageMatcher<Object>();
+	 *     LinkedHashMap&lt;MessageMatcher&lt;?&gt;,String&gt; matcherToExpression = new LinkedHashMap&lt;MessageMatcher&lt;Object&gt;,String&gt;();
 	 *     matcherToExpression.put(new SimDestinationMessageMatcher("/public/**"), "permitAll");
 	 *     matcherToExpression.put(new SimDestinationMessageMatcher("/admin/**"), "hasRole('ROLE_ADMIN')");
 	 *     matcherToExpression.put(new SimDestinationMessageMatcher("/**"), "authenticated");

--- a/messaging/src/main/java/org/springframework/security/messaging/access/intercept/ChannelSecurityInterceptor.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/access/intercept/ChannelSecurityInterceptor.java
@@ -30,12 +30,10 @@ import org.springframework.util.Assert;
  * <p>
  * The <code>SecurityMetadataSource</code> required by this security interceptor is of
  * type {@link MessageSecurityMetadataSource}.
- * </p>
  * <p>
  * Refer to {@link AbstractSecurityInterceptor} for details on the workflow.
- * </p>
  *
- * @see 4.0
+ * @since 4.0
  * @author Rob Winch
  */
 public final class ChannelSecurityInterceptor extends AbstractSecurityInterceptor

--- a/messaging/src/main/java/org/springframework/security/messaging/context/AuthenticationPrincipalArgumentResolver.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/context/AuthenticationPrincipalArgumentResolver.java
@@ -32,12 +32,13 @@ import org.springframework.stereotype.Controller;
  * {@link Controller}:
  *
  * <pre>
- * @Controller
+ * &#64;Controller
  * public class MyController {
- *     @MessageMapping("/im")
+ *     &#64;MessageMapping("/im")
  *     public void im(@AuthenticationPrincipal CustomUser customUser) {
  *         // do something with CustomUser
  *     }
+ * }
  * </pre>
  *
  * <p>
@@ -47,11 +48,9 @@ import org.springframework.stereotype.Controller;
  * match, null will be returned unless
  * {@link AuthenticationPrincipal#errorOnInvalidType()} is true in which case a
  * {@link ClassCastException} will be thrown.
- * </p>
  *
  * <p>
  * Alternatively, users can create a custom meta annotation as shown below:
- * </p>
  *
  * <pre>
  * &#064;Target({ ElementType.PARAMETER })
@@ -63,15 +62,15 @@ import org.springframework.stereotype.Controller;
  *
  * <p>
  * The custom annotation can then be used instead. For example:
- * </p>
  *
  * <pre>
- * @Controller
+ * &#64;Controller
  * public class MyController {
- *     @MessageMapping("/im")
+ *     &#64;MessageMapping("/im")
  *     public void im(@CurrentUser CustomUser customUser) {
  *         // do something with CustomUser
  *     }
+ * }
  * </pre>
  *
  * @author Rob Winch

--- a/messaging/src/main/java/org/springframework/security/messaging/util/matcher/SimpDestinationMessageMatcher.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/util/matcher/SimpDestinationMessageMatcher.java
@@ -55,7 +55,6 @@ public final class SimpDestinationMessageMatcher implements MessageMatcher<Objec
 	 * Creates a new instance with the specified pattern, null {@link SimpMessageType}
 	 * (matches any type), and a {@link AntPathMatcher} created from the default
 	 * constructor.
-	 * </p>
 	 *
 	 * <p>
 	 * The mapping matches destinations despite the using the following rules:
@@ -87,7 +86,6 @@ public final class SimpDestinationMessageMatcher implements MessageMatcher<Objec
 	/**
 	 * <p>
 	 * Creates a new instance with the specified pattern and {@link PathMatcher}.
-	 * </p>
 	 *
 	 * @param pattern the pattern to use
 	 * @param pathMatcher the {@link PathMatcher} to use.
@@ -100,7 +98,6 @@ public final class SimpDestinationMessageMatcher implements MessageMatcher<Objec
 	 * <p>
 	 * Creates a new instance with the specified pattern, {@link SimpMessageType}, and
 	 * {@link PathMatcher}.
-	 * </p>
 	 *
 	 * @param pattern the pattern to use
 	 * @param type the {@link SimpMessageType} to match on or null if any
@@ -155,10 +152,9 @@ public final class SimpDestinationMessageMatcher implements MessageMatcher<Objec
 	 * <p>
 	 * Creates a new instance with the specified pattern,
 	 * {@code SimpMessageType.SUBSCRIBE}, and {@link PathMatcher}.
-	 * </p>
 	 *
 	 * @param pattern the pattern to use
-	 * @param pathMatcher the {@link PathMatcher} to use.
+	 * @param matcher the {@link PathMatcher} to use.
 	 */
 	public static SimpDestinationMessageMatcher createSubscribeMatcher(String pattern,
 			PathMatcher matcher) {
@@ -170,10 +166,9 @@ public final class SimpDestinationMessageMatcher implements MessageMatcher<Objec
 	 * <p>
 	 * Creates a new instance with the specified pattern, {@code SimpMessageType.MESSAGE},
 	 * and {@link PathMatcher}.
-	 * </p>
 	 *
 	 * @param pattern the pattern to use
-	 * @param pathMatcher the {@link PathMatcher} to use.
+	 * @param matcher the {@link PathMatcher} to use.
 	 */
 	public static SimpDestinationMessageMatcher createMessageMatcher(String pattern,
 			PathMatcher matcher) {

--- a/openid/src/main/java/org/springframework/security/openid/OpenIDAuthenticationFilter.java
+++ b/openid/src/main/java/org/springframework/security/openid/OpenIDAuthenticationFilter.java
@@ -246,17 +246,17 @@ public class OpenIDAuthenticationFilter extends AbstractAuthenticationProcessing
 
 	/**
 	 * Maps the <tt>return_to url</tt> to a realm, for example:
-	 * 
+	 *
 	 * <pre>
-	 * http://www.example.com/login/openid -> http://www.example.com/realm</tt>
+	 * http://www.example.com/login/openid -&gt; http://www.example.com/realm
 	 * </pre>
-	 * 
+	 *
 	 * If no mapping is provided then the returnToUrl will be parsed to extract the
 	 * protocol, hostname and port followed by a trailing slash. This means that
 	 * <tt>http://www.example.com/login/openid</tt> will automatically become
 	 * <tt>http://www.example.com:80/</tt>
 	 *
-	 * @param realmMapping containing returnToUrl -> realm mappings
+	 * @param realmMapping containing returnToUrl -&gt; realm mappings
 	 */
 	public void setRealmMapping(Map<String, String> realmMapping) {
 		this.realmMapping = realmMapping;

--- a/remoting/src/main/java/org/springframework/security/remoting/dns/DnsResolver.java
+++ b/remoting/src/main/java/org/springframework/security/remoting/dns/DnsResolver.java
@@ -39,12 +39,11 @@ public interface DnsResolver {
 	/**
 	 * <p>
 	 * Resolves the host name for the specified service in the specified domain
-	 * </p>
+	 *
 	 * <p>
 	 * For example, if you need the host name for an LDAP server running in the domain
 	 * springsource.com, you would call <b>resolveServiceEntry("ldap",
 	 * "springsource.com")</b>.
-	 * </p>
 	 *
 	 * <p>
 	 * The DNS server needs to provide the service records for this, in the example above,
@@ -59,7 +58,6 @@ public interface DnsResolver {
 	 * priority, it will return the one with the highest weight. You will find more
 	 * informatione about DNS service records at <a
 	 * href="http://en.wikipedia.org/wiki/SRV_record">Wikipedia</a>.
-	 * </p>
 	 *
 	 * @param serviceType The service type you are searching for, e.g. ldap, kerberos, ...
 	 * @param domain The domain, in which you are searching for the service

--- a/samples/servletapi-xml/src/main/java/org/springframework/security/samples/servletapi/mvc/ServletApiController.java
+++ b/samples/servletapi-xml/src/main/java/org/springframework/security/samples/servletapi/mvc/ServletApiController.java
@@ -41,7 +41,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
  * {@link HttpServletRequest#authenticate(HttpServletResponse)}</li>
  * <li>{@link #login(HttpServletRequest, HttpServletResponse, LoginForm, BindingResult)} -
  * Integration with {@link HttpServletRequest#login(String, String)}</li>
- * <li>{@link #logout(HttpServletRequest, HttpServletResponse)} - Integration with
+ * <li>{@link #logout(HttpServletRequest, HttpServletResponse, RedirectAttributes)} - Integration with
  * {@link HttpServletRequest#logout()}</li>
  * <li>{@link #remoteUser(HttpServletRequest)} - Integration with
  * {@link HttpServletRequest#getRemoteUser()}</li>

--- a/taglibs/src/main/java/org/springframework/security/taglibs/authz/AbstractAuthorizeTag.java
+++ b/taglibs/src/main/java/org/springframework/security/taglibs/authz/AbstractAuthorizeTag.java
@@ -45,7 +45,7 @@ import org.springframework.web.context.support.WebApplicationContextUtils;
  * technology (JSP, Facelets). It treats tag attributes as simple strings rather than
  * strings that may contain expressions with the exception of the "access" attribute,
  * which is always expected to contain a Spring EL expression.
- * <p/>
+ * <p>
  * Subclasses are expected to extract tag attribute values from the specific rendering
  * technology, evaluate them as expressions if necessary, and set the String-based
  * attributes of this class.

--- a/test/src/main/java/org/springframework/security/test/context/support/WithUserDetails.java
+++ b/test/src/main/java/org/springframework/security/test/context/support/WithUserDetails.java
@@ -40,9 +40,7 @@ import org.springframework.test.web.servlet.MockMvc;
  * <li>The {@link SecurityContext} created with be that of
  * {@link SecurityContextHolder#createEmptyContext()}</li>
  * <li>It will be populated with an {@link UsernamePasswordAuthenticationToken} that uses
- * the username of either {@link #value()} or {@link #username()},
- * {@link GrantedAuthority} that are specified by {@link #roles()}, and a password
- * specified by {@link #password()}.
+ * the username of {@link #value()}.
  * </ul>
  *
  * @see WithMockUser

--- a/test/src/main/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessors.java
+++ b/test/src/main/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessors.java
@@ -168,7 +168,7 @@ public final class SecurityMockMvcRequestPostProcessors {
 	 * for the {@link Authentication#getPrincipal()} and a custom {@link UserDetails}. All
 	 * details are declarative and do not require that the user actually exists.
 	 *
-	 * @param user the UserDetails to populate
+	 * @param authentication the Authentication to populate
 	 * @return the {@link RequestPostProcessor} to use
 	 */
 	public static RequestPostProcessor authentication(Authentication authentication) {
@@ -635,10 +635,10 @@ public final class SecurityMockMvcRequestPostProcessors {
 		 * {@link #authorities(GrantedAuthority...)}, but just not as flexible.
 		 *
 		 * @param roles The roles to populate. Note that if the role does not start with
-		 * {@link #rolePrefix(String)} it will automatically be prepended. This means by
+		 * {@link #ROLE_PREFIX} it will automatically be prepended. This means by
 		 * default {@code roles("ROLE_USER")} and {@code roles("USER")} are equivalent.
 		 * @see #authorities(GrantedAuthority...)
-		 * @see #rolePrefix(String)
+		 * @see #ROLE_PREFIX
 		 * @return the UserRequestPostProcessor for further customizations
 		 */
 		public UserRequestPostProcessor roles(String... roles) {

--- a/test/src/main/java/org/springframework/security/test/web/servlet/response/SecurityMockMvcResultMatchers.java
+++ b/test/src/main/java/org/springframework/security/test/web/servlet/response/SecurityMockMvcResultMatchers.java
@@ -202,7 +202,7 @@ public final class SecurityMockMvcResultMatchers {
 		/**
 		 * Specifies the {@link Authentication#getAuthorities()}
 		 *
-		 * @param expected the roles. Each value is automatically prefixed with "ROLE_"
+		 * @param roles the roles. Each value is automatically prefixed with "ROLE_"
 		 * @return the {@link AuthenticatedMatcher} for further customization
 		 */
 		public AuthenticatedMatcher withRoles(String... roles) {

--- a/test/src/main/java/org/springframework/security/test/web/support/WebTestUtils.java
+++ b/test/src/main/java/org/springframework/security/test/web/support/WebTestUtils.java
@@ -69,8 +69,6 @@ public abstract class WebTestUtils {
 	 * @param request the {@link HttpServletRequest} to obtain the
 	 * {@link SecurityContextRepository}
 	 * @param securityContextRepository the {@link SecurityContextRepository} to set
-	 * @return the {@link SecurityContextRepository} for the specified
-	 * {@link HttpServletRequest}
 	 */
 	public static void setSecurityContextRepository(HttpServletRequest request,
 			SecurityContextRepository securityContextRepository) {

--- a/web/src/main/java/org/springframework/security/web/FilterChainProxy.java
+++ b/web/src/main/java/org/springframework/security/web/FilterChainProxy.java
@@ -59,14 +59,14 @@ import java.util.*;
  * requests which match the pattern. An example configuration might look like this:
  *
  * <pre>
- *  &lt;bean id="myfilterChainProxy" class="org.springframework.security.util.FilterChainProxy">
- *      &lt;constructor-arg>
- *          &lt;util:list>
- *              &lt;security:filter-chain pattern="/do/not/filter*" filters="none"/>
- *              &lt;security:filter-chain pattern="/**" filters="filter1,filter2,filter3"/>
- *          &lt;/util:list>
- *      &lt;/constructor-arg>
- *  &lt;/bean>
+ *  &lt;bean id="myfilterChainProxy" class="org.springframework.security.util.FilterChainProxy"&gt;
+ *      &lt;constructor-arg&gt;
+ *          &lt;util:list&gt;
+ *              &lt;security:filter-chain pattern="/do/not/filter*" filters="none"/&gt;
+ *              &lt;security:filter-chain pattern="/**" filters="filter1,filter2,filter3"/&gt;
+ *          &lt;/util:list&gt;
+ *      &lt;/constructor-arg&gt;
+ *  &lt;/bean&gt;
  * </pre>
  *
  * The names "filter1", "filter2", "filter3" should be the bean names of {@code Filter}

--- a/web/src/main/java/org/springframework/security/web/PortMapperImpl.java
+++ b/web/src/main/java/org/springframework/security/web/PortMapperImpl.java
@@ -50,7 +50,7 @@ public class PortMapperImpl implements PortMapper {
 	// ========================================================================================================
 
 	/**
-	 * Returns the translated (Integer -> Integer) version of the original port mapping
+	 * Returns the translated (Integer -&gt; Integer) version of the original port mapping
 	 * specified via setHttpsPortMapping()
 	 */
 	public Map<Integer, Integer> getTranslatedPortMappings() {
@@ -77,12 +77,12 @@ public class PortMapperImpl implements PortMapper {
 	 * like this:
 	 * 
 	 * <pre>
-	 *  &lt;property name="portMappings">
-	 *      &lt;map>
-	 *          &lt;entry key="80">&lt;value>443&lt;/value>&lt;/entry>
-	 *          &lt;entry key="8080">&lt;value>8443&lt;/value>&lt;/entry>
-	 *      &lt;/map>
-	 * &lt;/property>
+	 *  &lt;property name="portMappings"&gt;
+	 *      &lt;map&gt;
+	 *          &lt;entry key="80"&gt;&lt;value&gt;443&lt;/value&gt;&lt;/entry&gt;
+	 *          &lt;entry key="8080"&gt;&lt;value&gt;8443&lt;/value&gt;&lt;/entry&gt;
+	 *      &lt;/map&gt;
+	 * &lt;/property&gt;
 	 * </pre>
 	 *
 	 * @param newMappings A Map consisting of String keys and String values, where for

--- a/web/src/main/java/org/springframework/security/web/access/channel/ChannelProcessingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/access/channel/ChannelProcessingFilter.java
@@ -50,30 +50,30 @@ import org.springframework.web.filter.GenericFilterBean;
  * 
  * <pre>
  *
- * &lt;bean id="channelProcessingFilter" class="org.springframework.security.web.access.channel.ChannelProcessingFilter">
- *   &lt;property name="channelDecisionManager" ref="channelDecisionManager"/>
- *   &lt;property name="securityMetadataSource">
- *     &lt;security:filter-security-metadata-source request-matcher="regex">
- *       &lt;security:intercept-url pattern="\A/secure/.*\Z" access="REQUIRES_SECURE_CHANNEL"/>
- *       &lt;security:intercept-url pattern="\A/login.jsp.*\Z" access="REQUIRES_SECURE_CHANNEL"/>
- *       &lt;security:intercept-url pattern="\A/.*\Z" access="ANY_CHANNEL"/>
- *     &lt;/security:filter-security-metadata-source>
- *   &lt;/property>
- * &lt;/bean>
+ * &lt;bean id="channelProcessingFilter" class="org.springframework.security.web.access.channel.ChannelProcessingFilter"&gt;
+ *   &lt;property name="channelDecisionManager" ref="channelDecisionManager"/&gt;
+ *   &lt;property name="securityMetadataSource"&gt;
+ *     &lt;security:filter-security-metadata-source request-matcher="regex"&gt;
+ *       &lt;security:intercept-url pattern="\A/secure/.*\Z" access="REQUIRES_SECURE_CHANNEL"/&gt;
+ *       &lt;security:intercept-url pattern="\A/login.jsp.*\Z" access="REQUIRES_SECURE_CHANNEL"/&gt;
+ *       &lt;security:intercept-url pattern="\A/.*\Z" access="ANY_CHANNEL"/&gt;
+ *     &lt;/security:filter-security-metadata-source&gt;
+ *   &lt;/property&gt;
+ * &lt;/bean&gt;
  * 
- * &lt;bean id="channelDecisionManager" class="org.springframework.security.web.access.channel.ChannelDecisionManagerImpl">
- *   &lt;property name="channelProcessors">
- *     &lt;list>
- *     &lt;ref bean="secureChannelProcessor"/>
- *     &lt;ref bean="insecureChannelProcessor"/>
- *     &lt;/list>
- *   &lt;/property>
- * &lt;/bean>
+ * &lt;bean id="channelDecisionManager" class="org.springframework.security.web.access.channel.ChannelDecisionManagerImpl"&gt;
+ *   &lt;property name="channelProcessors"&gt;
+ *     &lt;list&gt;
+ *     &lt;ref bean="secureChannelProcessor"/&gt;
+ *     &lt;ref bean="insecureChannelProcessor"/&gt;
+ *     &lt;/list&gt;
+ *   &lt;/property&gt;
+ * &lt;/bean&gt;
  * 
  * &lt;bean id="secureChannelProcessor"
- *   class="org.springframework.security.web.access.channel.SecureChannelProcessor"/>
+ *   class="org.springframework.security.web.access.channel.SecureChannelProcessor"/&gt;
  * &lt;bean id="insecureChannelProcessor"
- *   class="org.springframework.security.web.access.channel.InsecureChannelProcessor"/>
+ *   class="org.springframework.security.web.access.channel.InsecureChannelProcessor"/&gt;
  * 
  * </pre>
  * 

--- a/web/src/main/java/org/springframework/security/web/access/expression/DefaultWebSecurityExpressionHandler.java
+++ b/web/src/main/java/org/springframework/security/web/access/expression/DefaultWebSecurityExpressionHandler.java
@@ -46,8 +46,8 @@ public class DefaultWebSecurityExpressionHandler extends
 
 	/**
 	 * <p>
-	 * Sets the default prefix to be added to {@link #hasAnyRole(String...)} or
-	 * {@link #hasRole(String)}. For example, if hasRole("ADMIN") or hasRole("ROLE_ADMIN")
+	 * Sets the default prefix to be added to {@link org.springframework.security.access.expression.SecurityExpressionRoot#hasAnyRole(String...)} or
+	 * {@link org.springframework.security.access.expression.SecurityExpressionRoot#hasRole(String)}. For example, if hasRole("ADMIN") or hasRole("ROLE_ADMIN")
 	 * is passed in, then the role ROLE_ADMIN will be used when the defaultRolePrefix is
 	 * "ROLE_" (default).
 	 * </p>

--- a/web/src/main/java/org/springframework/security/web/authentication/SavedRequestAwareAuthenticationSuccessHandler.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/SavedRequestAwareAuthenticationSuccessHandler.java
@@ -10,15 +10,14 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.access.ExceptionTranslationFilter;
-import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
-import org.springframework.security.web.savedrequest.RequestCache;
-import org.springframework.security.web.savedrequest.SavedRequest;
-import org.springframework.security.web.savedrequest.DefaultSavedRequest;
 import org.springframework.util.StringUtils;
+import org.springframework.security.web.savedrequest.SavedRequest;
+import org.springframework.security.web.savedrequest.RequestCache;
+import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
 
 /**
  * An authentication success strategy which can make use of the
- * {@link DefaultSavedRequest} which may have been stored in the session by the
+ * {@link org.springframework.security.web.savedrequest.DefaultSavedRequest} which may have been stored in the session by the
  * {@link ExceptionTranslationFilter}. When such a request is intercepted and requires
  * authentication, the request data is stored to record the original destination before
  * the authentication process commenced, and to allow the request to be reconstructed when
@@ -36,15 +35,15 @@ import org.springframework.util.StringUtils;
  * If the {@code targetUrlParameter} has been set on the request, the value will be used
  * as the destination. Any {@code DefaultSavedRequest} will again be removed.</li>
  * <li>
- * If a {@link SavedRequest} is found in the {@code RequestCache} (as set by the
+ * If a {@link org.springframework.security.web.savedrequest.SavedRequest} is found in the {@code RequestCache} (as set by the
  * {@link ExceptionTranslationFilter} to record the original destination before the
  * authentication process commenced), a redirect will be performed to the Url of that
  * original destination. The {@code SavedRequest} object will remain cached and be picked
  * up when the redirected request is received (See
- * {@link org.springframework.security.web.savedrequest.SavedRequestAwareWrapper
- * SavedRequestAwareWrapper}).</li>
+ * <a href="{@docRoot}/org/springframework/security/web/savedrequest/SavedRequestAwareWrapper.html">SavedRequestAwareWrapper</a>).
+ * </li>
  * <li>
- * If no {@code SavedRequest} is found, it will delegate to the base class.</li>
+ * If no {@link org.springframework.security.web.savedrequest.SavedRequest} is found, it will delegate to the base class.</li>
  * </ul>
  *
  * @author Luke Taylor

--- a/web/src/main/java/org/springframework/security/web/authentication/session/ChangeSessionIdAuthenticationStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/session/ChangeSessionIdAuthenticationStrategy.java
@@ -23,7 +23,7 @@ import javax.servlet.http.HttpSession;
 import org.springframework.util.ReflectionUtils;
 
 /**
- * Uses {@link HttpServletRequest#changeSessionId()} to protect against session fixation
+ * Uses {@code HttpServletRequest.changeSessionId()} to protect against session fixation
  * attacks. This is the default implementation for Servlet 3.1+.
  *
  * @author Rob Winch

--- a/web/src/main/java/org/springframework/security/web/authentication/session/RegisterSessionAuthenticationStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/session/RegisterSessionAuthenticationStrategy.java
@@ -16,13 +16,12 @@ import org.springframework.util.Assert;
  * {@link RegisterSessionAuthenticationStrategy} is typically used in combination with
  * {@link CompositeSessionAuthenticationStrategy} and
  * {@link ConcurrentSessionControlAuthenticationStrategy}, but can be used on its own if
- * tracking of sessions is desired but no need to control concurrency.</P
+ * tracking of sessions is desired but no need to control concurrency.
  *
  * <p>
  * NOTE: When using a {@link SessionRegistry} it is important that all sessions (including
  * timed out sessions) are removed. This is typically done by adding
  * {@link HttpSessionEventPublisher}.
- * </p>
  *
  * @see CompositeSessionAuthenticationStrategy
  *

--- a/web/src/main/java/org/springframework/security/web/authentication/session/SessionFixationProtectionStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/session/SessionFixationProtectionStrategy.java
@@ -27,7 +27,7 @@ import javax.servlet.http.HttpSession;
 import org.springframework.util.Assert;
 
 /**
- * The default implementation of {@link SessionAuthenticationStrategy} when using <
+ * The default implementation of {@link SessionAuthenticationStrategy} when using &lt;
  * Servlet 3.1.
  * <p>
  * Creates a new session for the newly authenticated user if they already have a session

--- a/web/src/main/java/org/springframework/security/web/authentication/switchuser/SwitchUserFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/switchuser/SwitchUserFilter.java
@@ -92,12 +92,12 @@ import org.springframework.web.filter.GenericFilterBean;
  * correct constraints to the <tt>switchUserUrl</tt>. Example:
  * 
  * <pre>
- * &lt;bean id="switchUserProcessingFilter" class="org.springframework.security.web.authentication.switchuser.SwitchUserFilter">
- *    &lt;property name="userDetailsService" ref="userDetailsService" />
- *    &lt;property name="switchUserUrl" value="/login/impersonate" />
- *    &lt;property name="exitUserUrl" value="/logout/impersonate" />
- *    &lt;property name="targetUrl" value="/index.jsp" />
- * &lt;/bean>
+ * &lt;bean id="switchUserProcessingFilter" class="org.springframework.security.web.authentication.switchuser.SwitchUserFilter"&gt;
+ *    &lt;property name="userDetailsService" ref="userDetailsService" /&gt;
+ *    &lt;property name="switchUserUrl" value="/login/impersonate" /&gt;
+ *    &lt;property name="exitUserUrl" value="/logout/impersonate" /&gt;
+ *    &lt;property name="targetUrl" value="/index.jsp" /&gt;
+ * &lt;/bean&gt;
  * </pre>
  *
  * @author Mark St.Godard

--- a/web/src/main/java/org/springframework/security/web/bind/support/AuthenticationPrincipalArgumentResolver.java
+++ b/web/src/main/java/org/springframework/security/web/bind/support/AuthenticationPrincipalArgumentResolver.java
@@ -34,13 +34,14 @@ import org.springframework.web.method.support.ModelAndViewContainer;
  * {@link Controller}:
  *
  * <pre>
- * @Controller
+ * &#64;Controller
  * public class MyController {
- *     @RequestMapping("/user/current/show")
+ *     &#64;RequestMapping("/user/current/show")
  *     public String show(@AuthenticationPrincipal CustomUser customUser) {
  *         // do something with CustomUser
  *         return "view";
  *     }
+ * }
  * </pre>
  *
  * <p>
@@ -50,11 +51,9 @@ import org.springframework.web.method.support.ModelAndViewContainer;
  * match, null will be returned unless
  * {@link AuthenticationPrincipal#errorOnInvalidType()} is true in which case a
  * {@link ClassCastException} will be thrown.
- * </p>
  *
  * <p>
  * Alternatively, users can create a custom meta annotation as shown below:
- * </p>
  *
  * <pre>
  * &#064;Target({ ElementType.PARAMETER })
@@ -66,16 +65,16 @@ import org.springframework.web.method.support.ModelAndViewContainer;
  *
  * <p>
  * The custom annotation can then be used instead. For example:
- * </p>
  *
  * <pre>
- * @Controller
+ * &#64;Controller
  * public class MyController {
- *     @RequestMapping("/user/current/show")
+ *     &#64;RequestMapping("/user/current/show")
  *     public String show(@CurrentUser CustomUser customUser) {
  *         // do something with CustomUser
  *         return "view";
  *     }
+ * }
  * </pre>
  *
  * @deprecated use org.springframework.security.web.method.annotation.

--- a/web/src/main/java/org/springframework/security/web/context/AbstractSecurityWebApplicationInitializer.java
+++ b/web/src/main/java/org/springframework/security/web/context/AbstractSecurityWebApplicationInitializer.java
@@ -267,7 +267,7 @@ public abstract class AbstractSecurityWebApplicationInitializer implements
 	}
 
 	/**
-	 * Return the <servlet-name> to use the DispatcherServlet's
+	 * Return the &lt;servlet-name&gt; to use the DispatcherServlet's
 	 * {@link WebApplicationContext} to find the {@link DelegatingFilterProxy} or null to
 	 * use the parent {@link ApplicationContext}.
 	 *
@@ -278,7 +278,7 @@ public abstract class AbstractSecurityWebApplicationInitializer implements
 	 * {@link WebApplicationContext}.
 	 * </p>
 	 *
-	 * @return the <servlet-name> of the DispatcherServlet to use its
+	 * @return the &lt;servlet-name&gt; of the DispatcherServlet to use its
 	 * {@link WebApplicationContext} or null (default) to use the parent
 	 * {@link ApplicationContext}.
 	 */

--- a/web/src/main/java/org/springframework/security/web/csrf/InvalidCsrfTokenException.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/InvalidCsrfTokenException.java
@@ -28,7 +28,8 @@ import javax.servlet.http.HttpServletRequest;
 public class InvalidCsrfTokenException extends CsrfException {
 
 	/**
-	 * @param msg
+	 * @param expectedAccessToken
+	 * @param actualAccessToken
 	 */
 	public InvalidCsrfTokenException(CsrfToken expectedAccessToken,
 			String actualAccessToken) {

--- a/web/src/main/java/org/springframework/security/web/header/writers/XXssProtectionHeaderWriter.java
+++ b/web/src/main/java/org/springframework/security/web/header/writers/XXssProtectionHeaderWriter.java
@@ -85,7 +85,7 @@ public final class XXssProtectionHeaderWriter implements HeaderWriter {
 	 * If false, will not specify the mode as blocked. In this instance, any content will
 	 * be attempted to be fixed. If true, the content will be replaced with "#".
 	 *
-	 * @param enabled the new value
+	 * @param block the new value
 	 */
 	public void setBlock(boolean block) {
 		if (!enabled && block) {

--- a/web/src/main/java/org/springframework/security/web/header/writers/frameoptions/RegExpAllowFromStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/header/writers/frameoptions/RegExpAllowFromStrategy.java
@@ -7,7 +7,7 @@ import java.util.regex.Pattern;
 /**
  * Implementation which uses a regular expression to validate the supplied origin. If the
  * value of the HTTP parameter matches the pattern, then the the result will be ALLOW-FROM
- * <paramter-value>.
+ * &lt;paramter-value&gt;.
  *
  * @author Marten Deinum
  * @since 3.2

--- a/web/src/main/java/org/springframework/security/web/header/writers/frameoptions/XFrameOptionsHeaderWriter.java
+++ b/web/src/main/java/org/springframework/security/web/header/writers/frameoptions/XFrameOptionsHeaderWriter.java
@@ -50,7 +50,7 @@ public final class XFrameOptionsHeaderWriter implements HeaderWriter {
 	 *
 	 * @param frameOptionsMode the {@link XFrameOptionsMode} to use. If using
 	 * {@link XFrameOptionsMode#ALLOW_FROM}, use
-	 * {@link #FrameOptionsHeaderWriter(AllowFromStrategy)} instead.
+	 * {@link #XFrameOptionsHeaderWriter(AllowFromStrategy)} instead.
 	 */
 	public XFrameOptionsHeaderWriter(XFrameOptionsMode frameOptionsMode) {
 		Assert.notNull(frameOptionsMode, "frameOptionsMode cannot be null");

--- a/web/src/main/java/org/springframework/security/web/method/annotation/AuthenticationPrincipalArgumentResolver.java
+++ b/web/src/main/java/org/springframework/security/web/method/annotation/AuthenticationPrincipalArgumentResolver.java
@@ -34,12 +34,13 @@ import org.springframework.web.method.support.ModelAndViewContainer;
  * {@link Controller}:
  *
  * <pre>
- * @Controller
+ * &#64;Controller
  * public class MyController {
- *     @MessageMapping("/im")
+ *     &#64;MessageMapping("/im")
  *     public void im(@AuthenticationPrincipal CustomUser customUser) {
  *         // do something with CustomUser
  *     }
+ * }
  * </pre>
  *
  * <p>
@@ -49,11 +50,9 @@ import org.springframework.web.method.support.ModelAndViewContainer;
  * match, null will be returned unless
  * {@link AuthenticationPrincipal#errorOnInvalidType()} is true in which case a
  * {@link ClassCastException} will be thrown.
- * </p>
  *
  * <p>
  * Alternatively, users can create a custom meta annotation as shown below:
- * </p>
  *
  * <pre>
  * &#064;Target({ ElementType.PARAMETER })
@@ -65,15 +64,15 @@ import org.springframework.web.method.support.ModelAndViewContainer;
  *
  * <p>
  * The custom annotation can then be used instead. For example:
- * </p>
  *
  * <pre>
- * @Controller
+ * &#64;Controller
  * public class MyController {
- *     @MessageMapping("/im")
+ *     &#64;MessageMapping("/im")
  *     public void im(@CurrentUser CustomUser customUser) {
  *         // do something with CustomUser
  *     }
+ * }
  * </pre>
  *
  * @author Rob Winch

--- a/web/src/main/java/org/springframework/security/web/savedrequest/SavedRequestAwareWrapper.java
+++ b/web/src/main/java/org/springframework/security/web/savedrequest/SavedRequestAwareWrapper.java
@@ -43,7 +43,6 @@ import org.apache.commons.logging.LogFactory;
  * wrapper. Nevertheless, the important data from the original request is emulated and
  * this should prove adequate for most purposes (in particular standard HTTP GET and POST
  * operations).
- * </p>
  *
  * <p>
  * Added into a request by

--- a/web/src/main/java/org/springframework/security/web/servletapi/SecurityContextHolderAwareRequestFilter.java
+++ b/web/src/main/java/org/springframework/security/web/servletapi/SecurityContextHolderAwareRequestFilter.java
@@ -155,7 +155,7 @@ public class SecurityContextHolderAwareRequestFilter extends GenericFilterBean {
 	 * when invoking {@link HttpServletRequest#logout()}.
 	 * </p>
 	 *
-	 * @param logoutHandlers the {@link List<LogoutHandler>}s when invoking
+	 * @param logoutHandlers the {@code List&lt;LogoutHandler&gt;}s when invoking
 	 * {@link HttpServletRequest#logout()}.
 	 *
 	 * @throws IllegalStateException if the Servlet 3 APIs are not found on the classpath

--- a/web/src/main/java/org/springframework/security/web/util/ThrowableAnalyzer.java
+++ b/web/src/main/java/org/springframework/security/web/util/ThrowableAnalyzer.java
@@ -102,8 +102,11 @@ public class ThrowableAnalyzer {
 	/**
 	 * Initializes associations between <code>Throwable</code>s and
 	 * <code>ThrowableCauseExtractor</code>s. The default implementation performs the
-	 * following registrations: <li>{@link #DEFAULT_EXTRACTOR} for {@link Throwable}</li>
-	 * <li>{@link #INVOCATIONTARGET_EXTRACTOR} for {@link InvocationTargetException}</li> <br>
+	 * following registrations:
+	 * <ul>
+	 * <li>{@link #DEFAULT_EXTRACTOR} for {@link Throwable}</li>
+	 * <li>{@link #INVOCATIONTARGET_EXTRACTOR} for {@link InvocationTargetException}</li>
+	 * </ul><br>
 	 * Subclasses overriding this method are encouraged to invoke the super method to
 	 * perform the default registrations. They can register additional extractors as
 	 * required.


### PR DESCRIPTION
Fixed JavaDoc errors accross multiple modules in order to make javadoc happy with Java 8.

Unsupported close-tags like `</p>` were removed or replaced with `<p>` where appropriate.
Correct parameter references in `@param` doclets.
Fixed unresolvable `@link`doclets by either using the right target if possible or generating a raw html link via `<a href="...">` tags.
Correctly encoded html entities in tags.
Fixed incorrectly closed tags.
Removed old documentation parts that weren't in sync with the actual code / API.

With this change the spring-security project can be build with Java 7 and Java 8 without any errors.