### PR TITLE
Resolves SEC-3066 by handling exception.

### DIFF
--- a/acl/src/main/java/org/springframework/security/acls/AclPermissionCacheOptimizer.java
+++ b/acl/src/main/java/org/springframework/security/acls/AclPermissionCacheOptimizer.java
@@ -10,6 +10,7 @@ import org.springframework.security.access.PermissionCacheOptimizer;
 import org.springframework.security.acls.domain.ObjectIdentityRetrievalStrategyImpl;
 import org.springframework.security.acls.domain.SidRetrievalStrategyImpl;
 import org.springframework.security.acls.model.AclService;
+import org.springframework.security.acls.model.NotFoundException;
 import org.springframework.security.acls.model.ObjectIdentity;
 import org.springframework.security.acls.model.ObjectIdentityRetrievalStrategy;
 import org.springframework.security.acls.model.Sid;
@@ -52,8 +53,11 @@ public class AclPermissionCacheOptimizer implements PermissionCacheOptimizer {
 		if (logger.isDebugEnabled()) {
 			logger.debug("Eagerly loading Acls for " + oidsToCache.size() + " objects");
 		}
-
-		aclService.readAclsById(oidsToCache, sids);
+		try {
+			aclService.readAclsById(oidsToCache, sids);
+		} catch (NotFoundException nfe) {
+			logger.debug("Not all ACLs are present for the listed oids");
+		}
 	}
 
 	public void setObjectIdentityRetrievalStrategy(


### PR DESCRIPTION
After thinking about it some more, realised that this is a much better solution.
By the time the Exception has been raised in AclService, the PermissionCacheOptimiser has done its job and already loaded the ACLs present.

So all thats required is to handle the Exception by a log entry and nothing else.

#3267