### PR TITLE
SEC-2557 Enabled configuration of GrantedAuthoritiesMapper in LdapAuthenticationProviderConfigurer

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/ldap/LdapAuthenticationProviderConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/ldap/LdapAuthenticationProviderConfigurer.java
@@ -24,6 +24,7 @@ import org.springframework.security.config.annotation.ObjectPostProcessor;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.authentication.ProviderManagerBuilder;
 import org.springframework.security.config.annotation.web.configurers.ChannelSecurityConfigurer;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper;
 import org.springframework.security.ldap.DefaultSpringSecurityContextSource;
 import org.springframework.security.ldap.authentication.AbstractLdapAuthenticator;
@@ -68,6 +69,7 @@ public class LdapAuthenticationProviderConfigurer<B extends ProviderManagerBuild
 	private Object passwordEncoder;
 	private String passwordAttribute;
 	private LdapAuthoritiesPopulator ldapAuthoritiesPopulator;
+	private GrantedAuthoritiesMapper authoritiesMapper;
 
 	private LdapAuthenticationProvider build() throws Exception {
 		BaseLdapPathContextSource contextSource = getContextSource();
@@ -77,10 +79,7 @@ public class LdapAuthenticationProviderConfigurer<B extends ProviderManagerBuild
 
 		LdapAuthenticationProvider ldapAuthenticationProvider = new LdapAuthenticationProvider(
 				ldapAuthenticator, authoritiesPopulator);
-		SimpleAuthorityMapper simpleAuthorityMapper = new SimpleAuthorityMapper();
-		simpleAuthorityMapper.setPrefix(rolePrefix);
-		simpleAuthorityMapper.afterPropertiesSet();
-		ldapAuthenticationProvider.setAuthoritiesMapper(simpleAuthorityMapper);
+		ldapAuthenticationProvider.setAuthoritiesMapper(getAuthoritiesMapper());
 		if (userDetailsContextMapper != null) {
 			ldapAuthenticationProvider
 					.setUserDetailsContextMapper(userDetailsContextMapper);
@@ -131,6 +130,38 @@ public class LdapAuthenticationProviderConfigurer<B extends ProviderManagerBuild
 
 		this.ldapAuthoritiesPopulator = defaultAuthoritiesPopulator;
 		return defaultAuthoritiesPopulator;
+	}
+
+	/**
+	 * Specifies the {@link GrantedAuthoritiesMapper}.
+	 *
+	 * @param grantedAuthoritiesMapper the {@link GrantedAuthoritiesMapper} the default is {@link SimpleAuthorityMapper}
+	 * @return the {@link LdapAuthenticationProviderConfigurer} for further customizations
+	 *
+	 * @author Tony Dalbrekt
+	 * @since 3.2.4
+	 */
+	public LdapAuthenticationProviderConfigurer<B> authoritiesMapper(GrantedAuthoritiesMapper grantedAuthoritiesMapper) {
+		this.authoritiesMapper = grantedAuthoritiesMapper;
+		return this;
+	}
+
+	/**
+	 * Gets the {@link GrantedAuthoritiesMapper} and defaults to {@link SimpleAuthorityMapper}.
+	 *
+	 * @return the {@link GrantedAuthoritiesMapper}
+	 * @throws Exception if errors in {@link SimpleAuthorityMapper#afterPropertiesSet()}
+	 */
+	protected GrantedAuthoritiesMapper getAuthoritiesMapper() throws Exception {
+		if(authoritiesMapper != null) {
+			return authoritiesMapper;
+		}
+
+		SimpleAuthorityMapper simpleAuthorityMapper = new SimpleAuthorityMapper();
+		simpleAuthorityMapper.setPrefix(rolePrefix);
+		simpleAuthorityMapper.afterPropertiesSet();
+		this.authoritiesMapper = simpleAuthorityMapper;
+		return simpleAuthorityMapper;
 	}
 
 	/**

--- a/config/src/test/java/org/springframework/security/config/annotation/authentication/configurers/ldap/LdapAuthenticationProviderConfigurerTest.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/authentication/configurers/ldap/LdapAuthenticationProviderConfigurerTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.security.config.annotation.authentication.configurers.ldap;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
+import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper;
+
+public class LdapAuthenticationProviderConfigurerTest {
+
+    private LdapAuthenticationProviderConfigurer configurer;
+
+    @Before
+    public void setUp() {
+        configurer = new LdapAuthenticationProviderConfigurer();
+    }
+
+    // SEC-2557
+    @Test
+    public void getAuthoritiesMapper() throws Exception {
+        assertEquals(SimpleAuthorityMapper.class, configurer.getAuthoritiesMapper().getClass());
+        configurer.authoritiesMapper(new NullAuthoritiesMapper());
+        assertEquals(NullAuthoritiesMapper.class, configurer.getAuthoritiesMapper().getClass());
+
+    }
+}


### PR DESCRIPTION
Since the original PR #82 for https://jira.spring.io/browse/SEC-2557 needed some git cleanup I took the liberty to extract the relevant original commit by @dalbrekt and post as a new PR.

(I did not change the code but signed the contributors agreement just in case)
