### PR TITLE
Fix sessionAuthenticationStrategy setter

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
@@ -188,7 +188,7 @@ public final class SessionManagementConfigurer<H extends HttpSecurityBuilder<H>>
 	 */
 	public SessionManagementConfigurer<H> sessionAuthenticationStrategy(
 			SessionAuthenticationStrategy sessionAuthenticationStrategy) {
-		this.sessionFixationAuthenticationStrategy = sessionAuthenticationStrategy;
+		this.sessionAuthenticationStrategy = sessionAuthenticationStrategy;
 		return this;
 	}
 


### PR DESCRIPTION
JIRA issue: https://jira.spring.io/browse/SEC-3143
SessionManagementConfigurer does not allow to inject a custom SessionAuthenticationStrategy due to a typo in the assignment to the member field.