### PR TITLE
Fix logout url in doc

### DIFF
--- a/docs/manual/src/docs/asciidoc/index.adoc
+++ b/docs/manual/src/docs/asciidoc/index.adoc
@@ -709,7 +709,7 @@ URL `/logout` will log the user out by:
 - Invalidating the HTTP Session
 - Cleaning up any RememberMe authentication that was configured
 - Clearing the `SecurityContextHolder`
-- Redirect to `/login?success`
+- Redirect to `/login?logout`
 
 Similar to configuring login capabilities, however, you also have various options
 to further customize your logout requirements:


### PR DESCRIPTION
The default for logout is to redirect to `/login?logout` as is correctly written below (in note <3> )