### PR TITLE
SEC-3190: Add support for colons in remember-me token values

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/rememberme/AbstractRememberMeServices.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/rememberme/AbstractRememberMeServices.java
@@ -1,6 +1,10 @@
 package org.springframework.security.web.authentication.rememberme;
 
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -209,13 +213,16 @@ public abstract class AbstractRememberMeServices implements RememberMeServices,
 		String[] tokens = StringUtils.delimitedListToStringArray(cookieAsPlainText,
 				DELIMITER);
 
-		if ((tokens[0].equalsIgnoreCase("http") || tokens[0].equalsIgnoreCase("https"))
-				&& tokens[1].startsWith("//")) {
-			// Assume we've accidentally split a URL (OpenID identifier)
-			String[] newTokens = new String[tokens.length - 1];
-			newTokens[0] = tokens[0] + ":" + tokens[1];
-			System.arraycopy(tokens, 2, newTokens, 1, newTokens.length - 1);
-			tokens = newTokens;
+		for (int i = 0; i < tokens.length; i++)
+		{
+			try
+			{
+				tokens[i] = URLDecoder.decode(tokens[i], StandardCharsets.UTF_8.toString());
+			}
+			catch (UnsupportedEncodingException e)
+			{
+				logger.error(e.getMessage(), e);
+			}
 		}
 
 		return tokens;
@@ -230,7 +237,14 @@ public abstract class AbstractRememberMeServices implements RememberMeServices,
 	protected String encodeCookie(String[] cookieTokens) {
 		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < cookieTokens.length; i++) {
-			sb.append(cookieTokens[i]);
+			try
+			{
+				sb.append(URLEncoder.encode(cookieTokens[i], StandardCharsets.UTF_8.toString()));
+			}
+			catch (UnsupportedEncodingException e)
+			{
+				logger.error(e.getMessage(), e);
+			}
 
 			if (i < cookieTokens.length - 1) {
 				sb.append(DELIMITER);

--- a/web/src/test/java/org/springframework/security/web/authentication/rememberme/AbstractRememberMeServicesTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/rememberme/AbstractRememberMeServicesTests.java
@@ -79,7 +79,7 @@ public class AbstractRememberMeServicesTests {
 
 	@Test
 	public void cookieShouldBeCorrectlyEncodedAndDecoded() throws Exception {
-		String[] cookie = new String[] { "name", "cookie", "tokens", "blah" };
+		String[] cookie = new String[] { "name:with:colon", "cookie", "tokens", "blah" };
 		MockRememberMeServices services = new MockRememberMeServices(uds);
 
 		String encoded = services.encodeCookie(cookie);
@@ -88,7 +88,7 @@ public class AbstractRememberMeServicesTests {
 		String[] decoded = services.decodeCookie(encoded);
 
 		assertEquals(4, decoded.length);
-		assertEquals("name", decoded[0]);
+		assertEquals("name:with:colon", decoded[0]);
 		assertEquals("cookie", decoded[1]);
 		assertEquals("tokens", decoded[2]);
 		assertEquals("blah", decoded[3]);


### PR DESCRIPTION
https://jira.spring.io/browse/SEC-3190

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.

We have an issue where remeber-me cookie token strings that contain a colon break the existing decoding strategy, which tokenizes on colons.  Note that this happens as a matter of course when using spring-social, which adopts a username convention of <provider>:<userId> (e.g. "twitter:123245").  Username is one of the token values stored in the remeber-me cookie.

This change urlencodes the individual tokens when creating the cookie string; and urldecodes them decoding the cookie and extracting the tokens; such that colons are now supported in the token values.  This also eliminates the need for some existing code in decodeCookie() that deals with openid tokens which contain urls, and thus colons.
