### PR TITLE
SEC-3191 - Add support method to AuthenticationProvider

### DIFF
--- a/cas/src/main/java/org/springframework/security/cas/authentication/CasAuthenticationProvider.java
+++ b/cas/src/main/java/org/springframework/security/cas/authentication/CasAuthenticationProvider.java
@@ -93,6 +93,10 @@ public class CasAuthenticationProvider implements AuthenticationProvider,
 			return null;
 		}
 
+		if (!supports(authentication)) {
+			return null;
+		}
+
 		if (authentication instanceof UsernamePasswordAuthenticationToken
 				&& (!CasAuthenticationFilter.CAS_STATEFUL_IDENTIFIER
 						.equals(authentication.getPrincipal().toString()) && !CasAuthenticationFilter.CAS_STATELESS_IDENTIFIER
@@ -270,5 +274,9 @@ public class CasAuthenticationProvider implements AuthenticationProvider,
 				|| (CasAuthenticationToken.class.isAssignableFrom(authentication))
 				|| (CasAssertionAuthenticationToken.class
 						.isAssignableFrom(authentication));
+	}
+
+	public boolean supports(Authentication authentication) {
+		return true;
 	}
 }

--- a/config/src/main/java/org/springframework/security/config/authentication/AuthenticationManagerBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/authentication/AuthenticationManagerBeanDefinitionParser.java
@@ -146,5 +146,9 @@ public class AuthenticationManagerBeanDefinitionParser implements BeanDefinition
 		public boolean supports(Class<?> authentication) {
 			return false;
 		}
+
+		public boolean supports(Authentication authentication) {
+			return true;
+		}
 	}
 }

--- a/config/src/test/groovy/org/springframework/security/config/annotation/issue50/SecurityConfig.java
+++ b/config/src/test/groovy/org/springframework/security/config/annotation/issue50/SecurityConfig.java
@@ -76,6 +76,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 				return true;
 			}
 
+			public boolean supports(Authentication authentication) {
+				return true;
+			}
+
 			public Authentication authenticate(Authentication authentication)
 					throws AuthenticationException {
 				Object principal = authentication.getPrincipal();

--- a/core/src/main/java/org/springframework/security/access/intercept/RunAsImplAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/access/intercept/RunAsImplAuthenticationProvider.java
@@ -87,4 +87,8 @@ public class RunAsImplAuthenticationProvider implements InitializingBean,
 	public boolean supports(Class<?> authentication) {
 		return RunAsUserToken.class.isAssignableFrom(authentication);
 	}
+
+	public boolean supports(Authentication authentication) {
+		return true;
+	}
 }

--- a/core/src/main/java/org/springframework/security/authentication/AnonymousAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/AnonymousAuthenticationProvider.java
@@ -77,4 +77,8 @@ public class AnonymousAuthenticationProvider implements AuthenticationProvider,
 	public boolean supports(Class<?> authentication) {
 		return (AnonymousAuthenticationToken.class.isAssignableFrom(authentication));
 	}
+
+	public boolean supports(Authentication authentication) {
+		return true;
+	}
 }

--- a/core/src/main/java/org/springframework/security/authentication/AuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/AuthenticationProvider.java
@@ -62,10 +62,33 @@ public interface AuthenticationProvider {
 	 * authentication is conducted at runtime the <code>ProviderManager</code>.
 	 * </p>
 	 *
-	 * @param authentication
+	 * @param authenticationType
 	 *
 	 * @return <code>true</code> if the implementation can more closely evaluate the
 	 * <code>Authentication</code> class presented
 	 */
-	boolean supports(Class<?> authentication);
+	boolean supports(Class<?> authenticationType);
+
+	/**
+	 * Returns <code>true</code> if this <Code>AuthenticationProvider</code> supports the
+	 * given <Code>Authentication</code> object.
+	 * <p>
+	 * Returning <code>true</code> does not guarantee an
+	 * <code>AuthenticationProvider</code> will be able to authenticate the presented
+	 * instance of the <code>Authentication</code> class. It simply indicates it can
+	 * support closer evaluation of it. An <code>AuthenticationProvider</code> can still
+	 * return <code>null</code> from the {@link #authenticate(Authentication)} method to
+	 * indicate another <code>AuthenticationProvider</code> should be tried.
+	 * </p>
+	 * <p>
+	 * Selection of an <code>AuthenticationProvider</code> capable of performing
+	 * authentication is conducted at runtime the <code>ProviderManager</code>.
+	 * </p>
+	 *
+	 * @param authentication
+	 *
+	 * @return <code>true</code> if the implementation can more closely evaluate the
+	 * <code>Authentication</code> instance presented
+	 */
+	boolean supports(Authentication authentication);
 }

--- a/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
@@ -157,6 +157,9 @@ public class ProviderManager implements AuthenticationManager, MessageSourceAwar
 			if (!provider.supports(toTest)) {
 				continue;
 			}
+			if (!provider.supports(authentication)) {
+				continue;
+			}
 
 			if (debug) {
 				logger.debug("Authentication attempt using "

--- a/core/src/main/java/org/springframework/security/authentication/RememberMeAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/RememberMeAuthenticationProvider.java
@@ -78,4 +78,8 @@ public class RememberMeAuthenticationProvider implements AuthenticationProvider,
 	public boolean supports(Class<?> authentication) {
 		return (RememberMeAuthenticationToken.class.isAssignableFrom(authentication));
 	}
+
+	public boolean supports(Authentication authentication) {
+		return true;
+	}
 }

--- a/core/src/main/java/org/springframework/security/authentication/TestingAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/TestingAuthenticationProvider.java
@@ -43,4 +43,8 @@ public class TestingAuthenticationProvider implements AuthenticationProvider {
 	public boolean supports(Class<?> authentication) {
 		return TestingAuthenticationToken.class.isAssignableFrom(authentication);
 	}
+
+	public boolean supports(Authentication authentication) {
+		return true;
+	}
 }

--- a/core/src/main/java/org/springframework/security/authentication/dao/AbstractUserDetailsAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/dao/AbstractUserDetailsAuthenticationProvider.java
@@ -320,6 +320,10 @@ public abstract class AbstractUserDetailsAuthenticationProvider implements
 				.isAssignableFrom(authentication));
 	}
 
+	public boolean supports(Authentication authentication) {
+		return true;
+	}
+
 	protected UserDetailsChecker getPreAuthenticationChecks() {
 		return preAuthenticationChecks;
 	}

--- a/core/src/main/java/org/springframework/security/authentication/jaas/AbstractJaasAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/jaas/AbstractJaasAuthenticationProvider.java
@@ -376,6 +376,10 @@ public abstract class AbstractJaasAuthenticationProvider implements
 		return UsernamePasswordAuthenticationToken.class.isAssignableFrom(aClass);
 	}
 
+	public boolean supports(Authentication authentication) {
+		return true;
+	}
+
 	public void setApplicationEventPublisher(
 			ApplicationEventPublisher applicationEventPublisher) {
 		this.applicationEventPublisher = applicationEventPublisher;

--- a/core/src/main/java/org/springframework/security/authentication/rcp/RemoteAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/rcp/RemoteAuthenticationProvider.java
@@ -88,4 +88,8 @@ public class RemoteAuthenticationProvider implements AuthenticationProvider,
 		return (UsernamePasswordAuthenticationToken.class
 				.isAssignableFrom(authentication));
 	}
+
+	public boolean supports(Authentication authentication) {
+		return true;
+	}
 }

--- a/docs/manual/src/docs/asciidoc/_includes/test.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/test.adoc
@@ -252,7 +252,7 @@ public class WithMockCustomUserSecurityContextFactory
 }
 ----
 
-We can now annotate a test class or a test method with our new annotation and Spring Security's `WithSecurityContextTestExcecutionListener` will ensure that our `SecurityContext` is populated appropriately.
+We can now annotate a test class or a test method with our new annotation and Spring Security's `WithSecurityContextTestExecutionListener` will ensure that our `SecurityContext` is populated appropriately.
 
 When creating your own `WithSecurityContextFactory` implementations, it is nice to know that they can be annotated with standard Spring annotations.
 For example, the `WithUserDetailsSecurityContextFactory` uses the `@Autowired` annotation to acquire the `UserDetailsService`:

--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/AbstractLdapAuthenticationProvider.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/AbstractLdapAuthenticationProvider.java
@@ -121,6 +121,10 @@ public abstract class AbstractLdapAuthenticationProvider implements
 		return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
 	}
 
+	public boolean supports(Authentication authentication) {
+		return true;
+	}
+
 	/**
 	 * Determines whether the supplied password will be used as the credentials in the
 	 * successful authentication token. If set to false, then the password will be

--- a/openid/src/main/java/org/springframework/security/openid/OpenIDAuthenticationProvider.java
+++ b/openid/src/main/java/org/springframework/security/openid/OpenIDAuthenticationProvider.java
@@ -157,6 +157,10 @@ public class OpenIDAuthenticationProvider implements AuthenticationProvider,
 		return OpenIDAuthenticationToken.class.isAssignableFrom(authentication);
 	}
 
+	public boolean supports(Authentication authentication) {
+		return true;
+	}
+
 	public void setAuthoritiesMapper(GrantedAuthoritiesMapper authoritiesMapper) {
 		this.authoritiesMapper = authoritiesMapper;
 	}

--- a/samples/gae-xml/src/main/java/samples/gae/security/GoogleAccountsAuthenticationProvider.java
+++ b/samples/gae-xml/src/main/java/samples/gae/security/GoogleAccountsAuthenticationProvider.java
@@ -59,6 +59,10 @@ public class GoogleAccountsAuthenticationProvider implements AuthenticationProvi
 		return PreAuthenticatedAuthenticationToken.class.isAssignableFrom(authentication);
 	}
 
+	public boolean supports(Authentication authentication) {
+		return true;
+	}
+
 	public void setUserRegistry(UserRegistry userRegistry) {
 		this.userRegistry = userRegistry;
 	}

--- a/web/src/main/java/org/springframework/security/web/authentication/preauth/PreAuthenticatedAuthenticationProvider.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/preauth/PreAuthenticatedAuthenticationProvider.java
@@ -104,6 +104,10 @@ public class PreAuthenticatedAuthenticationProvider implements AuthenticationPro
 		return PreAuthenticatedAuthenticationToken.class.isAssignableFrom(authentication);
 	}
 
+	public boolean supports(Authentication authentication) {
+		return true;
+	}
+
 	/**
 	 * Set the AuthenticatedUserDetailsService to be used to load the {@code UserDetails}
 	 * for the authenticated user.


### PR DESCRIPTION
Allow an AuthenticationProvider to decide if it supports a given
Authentication instance, e.g. by deciding on the username if it should
try authentication.