### PR TITLE
Enforce constant time comparison

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/encoding/PasswordEncoderUtils.java
+++ b/core/src/main/java/org/springframework/security/authentication/encoding/PasswordEncoderUtils.java
@@ -32,7 +32,7 @@ class PasswordEncoderUtils {
 		}
 			
 		for (int i = 0; i < actualLength; i++) {
-			result |= expectedBytes[i % expectedLength] ^ actualBytes[i % actualLength];
+			result |= expectedBytes[i % (expectedLength!=0?expectedLength:1)] ^ actualBytes[i % actualLength];
 		}
 		return result == 0;
 	}

--- a/core/src/main/java/org/springframework/security/authentication/encoding/PasswordEncoderUtils.java
+++ b/core/src/main/java/org/springframework/security/authentication/encoding/PasswordEncoderUtils.java
@@ -22,13 +22,10 @@ class PasswordEncoderUtils {
 		byte[] actualBytes = bytesUtf8(actual);
 		int expectedLength = expectedBytes == null ? -1 : expectedBytes.length;
 		int actualLength = actualBytes == null ? -1 : actualBytes.length;
-		if (expectedLength != actualLength) {
-			return false;
-		}
 
-		int result = 0;
-		for (int i = 0; i < expectedLength; i++) {
-			result |= expectedBytes[i] ^ actualBytes[i];
+		int result = expectedLength != actualLength ? 1 : 0;
+		for (int i = 0; i < actualLength; i++) {
+			result |= expectedBytes[i % expectedLength] ^ actualBytes[i % actualLength];
 		}
 		return result == 0;
 	}

--- a/core/src/main/java/org/springframework/security/authentication/encoding/PasswordEncoderUtils.java
+++ b/core/src/main/java/org/springframework/security/authentication/encoding/PasswordEncoderUtils.java
@@ -21,10 +21,16 @@ class PasswordEncoderUtils {
 		byte[] expectedBytes = bytesUtf8(expected);
 		byte[] actualBytes = bytesUtf8(actual);
 		int expectedLength = expectedBytes == null ? 0 : expectedBytes.length;
-		int actualLength = actualBytes == null ? -1 : actualBytes.length;
+		int actualLength = actualBytes == null ? 0 : actualBytes.length;
 
 		int result = expectedLength != actualLength ? 1 : 0;
 		result |= ((expectedBytes == null && actualBytes != null) || (expectedBytes != null && actualBytes == null)) ? 1 : 0;
+		
+		if (expectedBytes == null) {
+			expectedBytes = new byte[1];
+			expectedBytes[0] = (byte) 0xFF; // value is ignored, just initializing.
+		}
+			
 		for (int i = 0; i < actualLength; i++) {
 			result |= expectedBytes[i % expectedLength] ^ actualBytes[i % actualLength];
 		}

--- a/core/src/main/java/org/springframework/security/authentication/encoding/PasswordEncoderUtils.java
+++ b/core/src/main/java/org/springframework/security/authentication/encoding/PasswordEncoderUtils.java
@@ -20,10 +20,11 @@ class PasswordEncoderUtils {
 	static boolean equals(String expected, String actual) {
 		byte[] expectedBytes = bytesUtf8(expected);
 		byte[] actualBytes = bytesUtf8(actual);
-		int expectedLength = expectedBytes == null ? -1 : expectedBytes.length;
+		int expectedLength = expectedBytes == null ? 0 : expectedBytes.length;
 		int actualLength = actualBytes == null ? -1 : actualBytes.length;
 
 		int result = expectedLength != actualLength ? 1 : 0;
+		result |= ((expectedBytes == null && actualBytes != null) || (expectedBytes != null && actualBytes == null)) ? 1 : 0;
 		for (int i = 0; i < actualLength; i++) {
 			result |= expectedBytes[i % expectedLength] ^ actualBytes[i % actualLength];
 		}

--- a/core/src/main/java/org/springframework/security/authentication/encoding/PasswordEncoderUtils.java
+++ b/core/src/main/java/org/springframework/security/authentication/encoding/PasswordEncoderUtils.java
@@ -22,15 +22,14 @@ class PasswordEncoderUtils {
 		byte[] actualBytes = bytesUtf8(actual);
 		int expectedLength = expectedBytes == null ? 0 : expectedBytes.length;
 		int actualLength = actualBytes == null ? 0 : actualBytes.length;
-
-		int result = expectedLength != actualLength ? 1 : 0;
+		byte[] tmpBytes = new byte[1];
+		int result = (expectedLength != actualLength) ? 1 : 0;
+		
+		tmpBytes[0] = (byte) 0xFF; // value is ignored, just initializing.
 		result |= ((expectedBytes == null && actualBytes != null) || (expectedBytes != null && actualBytes == null)) ? 1 : 0;
 		
-		if (expectedBytes == null) {
-			expectedBytes = new byte[1];
-			expectedBytes[0] = (byte) 0xFF; // value is ignored, just initializing.
-		}
-			
+		expectedBytes = (expectedBytes == null ? expectedBytes : tmpBytes);
+
 		for (int i = 0; i < actualLength; i++) {
 			result |= expectedBytes[i % (expectedLength!=0?expectedLength:1)] ^ actualBytes[i % actualLength];
 		}
@@ -42,7 +41,7 @@ class PasswordEncoderUtils {
 			return null;
 		}
 
-		return Utf8.encode(s);
+		return Utf8.encode(s); // need to check if Utf8.encode() runs in constant time (probably not). This may leak length of string.
 	}
 
 	private PasswordEncoderUtils() {


### PR DESCRIPTION
To prevent side-channel leakage of actual password length, enforce constant time even when expectedLength != actualLength.