### PR TITLE
Log AuthenticationException on unsuccessful authentication

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.java
@@ -347,7 +347,7 @@ public abstract class AbstractAuthenticationProcessingFilter extends GenericFilt
 		SecurityContextHolder.clearContext();
 
 		if (logger.isDebugEnabled()) {
-			logger.debug("Authentication request failed: " + failed.toString());
+			logger.debug("Authentication request failed: " + failed.toString(), failed);
 			logger.debug("Updated SecurityContextHolder to contain null Authentication");
 			logger.debug("Delegating to authentication failure handler " + failureHandler);
 		}


### PR DESCRIPTION
I suggest we log the exception object for more effective debugging. 

I am currently troubleshooting an SAML authentication issue in my project, I was not able to see the detailed stack trace and root exception in console log but I had to debug through the spring source code, which was not very convenient.