### PR TITLE
HTTP Public Key Pinning

### DIFF
--- a/config/src/main/java/org/springframework/security/config/SecurityNamespaceHandler.java
+++ b/config/src/main/java/org/springframework/security/config/SecurityNamespaceHandler.java
@@ -85,8 +85,8 @@ public final class SecurityNamespaceHandler implements NamespaceHandler {
 	public BeanDefinition parse(Element element, ParserContext pc) {
 		if (!namespaceMatchesVersion(element)) {
 			pc.getReaderContext()
-					.fatal("You cannot use a spring-security-2.0.xsd or spring-security-3.0.xsd or spring-security-3.1.xsd schema or spring-security-3.2.xsd schema "
-							+ "with Spring Security 4.0. Please update your schema declarations to the 4.0 schema.",
+					.fatal("You cannot use a spring-security-2.0.xsd or spring-security-3.0.xsd or spring-security-3.1.xsd schema or spring-security-3.2.xsd schema or spring-security-4.0.xsd schema "
+							+ "with Spring Security 4.1. Please update your schema declarations to the 4.1 schema.",
 							element);
 		}
 		String name = pc.getDelegate().getLocalName(element);
@@ -222,7 +222,7 @@ public final class SecurityNamespaceHandler implements NamespaceHandler {
 	private boolean matchesVersionInternal(Element element) {
 		String schemaLocation = element.getAttributeNS(
 				"http://www.w3.org/2001/XMLSchema-instance", "schemaLocation");
-		return schemaLocation.matches("(?m).*spring-security-4\\.0.*.xsd.*")
+		return schemaLocation.matches("(?m).*spring-security-4\\.1.*.xsd.*")
 				|| schemaLocation.matches("(?m).*spring-security.xsd.*")
 				|| !schemaLocation.matches("(?m).*spring-security.*");
 	}

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HeadersConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HeadersConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,10 @@
  */
 package org.springframework.security.config.annotation.web.configurers;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -26,6 +28,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.web.header.HeaderWriter;
 import org.springframework.security.web.header.HeaderWriterFilter;
 import org.springframework.security.web.header.writers.CacheControlHeadersWriter;
+import org.springframework.security.web.header.writers.HpkpHeaderWriter;
 import org.springframework.security.web.header.writers.HstsHeaderWriter;
 import org.springframework.security.web.header.writers.XContentTypeOptionsHeaderWriter;
 import org.springframework.security.web.header.writers.XXssProtectionHeaderWriter;
@@ -41,7 +44,7 @@ import org.springframework.util.Assert;
  * </p>
  *
  * <p>
- * The default headers are include are:
+ * The default headers include are:
  * </p>
  *
  * <pre>
@@ -55,6 +58,7 @@ import org.springframework.util.Assert;
  * </pre>
  *
  * @author Rob Winch
+ * @author Tim Ysewyn
  * @since 3.2
  */
 public class HeadersConfigurer<H extends HttpSecurityBuilder<H>> extends
@@ -72,6 +76,8 @@ public class HeadersConfigurer<H extends HttpSecurityBuilder<H>> extends
 	private final HstsConfig hsts = new HstsConfig();
 
 	private final FrameOptionsConfig frameOptions = new FrameOptionsConfig();
+
+	private final HpkpConfig hpkp = new HpkpConfig();
 
 	/**
 	 * Creates a new instance
@@ -473,6 +479,185 @@ public class HeadersConfigurer<H extends HttpSecurityBuilder<H>> extends
 	}
 
 	/**
+	 * Allows customizing the {@link HpkpHeaderWriter} which provides support for <a
+	 * href="http://tools.ietf.org/html/rfc7469">HTTP Public Key Pinning (HPKP)</a>.
+	 *
+	 * @return the {@link HeadersConfigurer} for additional customizations
+	 *
+	 * @since 4.1
+	 */
+	public HpkpConfig httpPublicKeyPinning() {
+		return hpkp.enable();
+	}
+
+	public final class HpkpConfig {
+		private HpkpHeaderWriter writer;
+
+		private HpkpConfig() {}
+
+		/**
+		 * <p>
+		 * Sets the value for the pin- directive of the Public-Key-Pins header.
+		 * </p>
+		 *
+		 * <p>
+		 * The pin directive specifies a way for web host operators to indicate
+		 * a cryptographic identity that should be bound to a given web host.
+		 * See <a href="http://tools.ietf.org/html/rfc7469#section-2.1.1">Section 2.1.1</a> for additional details.
+		 * </p>
+		 *
+		 * @param pins the map of base64-encoded SPKI fingerprint &amp; cryptographic hash algorithm pairs.
+		 * @throws IllegalArgumentException if pins is null
+		 */
+		public HpkpConfig withPins(Map<String, String> pins) {
+			writer.setPins(pins);
+			return this;
+		}
+
+		/**
+		 * <p>
+		 * Adds a list of SHA256 hashed pins for the pin- directive of the Public-Key-Pins header.
+		 * </p>
+		 *
+		 * <p>
+		 * The pin directive specifies a way for web host operators to indicate
+		 * a cryptographic identity that should be bound to a given web host.
+		 * See <a href="http://tools.ietf.org/html/rfc7469#section-2.1.1">Section 2.1.1</a> for additional details.
+		 * </p>
+		 *
+		 * @param pins a list of base64-encoded SPKI fingerprints.
+		 * @throws IllegalArgumentException if a pin is null
+		 */
+		public HpkpConfig addSha256Pins(String ... pins) {
+			writer.addSha256Pins(pins);
+			return this;
+		}
+
+		/**
+		 * <p>
+		 * Sets the value (in seconds) for the max-age directive of the Public-Key-Pins header.
+		 * The default is 60 days.
+		 * </p>
+		 *
+		 * <p>
+		 * This instructs browsers how long they should regard the host (from whom the message was received)
+		 * as a known pinned host. See <a href="http://tools.ietf.org/html/rfc7469#section-2.1.2">Section
+		 * 2.1.2</a> for additional details.
+		 * </p>
+		 *
+		 * @param maxAgeInSeconds the maximum amount of time (in seconds) to regard the host
+		 * as a known pinned host.
+		 * @throws IllegalArgumentException if maxAgeInSeconds is negative
+		 */
+		public HpkpConfig maxAgeInSeconds(long maxAgeInSeconds) {
+			writer.setMaxAgeInSeconds(maxAgeInSeconds);
+			return this;
+		}
+
+		/**
+		 * <p>
+		 * If true, the pinning policy applies to this pinned host as well as any subdomains
+		 * of the host's domain name. The default is false.
+		 * </p>
+		 *
+		 * <p>
+		 * See <a href="http://tools.ietf.org/html/rfc7469#section-2.1.3">Section 2.1.3</a>
+		 * for additional details.
+		 * </p>
+		 *
+		 * @param includeSubDomains true to include subdomains, else false
+		 */
+		public HpkpConfig includeSubDomains(boolean includeSubDomains) {
+			writer.setIncludeSubDomains(includeSubDomains);
+			return this;
+		}
+
+		/**
+		 * <p>
+		 * If true, the browser should not terminate the connection with the server. The default is true.
+		 * </p>
+		 *
+		 * <p>
+		 * See <a href="http://tools.ietf.org/html/rfc7469#section-2.1">Section 2.1</a>
+		 * for additional details.
+		 * </p>
+		 *
+		 * @param reportOnly true to report only, else false
+		 */
+		public HpkpConfig reportOnly(boolean reportOnly) {
+			writer.setReportOnly(reportOnly);
+			return this;
+		}
+
+		/**
+		 * <p>
+		 * Sets the URI to which the browser should report pin validation failures.
+		 * </p>
+		 *
+		 * <p>
+		 * See <a href="http://tools.ietf.org/html/rfc7469#section-2.1.4">Section 2.1.4</a>
+		 * for additional details.
+		 * </p>
+		 *
+		 * @param reportUri the URI where the browser should send the report to.
+		 */
+		public HpkpConfig reportUri(URI reportUri) {
+			writer.setReportUri(reportUri);
+			return this;
+		}
+
+		/**
+		 * <p>
+		 * Sets the URI to which the browser should report pin validation failures.
+		 * </p>
+		 *
+		 * <p>
+		 * See <a href="http://tools.ietf.org/html/rfc7469#section-2.1.4">Section 2.1.4</a>
+		 * for additional details.
+		 * </p>
+		 *
+		 * @param reportUri the URI where the browser should send the report to.
+		 * @throws IllegalArgumentException if the reportUri is not a valid URI
+		 */
+		public HpkpConfig reportUri(String reportUri) {
+			writer.setReportUri(reportUri);
+			return this;
+		}
+
+		/**
+		 * Prevents the header from being added to the response.
+		 *
+		 * @return the {@link HeadersConfigurer} for additional configuration.
+		 */
+		public HeadersConfigurer<H> disable() {
+			writer = null;
+			return and();
+		}
+
+		/**
+		 * Allows completing configuration of Public Key Pinning and continuing
+		 * configuration of headers.
+		 *
+		 * @return the {@link HeadersConfigurer} for additional configuration
+		 */
+		public HeadersConfigurer<H> and() {
+			return HeadersConfigurer.this;
+		}
+
+		/**
+		 * Ensures that Public-Key-Pins or Public-Key-Pins-Report-Only is enabled if it is not already
+		 *
+		 * @return the {@link HstsConfig} for additional customization
+		 */
+		private HpkpConfig enable() {
+			if (writer == null) {
+				writer = new HpkpHeaderWriter();
+			}
+			return this;
+		}
+	}
+
+	/**
 	 * Clears all of the default headers from the response. After doing so, one can add
 	 * headers back. For example, if you only want to use Spring Security's cache control
 	 * you can use the following:
@@ -526,6 +711,7 @@ public class HeadersConfigurer<H extends HttpSecurityBuilder<H>> extends
 		addIfNotNull(writers, cacheControl.writer);
 		addIfNotNull(writers, hsts.writer);
 		addIfNotNull(writers, frameOptions.writer);
+		addIfNotNull(writers, hpkp.writer);
 		writers.addAll(headerWriters);
 		return writers;
 	}

--- a/config/src/main/resources/META-INF/spring.schemas
+++ b/config/src/main/resources/META-INF/spring.schemas
@@ -1,4 +1,5 @@
-http\://www.springframework.org/schema/security/spring-security.xsd=org/springframework/security/config/spring-security-4.0.xsd
+http\://www.springframework.org/schema/security/spring-security.xsd=org/springframework/security/config/spring-security-4.1.xsd
+http\://www.springframework.org/schema/security/spring-security-4.1.xsd=org/springframework/security/config/spring-security-4.1.xsd
 http\://www.springframework.org/schema/security/spring-security-4.0.xsd=org/springframework/security/config/spring-security-4.0.xsd
 http\://www.springframework.org/schema/security/spring-security-3.2.xsd=org/springframework/security/config/spring-security-3.2.xsd
 http\://www.springframework.org/schema/security/spring-security-3.1.xsd=org/springframework/security/config/spring-security-3.1.xsd

--- a/config/src/main/resources/org/springframework/security/config/spring-security-4.1.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-4.1.rnc
@@ -1,0 +1,882 @@
+namespace a = "http://relaxng.org/ns/compatibility/annotations/1.0"
+datatypes xsd = "http://www.w3.org/2001/XMLSchema-datatypes"
+
+default namespace = "http://www.springframework.org/schema/security"
+
+start = http | ldap-server | authentication-provider | ldap-authentication-provider | any-user-service | ldap-server | ldap-authentication-provider
+
+hash =
+	## Defines the hashing algorithm used on user passwords. Bcrypt is recommended.
+	attribute hash {"bcrypt" | "plaintext" | "sha" | "sha-256" | "md5" | "md4" | "{sha}" | "{ssha}"}
+base64 =
+	## Whether a string should be base64 encoded
+	attribute base64 {xsd:boolean}
+request-matcher =
+	## Defines the strategy use for matching incoming requests. Currently the options are 'ant' (for ant path patterns), 'regex' for regular expressions and 'ciRegex' for case-insensitive regular expressions.
+	attribute request-matcher {"ant" | "regex" | "ciRegex"}
+port =
+	## Specifies an IP port number. Used to configure an embedded LDAP server, for example.
+	attribute port { xsd:positiveInteger }
+url =
+	## Specifies a URL.
+	attribute url { xsd:token }
+id =
+	## A bean identifier, used for referring to the bean elsewhere in the context.
+	attribute id {xsd:token}
+name =
+	## A bean identifier, used for referring to the bean elsewhere in the context.
+	attribute name {xsd:token}
+ref =
+	## Defines a reference to a Spring bean Id.
+	attribute ref {xsd:token}
+
+cache-ref =
+	## Defines a reference to a cache for use with a UserDetailsService.
+	attribute cache-ref {xsd:token}
+
+user-service-ref =
+	## A reference to a user-service (or UserDetailsService bean) Id
+	attribute user-service-ref {xsd:token}
+
+authentication-manager-ref =
+	## A reference to an AuthenticationManager bean
+	attribute authentication-manager-ref {xsd:token}
+
+data-source-ref =
+	## A reference to a DataSource bean
+	attribute data-source-ref {xsd:token}
+
+
+
+debug =
+	## Enables Spring Security debugging infrastructure. This will provide human-readable (multi-line) debugging information to monitor requests coming into the security filters. This may include sensitive information, such as request parameters or headers, and should only be used in a development environment.
+	element debug {empty}
+
+password-encoder =
+	## element which defines a password encoding strategy. Used by an authentication provider to convert submitted passwords to hashed versions, for example.
+	element password-encoder {password-encoder.attlist, salt-source?}
+password-encoder.attlist &=
+	ref | (hash? & base64?)
+
+salt-source =
+	## Password salting strategy. A system-wide constant or a property from the UserDetails object can be used.
+	element salt-source {user-property | system-wide | ref}
+user-property =
+	## A property of the UserDetails object which will be used as salt by a password encoder. Typically something like "username" might be used.
+	attribute user-property {xsd:token}
+system-wide =
+	## A single value that will be used as the salt for a password encoder.
+	attribute system-wide {xsd:token}
+
+role-prefix =
+	## A non-empty string prefix that will be added to role strings loaded from persistent storage (e.g. "ROLE_"). Use the value "none" for no prefix in cases where the default is non-empty.
+	attribute role-prefix {xsd:token}
+
+use-expressions =
+	## Enables the use of expressions in the 'access' attributes in <intercept-url> elements rather than the traditional list of configuration attributes. Defaults to 'true'. If enabled, each attribute should contain a single boolean expression. If the expression evaluates to 'true', access will be granted.
+	attribute use-expressions {xsd:boolean}
+
+ldap-server =
+	## Defines an LDAP server location or starts an embedded server. The url indicates the location of a remote server. If no url is given, an embedded server will be started, listening on the supplied port number. The port is optional and defaults to 33389. A Spring LDAP ContextSource bean will be registered for the server with the id supplied.
+	element ldap-server {ldap-server.attlist}
+ldap-server.attlist &= id?
+ldap-server.attlist &= (url | port)?
+ldap-server.attlist &=
+	## Username (DN) of the "manager" user identity which will be used to authenticate to a (non-embedded) LDAP server. If omitted, anonymous access will be used.
+	attribute manager-dn {xsd:string}?
+ldap-server.attlist &=
+	## The password for the manager DN. This is required if the manager-dn is specified.
+	attribute manager-password {xsd:string}?
+ldap-server.attlist &=
+	## Explicitly specifies an ldif file resource to load into an embedded LDAP server. The default is classpath*:*.ldiff
+	attribute ldif { xsd:string }?
+ldap-server.attlist &=
+	## Optional root suffix for the embedded LDAP server. Default is "dc=springframework,dc=org"
+	attribute root { xsd:string }?
+
+ldap-server-ref-attribute =
+	## The optional server to use. If omitted, and a default LDAP server is registered (using <ldap-server> with no Id), that server will be used.
+	attribute server-ref {xsd:token}
+
+
+group-search-filter-attribute =
+	## Group search filter. Defaults to (uniqueMember={0}). The substituted parameter is the DN of the user.
+	attribute group-search-filter {xsd:token}
+group-search-base-attribute =
+	## Search base for group membership searches. Defaults to "" (searching from the root).
+	attribute group-search-base {xsd:token}
+user-search-filter-attribute =
+	## The LDAP filter used to search for users (optional). For example "(uid={0})". The substituted parameter is the user's login name.
+	attribute user-search-filter {xsd:token}
+user-search-base-attribute =
+	## Search base for user searches. Defaults to "". Only used with a 'user-search-filter'.
+	attribute user-search-base {xsd:token}
+group-role-attribute-attribute =
+	## The LDAP attribute name which contains the role name which will be used within Spring Security. Defaults to "cn".
+	attribute group-role-attribute {xsd:token}
+user-details-class-attribute =
+	## Allows the objectClass of the user entry to be specified. If set, the framework will attempt to load standard attributes for the defined class into the returned UserDetails object
+	attribute user-details-class {"person" | "inetOrgPerson"}
+user-context-mapper-attribute =
+	## Allows explicit customization of the loaded user object by specifying a UserDetailsContextMapper bean which will be called with the context information from the user's directory entry
+	attribute user-context-mapper-ref {xsd:token}
+
+
+ldap-user-service =
+	## This element configures a LdapUserDetailsService which is a combination of a FilterBasedLdapUserSearch and a DefaultLdapAuthoritiesPopulator.
+	element ldap-user-service {ldap-us.attlist}
+ldap-us.attlist &= id?
+ldap-us.attlist &=
+	ldap-server-ref-attribute?
+ldap-us.attlist &=
+	user-search-filter-attribute?
+ldap-us.attlist &=
+	user-search-base-attribute?
+ldap-us.attlist &=
+	group-search-filter-attribute?
+ldap-us.attlist &=
+	group-search-base-attribute?
+ldap-us.attlist &=
+	group-role-attribute-attribute?
+ldap-us.attlist &=
+	cache-ref?
+ldap-us.attlist &=
+	role-prefix?
+ldap-us.attlist &=
+	(user-details-class-attribute | user-context-mapper-attribute)?
+
+ldap-authentication-provider =
+	## Sets up an ldap authentication provider
+	element ldap-authentication-provider {ldap-ap.attlist, password-compare-element?}
+ldap-ap.attlist &=
+	ldap-server-ref-attribute?
+ldap-ap.attlist &=
+	user-search-base-attribute?
+ldap-ap.attlist &=
+	user-search-filter-attribute?
+ldap-ap.attlist &=
+	group-search-base-attribute?
+ldap-ap.attlist &=
+	group-search-filter-attribute?
+ldap-ap.attlist &=
+	group-role-attribute-attribute?
+ldap-ap.attlist &=
+	## A specific pattern used to build the user's DN, for example "uid={0},ou=people". The key "{0}" must be present and will be substituted with the username.
+	attribute user-dn-pattern {xsd:token}?
+ldap-ap.attlist &=
+	role-prefix?
+ldap-ap.attlist &=
+	(user-details-class-attribute | user-context-mapper-attribute)?
+
+password-compare-element =
+	## Specifies that an LDAP provider should use an LDAP compare operation of the user's password to authenticate the user
+	element password-compare {password-compare.attlist, password-encoder?}
+
+password-compare.attlist &=
+	## The attribute in the directory which contains the user password. Defaults to "userPassword".
+	attribute password-attribute {xsd:token}?
+password-compare.attlist &=
+	hash?
+
+intercept-methods =
+	## Can be used inside a bean definition to add a security interceptor to the bean and set up access configuration attributes for the bean's methods
+	element intercept-methods {intercept-methods.attlist, protect+}
+intercept-methods.attlist &=
+	## Optional AccessDecisionManager bean ID to be used by the created method security interceptor.
+	attribute access-decision-manager-ref {xsd:token}?
+
+
+protect =
+	## Defines a protected method and the access control configuration attributes that apply to it. We strongly advise you NOT to mix "protect" declarations with any services provided "global-method-security".
+	element protect {protect.attlist, empty}
+protect.attlist &=
+	## A method name
+	attribute method {xsd:token}
+protect.attlist &=
+	## Access configuration attributes list that applies to the method, e.g. "ROLE_A,ROLE_B".
+	attribute access {xsd:token}
+
+method-security-metadata-source =
+	## Creates a MethodSecurityMetadataSource instance
+	element method-security-metadata-source {msmds.attlist, protect+}
+msmds.attlist &= id?
+
+msmds.attlist &= use-expressions?
+
+global-method-security =
+	## Provides method security for all beans registered in the Spring application context. Specifically, beans will be scanned for matches with the ordered list of "protect-pointcut" sub-elements, Spring Security annotations and/or. Where there is a match, the beans will automatically be proxied and security authorization applied to the methods accordingly. If you use and enable all four sources of method security metadata (ie "protect-pointcut" declarations, expression annotations, @Secured and also JSR250 security annotations), the metadata sources will be queried in that order. In practical terms, this enables you to use XML to override method security metadata expressed in annotations. If using annotations, the order of precedence is EL-based (@PreAuthorize etc.), @Secured and finally JSR-250.
+	element global-method-security {global-method-security.attlist, (pre-post-annotation-handling | expression-handler)?, protect-pointcut*, after-invocation-provider*}
+global-method-security.attlist &=
+	## Specifies whether the use of Spring Security's pre and post invocation annotations (@PreFilter, @PreAuthorize, @PostFilter, @PostAuthorize) should be enabled for this application context. Defaults to "disabled".
+	attribute pre-post-annotations {"disabled" | "enabled" }?
+global-method-security.attlist &=
+	## Specifies whether the use of Spring Security's @Secured annotations should be enabled for this application context. Defaults to "disabled".
+	attribute secured-annotations {"disabled" | "enabled" }?
+global-method-security.attlist &=
+	## Specifies whether JSR-250 style attributes are to be used (for example "RolesAllowed"). This will require the javax.annotation.security classes on the classpath. Defaults to "disabled".
+	attribute jsr250-annotations {"disabled" | "enabled" }?
+global-method-security.attlist &=
+	## Optional AccessDecisionManager bean ID to override the default used for method security.
+	attribute access-decision-manager-ref {xsd:token}?
+global-method-security.attlist &=
+	## Optional RunAsmanager implementation which will be used by the configured MethodSecurityInterceptor
+	attribute run-as-manager-ref {xsd:token}?
+global-method-security.attlist &=
+	## Allows the advice "order" to be set for the method security interceptor.
+	attribute order {xsd:token}?
+global-method-security.attlist &=
+	## If true, class based proxying will be used instead of interface based proxying.
+	attribute proxy-target-class {xsd:boolean}?
+global-method-security.attlist &=
+	## Can be used to specify that AspectJ should be used instead of the default Spring AOP. If set, secured classes must be woven with the AnnotationSecurityAspect from the spring-security-aspects module.
+	attribute mode {"aspectj"}?
+global-method-security.attlist &=
+	## An external MethodSecurityMetadataSource instance can be supplied which will take priority over other sources (such as the default annotations).
+	attribute metadata-source-ref {xsd:token}?
+global-method-security.attlist &=
+	authentication-manager-ref?
+
+
+after-invocation-provider =
+	## Allows addition of extra AfterInvocationProvider beans which should be called by the MethodSecurityInterceptor created by global-method-security.
+	element after-invocation-provider {ref}
+
+pre-post-annotation-handling =
+	## Allows the default expression-based mechanism for handling Spring Security's pre and post invocation annotations (@PreFilter, @PreAuthorize, @PostFilter, @PostAuthorize) to be replace entirely. Only applies if these annotations are enabled.
+	element pre-post-annotation-handling {invocation-attribute-factory, pre-invocation-advice, post-invocation-advice}
+
+invocation-attribute-factory =
+	## Defines the PrePostInvocationAttributeFactory instance which is used to generate pre and post invocation metadata from the annotated methods.
+	element invocation-attribute-factory {ref}
+
+pre-invocation-advice =
+	## Customizes the PreInvocationAuthorizationAdviceVoter with the ref as the PreInvocationAuthorizationAdviceVoter for the <pre-post-annotation-handling> element.
+	element pre-invocation-advice {ref}
+
+post-invocation-advice =
+	## Customizes the PostInvocationAdviceProvider with the ref as the PostInvocationAuthorizationAdvice for the <pre-post-annotation-handling> element.
+	element post-invocation-advice {ref}
+
+
+expression-handler =
+	## Defines the SecurityExpressionHandler instance which will be used if expression-based access-control is enabled. A default implementation (with no ACL support) will be used if not supplied.
+	element expression-handler {ref}
+
+protect-pointcut =
+	## Defines a protected pointcut and the access control configuration attributes that apply to it. Every bean registered in the Spring application context that provides a method that matches the pointcut will receive security authorization.
+	element protect-pointcut {protect-pointcut.attlist, empty}
+protect-pointcut.attlist &=
+	## An AspectJ expression, including the 'execution' keyword. For example, 'execution(int com.foo.TargetObject.countLength(String))' (without the quotes).
+	attribute expression {xsd:string}
+protect-pointcut.attlist &=
+	## Access configuration attributes list that applies to all methods matching the pointcut, e.g. "ROLE_A,ROLE_B"
+	attribute access {xsd:token}
+
+websocket-message-broker =
+	## Allows securing a Message Broker. There are two modes. If no id is specified: ensures that any SimpAnnotationMethodMessageHandler has the AuthenticationPrincipalArgumentResolver registered as a custom argument resolver; ensures that the SecurityContextChannelInterceptor is automatically registered for the clientInboundChannel; and that a ChannelSecurityInterceptor is registered with the clientInboundChannel. If the id is specified, creates a ChannelSecurityInterceptor that can be manually registered with the clientInboundChannel.
+	element websocket-message-broker { websocket-message-broker.attrlist, (intercept-message* & expression-handler?) }
+
+websocket-message-broker.attrlist &=
+	## A bean identifier, used for referring to the bean elsewhere in the context. If specified, explicit configuration within clientInboundChannel is required. If not specified, ensures that any SimpAnnotationMethodMessageHandler has the AuthenticationPrincipalArgumentResolver registered as a custom argument resolver; ensures that the SecurityContextChannelInterceptor is automatically registered for the clientInboundChannel; and that a ChannelSecurityInterceptor is registered with the clientInboundChannel.
+	attribute id {xsd:token}?
+websocket-message-broker.attrlist &=
+	## Disables the requirement for CSRF token to be present in the Stomp headers (default false). Changing the default is useful if it is necessary to allow other origins to make SockJS connections.
+	attribute same-origin-disabled {xsd:boolean}?
+
+intercept-message =
+	## Creates an authorization rule for a websocket message.
+	element intercept-message {intercept-message.attrlist}
+
+intercept-message.attrlist &=
+	## The destination ant pattern which will be mapped to the access attribute. For example, /** matches any message with a destination, /admin/** matches any message that has a destination that starts with admin.
+	attribute pattern {xsd:token}?
+intercept-message.attrlist &=
+	## The access configuration attributes that apply for the configured message. For example, permitAll grants access to anyone, hasRole('ROLE_ADMIN') requires the user have the role 'ROLE_ADMIN'.
+	attribute access {xsd:token}?
+intercept-message.attrlist &=
+	## The type of message to match on. Valid values are defined in SimpMessageType (i.e. CONNECT, CONNECT_ACK, HEARTBEAT, MESSAGE, SUBSCRIBE, UNSUBSCRIBE, DISCONNECT, DISCONNECT_ACK, OTHER).
+	attribute type {"CONNECT" | "CONNECT_ACK" | "HEARTBEAT" | "MESSAGE" | "SUBSCRIBE"| "UNSUBSCRIBE" | "DISCONNECT" | "DISCONNECT_ACK" | "OTHER"}?
+
+http-firewall =
+	## Allows a custom instance of HttpFirewall to be injected into the FilterChainProxy created by the namespace.
+	element http-firewall {ref}
+
+http =
+	## Container element for HTTP security configuration. Multiple elements can now be defined, each with a specific pattern to which the enclosed security configuration applies. A pattern can also be configured to bypass Spring Security's filters completely by setting the "security" attribute to "none".
+	element http {http.attlist, (intercept-url* & access-denied-handler? & form-login? & openid-login? & x509? & jee? & http-basic? & logout? & session-management & remember-me? & anonymous? & port-mappings & custom-filter* & request-cache? & expression-handler? & headers? & csrf?) }
+http.attlist &=
+	## The request URL pattern which will be mapped to the filter chain created by this <http> element. If omitted, the filter chain will match all requests.
+	attribute pattern {xsd:token}?
+http.attlist &=
+	## When set to 'none', requests matching the pattern attribute will be ignored by Spring Security. No security filters will be applied and no SecurityContext will be available. If set, the <http> element must be empty, with no children.
+	attribute security {"none"}?
+http.attlist &=
+	## Allows a RequestMatcher instance to be used, as an alternative to pattern-matching.
+	attribute request-matcher-ref { xsd:token }?
+http.attlist &=
+	## A legacy attribute which automatically registers a login form, BASIC authentication and a logout URL and logout services. If unspecified, defaults to "false". We'd recommend you avoid using this and instead explicitly configure the services you require.
+	attribute auto-config {xsd:boolean}?
+http.attlist &=
+	use-expressions?
+http.attlist &=
+	## Controls the eagerness with which an HTTP session is created by Spring Security classes. If not set, defaults to "ifRequired". If "stateless" is used, this implies that the application guarantees that it will not create a session. This differs from the use of "never" which mans that Spring Security will not create a session, but will make use of one if the application does.
+	attribute create-session {"ifRequired" | "always" | "never" | "stateless"}?
+http.attlist &=
+	## A reference to a SecurityContextRepository bean. This can be used to customize how the SecurityContext is stored between requests.
+	attribute security-context-repository-ref {xsd:token}?
+http.attlist &=
+	request-matcher?
+http.attlist &=
+	## Provides versions of HttpServletRequest security methods such as isUserInRole() and getPrincipal() which are implemented by accessing the Spring SecurityContext. Defaults to "true".
+	attribute servlet-api-provision {xsd:boolean}?
+http.attlist &=
+	## If available, runs the request as the Subject acquired from the JaasAuthenticationToken. Defaults to "false".
+	attribute jaas-api-provision {xsd:boolean}?
+http.attlist &=
+	## Optional attribute specifying the ID of the AccessDecisionManager implementation which should be used for authorizing HTTP requests.
+	attribute access-decision-manager-ref {xsd:token}?
+http.attlist &=
+	## Optional attribute specifying the realm name that will be used for all authentication features that require a realm name (eg BASIC and Digest authentication). If unspecified, defaults to "Spring Security Application".
+	attribute realm {xsd:token}?
+http.attlist &=
+	## Allows a customized AuthenticationEntryPoint to be set on the ExceptionTranslationFilter.
+	attribute entry-point-ref {xsd:token}?
+http.attlist &=
+	## Corresponds to the observeOncePerRequest property of FilterSecurityInterceptor. Defaults to "true"
+	attribute once-per-request {xsd:boolean}?
+http.attlist &=
+	## Prevents the jsessionid parameter from being added to rendered URLs. Defaults to "true" (rewriting is disabled).
+	attribute disable-url-rewriting {xsd:boolean}?
+http.attlist &=
+	## Exposes the list of filters defined by this configuration under this bean name in the application context.
+	name?
+http.attlist &=
+	authentication-manager-ref?
+
+access-denied-handler =
+	## Defines the access-denied strategy that should be used. An access denied page can be defined or a reference to an AccessDeniedHandler instance.
+	element access-denied-handler {access-denied-handler.attlist, empty}
+access-denied-handler.attlist &= (ref | access-denied-handler-page)
+
+access-denied-handler-page =
+	## The access denied page that an authenticated user will be redirected to if they request a page which they don't have the authority to access.
+	attribute error-page {xsd:token}
+
+intercept-url =
+	## Specifies the access attributes and/or filter list for a particular set of URLs.
+	element intercept-url {intercept-url.attlist, empty}
+intercept-url.attlist &=
+	## The pattern which defines the URL path. The content will depend on the type set in the containing http element, so will default to ant path syntax.
+	attribute pattern {xsd:token}
+intercept-url.attlist &=
+	## The access configuration attributes that apply for the configured path.
+	attribute access {xsd:token}?
+intercept-url.attlist &=
+	## The HTTP Method for which the access configuration attributes should apply. If not specified, the attributes will apply to any method.
+	attribute method {"GET" | "DELETE" | "HEAD" | "OPTIONS" | "POST" | "PUT" | "PATCH" | "TRACE"}?
+
+intercept-url.attlist &=
+	## The filter list for the path. Currently can be set to "none" to remove a path from having any filters applied. The full filter stack (consisting of all filters created by the namespace configuration, and any added using 'custom-filter'), will be applied to any other paths.
+	attribute filters {"none"}?
+intercept-url.attlist &=
+	## Used to specify that a URL must be accessed over http or https, or that there is no preference. The value should be "http", "https" or "any", respectively.
+	attribute requires-channel {xsd:token}?
+
+logout =
+	## Incorporates a logout processing filter. Most web applications require a logout filter, although you may not require one if you write a controller to provider similar logic.
+	element logout {logout.attlist, empty}
+logout.attlist &=
+	## Specifies the URL that will cause a logout. Spring Security will initialize a filter that responds to this particular URL. Defaults to /logout if unspecified.
+	attribute logout-url {xsd:token}?
+logout.attlist &=
+	## Specifies the URL to display once the user has logged out. If not specified, defaults to <form-login-login-page>/?logout (i.e. /login?logout).
+	attribute logout-success-url {xsd:token}?
+logout.attlist &=
+	## Specifies whether a logout also causes HttpSession invalidation, which is generally desirable. If unspecified, defaults to true.
+	attribute invalidate-session {xsd:boolean}?
+logout.attlist &=
+	## A reference to a LogoutSuccessHandler implementation which will be used to determine the destination to which the user is taken after logging out.
+	attribute success-handler-ref {xsd:token}?
+logout.attlist &=
+	## A comma-separated list of the names of cookies which should be deleted when the user logs out
+	attribute delete-cookies {xsd:token}?
+
+request-cache =
+	## Allow the RequestCache used for saving requests during the login process to be set
+	element request-cache {ref}
+
+form-login =
+	## Sets up a form login configuration for authentication with a username and password
+	element form-login {form-login.attlist, empty}
+form-login.attlist &=
+	## The URL that the login form is posted to. If unspecified, it defaults to /login.
+	attribute login-processing-url {xsd:token}?
+form-login.attlist &=
+	## The name of the request parameter which contains the username. Defaults to 'username'.
+	attribute username-parameter {xsd:token}?
+form-login.attlist &=
+	## The name of the request parameter which contains the password. Defaults to 'password'.
+	attribute password-parameter {xsd:token}?
+form-login.attlist &=
+	## The URL that will be redirected to after successful authentication, if the user's previous action could not be resumed. This generally happens if the user visits a login page without having first requested a secured operation that triggers authentication. If unspecified, defaults to the root of the application.
+	attribute default-target-url {xsd:token}?
+form-login.attlist &=
+	## Whether the user should always be redirected to the default-target-url after login.
+	attribute always-use-default-target {xsd:boolean}?
+form-login.attlist &=
+	## The URL for the login page. If no login URL is specified, Spring Security will automatically create a login URL at GET /login and a corresponding filter to render that login URL when requested.
+	attribute login-page {xsd:token}?
+form-login.attlist &=
+	## The URL for the login failure page. If no login failure URL is specified, Spring Security will automatically create a failure login URL at /login?error and a corresponding filter to render that login failure URL when requested.
+	attribute authentication-failure-url {xsd:token}?
+form-login.attlist &=
+	## Reference to an AuthenticationSuccessHandler bean which should be used to handle a successful authentication request. Should not be used in combination with default-target-url (or always-use-default-target-url) as the implementation should always deal with navigation to the subsequent destination
+	attribute authentication-success-handler-ref {xsd:token}?
+form-login.attlist &=
+	## Reference to an AuthenticationFailureHandler bean which should be used to handle a failed authentication request. Should not be used in combination with authentication-failure-url as the implementation should always deal with navigation to the subsequent destination
+	attribute authentication-failure-handler-ref {xsd:token}?
+form-login.attlist &=
+	## Reference to an AuthenticationDetailsSource which will be used by the authentication filter
+	attribute authentication-details-source-ref {xsd:token}?
+
+
+openid-login =
+	## Sets up form login for authentication with an Open ID identity
+	element openid-login {form-login.attlist, user-service-ref?, attribute-exchange*}
+
+attribute-exchange =
+	## Sets up an attribute exchange configuration to request specified attributes from the OpenID identity provider. When multiple elements are used, each must have an identifier-attribute attribute. Each configuration will be matched in turn against the supplied login identifier until a match is found.
+	element attribute-exchange {attribute-exchange.attlist, openid-attribute+}
+
+attribute-exchange.attlist &=
+	## A regular expression which will be compared against the claimed identity, when deciding which attribute-exchange configuration to use during authentication.
+	attribute identifier-match {xsd:token}?
+
+openid-attribute =
+	## Attributes used when making an OpenID AX Fetch Request
+	element openid-attribute {openid-attribute.attlist}
+
+openid-attribute.attlist &=
+	## Specifies the name of the attribute that you wish to get back. For example, email.
+	attribute name {xsd:token}
+openid-attribute.attlist &=
+	## Specifies the attribute type. For example, http://axschema.org/contact/email. See your OP's documentation for valid attribute types.
+	attribute type {xsd:token}
+openid-attribute.attlist &=
+	## Specifies if this attribute is required to the OP, but does not error out if the OP does not return the attribute. Default is false.
+	attribute required {xsd:boolean}?
+openid-attribute.attlist &=
+	## Specifies the number of attributes that you wish to get back. For example, return 3 emails. The default value is 1.
+	attribute count {xsd:int}?
+
+
+filter-chain-map =
+	## Used to explicitly configure a FilterChainProxy instance with a FilterChainMap
+	element filter-chain-map {filter-chain-map.attlist, filter-chain+}
+filter-chain-map.attlist &=
+	request-matcher?
+
+filter-chain =
+	## Used within to define a specific URL pattern and the list of filters which apply to the URLs matching that pattern. When multiple filter-chain elements are assembled in a list in order to configure a FilterChainProxy, the most specific patterns must be placed at the top of the list, with  most general ones at the bottom.
+	element filter-chain {filter-chain.attlist, empty}
+filter-chain.attlist &=
+	(pattern | request-matcher-ref)
+filter-chain.attlist &=
+	## A comma separated list of bean names that implement Filter that should be processed for this FilterChain. If the value is none, then no Filters will be used for this FilterChain.
+	attribute filters {xsd:token}
+
+pattern =
+	## The request URL pattern which will be mapped to the FilterChain.
+	attribute pattern {xsd:token}
+request-matcher-ref =
+	## Allows a RequestMatcher instance to be used, as an alternative to pattern-matching.
+	attribute request-matcher-ref {xsd:token}
+
+filter-security-metadata-source =
+	## Used to explicitly configure a FilterSecurityMetadataSource bean for use with a FilterSecurityInterceptor. Usually only needed if you are configuring a FilterChainProxy explicitly, rather than using the <http> element. The intercept-url elements used should only contain pattern, method and access attributes. Any others will result in a configuration error.
+	element filter-security-metadata-source {fsmds.attlist, intercept-url+}
+fsmds.attlist &=
+	use-expressions?
+fsmds.attlist &=
+	id?
+fsmds.attlist &=
+	## Compare after forcing to lowercase
+	attribute lowercase-comparisons {xsd:boolean}?
+fsmds.attlist &=
+	request-matcher?
+
+http-basic =
+	## Adds support for basic authentication
+	element http-basic {http-basic.attlist, empty}
+
+http-basic.attlist &=
+	## Sets the AuthenticationEntryPoint which is used by the BasicAuthenticationFilter.
+	attribute entry-point-ref {xsd:token}?
+http-basic.attlist &=
+	## Reference to an AuthenticationDetailsSource which will be used by the authentication filter
+	attribute authentication-details-source-ref {xsd:token}?
+
+session-management =
+	## Session-management related functionality is implemented by the addition of a SessionManagementFilter to the filter stack.
+	element session-management {session-management.attlist, concurrency-control?}
+
+session-management.attlist &=
+	## Indicates how session fixation protection will be applied when a user authenticates. If set to "none", no protection will be applied. "newSession" will create a new empty session, with only Spring Security-related attributes migrated. "migrateSession" will create a new session and copy all session attributes to the new session. In Servlet 3.1 (Java EE 7) and newer containers, specifying "changeSessionId" will keep the existing session and use the container-supplied session fixation protection (HttpServletRequest#changeSessionId()). Defaults to "changeSessionId" in Servlet 3.1 and newer containers, "migrateSession" in older containers. Throws an exception if "changeSessionId" is used in older containers.
+	attribute session-fixation-protection {"none" | "newSession" | "migrateSession" | "changeSessionId" }?
+session-management.attlist &=
+	## The URL to which a user will be redirected if they submit an invalid session indentifier. Typically used to detect session timeouts.
+	attribute invalid-session-url {xsd:token}?
+session-management.attlist &=
+	## Allows injection of the SessionAuthenticationStrategy instance used by the SessionManagementFilter
+	attribute session-authentication-strategy-ref {xsd:token}?
+session-management.attlist &=
+	## Defines the URL of the error page which should be shown when the SessionAuthenticationStrategy raises an exception. If not set, an unauthorized (401) error code will be returned to the client. Note that this attribute doesn't apply if the error occurs during a form-based login, where the URL for authentication failure will take precedence.
+	attribute session-authentication-error-url {xsd:token}?
+
+
+concurrency-control =
+	## Enables concurrent session control, limiting the number of authenticated sessions a user may have at the same time.
+	element concurrency-control {concurrency-control.attlist, empty}
+
+concurrency-control.attlist &=
+	## The maximum number of sessions a single authenticated user can have open at the same time. Defaults to "1".
+	attribute max-sessions {xsd:positiveInteger}?
+concurrency-control.attlist &=
+	## The URL a user will be redirected to if they attempt to use a session which has been "expired" because they have logged in again.
+	attribute expired-url {xsd:token}?
+concurrency-control.attlist &=
+	## Specifies that an unauthorized error should be reported when a user attempts to login when they already have the maximum configured sessions open. The default behaviour is to expire the original session. If the session-authentication-error-url attribute is set on the session-management URL, the user will be redirected to this URL.
+	attribute error-if-maximum-exceeded {xsd:boolean}?
+concurrency-control.attlist &=
+	## Allows you to define an alias for the SessionRegistry bean in order to access it in your own configuration.
+	attribute session-registry-alias {xsd:token}?
+concurrency-control.attlist &=
+	## Allows you to define an external SessionRegistry bean to be used by the concurrency control setup.
+	attribute session-registry-ref {xsd:token}?
+
+
+remember-me =
+	## Sets up remember-me authentication. If used with the "key" attribute (or no attributes) the cookie-only implementation will be used. Specifying "token-repository-ref" or "remember-me-data-source-ref" will use the more secure, persisten token approach.
+	element remember-me {remember-me.attlist}
+remember-me.attlist &=
+	## The "key" used to identify cookies from a specific token-based remember-me application. You should set this to a unique value for your application. If unset, it will default to a random value generated by SecureRandom.
+	attribute key {xsd:token}?
+
+remember-me.attlist &=
+	(token-repository-ref | remember-me-data-source-ref | remember-me-services-ref)
+
+remember-me.attlist &=
+	user-service-ref?
+
+remember-me.attlist &=
+	## Exports the internally defined RememberMeServices as a bean alias, allowing it to be used by other beans in the application context.
+	attribute services-alias {xsd:token}?
+
+remember-me.attlist &=
+	## Determines whether the "secure" flag will be set on the remember-me cookie. If set to true, the cookie will only be submitted over HTTPS (recommended). By default, secure cookies will be used if the request is made on a secure connection.
+	attribute use-secure-cookie {xsd:boolean}?
+
+remember-me.attlist &=
+	## The period (in seconds) for which the remember-me cookie should be valid.
+	attribute token-validity-seconds {xsd:string}?
+
+remember-me.attlist &=
+	## Reference to an AuthenticationSuccessHandler bean which should be used to handle a successful remember-me authentication.
+	attribute authentication-success-handler-ref {xsd:token}?
+remember-me.attlist &=
+	## The name of the request parameter which toggles remember-me authentication. Defaults to 'remember-me'.
+	attribute remember-me-parameter {xsd:token}?
+remember-me.attlist &=
+	## The name of cookie which store the token for remember-me authentication. Defaults to 'remember-me'.
+	attribute remember-me-cookie {xsd:token}?
+
+token-repository-ref =
+	## Reference to a PersistentTokenRepository bean for use with the persistent token remember-me implementation.
+	attribute token-repository-ref {xsd:token}
+remember-me-services-ref =
+	## Allows a custom implementation of RememberMeServices to be used. Note that this implementation should return RememberMeAuthenticationToken instances with the same "key" value as specified in the remember-me element. Alternatively it should register its own AuthenticationProvider. It should also implement the LogoutHandler interface, which will be invoked when a user logs out. Typically the remember-me cookie would be removed on logout.
+	attribute services-ref {xsd:token}?
+remember-me-data-source-ref =
+	## DataSource bean for the database that contains the token repository schema.
+	data-source-ref
+
+anonymous =
+	## Adds support for automatically granting all anonymous web requests a particular principal identity and a corresponding granted authority.
+	element anonymous {anonymous.attlist}
+anonymous.attlist &=
+	## The key shared between the provider and filter. This generally does not need to be set. If unset, it will default to a random value generated by SecureRandom.
+	attribute key {xsd:token}?
+anonymous.attlist &=
+	## The username that should be assigned to the anonymous request. This allows the principal to be identified, which may be important for logging and auditing. if unset, defaults to "anonymousUser".
+	attribute username {xsd:token}?
+anonymous.attlist &=
+	## The granted authority that should be assigned to the anonymous request. Commonly this is used to assign the anonymous request particular roles, which can subsequently be used in authorization decisions. If unset, defaults to "ROLE_ANONYMOUS".
+	attribute granted-authority {xsd:token}?
+anonymous.attlist &=
+	## With the default namespace setup, the anonymous "authentication" facility is automatically enabled. You can disable it using this property.
+	attribute enabled {xsd:boolean}?
+
+
+port-mappings =
+	## Defines the list of mappings between http and https ports for use in redirects
+	element port-mappings {port-mappings.attlist, port-mapping+}
+
+port-mappings.attlist &= empty
+
+port-mapping =
+	## Provides a method to map http ports to https ports when forcing a redirect.
+	element port-mapping {http-port, https-port}
+
+http-port =
+	## The http port to use.
+	attribute http {xsd:token}
+
+https-port =
+	## The https port to use.
+	attribute https {xsd:token}
+
+
+x509 =
+	## Adds support for X.509 client authentication.
+	element x509 {x509.attlist}
+x509.attlist &=
+	## The regular expression used to obtain the username from the certificate's subject. Defaults to matching on the common name using the pattern "CN=(.*?),".
+	attribute subject-principal-regex {xsd:token}?
+x509.attlist &=
+	## Explicitly specifies which user-service should be used to load user data for X.509 authenticated clients. If ommitted, the default user-service will be used.
+	user-service-ref?
+x509.attlist &=
+	## Reference to an AuthenticationDetailsSource which will be used by the authentication filter
+	attribute authentication-details-source-ref {xsd:token}?
+
+jee =
+	## Adds a J2eePreAuthenticatedProcessingFilter to the filter chain to provide integration with container authentication.
+	element jee {jee.attlist}
+jee.attlist &=
+	## A comma-separate list of roles to look for in the incoming HttpServletRequest.
+	attribute mappable-roles {xsd:token}
+jee.attlist &=
+	## Explicitly specifies which user-service should be used to load user data for container authenticated clients. If ommitted, the set of mappable-roles will be used to construct the authorities for the user.
+	user-service-ref?
+
+authentication-manager =
+	## Registers the AuthenticationManager instance and allows its list of AuthenticationProviders to be defined. Also allows you to define an alias to allow you to reference the AuthenticationManager in your own beans.
+	element authentication-manager {authman.attlist & authentication-provider* & ldap-authentication-provider*}
+authman.attlist &=
+	id?
+authman.attlist &=
+	## An alias you wish to use for the AuthenticationManager bean (not required it you are using a specific id)
+	attribute alias {xsd:token}?
+authman.attlist &=
+	## If set to true, the AuthenticationManger will attempt to clear any credentials data in the returned Authentication object, once the user has been authenticated.
+	attribute erase-credentials {xsd:boolean}?
+
+authentication-provider =
+	## Indicates that the contained user-service should be used as an authentication source.
+	element authentication-provider {ap.attlist & any-user-service & password-encoder?}
+ap.attlist &=
+	## Specifies a reference to a separately configured AuthenticationProvider instance which should be registered within the AuthenticationManager.
+	ref?
+ap.attlist &=
+	## Specifies a reference to a separately configured UserDetailsService from which to obtain authentication data.
+	user-service-ref?
+
+user-service =
+	## Creates an in-memory UserDetailsService from a properties file or a list of "user" child elements. Usernames are converted to lower-case internally to allow for case-insensitive lookups, so this should not be used if case-sensitivity is required.
+	element user-service {id? & (properties-file | (user*))}
+properties-file =
+	## The location of a Properties file where each line is in the format of username=password,grantedAuthority[,grantedAuthority][,enabled|disabled]
+	attribute properties {xsd:token}?
+
+user =
+	## Represents a user in the application.
+	element user {user.attlist, empty}
+user.attlist &=
+	## The username assigned to the user.
+	attribute name {xsd:token}
+user.attlist &=
+	## The password assigned to the user. This may be hashed if the corresponding authentication provider supports hashing (remember to set the "hash" attribute of the "user-service" element). This attribute be omitted in the case where the data will not be used for authentication, but only for accessing authorities. If omitted, the namespace will generate a random value, preventing its accidental use for authentication. Cannot be empty.
+	attribute password {xsd:string}?
+user.attlist &=
+	## One of more authorities granted to the user. Separate authorities with a comma (but no space). For example, "ROLE_USER,ROLE_ADMINISTRATOR"
+	attribute authorities {xsd:token}
+user.attlist &=
+	## Can be set to "true" to mark an account as locked and unusable.
+	attribute locked {xsd:boolean}?
+user.attlist &=
+	## Can be set to "true" to mark an account as disabled and unusable.
+	attribute disabled {xsd:boolean}?
+
+jdbc-user-service =
+	## Causes creation of a JDBC-based UserDetailsService.
+	element jdbc-user-service {id? & jdbc-user-service.attlist}
+jdbc-user-service.attlist &=
+	## The bean ID of the DataSource which provides the required tables.
+	attribute data-source-ref {xsd:token}
+jdbc-user-service.attlist &=
+	cache-ref?
+jdbc-user-service.attlist &=
+	## An SQL statement to query a username, password, and enabled status given a username. Default is "select username,password,enabled from users where username = ?"
+	attribute users-by-username-query {xsd:token}?
+jdbc-user-service.attlist &=
+	## An SQL statement to query for a user's granted authorities given a username. The default is "select username, authority from authorities where username = ?"
+	attribute authorities-by-username-query {xsd:token}?
+jdbc-user-service.attlist &=
+	## An SQL statement to query user's group authorities given a username. The default is "select g.id, g.group_name, ga.authority from groups g, group_members gm, group_authorities ga where gm.username = ? and g.id = ga.group_id and g.id = gm.group_id"
+	attribute group-authorities-by-username-query {xsd:token}?
+jdbc-user-service.attlist &=
+	role-prefix?
+
+csrf =
+## Element for configuration of the CsrfFilter for protection against CSRF. It also updates the default RequestCache to only replay "GET" requests.
+	element csrf {csrf-options.attlist}
+csrf-options.attlist &=
+	## Specifies if csrf protection should be disabled. Default false (i.e. CSRF protection is enabled).
+	attribute disabled {xsd:boolean}?
+csrf-options.attlist &=
+	## The RequestMatcher instance to be used to determine if CSRF should be applied. Default is any HTTP method except "GET", "TRACE", "HEAD", "OPTIONS"
+	attribute request-matcher-ref { xsd:token }?
+csrf-options.attlist &=
+	## The CsrfTokenRepository to use. The default is HttpSessionCsrfTokenRepository
+	attribute token-repository-ref { xsd:token }?
+
+headers =
+## Element for configuration of the HeaderWritersFilter. Enables easy setting for the X-Frame-Options, X-XSS-Protection and X-Content-Type-Options headers.
+element headers { headers-options.attlist, (cache-control? & xss-protection? & hsts? & frame-options? & content-type-options? & hpkp? & header*)}
+headers-options.attlist &=
+	## Specifies if the default headers should be disabled. Default false.
+	attribute defaults-disabled {xsd:boolean}?
+headers-options.attlist &=
+	## Specifies if headers should be disabled. Default false.
+	attribute disabled {xsd:boolean}?
+hsts =
+	## Adds support for HTTP Strict Transport Security (HSTS)
+	element hsts {hsts-options.attlist}
+hsts-options.attlist &=
+	## Specifies if HTTP Strict Transport Security (HSTS) should be disabled. Default false.
+	attribute disabled {xsd:boolean}?
+hsts-options.attlist &=
+	## Specifies if subdomains should be included. Default true.
+	attribute include-subdomains {xsd:boolean}?
+hsts-options.attlist &=
+	## Specifies the maximum ammount of time the host should be considered a Known HSTS Host. Default one year.
+	attribute max-age-seconds {xsd:integer}?
+hsts-options.attlist &=
+	## The RequestMatcher instance to be used to determine if the header should be set. Default is if HttpServletRequest.isSecure() is true.
+	attribute request-matcher-ref { xsd:token }?
+
+hpkp =
+	## Adds support for HTTP Public Key Pinning (HPKP).
+	element hpkp {hpkp.pins,hpkp.attlist}
+hpkp.pins =
+	## The list with pins
+ 	element pins {hpkp.pin+}
+hpkp.pin =
+	## A pin is specified using the base64-encoded SPKI fingerprint as value and the cryptographic hash algorithm as attribute
+	element pin {
+		## The cryptographic hash algorithm
+		attribute algorithm { xsd:string }?,
+		text
+	}
+hpkp.attlist &=
+	## Specifies if HTTP Public Key Pinning (HPKP) should be disabled. Default false.
+	attribute disabled {xsd:boolean}?
+hpkp.attlist &=
+	## Specifies if subdomains should be included. Default false.
+	attribute include-subdomains {xsd:boolean}?
+hpkp.attlist &=
+	## Sets the value for the max-age directive of the Public-Key-Pins header. Default 60 days.
+	attribute max-age-seconds {xsd:integer}?
+hpkp.attlist &=
+	## Specifies if the browser should only report pin validation failures. Default true.
+	attribute report-only {xsd:boolean}?
+hpkp.attlist &=
+	## Specifies the URI to which the browser should report pin validation failures.
+	attribute report-uri {xsd:string}?
+
+cache-control =
+	## Adds Cache-Control no-cache, no-store, must-revalidate, Pragma no-cache, and Expires 0 for every request
+	element cache-control {cache-control.attlist}
+cache-control.attlist &=
+	## Specifies if Cache Control should be disabled. Default false.
+	attribute disabled {xsd:boolean}?
+
+frame-options =
+	## Enable basic clickjacking support for newer browsers (IE8+), will set the X-Frame-Options header.
+	element frame-options {frame-options.attlist,empty}
+frame-options.attlist &=
+	## If disabled, the X-Frame-Options header will not be included. Default false.
+	attribute disabled {xsd:boolean}?
+frame-options.attlist &=
+	## Specify the policy to use for the X-Frame-Options-Header.
+	attribute policy {"DENY","SAMEORIGIN","ALLOW-FROM"}?
+frame-options.attlist &=
+	## Specify the strategy to use when ALLOW-FROM is chosen.
+	attribute strategy {"static","whitelist","regexp"}?
+frame-options.attlist &=
+	## Specify the a reference to the custom AllowFromStrategy to use when ALLOW-FROM is chosen.
+	ref?
+frame-options.attlist &=
+	## Specify the a value to use for the chosen strategy.
+	attribute value {xsd:string}?
+frame-options.attlist &=
+	## Specify the request parameter to use for the origin when using a 'whitelist' or 'regexp' based strategy. Default is 'from'.
+	attribute from-parameter {xsd:string}?
+
+
+xss-protection =
+	## Enable basic XSS browser protection, supported by newer browsers (IE8+), will set the X-XSS-Protection header.
+	element xss-protection {xss-protection.attlist,empty}
+xss-protection.attlist &=
+	## disable the X-XSS-Protection header. Default is 'false' meaning it is enabled.
+	attribute disabled {xsd:boolean}?
+xss-protection.attlist &=
+	## specify that XSS Protection should be explicitly enabled or disabled. Default is 'true' meaning it is enabled.
+	attribute enabled {xsd:boolean}?
+xss-protection.attlist &=
+	## Add mode=block to the header or not, default is on.
+	attribute block {xsd:boolean}?
+
+content-type-options =
+	## Add a X-Content-Type-Options header to the resopnse. Value is always 'nosniff'.
+	element content-type-options {content-type-options.attlist, empty}
+content-type-options.attlist &=
+	## If disabled, the X-Content-Type-Options header will not be included. Default false.
+	attribute disabled {xsd:boolean}?
+
+header=
+	## Add additional headers to the response.
+	element header {header.attlist}
+header.attlist &=
+	## The name of the header to add.
+	attribute name {xsd:token}?
+header.attlist &=
+	## The value for the header.
+	attribute value {xsd:token}?
+header.attlist &=
+	## Reference to a custom HeaderWriter implementation.
+	ref?
+
+any-user-service = user-service | jdbc-user-service | ldap-user-service
+
+custom-filter =
+	## Used to indicate that a filter bean declaration should be incorporated into the security filter chain.
+	element custom-filter {custom-filter.attlist}
+
+custom-filter.attlist &=
+	ref
+
+custom-filter.attlist &=
+	(after | before | position)
+
+after =
+	## The filter immediately after which the custom-filter should be placed in the chain. This feature will only be needed by advanced users who wish to mix their own filters into the security filter chain and have some knowledge of the standard Spring Security filters. The filter names map to specific Spring Security implementation filters.
+	attribute after {named-security-filter}
+before =
+	## The filter immediately before which the custom-filter should be placed in the chain
+	attribute before {named-security-filter}
+position =
+	## The explicit position at which the custom-filter should be placed in the chain. Use if you are replacing a standard filter.
+	attribute position {named-security-filter}
+
+named-security-filter = "FIRST" | "CHANNEL_FILTER" | "SECURITY_CONTEXT_FILTER" | "CONCURRENT_SESSION_FILTER" | "WEB_ASYNC_MANAGER_FILTER" | "HEADERS_FILTER" | "CSRF_FILTER" | "LOGOUT_FILTER" | "X509_FILTER" | "PRE_AUTH_FILTER" | "CAS_FILTER" | "FORM_LOGIN_FILTER" | "OPENID_FILTER" | "LOGIN_PAGE_FILTER" | "DIGEST_AUTH_FILTER" | "BASIC_AUTH_FILTER" | "REQUEST_CACHE_FILTER" | "SERVLET_API_SUPPORT_FILTER" | "JAAS_API_SUPPORT_FILTER" | "REMEMBER_ME_FILTER" | "ANONYMOUS_FILTER" | "SESSION_MANAGEMENT_FILTER" | "EXCEPTION_TRANSLATION_FILTER" | "FILTER_SECURITY_INTERCEPTOR" | "SWITCH_USER_FILTER" | "LAST"

--- a/config/src/main/resources/org/springframework/security/config/spring-security-4.1.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-4.1.xsd
@@ -1,0 +1,2703 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:security="http://www.springframework.org/schema/security"
+           elementFormDefault="qualified"
+           targetNamespace="http://www.springframework.org/schema/security">
+  <xs:attributeGroup name="hash">
+      <xs:attribute name="hash" use="required">
+         <xs:annotation>
+            <xs:documentation>Defines the hashing algorithm used on user passwords. Bcrypt is recommended.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="bcrypt"/>
+               <xs:enumeration value="plaintext"/>
+               <xs:enumeration value="sha"/>
+               <xs:enumeration value="sha-256"/>
+               <xs:enumeration value="md5"/>
+               <xs:enumeration value="md4"/>
+               <xs:enumeration value="{sha}"/>
+               <xs:enumeration value="{ssha}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="base64">
+      <xs:attribute name="base64" use="required" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Whether a string should be base64 encoded
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="request-matcher">
+      <xs:attribute name="request-matcher" use="required">
+         <xs:annotation>
+            <xs:documentation>Defines the strategy use for matching incoming requests. Currently the options are 'ant'
+                (for ant path patterns), 'regex' for regular expressions and 'ciRegex' for
+                case-insensitive regular expressions.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="ant"/>
+               <xs:enumeration value="regex"/>
+               <xs:enumeration value="ciRegex"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="port">
+      <xs:attribute name="port" use="required" type="xs:positiveInteger">
+         <xs:annotation>
+            <xs:documentation>Specifies an IP port number. Used to configure an embedded LDAP server, for example.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="url">
+      <xs:attribute name="url" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Specifies a URL.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="id">
+      <xs:attribute name="id" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="name">
+      <xs:attribute name="name" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="ref">
+      <xs:attribute name="ref" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines a reference to a Spring bean Id.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="cache-ref">
+      <xs:attribute name="cache-ref" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines a reference to a cache for use with a UserDetailsService.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="user-service-ref">
+      <xs:attribute name="user-service-ref" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to a user-service (or UserDetailsService bean) Id
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="authentication-manager-ref">
+      <xs:attribute name="authentication-manager-ref" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to an AuthenticationManager bean
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="data-source-ref">
+      <xs:attribute name="data-source-ref" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to a DataSource bean
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="debug">
+      <xs:annotation>
+         <xs:documentation>Enables Spring Security debugging infrastructure. This will provide human-readable
+                (multi-line) debugging information to monitor requests coming into the security filters.
+                This may include sensitive information, such as request parameters or headers, and should
+                only be used in a development environment.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType/>
+   </xs:element>
+  
+  <xs:attributeGroup name="password-encoder.attlist">
+      <xs:attribute name="ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines a reference to a Spring bean Id.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="hash">
+         <xs:annotation>
+            <xs:documentation>Defines the hashing algorithm used on user passwords. Bcrypt is recommended.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="bcrypt"/>
+               <xs:enumeration value="plaintext"/>
+               <xs:enumeration value="sha"/>
+               <xs:enumeration value="sha-256"/>
+               <xs:enumeration value="md5"/>
+               <xs:enumeration value="md4"/>
+               <xs:enumeration value="{sha}"/>
+               <xs:enumeration value="{ssha}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="base64" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Whether a string should be base64 encoded
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="user-property">
+      <xs:attribute name="user-property" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A property of the UserDetails object which will be used as salt by a password encoder.
+                Typically something like "username" might be used.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="system-wide">
+      <xs:attribute name="system-wide" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A single value that will be used as the salt for a password encoder.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="role-prefix">
+      <xs:attribute name="role-prefix" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A non-empty string prefix that will be added to role strings loaded from persistent
+                storage (e.g. "ROLE_"). Use the value "none" for no prefix in cases where the default is
+                non-empty.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="use-expressions">
+      <xs:attribute name="use-expressions" use="required" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Enables the use of expressions in the 'access' attributes in &lt;intercept-url&gt; elements
+                rather than the traditional list of configuration attributes. Defaults to 'true'. If
+                enabled, each attribute should contain a single boolean expression. If the expression
+                evaluates to 'true', access will be granted.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="ldap-server">
+      <xs:annotation>
+         <xs:documentation>Defines an LDAP server location or starts an embedded server. The url indicates the
+                location of a remote server. If no url is given, an embedded server will be started,
+                listening on the supplied port number. The port is optional and defaults to 33389. A
+                Spring LDAP ContextSource bean will be registered for the server with the id supplied.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:ldap-server.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="ldap-server.attlist">
+      <xs:attribute name="id" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Specifies a URL.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="port" type="xs:positiveInteger">
+         <xs:annotation>
+            <xs:documentation>Specifies an IP port number. Used to configure an embedded LDAP server, for example.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="manager-dn" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>Username (DN) of the "manager" user identity which will be used to authenticate to a
+                (non-embedded) LDAP server. If omitted, anonymous access will be used.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="manager-password" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>The password for the manager DN. This is required if the manager-dn is specified.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ldif" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>Explicitly specifies an ldif file resource to load into an embedded LDAP server. The
+                default is classpath*:*.ldiff
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="root" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>Optional root suffix for the embedded LDAP server. Default is "dc=springframework,dc=org"
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="ldap-server-ref-attribute">
+      <xs:attribute name="server-ref" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The optional server to use. If omitted, and a default LDAP server is registered (using
+                &lt;ldap-server&gt; with no Id), that server will be used.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="group-search-filter-attribute">
+      <xs:attribute name="group-search-filter" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Group search filter. Defaults to (uniqueMember={0}). The substituted parameter is the DN
+                of the user.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="group-search-base-attribute">
+      <xs:attribute name="group-search-base" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Search base for group membership searches. Defaults to "" (searching from the root).
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="user-search-filter-attribute">
+      <xs:attribute name="user-search-filter" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The LDAP filter used to search for users (optional). For example "(uid={0})". The
+                substituted parameter is the user's login name.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="user-search-base-attribute">
+      <xs:attribute name="user-search-base" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Search base for user searches. Defaults to "". Only used with a 'user-search-filter'.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="group-role-attribute-attribute">
+      <xs:attribute name="group-role-attribute" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The LDAP attribute name which contains the role name which will be used within Spring
+                Security. Defaults to "cn".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="user-details-class-attribute">
+      <xs:attribute name="user-details-class" use="required">
+         <xs:annotation>
+            <xs:documentation>Allows the objectClass of the user entry to be specified. If set, the framework will
+                attempt to load standard attributes for the defined class into the returned UserDetails
+                object
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="person"/>
+               <xs:enumeration value="inetOrgPerson"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="user-context-mapper-attribute">
+      <xs:attribute name="user-context-mapper-ref" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows explicit customization of the loaded user object by specifying a
+                UserDetailsContextMapper bean which will be called with the context information from the
+                user's directory entry
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="ldap-user-service" substitutionGroup="security:any-user-service">
+      <xs:annotation>
+         <xs:documentation>This element configures a LdapUserDetailsService which is a combination of a
+                FilterBasedLdapUserSearch and a DefaultLdapAuthoritiesPopulator.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:ldap-us.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="ldap-us.attlist">
+      <xs:attribute name="id" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="server-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The optional server to use. If omitted, and a default LDAP server is registered (using
+                &lt;ldap-server&gt; with no Id), that server will be used.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-search-filter" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The LDAP filter used to search for users (optional). For example "(uid={0})". The
+                substituted parameter is the user's login name.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-search-base" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Search base for user searches. Defaults to "". Only used with a 'user-search-filter'.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="group-search-filter" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Group search filter. Defaults to (uniqueMember={0}). The substituted parameter is the DN
+                of the user.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="group-search-base" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Search base for group membership searches. Defaults to "" (searching from the root).
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="group-role-attribute" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The LDAP attribute name which contains the role name which will be used within Spring
+                Security. Defaults to "cn".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="cache-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines a reference to a cache for use with a UserDetailsService.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="role-prefix" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A non-empty string prefix that will be added to role strings loaded from persistent
+                storage (e.g. "ROLE_"). Use the value "none" for no prefix in cases where the default is
+                non-empty.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-details-class">
+         <xs:annotation>
+            <xs:documentation>Allows the objectClass of the user entry to be specified. If set, the framework will
+                attempt to load standard attributes for the defined class into the returned UserDetails
+                object
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="person"/>
+               <xs:enumeration value="inetOrgPerson"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="user-context-mapper-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows explicit customization of the loaded user object by specifying a
+                UserDetailsContextMapper bean which will be called with the context information from the
+                user's directory entry
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="ldap-ap.attlist">
+      <xs:attribute name="server-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The optional server to use. If omitted, and a default LDAP server is registered (using
+                &lt;ldap-server&gt; with no Id), that server will be used.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-search-base" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Search base for user searches. Defaults to "". Only used with a 'user-search-filter'.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-search-filter" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The LDAP filter used to search for users (optional). For example "(uid={0})". The
+                substituted parameter is the user's login name.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="group-search-base" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Search base for group membership searches. Defaults to "" (searching from the root).
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="group-search-filter" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Group search filter. Defaults to (uniqueMember={0}). The substituted parameter is the DN
+                of the user.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="group-role-attribute" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The LDAP attribute name which contains the role name which will be used within Spring
+                Security. Defaults to "cn".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-dn-pattern" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A specific pattern used to build the user's DN, for example "uid={0},ou=people". The key
+                "{0}" must be present and will be substituted with the username.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="role-prefix" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A non-empty string prefix that will be added to role strings loaded from persistent
+                storage (e.g. "ROLE_"). Use the value "none" for no prefix in cases where the default is
+                non-empty.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-details-class">
+         <xs:annotation>
+            <xs:documentation>Allows the objectClass of the user entry to be specified. If set, the framework will
+                attempt to load standard attributes for the defined class into the returned UserDetails
+                object
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="person"/>
+               <xs:enumeration value="inetOrgPerson"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="user-context-mapper-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows explicit customization of the loaded user object by specifying a
+                UserDetailsContextMapper bean which will be called with the context information from the
+                user's directory entry
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="password-compare.attlist">
+      <xs:attribute name="password-attribute" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The attribute in the directory which contains the user password. Defaults to
+                "userPassword".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="hash">
+         <xs:annotation>
+            <xs:documentation>Defines the hashing algorithm used on user passwords. Bcrypt is recommended.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="bcrypt"/>
+               <xs:enumeration value="plaintext"/>
+               <xs:enumeration value="sha"/>
+               <xs:enumeration value="sha-256"/>
+               <xs:enumeration value="md5"/>
+               <xs:enumeration value="md4"/>
+               <xs:enumeration value="{sha}"/>
+               <xs:enumeration value="{ssha}"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="intercept-methods">
+      <xs:annotation>
+         <xs:documentation>Can be used inside a bean definition to add a security interceptor to the bean and set up
+                access configuration attributes for the bean's methods
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="protect">
+               <xs:annotation>
+                  <xs:documentation>Defines a protected method and the access control configuration attributes that apply to
+                it. We strongly advise you NOT to mix "protect" declarations with any services provided
+                "global-method-security".
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:protect.attlist"/>
+               </xs:complexType>
+            </xs:element>
+         </xs:sequence>
+         <xs:attributeGroup ref="security:intercept-methods.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="intercept-methods.attlist">
+      <xs:attribute name="access-decision-manager-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Optional AccessDecisionManager bean ID to be used by the created method security
+                interceptor.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="protect.attlist">
+      <xs:attribute name="method" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A method name
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="access" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Access configuration attributes list that applies to the method, e.g. "ROLE_A,ROLE_B".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="method-security-metadata-source">
+      <xs:annotation>
+         <xs:documentation>Creates a MethodSecurityMetadataSource instance
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="protect">
+               <xs:annotation>
+                  <xs:documentation>Defines a protected method and the access control configuration attributes that apply to
+                it. We strongly advise you NOT to mix "protect" declarations with any services provided
+                "global-method-security".
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:protect.attlist"/>
+               </xs:complexType>
+            </xs:element>
+         </xs:sequence>
+         <xs:attributeGroup ref="security:msmds.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="msmds.attlist">
+      <xs:attribute name="id" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="use-expressions" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Enables the use of expressions in the 'access' attributes in &lt;intercept-url&gt; elements
+                rather than the traditional list of configuration attributes. Defaults to 'true'. If
+                enabled, each attribute should contain a single boolean expression. If the expression
+                evaluates to 'true', access will be granted.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="global-method-security">
+      <xs:annotation>
+         <xs:documentation>Provides method security for all beans registered in the Spring application context.
+                Specifically, beans will be scanned for matches with the ordered list of
+                "protect-pointcut" sub-elements, Spring Security annotations and/or. Where there is a
+                match, the beans will automatically be proxied and security authorization applied to the
+                methods accordingly. If you use and enable all four sources of method security metadata
+                (ie "protect-pointcut" declarations, expression annotations, @Secured and also JSR250
+                security annotations), the metadata sources will be queried in that order. In practical
+                terms, this enables you to use XML to override method security metadata expressed in
+                annotations. If using annotations, the order of precedence is EL-based (@PreAuthorize
+                etc.), @Secured and finally JSR-250.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:choice minOccurs="0">
+               <xs:element name="pre-post-annotation-handling">
+                  <xs:annotation>
+                     <xs:documentation>Allows the default expression-based mechanism for handling Spring Security's pre and post
+                invocation annotations (@PreFilter, @PreAuthorize, @PostFilter, @PostAuthorize) to be
+                replace entirely. Only applies if these annotations are enabled.
+                </xs:documentation>
+                  </xs:annotation>
+                  <xs:complexType>
+                     <xs:sequence>
+                        <xs:element name="invocation-attribute-factory">
+                           <xs:annotation>
+                              <xs:documentation>Defines the PrePostInvocationAttributeFactory instance which is used to generate pre and
+                post invocation metadata from the annotated methods.
+                </xs:documentation>
+                           </xs:annotation>
+                           <xs:complexType>
+                              <xs:attributeGroup ref="security:ref"/>
+                           </xs:complexType>
+                        </xs:element>
+                        <xs:element name="pre-invocation-advice">
+                           <xs:annotation>
+                              <xs:documentation>Customizes the PreInvocationAuthorizationAdviceVoter with the ref as the
+                PreInvocationAuthorizationAdviceVoter for the &lt;pre-post-annotation-handling&gt; element.
+                </xs:documentation>
+                           </xs:annotation>
+                           <xs:complexType>
+                              <xs:attributeGroup ref="security:ref"/>
+                           </xs:complexType>
+                        </xs:element>
+                        <xs:element name="post-invocation-advice">
+                           <xs:annotation>
+                              <xs:documentation>Customizes the PostInvocationAdviceProvider with the ref as the
+                PostInvocationAuthorizationAdvice for the &lt;pre-post-annotation-handling&gt; element.
+                </xs:documentation>
+                           </xs:annotation>
+                           <xs:complexType>
+                              <xs:attributeGroup ref="security:ref"/>
+                           </xs:complexType>
+                        </xs:element>
+                     </xs:sequence>
+                  </xs:complexType>
+               </xs:element>
+               <xs:element name="expression-handler">
+                  <xs:annotation>
+                     <xs:documentation>Defines the SecurityExpressionHandler instance which will be used if expression-based
+                access-control is enabled. A default implementation (with no ACL support) will be used if
+                not supplied.
+                </xs:documentation>
+                  </xs:annotation>
+                  <xs:complexType>
+                     <xs:attributeGroup ref="security:ref"/>
+                  </xs:complexType>
+               </xs:element>
+            </xs:choice>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="protect-pointcut">
+               <xs:annotation>
+                  <xs:documentation>Defines a protected pointcut and the access control configuration attributes that apply to
+                it. Every bean registered in the Spring application context that provides a method that
+                matches the pointcut will receive security authorization.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:protect-pointcut.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="after-invocation-provider">
+               <xs:annotation>
+                  <xs:documentation>Allows addition of extra AfterInvocationProvider beans which should be called by the
+                MethodSecurityInterceptor created by global-method-security.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:ref"/>
+               </xs:complexType>
+            </xs:element>
+         </xs:sequence>
+         <xs:attributeGroup ref="security:global-method-security.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="global-method-security.attlist">
+      <xs:attribute name="pre-post-annotations">
+         <xs:annotation>
+            <xs:documentation>Specifies whether the use of Spring Security's pre and post invocation annotations
+                (@PreFilter, @PreAuthorize, @PostFilter, @PostAuthorize) should be enabled for this
+                application context. Defaults to "disabled".
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="disabled"/>
+               <xs:enumeration value="enabled"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="secured-annotations">
+         <xs:annotation>
+            <xs:documentation>Specifies whether the use of Spring Security's @Secured annotations should be enabled for
+                this application context. Defaults to "disabled".
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="disabled"/>
+               <xs:enumeration value="enabled"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="jsr250-annotations">
+         <xs:annotation>
+            <xs:documentation>Specifies whether JSR-250 style attributes are to be used (for example "RolesAllowed").
+                This will require the javax.annotation.security classes on the classpath. Defaults to
+                "disabled".
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="disabled"/>
+               <xs:enumeration value="enabled"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="access-decision-manager-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Optional AccessDecisionManager bean ID to override the default used for method security.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="run-as-manager-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Optional RunAsmanager implementation which will be used by the configured
+                MethodSecurityInterceptor
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="order" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows the advice "order" to be set for the method security interceptor.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="proxy-target-class" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>If true, class based proxying will be used instead of interface based proxying.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="mode">
+         <xs:annotation>
+            <xs:documentation>Can be used to specify that AspectJ should be used instead of the default Spring AOP. If
+                set, secured classes must be woven with the AnnotationSecurityAspect from the
+                spring-security-aspects module.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="aspectj"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="metadata-source-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>An external MethodSecurityMetadataSource instance can be supplied which will take priority
+                over other sources (such as the default annotations).
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-manager-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to an AuthenticationManager bean
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  
+  
+  
+  
+  
+  
+  <xs:attributeGroup name="protect-pointcut.attlist">
+      <xs:attribute name="expression" use="required" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>An AspectJ expression, including the 'execution' keyword. For example, 'execution(int
+                com.foo.TargetObject.countLength(String))' (without the quotes).
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="access" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Access configuration attributes list that applies to all methods matching the pointcut,
+                e.g. "ROLE_A,ROLE_B"
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="websocket-message-broker">
+      <xs:annotation>
+         <xs:documentation>Allows securing a Message Broker. There are two modes. If no id is specified: ensures that
+                any SimpAnnotationMethodMessageHandler has the AuthenticationPrincipalArgumentResolver
+                registered as a custom argument resolver; ensures that the
+                SecurityContextChannelInterceptor is automatically registered for the
+                clientInboundChannel; and that a ChannelSecurityInterceptor is registered with the
+                clientInboundChannel. If the id is specified, creates a ChannelSecurityInterceptor that
+                can be manually registered with the clientInboundChannel.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="security:intercept-message"/>
+            <xs:element name="expression-handler">
+               <xs:annotation>
+                  <xs:documentation>Defines the SecurityExpressionHandler instance which will be used if expression-based
+                access-control is enabled. A default implementation (with no ACL support) will be used if
+                not supplied.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:ref"/>
+               </xs:complexType>
+            </xs:element>
+         </xs:choice>
+         <xs:attributeGroup ref="security:websocket-message-broker.attrlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="websocket-message-broker.attrlist">
+      <xs:attribute name="id" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context. If specified,
+                explicit configuration within clientInboundChannel is required. If not specified, ensures
+                that any SimpAnnotationMethodMessageHandler has the
+                AuthenticationPrincipalArgumentResolver registered as a custom argument resolver; ensures
+                that the SecurityContextChannelInterceptor is automatically registered for the
+                clientInboundChannel; and that a ChannelSecurityInterceptor is registered with the
+                clientInboundChannel.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="same-origin-disabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Disables the requirement for CSRF token to be present in the Stomp headers (default
+                false). Changing the default is useful if it is necessary to allow other origins to make
+                SockJS connections.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="intercept-message">
+      <xs:annotation>
+         <xs:documentation>Creates an authorization rule for a websocket message.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:intercept-message.attrlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="intercept-message.attrlist">
+      <xs:attribute name="pattern" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The destination ant pattern which will be mapped to the access attribute. For example, /**
+                matches any message with a destination, /admin/** matches any message that has a
+                destination that starts with admin.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="access" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The access configuration attributes that apply for the configured message. For example,
+                permitAll grants access to anyone, hasRole('ROLE_ADMIN') requires the user have the role
+                'ROLE_ADMIN'.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="type">
+         <xs:annotation>
+            <xs:documentation>The type of message to match on. Valid values are defined in SimpMessageType (i.e.
+                CONNECT, CONNECT_ACK, HEARTBEAT, MESSAGE, SUBSCRIBE, UNSUBSCRIBE, DISCONNECT,
+                DISCONNECT_ACK, OTHER).
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="CONNECT"/>
+               <xs:enumeration value="CONNECT_ACK"/>
+               <xs:enumeration value="HEARTBEAT"/>
+               <xs:enumeration value="MESSAGE"/>
+               <xs:enumeration value="SUBSCRIBE"/>
+               <xs:enumeration value="UNSUBSCRIBE"/>
+               <xs:enumeration value="DISCONNECT"/>
+               <xs:enumeration value="DISCONNECT_ACK"/>
+               <xs:enumeration value="OTHER"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="http-firewall">
+      <xs:annotation>
+         <xs:documentation>Allows a custom instance of HttpFirewall to be injected into the FilterChainProxy created
+                by the namespace.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:ref"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:element name="http">
+      <xs:annotation>
+         <xs:documentation>Container element for HTTP security configuration. Multiple elements can now be defined,
+                each with a specific pattern to which the enclosed security configuration applies. A
+                pattern can also be configured to bypass Spring Security's filters completely by setting
+                the "security" attribute to "none".
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="intercept-url">
+               <xs:annotation>
+                  <xs:documentation>Specifies the access attributes and/or filter list for a particular set of URLs.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:intercept-url.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="access-denied-handler">
+               <xs:annotation>
+                  <xs:documentation>Defines the access-denied strategy that should be used. An access denied page can be
+                defined or a reference to an AccessDeniedHandler instance.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:access-denied-handler.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="form-login">
+               <xs:annotation>
+                  <xs:documentation>Sets up a form login configuration for authentication with a username and password
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:form-login.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="openid-login">
+               <xs:annotation>
+                  <xs:documentation>Sets up form login for authentication with an Open ID identity
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:sequence>
+                     <xs:element minOccurs="0" maxOccurs="unbounded" ref="security:attribute-exchange"/>
+                  </xs:sequence>
+                  <xs:attributeGroup ref="security:form-login.attlist"/>
+                  <xs:attribute name="user-service-ref" type="xs:token">
+                     <xs:annotation>
+                        <xs:documentation>A reference to a user-service (or UserDetailsService bean) Id
+                </xs:documentation>
+                     </xs:annotation>
+                  </xs:attribute>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="x509">
+               <xs:annotation>
+                  <xs:documentation>Adds support for X.509 client authentication.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:x509.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element ref="security:jee"/>
+            <xs:element name="http-basic">
+               <xs:annotation>
+                  <xs:documentation>Adds support for basic authentication
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:http-basic.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="logout">
+               <xs:annotation>
+                  <xs:documentation>Incorporates a logout processing filter. Most web applications require a logout filter,
+                although you may not require one if you write a controller to provider similar logic.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:logout.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="session-management">
+               <xs:annotation>
+                  <xs:documentation>Session-management related functionality is implemented by the addition of a
+                SessionManagementFilter to the filter stack.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:sequence>
+                     <xs:element minOccurs="0" name="concurrency-control">
+                        <xs:annotation>
+                           <xs:documentation>Enables concurrent session control, limiting the number of authenticated sessions a user
+                may have at the same time.
+                </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                           <xs:attributeGroup ref="security:concurrency-control.attlist"/>
+                        </xs:complexType>
+                     </xs:element>
+                  </xs:sequence>
+                  <xs:attributeGroup ref="security:session-management.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="remember-me">
+               <xs:annotation>
+                  <xs:documentation>Sets up remember-me authentication. If used with the "key" attribute (or no attributes)
+                the cookie-only implementation will be used. Specifying "token-repository-ref" or
+                "remember-me-data-source-ref" will use the more secure, persisten token approach.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:remember-me.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="anonymous">
+               <xs:annotation>
+                  <xs:documentation>Adds support for automatically granting all anonymous web requests a particular principal
+                identity and a corresponding granted authority.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:anonymous.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="port-mappings">
+               <xs:annotation>
+                  <xs:documentation>Defines the list of mappings between http and https ports for use in redirects
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:sequence>
+                     <xs:element maxOccurs="unbounded" name="port-mapping">
+                        <xs:annotation>
+                           <xs:documentation>Provides a method to map http ports to https ports when forcing a redirect.
+                </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                           <xs:attributeGroup ref="security:http-port"/>
+                           <xs:attributeGroup ref="security:https-port"/>
+                        </xs:complexType>
+                     </xs:element>
+                  </xs:sequence>
+               </xs:complexType>
+            </xs:element>
+            <xs:element ref="security:custom-filter"/>
+            <xs:element ref="security:request-cache"/>
+            <xs:element name="expression-handler">
+               <xs:annotation>
+                  <xs:documentation>Defines the SecurityExpressionHandler instance which will be used if expression-based
+                access-control is enabled. A default implementation (with no ACL support) will be used if
+                not supplied.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:ref"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element ref="security:headers"/>
+            <xs:element ref="security:csrf"/>
+         </xs:choice>
+         <xs:attributeGroup ref="security:http.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="http.attlist">
+      <xs:attribute name="pattern" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The request URL pattern which will be mapped to the filter chain created by this &lt;http&gt;
+                element. If omitted, the filter chain will match all requests.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="security">
+         <xs:annotation>
+            <xs:documentation>When set to 'none', requests matching the pattern attribute will be ignored by Spring
+                Security. No security filters will be applied and no SecurityContext will be available. If
+                set, the &lt;http&gt; element must be empty, with no children.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="none"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="request-matcher-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows a RequestMatcher instance to be used, as an alternative to pattern-matching.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="auto-config" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>A legacy attribute which automatically registers a login form, BASIC authentication and a
+                logout URL and logout services. If unspecified, defaults to "false". We'd recommend you
+                avoid using this and instead explicitly configure the services you require.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="use-expressions" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Enables the use of expressions in the 'access' attributes in &lt;intercept-url&gt; elements
+                rather than the traditional list of configuration attributes. Defaults to 'true'. If
+                enabled, each attribute should contain a single boolean expression. If the expression
+                evaluates to 'true', access will be granted.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="create-session">
+         <xs:annotation>
+            <xs:documentation>Controls the eagerness with which an HTTP session is created by Spring Security classes.
+                If not set, defaults to "ifRequired". If "stateless" is used, this implies that the
+                application guarantees that it will not create a session. This differs from the use of
+                "never" which mans that Spring Security will not create a session, but will make use of
+                one if the application does.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="ifRequired"/>
+               <xs:enumeration value="always"/>
+               <xs:enumeration value="never"/>
+               <xs:enumeration value="stateless"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="security-context-repository-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to a SecurityContextRepository bean. This can be used to customize how the
+                SecurityContext is stored between requests.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="request-matcher">
+         <xs:annotation>
+            <xs:documentation>Defines the strategy use for matching incoming requests. Currently the options are 'ant'
+                (for ant path patterns), 'regex' for regular expressions and 'ciRegex' for
+                case-insensitive regular expressions.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="ant"/>
+               <xs:enumeration value="regex"/>
+               <xs:enumeration value="ciRegex"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="servlet-api-provision" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Provides versions of HttpServletRequest security methods such as isUserInRole() and
+                getPrincipal() which are implemented by accessing the Spring SecurityContext. Defaults to
+                "true".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="jaas-api-provision" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>If available, runs the request as the Subject acquired from the JaasAuthenticationToken.
+                Defaults to "false".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="access-decision-manager-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Optional attribute specifying the ID of the AccessDecisionManager implementation which
+                should be used for authorizing HTTP requests.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="realm" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Optional attribute specifying the realm name that will be used for all authentication
+                features that require a realm name (eg BASIC and Digest authentication). If unspecified,
+                defaults to "Spring Security Application".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="entry-point-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows a customized AuthenticationEntryPoint to be set on the ExceptionTranslationFilter.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="once-per-request" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Corresponds to the observeOncePerRequest property of FilterSecurityInterceptor. Defaults
+                to "true"
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="disable-url-rewriting" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Prevents the jsessionid parameter from being added to rendered URLs. Defaults to "true"
+                (rewriting is disabled).
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="name" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-manager-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to an AuthenticationManager bean
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="access-denied-handler.attlist">
+      <xs:attribute name="ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines a reference to a Spring bean Id.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="error-page" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The access denied page that an authenticated user will be redirected to if they request a
+                page which they don't have the authority to access.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="access-denied-handler-page">
+      <xs:attribute name="error-page" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The access denied page that an authenticated user will be redirected to if they request a
+                page which they don't have the authority to access.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="intercept-url.attlist">
+      <xs:attribute name="pattern" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The pattern which defines the URL path. The content will depend on the type set in the
+                containing http element, so will default to ant path syntax.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="access" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The access configuration attributes that apply for the configured path.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="method">
+         <xs:annotation>
+            <xs:documentation>The HTTP Method for which the access configuration attributes should apply. If not
+                specified, the attributes will apply to any method.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="GET"/>
+               <xs:enumeration value="DELETE"/>
+               <xs:enumeration value="HEAD"/>
+               <xs:enumeration value="OPTIONS"/>
+               <xs:enumeration value="POST"/>
+               <xs:enumeration value="PUT"/>
+               <xs:enumeration value="PATCH"/>
+               <xs:enumeration value="TRACE"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="filters">
+         <xs:annotation>
+            <xs:documentation>The filter list for the path. Currently can be set to "none" to remove a path from having
+                any filters applied. The full filter stack (consisting of all filters created by the
+                namespace configuration, and any added using 'custom-filter'), will be applied to any
+                other paths.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="none"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="requires-channel" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Used to specify that a URL must be accessed over http or https, or that there is no
+                preference. The value should be "http", "https" or "any", respectively.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="logout.attlist">
+      <xs:attribute name="logout-url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Specifies the URL that will cause a logout. Spring Security will initialize a filter that
+                responds to this particular URL. Defaults to /logout if unspecified.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="logout-success-url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Specifies the URL to display once the user has logged out. If not specified, defaults to
+                &lt;form-login-login-page&gt;/?logout (i.e. /login?logout).
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="invalidate-session" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies whether a logout also causes HttpSession invalidation, which is generally
+                desirable. If unspecified, defaults to true.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="success-handler-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to a LogoutSuccessHandler implementation which will be used to determine the
+                destination to which the user is taken after logging out.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="delete-cookies" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A comma-separated list of the names of cookies which should be deleted when the user logs
+                out
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="request-cache">
+      <xs:annotation>
+         <xs:documentation>Allow the RequestCache used for saving requests during the login process to be set
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:ref"/>
+      </xs:complexType>
+   </xs:element>
+  
+  <xs:attributeGroup name="form-login.attlist">
+      <xs:attribute name="login-processing-url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The URL that the login form is posted to. If unspecified, it defaults to /login.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="username-parameter" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The name of the request parameter which contains the username. Defaults to 'username'.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="password-parameter" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The name of the request parameter which contains the password. Defaults to 'password'.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="default-target-url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The URL that will be redirected to after successful authentication, if the user's previous
+                action could not be resumed. This generally happens if the user visits a login page
+                without having first requested a secured operation that triggers authentication. If
+                unspecified, defaults to the root of the application.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="always-use-default-target" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Whether the user should always be redirected to the default-target-url after login.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="login-page" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The URL for the login page. If no login URL is specified, Spring Security will
+                automatically create a login URL at GET /login and a corresponding filter to render that
+                login URL when requested.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-failure-url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The URL for the login failure page. If no login failure URL is specified, Spring Security
+                will automatically create a failure login URL at /login?error and a corresponding filter
+                to render that login failure URL when requested.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-success-handler-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationSuccessHandler bean which should be used to handle a
+                successful authentication request. Should not be used in combination with
+                default-target-url (or always-use-default-target-url) as the implementation should always
+                deal with navigation to the subsequent destination
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-failure-handler-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationFailureHandler bean which should be used to handle a failed
+                authentication request. Should not be used in combination with authentication-failure-url
+                as the implementation should always deal with navigation to the subsequent destination
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-details-source-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationDetailsSource which will be used by the authentication
+                filter
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:element name="attribute-exchange">
+      <xs:annotation>
+         <xs:documentation>Sets up an attribute exchange configuration to request specified attributes from the
+                OpenID identity provider. When multiple elements are used, each must have an
+                identifier-attribute attribute. Each configuration will be matched in turn against the
+                supplied login identifier until a match is found.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="security:openid-attribute"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="security:attribute-exchange.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="attribute-exchange.attlist">
+      <xs:attribute name="identifier-match" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A regular expression which will be compared against the claimed identity, when deciding
+                which attribute-exchange configuration to use during authentication.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="openid-attribute">
+      <xs:annotation>
+         <xs:documentation>Attributes used when making an OpenID AX Fetch Request
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:openid-attribute.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="openid-attribute.attlist">
+      <xs:attribute name="name" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Specifies the name of the attribute that you wish to get back. For example, email.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="type" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Specifies the attribute type. For example, http://axschema.org/contact/email. See your
+                OP's documentation for valid attribute types.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="required" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies if this attribute is required to the OP, but does not error out if the OP does
+                not return the attribute. Default is false.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="count" type="xs:int">
+         <xs:annotation>
+            <xs:documentation>Specifies the number of attributes that you wish to get back. For example, return 3
+                emails. The default value is 1.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="filter-chain-map">
+      <xs:annotation>
+         <xs:documentation>Used to explicitly configure a FilterChainProxy instance with a FilterChainMap
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="security:filter-chain"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="security:filter-chain-map.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="filter-chain-map.attlist">
+      <xs:attribute name="request-matcher">
+         <xs:annotation>
+            <xs:documentation>Defines the strategy use for matching incoming requests. Currently the options are 'ant'
+                (for ant path patterns), 'regex' for regular expressions and 'ciRegex' for
+                case-insensitive regular expressions.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="ant"/>
+               <xs:enumeration value="regex"/>
+               <xs:enumeration value="ciRegex"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="filter-chain">
+      <xs:annotation>
+         <xs:documentation>Used within to define a specific URL pattern and the list of filters which apply to the
+                URLs matching that pattern. When multiple filter-chain elements are assembled in a list in
+                order to configure a FilterChainProxy, the most specific patterns must be placed at the
+                top of the list, with most general ones at the bottom.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:filter-chain.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="filter-chain.attlist">
+      <xs:attribute name="pattern" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The request URL pattern which will be mapped to the FilterChain.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="request-matcher-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows a RequestMatcher instance to be used, as an alternative to pattern-matching.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="filters" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A comma separated list of bean names that implement Filter that should be processed for
+                this FilterChain. If the value is none, then no Filters will be used for this FilterChain.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="pattern">
+      <xs:attribute name="pattern" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The request URL pattern which will be mapped to the FilterChain.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="request-matcher-ref">
+      <xs:attribute name="request-matcher-ref" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows a RequestMatcher instance to be used, as an alternative to pattern-matching.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="filter-security-metadata-source">
+      <xs:annotation>
+         <xs:documentation>Used to explicitly configure a FilterSecurityMetadataSource bean for use with a
+                FilterSecurityInterceptor. Usually only needed if you are configuring a FilterChainProxy
+                explicitly, rather than using the &lt;http&gt; element. The intercept-url elements used should
+                only contain pattern, method and access attributes. Any others will result in a
+                configuration error.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="intercept-url">
+               <xs:annotation>
+                  <xs:documentation>Specifies the access attributes and/or filter list for a particular set of URLs.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:intercept-url.attlist"/>
+               </xs:complexType>
+            </xs:element>
+         </xs:sequence>
+         <xs:attributeGroup ref="security:fsmds.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="fsmds.attlist">
+      <xs:attribute name="use-expressions" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Enables the use of expressions in the 'access' attributes in &lt;intercept-url&gt; elements
+                rather than the traditional list of configuration attributes. Defaults to 'true'. If
+                enabled, each attribute should contain a single boolean expression. If the expression
+                evaluates to 'true', access will be granted.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="id" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="lowercase-comparisons" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Compare after forcing to lowercase
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="request-matcher">
+         <xs:annotation>
+            <xs:documentation>Defines the strategy use for matching incoming requests. Currently the options are 'ant'
+                (for ant path patterns), 'regex' for regular expressions and 'ciRegex' for
+                case-insensitive regular expressions.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="ant"/>
+               <xs:enumeration value="regex"/>
+               <xs:enumeration value="ciRegex"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="http-basic.attlist">
+      <xs:attribute name="entry-point-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Sets the AuthenticationEntryPoint which is used by the BasicAuthenticationFilter.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-details-source-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationDetailsSource which will be used by the authentication
+                filter
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="session-management.attlist">
+      <xs:attribute name="session-fixation-protection">
+         <xs:annotation>
+            <xs:documentation>Indicates how session fixation protection will be applied when a user authenticates. If
+                set to "none", no protection will be applied. "newSession" will create a new empty
+                session, with only Spring Security-related attributes migrated. "migrateSession" will
+                create a new session and copy all session attributes to the new session. In Servlet 3.1
+                (Java EE 7) and newer containers, specifying "changeSessionId" will keep the existing
+                session and use the container-supplied session fixation protection
+                (HttpServletRequest#changeSessionId()). Defaults to "changeSessionId" in Servlet 3.1 and
+                newer containers, "migrateSession" in older containers. Throws an exception if
+                "changeSessionId" is used in older containers.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="none"/>
+               <xs:enumeration value="newSession"/>
+               <xs:enumeration value="migrateSession"/>
+               <xs:enumeration value="changeSessionId"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="invalid-session-url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The URL to which a user will be redirected if they submit an invalid session indentifier.
+                Typically used to detect session timeouts.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="session-authentication-strategy-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows injection of the SessionAuthenticationStrategy instance used by the
+                SessionManagementFilter
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="session-authentication-error-url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines the URL of the error page which should be shown when the
+                SessionAuthenticationStrategy raises an exception. If not set, an unauthorized (401) error
+                code will be returned to the client. Note that this attribute doesn't apply if the error
+                occurs during a form-based login, where the URL for authentication failure will take
+                precedence.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="concurrency-control.attlist">
+      <xs:attribute name="max-sessions" type="xs:positiveInteger">
+         <xs:annotation>
+            <xs:documentation>The maximum number of sessions a single authenticated user can have open at the same time.
+                Defaults to "1".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="expired-url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The URL a user will be redirected to if they attempt to use a session which has been
+                "expired" because they have logged in again.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="error-if-maximum-exceeded" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies that an unauthorized error should be reported when a user attempts to login when
+                they already have the maximum configured sessions open. The default behaviour is to expire
+                the original session. If the session-authentication-error-url attribute is set on the
+                session-management URL, the user will be redirected to this URL.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="session-registry-alias" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows you to define an alias for the SessionRegistry bean in order to access it in your
+                own configuration.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="session-registry-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows you to define an external SessionRegistry bean to be used by the concurrency
+                control setup.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="remember-me.attlist">
+      <xs:attribute name="key" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The "key" used to identify cookies from a specific token-based remember-me application.
+                You should set this to a unique value for your application. If unset, it will default to a
+                random value generated by SecureRandom.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="token-repository-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to a PersistentTokenRepository bean for use with the persistent token
+                remember-me implementation.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="data-source-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to a DataSource bean
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attributeGroup ref="security:remember-me-services-ref"/>
+      <xs:attribute name="user-service-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to a user-service (or UserDetailsService bean) Id
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="services-alias" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Exports the internally defined RememberMeServices as a bean alias, allowing it to be used
+                by other beans in the application context.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="use-secure-cookie" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Determines whether the "secure" flag will be set on the remember-me cookie. If set to
+                true, the cookie will only be submitted over HTTPS (recommended). By default, secure
+                cookies will be used if the request is made on a secure connection.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="token-validity-seconds" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>The period (in seconds) for which the remember-me cookie should be valid.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-success-handler-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationSuccessHandler bean which should be used to handle a
+                successful remember-me authentication.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="remember-me-parameter" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The name of the request parameter which toggles remember-me authentication. Defaults to
+                'remember-me'.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="remember-me-cookie" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The name of cookie which store the token for remember-me authentication. Defaults to
+                'remember-me'.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="token-repository-ref">
+      <xs:attribute name="token-repository-ref" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to a PersistentTokenRepository bean for use with the persistent token
+                remember-me implementation.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="remember-me-services-ref">
+      <xs:attribute name="services-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows a custom implementation of RememberMeServices to be used. Note that this
+                implementation should return RememberMeAuthenticationToken instances with the same "key"
+                value as specified in the remember-me element. Alternatively it should register its own
+                AuthenticationProvider. It should also implement the LogoutHandler interface, which will
+                be invoked when a user logs out. Typically the remember-me cookie would be removed on
+                logout.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="remember-me-data-source-ref">
+      <xs:attributeGroup ref="security:data-source-ref"/>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="anonymous.attlist">
+      <xs:attribute name="key" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The key shared between the provider and filter. This generally does not need to be set. If
+                unset, it will default to a random value generated by SecureRandom.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="username" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The username that should be assigned to the anonymous request. This allows the principal
+                to be identified, which may be important for logging and auditing. if unset, defaults to
+                "anonymousUser".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="granted-authority" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The granted authority that should be assigned to the anonymous request. Commonly this is
+                used to assign the anonymous request particular roles, which can subsequently be used in
+                authorization decisions. If unset, defaults to "ROLE_ANONYMOUS".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="enabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>With the default namespace setup, the anonymous "authentication" facility is automatically
+                enabled. You can disable it using this property.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  
+  <xs:attributeGroup name="http-port">
+      <xs:attribute name="http" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The http port to use.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="https-port">
+      <xs:attribute name="https" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The https port to use.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="x509.attlist">
+      <xs:attribute name="subject-principal-regex" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The regular expression used to obtain the username from the certificate's subject.
+                Defaults to matching on the common name using the pattern "CN=(.*?),".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-service-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to a user-service (or UserDetailsService bean) Id
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-details-source-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationDetailsSource which will be used by the authentication
+                filter
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="jee">
+      <xs:annotation>
+         <xs:documentation>Adds a J2eePreAuthenticatedProcessingFilter to the filter chain to provide integration
+                with container authentication.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:jee.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="jee.attlist">
+      <xs:attribute name="mappable-roles" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A comma-separate list of roles to look for in the incoming HttpServletRequest.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-service-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to a user-service (or UserDetailsService bean) Id
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="authentication-manager">
+      <xs:annotation>
+         <xs:documentation>Registers the AuthenticationManager instance and allows its list of
+                AuthenticationProviders to be defined. Also allows you to define an alias to allow you to
+                reference the AuthenticationManager in your own beans.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="authentication-provider">
+               <xs:annotation>
+                  <xs:documentation>Indicates that the contained user-service should be used as an authentication source.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:choice minOccurs="0" maxOccurs="unbounded">
+                     <xs:element ref="security:any-user-service"/>
+                     <xs:element name="password-encoder">
+                        <xs:annotation>
+                           <xs:documentation>element which defines a password encoding strategy. Used by an authentication provider to
+                convert submitted passwords to hashed versions, for example.
+                </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                           <xs:sequence>
+                              <xs:element minOccurs="0" name="salt-source">
+                                 <xs:annotation>
+                                    <xs:documentation>Password salting strategy. A system-wide constant or a property from the UserDetails
+                object can be used.
+                </xs:documentation>
+                                 </xs:annotation>
+                                 <xs:complexType>
+                                    <xs:attribute name="user-property" type="xs:token">
+                                       <xs:annotation>
+                                          <xs:documentation>A property of the UserDetails object which will be used as salt by a password encoder.
+                Typically something like "username" might be used.
+                </xs:documentation>
+                                       </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="system-wide" type="xs:token">
+                                       <xs:annotation>
+                                          <xs:documentation>A single value that will be used as the salt for a password encoder.
+                </xs:documentation>
+                                       </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="ref" type="xs:token">
+                                       <xs:annotation>
+                                          <xs:documentation>Defines a reference to a Spring bean Id.
+                </xs:documentation>
+                                       </xs:annotation>
+                                    </xs:attribute>
+                                 </xs:complexType>
+                              </xs:element>
+                           </xs:sequence>
+                           <xs:attributeGroup ref="security:password-encoder.attlist"/>
+                        </xs:complexType>
+                     </xs:element>
+                  </xs:choice>
+                  <xs:attributeGroup ref="security:ap.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="ldap-authentication-provider">
+               <xs:annotation>
+                  <xs:documentation>Sets up an ldap authentication provider
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:sequence>
+                     <xs:element minOccurs="0" name="password-compare">
+                        <xs:annotation>
+                           <xs:documentation>Specifies that an LDAP provider should use an LDAP compare operation of the user's
+                password to authenticate the user
+                </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                           <xs:sequence>
+                              <xs:element minOccurs="0" name="password-encoder">
+                                 <xs:annotation>
+                                    <xs:documentation>element which defines a password encoding strategy. Used by an authentication provider to
+                convert submitted passwords to hashed versions, for example.
+                </xs:documentation>
+                                 </xs:annotation>
+                                 <xs:complexType>
+                                    <xs:sequence>
+                                       <xs:element minOccurs="0" name="salt-source">
+                                          <xs:annotation>
+                                             <xs:documentation>Password salting strategy. A system-wide constant or a property from the UserDetails
+                object can be used.
+                </xs:documentation>
+                                          </xs:annotation>
+                                          <xs:complexType>
+                                             <xs:attribute name="user-property" type="xs:token">
+                                                <xs:annotation>
+                                                   <xs:documentation>A property of the UserDetails object which will be used as salt by a password encoder.
+                Typically something like "username" might be used.
+                </xs:documentation>
+                                                </xs:annotation>
+                                             </xs:attribute>
+                                             <xs:attribute name="system-wide" type="xs:token">
+                                                <xs:annotation>
+                                                   <xs:documentation>A single value that will be used as the salt for a password encoder.
+                </xs:documentation>
+                                                </xs:annotation>
+                                             </xs:attribute>
+                                             <xs:attribute name="ref" type="xs:token">
+                                                <xs:annotation>
+                                                   <xs:documentation>Defines a reference to a Spring bean Id.
+                </xs:documentation>
+                                                </xs:annotation>
+                                             </xs:attribute>
+                                          </xs:complexType>
+                                       </xs:element>
+                                    </xs:sequence>
+                                    <xs:attributeGroup ref="security:password-encoder.attlist"/>
+                                 </xs:complexType>
+                              </xs:element>
+                           </xs:sequence>
+                           <xs:attributeGroup ref="security:password-compare.attlist"/>
+                        </xs:complexType>
+                     </xs:element>
+                  </xs:sequence>
+                  <xs:attributeGroup ref="security:ldap-ap.attlist"/>
+               </xs:complexType>
+            </xs:element>
+         </xs:choice>
+         <xs:attributeGroup ref="security:authman.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="authman.attlist">
+      <xs:attribute name="id" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="alias" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>An alias you wish to use for the AuthenticationManager bean (not required it you are using
+                a specific id)
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="erase-credentials" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>If set to true, the AuthenticationManger will attempt to clear any credentials data in the
+                returned Authentication object, once the user has been authenticated.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="ap.attlist">
+      <xs:attribute name="ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines a reference to a Spring bean Id.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-service-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to a user-service (or UserDetailsService bean) Id
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="user-service" substitutionGroup="security:any-user-service">
+      <xs:annotation>
+         <xs:documentation>Creates an in-memory UserDetailsService from a properties file or a list of "user" child
+                elements. Usernames are converted to lower-case internally to allow for case-insensitive
+                lookups, so this should not be used if case-sensitivity is required.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="user">
+               <xs:annotation>
+                  <xs:documentation>Represents a user in the application.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:user.attlist"/>
+               </xs:complexType>
+            </xs:element>
+         </xs:sequence>
+         <xs:attribute name="id" type="xs:token">
+            <xs:annotation>
+               <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context.
+                </xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attributeGroup ref="security:properties-file"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="properties-file">
+      <xs:attribute name="properties" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The location of a Properties file where each line is in the format of
+                username=password,grantedAuthority[,grantedAuthority][,enabled|disabled]
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="user.attlist">
+      <xs:attribute name="name" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The username assigned to the user.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="password" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>The password assigned to the user. This may be hashed if the corresponding authentication
+                provider supports hashing (remember to set the "hash" attribute of the "user-service"
+                element). This attribute be omitted in the case where the data will not be used for
+                authentication, but only for accessing authorities. If omitted, the namespace will
+                generate a random value, preventing its accidental use for authentication. Cannot be
+                empty.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authorities" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>One of more authorities granted to the user. Separate authorities with a comma (but no
+                space). For example, "ROLE_USER,ROLE_ADMINISTRATOR"
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="locked" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Can be set to "true" to mark an account as locked and unusable.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="disabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Can be set to "true" to mark an account as disabled and unusable.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="jdbc-user-service" substitutionGroup="security:any-user-service">
+      <xs:annotation>
+         <xs:documentation>Causes creation of a JDBC-based UserDetailsService.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attribute name="id" type="xs:token">
+            <xs:annotation>
+               <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context.
+                </xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attributeGroup ref="security:jdbc-user-service.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="jdbc-user-service.attlist">
+      <xs:attribute name="data-source-ref" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The bean ID of the DataSource which provides the required tables.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="cache-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines a reference to a cache for use with a UserDetailsService.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="users-by-username-query" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>An SQL statement to query a username, password, and enabled status given a username.
+                Default is "select username,password,enabled from users where username = ?"
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authorities-by-username-query" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>An SQL statement to query for a user's granted authorities given a username. The default
+                is "select username, authority from authorities where username = ?"
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="group-authorities-by-username-query" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>An SQL statement to query user's group authorities given a username. The default is
+                "select g.id, g.group_name, ga.authority from groups g, group_members gm,
+                group_authorities ga where gm.username = ? and g.id = ga.group_id and g.id = gm.group_id"
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="role-prefix" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A non-empty string prefix that will be added to role strings loaded from persistent
+                storage (e.g. "ROLE_"). Use the value "none" for no prefix in cases where the default is
+                non-empty.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="csrf">
+      <xs:annotation>
+         <xs:documentation>Element for configuration of the CsrfFilter for protection against CSRF. It also updates
+                the default RequestCache to only replay "GET" requests.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:csrf-options.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="csrf-options.attlist">
+      <xs:attribute name="disabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies if csrf protection should be disabled. Default false (i.e. CSRF protection is
+                enabled).
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="request-matcher-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The RequestMatcher instance to be used to determine if CSRF should be applied. Default is
+                any HTTP method except "GET", "TRACE", "HEAD", "OPTIONS"
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="token-repository-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The CsrfTokenRepository to use. The default is HttpSessionCsrfTokenRepository
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="headers">
+      <xs:annotation>
+         <xs:documentation>Element for configuration of the HeaderWritersFilter. Enables easy setting for the
+                X-Frame-Options, X-XSS-Protection and X-Content-Type-Options headers.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="security:cache-control"/>
+            <xs:element ref="security:xss-protection"/>
+            <xs:element ref="security:hsts"/>
+            <xs:element ref="security:frame-options"/>
+            <xs:element ref="security:content-type-options"/>
+            <xs:element ref="security:hpkp"/>
+            <xs:element ref="security:header"/>
+         </xs:choice>
+         <xs:attributeGroup ref="security:headers-options.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="headers-options.attlist">
+      <xs:attribute name="defaults-disabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies if the default headers should be disabled. Default false.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="disabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies if headers should be disabled. Default false.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="hsts">
+      <xs:annotation>
+         <xs:documentation>Adds support for HTTP Strict Transport Security (HSTS)
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:hsts-options.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="hsts-options.attlist">
+      <xs:attribute name="disabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies if HTTP Strict Transport Security (HSTS) should be disabled. Default false.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="include-subdomains" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies if subdomains should be included. Default true.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="max-age-seconds" type="xs:integer">
+         <xs:annotation>
+            <xs:documentation>Specifies the maximum ammount of time the host should be considered a Known HSTS Host.
+                Default one year.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="request-matcher-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The RequestMatcher instance to be used to determine if the header should be set. Default
+                is if HttpServletRequest.isSecure() is true.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="hpkp">
+      <xs:annotation>
+         <xs:documentation>Adds support for HTTP Public Key Pinning (HPKP).
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="security:hpkp.pins">
+               <xs:attributeGroup ref="security:hpkp.attlist"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+  <xs:complexType name="hpkp.pins">
+      <xs:sequence>
+         <xs:element ref="security:pins"/>
+      </xs:sequence>
+  </xs:complexType>
+  <xs:element name="pins">
+      <xs:annotation>
+         <xs:documentation>The list with pins
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="security:pin"/>
+         </xs:sequence>
+      </xs:complexType>
+   </xs:element>
+  <xs:element name="pin">
+      <xs:annotation>
+         <xs:documentation>A pin is specified using the base64-encoded SPKI fingerprint as value and the
+                cryptographic hash algorithm as attribute
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType mixed="true">
+         <xs:attribute name="algorithm" type="xs:string">
+            <xs:annotation>
+               <xs:documentation>The cryptographic hash algorithm
+                </xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="hpkp.attlist">
+      <xs:attribute name="disabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies if HTTP Public Key Pinning (HPKP) should be disabled. Default false.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="include-subdomains" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies if subdomains should be included. Default false.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="max-age-seconds" type="xs:integer">
+         <xs:annotation>
+            <xs:documentation>Sets the value for the max-age directive of the Public-Key-Pins header. Default 60 days.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="report-only" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies if the browser should only report pin validation failures. Default true.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="report-uri" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>Specifies the URI to which the browser should report pin validation failures.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="cache-control">
+      <xs:annotation>
+         <xs:documentation>Adds Cache-Control no-cache, no-store, must-revalidate, Pragma no-cache, and Expires 0 for
+                every request
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:cache-control.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="cache-control.attlist">
+      <xs:attribute name="disabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies if Cache Control should be disabled. Default false.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="frame-options">
+      <xs:annotation>
+         <xs:documentation>Enable basic clickjacking support for newer browsers (IE8+), will set the X-Frame-Options
+                header.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:frame-options.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="frame-options.attlist">
+      <xs:attribute name="disabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>If disabled, the X-Frame-Options header will not be included. Default false.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="policy">
+         <xs:annotation>
+            <xs:documentation>Specify the policy to use for the X-Frame-Options-Header.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="DENY"/>
+               <xs:enumeration value="SAMEORIGIN"/>
+               <xs:enumeration value="ALLOW-FROM"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="strategy">
+         <xs:annotation>
+            <xs:documentation>Specify the strategy to use when ALLOW-FROM is chosen.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="static"/>
+               <xs:enumeration value="whitelist"/>
+               <xs:enumeration value="regexp"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines a reference to a Spring bean Id.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="value" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>Specify the a value to use for the chosen strategy.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="from-parameter" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>Specify the request parameter to use for the origin when using a 'whitelist' or 'regexp'
+                based strategy. Default is 'from'.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="xss-protection">
+      <xs:annotation>
+         <xs:documentation>Enable basic XSS browser protection, supported by newer browsers (IE8+), will set the
+                X-XSS-Protection header.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:xss-protection.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="xss-protection.attlist">
+      <xs:attribute name="disabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>disable the X-XSS-Protection header. Default is 'false' meaning it is enabled.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="enabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>specify that XSS Protection should be explicitly enabled or disabled. Default is 'true'
+                meaning it is enabled.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="block" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Add mode=block to the header or not, default is on.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="content-type-options">
+      <xs:annotation>
+         <xs:documentation>Add a X-Content-Type-Options header to the resopnse. Value is always 'nosniff'.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:content-type-options.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="content-type-options.attlist">
+      <xs:attribute name="disabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>If disabled, the X-Content-Type-Options header will not be included. Default false.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="header">
+      <xs:annotation>
+         <xs:documentation>Add additional headers to the response.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:header.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="header.attlist">
+      <xs:attribute name="name" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The name of the header to add.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="value" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The value for the header.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines a reference to a Spring bean Id.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="any-user-service" abstract="true"/>
+  <xs:element name="custom-filter">
+      <xs:annotation>
+         <xs:documentation>Used to indicate that a filter bean declaration should be incorporated into the security
+                filter chain.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:custom-filter.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="custom-filter.attlist">
+      <xs:attributeGroup ref="security:ref"/>
+      <xs:attribute name="after" type="security:named-security-filter">
+         <xs:annotation>
+            <xs:documentation>The filter immediately after which the custom-filter should be placed in the chain. This
+                feature will only be needed by advanced users who wish to mix their own filters into the
+                security filter chain and have some knowledge of the standard Spring Security filters. The
+                filter names map to specific Spring Security implementation filters.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="before" type="security:named-security-filter">
+         <xs:annotation>
+            <xs:documentation>The filter immediately before which the custom-filter should be placed in the chain
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="position" type="security:named-security-filter">
+         <xs:annotation>
+            <xs:documentation>The explicit position at which the custom-filter should be placed in the chain. Use if you
+                are replacing a standard filter.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="after">
+      <xs:attribute name="after" use="required" type="security:named-security-filter">
+         <xs:annotation>
+            <xs:documentation>The filter immediately after which the custom-filter should be placed in the chain. This
+                feature will only be needed by advanced users who wish to mix their own filters into the
+                security filter chain and have some knowledge of the standard Spring Security filters. The
+                filter names map to specific Spring Security implementation filters.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="before">
+      <xs:attribute name="before" use="required" type="security:named-security-filter">
+         <xs:annotation>
+            <xs:documentation>The filter immediately before which the custom-filter should be placed in the chain
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="position">
+      <xs:attribute name="position" use="required" type="security:named-security-filter">
+         <xs:annotation>
+            <xs:documentation>The explicit position at which the custom-filter should be placed in the chain. Use if you
+                are replacing a standard filter.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:simpleType name="named-security-filter">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="FIRST"/>
+         <xs:enumeration value="CHANNEL_FILTER"/>
+         <xs:enumeration value="SECURITY_CONTEXT_FILTER"/>
+         <xs:enumeration value="CONCURRENT_SESSION_FILTER"/>
+         <xs:enumeration value="WEB_ASYNC_MANAGER_FILTER"/>
+         <xs:enumeration value="HEADERS_FILTER"/>
+         <xs:enumeration value="CSRF_FILTER"/>
+         <xs:enumeration value="LOGOUT_FILTER"/>
+         <xs:enumeration value="X509_FILTER"/>
+         <xs:enumeration value="PRE_AUTH_FILTER"/>
+         <xs:enumeration value="CAS_FILTER"/>
+         <xs:enumeration value="FORM_LOGIN_FILTER"/>
+         <xs:enumeration value="OPENID_FILTER"/>
+         <xs:enumeration value="LOGIN_PAGE_FILTER"/>
+         <xs:enumeration value="DIGEST_AUTH_FILTER"/>
+         <xs:enumeration value="BASIC_AUTH_FILTER"/>
+         <xs:enumeration value="REQUEST_CACHE_FILTER"/>
+         <xs:enumeration value="SERVLET_API_SUPPORT_FILTER"/>
+         <xs:enumeration value="JAAS_API_SUPPORT_FILTER"/>
+         <xs:enumeration value="REMEMBER_ME_FILTER"/>
+         <xs:enumeration value="ANONYMOUS_FILTER"/>
+         <xs:enumeration value="SESSION_MANAGEMENT_FILTER"/>
+         <xs:enumeration value="EXCEPTION_TRANSLATION_FILTER"/>
+         <xs:enumeration value="FILTER_SECURITY_INTERCEPTOR"/>
+         <xs:enumeration value="SWITCH_USER_FILTER"/>
+         <xs:enumeration value="LAST"/>
+      </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/config/src/test/groovy/org/springframework/security/config/annotation/web/configurers/HeadersConfigurerTests.groovy
+++ b/config/src/test/groovy/org/springframework/security/config/annotation/web/configurers/HeadersConfigurerTests.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,27 +15,15 @@
  */
 package org.springframework.security.config.annotation.web.configurers
 
-import javax.servlet.http.HttpServletResponse
-
-import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.BaseSpringSpec
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
-import org.springframework.security.web.access.AccessDeniedHandler
-import org.springframework.security.web.csrf.CsrfFilter;
-import org.springframework.security.web.csrf.CsrfTokenRepository;
-import org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter.XFrameOptionsMode;
-import org.springframework.security.web.servlet.support.csrf.CsrfRequestDataValueProcessor;
-import org.springframework.security.web.util.matcher.RequestMatcher;
-import org.springframework.web.servlet.support.RequestDataValueProcessor;
-
-import spock.lang.Unroll;
 
 /**
  *
  * @author Rob Winch
+ * @author Tim Ysewyn
  */
 class HeadersConfigurerTests extends BaseSpringSpec {
 
@@ -196,6 +184,207 @@ class HeadersConfigurerTests extends BaseSpringSpec {
 			http
 				.headers()
 					.frameOptions().sameOrigin()
+		}
+	}
+
+	def "headers.hpkp no pins"() {
+		setup:
+			loadConfig(HpkpConfigNoPins)
+			request.secure = true
+		when:
+			springSecurityFilterChain.doFilter(request,response,chain)
+		then:
+			responseHeaders == [:]
+	}
+
+	@EnableWebSecurity
+	static class HpkpConfigNoPins extends WebSecurityConfigurerAdapter {
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			http
+					.headers()
+					.defaultsDisabled()
+					.httpPublicKeyPinning()
+		}
+	}
+
+	def "headers.hpkp"() {
+		setup:
+			loadConfig(HpkpConfig)
+			request.secure = true
+		when:
+			springSecurityFilterChain.doFilter(request,response,chain)
+		then:
+			responseHeaders == ['Public-Key-Pins-Report-Only' : 'max-age=5184000 ; pin-sha256="d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM="']
+	}
+
+	def "headers.hpkp no secure request"() {
+		setup:
+			loadConfig(HpkpConfig)
+		when:
+			springSecurityFilterChain.doFilter(request,response,chain)
+			then:
+			responseHeaders == [:]
+	}
+
+	@EnableWebSecurity
+	static class HpkpConfig extends WebSecurityConfigurerAdapter {
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			http
+					.headers()
+					.defaultsDisabled()
+					.httpPublicKeyPinning()
+					.addSha256Pins("d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=")
+		}
+	}
+
+	def "headers.hpkp with pins"() {
+		setup:
+			loadConfig(HpkpConfigWithPins)
+			request.secure = true
+		when:
+			springSecurityFilterChain.doFilter(request,response,chain)
+		then:
+			responseHeaders == ['Public-Key-Pins-Report-Only' : 'max-age=5184000 ; pin-sha256="d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=" ; pin-sha256="E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g="']
+	}
+
+	@EnableWebSecurity
+	static class HpkpConfigWithPins extends WebSecurityConfigurerAdapter {
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			Map<String, String> pins = new LinkedHashMap<>();
+			pins.put("d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=", "sha256");
+			pins.put("E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g=", "sha256");
+
+			http
+					.headers()
+					.defaultsDisabled()
+					.httpPublicKeyPinning()
+					.withPins(pins)
+		}
+	}
+
+	def "headers.hpkp custom age"() {
+		setup:
+			loadConfig(HpkpConfigCustomAge)
+			request.secure = true
+		when:
+			springSecurityFilterChain.doFilter(request,response,chain)
+		then:
+			responseHeaders == ['Public-Key-Pins-Report-Only' : 'max-age=604800 ; pin-sha256="d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM="']
+	}
+
+	@EnableWebSecurity
+	static class HpkpConfigCustomAge extends WebSecurityConfigurerAdapter {
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			http
+					.headers()
+					.defaultsDisabled()
+					.httpPublicKeyPinning()
+					.addSha256Pins("d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=")
+					.maxAgeInSeconds(604800)
+		}
+	}
+
+	def "headers.hpkp terminate connection"() {
+		setup:
+			loadConfig(HpkpConfigTerminateConnection)
+			request.secure = true
+		when:
+			springSecurityFilterChain.doFilter(request,response,chain)
+		then:
+			responseHeaders == ['Public-Key-Pins' : 'max-age=5184000 ; pin-sha256="d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM="']
+	}
+
+	@EnableWebSecurity
+	static class HpkpConfigTerminateConnection extends WebSecurityConfigurerAdapter {
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			http
+					.headers()
+					.defaultsDisabled()
+					.httpPublicKeyPinning()
+					.addSha256Pins("d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=")
+					.reportOnly(false)
+		}
+	}
+
+	def "headers.hpkp include subdomains"() {
+		setup:
+			loadConfig(HpkpConfigIncludeSubDomains)
+			request.secure = true
+		when:
+			springSecurityFilterChain.doFilter(request,response,chain)
+		then:
+			responseHeaders == ['Public-Key-Pins-Report-Only' : 'max-age=5184000 ; pin-sha256="d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=" ; includeSubDomains']
+	}
+
+	@EnableWebSecurity
+	static class HpkpConfigIncludeSubDomains extends WebSecurityConfigurerAdapter {
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			http
+					.headers()
+					.defaultsDisabled()
+					.httpPublicKeyPinning()
+					.addSha256Pins("d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=")
+					.includeSubDomains(true)
+		}
+	}
+
+	def "headers.hpkp with report URI"() {
+		setup:
+			loadConfig(HpkpConfigWithReportURI)
+			request.secure = true
+		when:
+			springSecurityFilterChain.doFilter(request,response,chain)
+		then:
+			responseHeaders == ['Public-Key-Pins-Report-Only' : 'max-age=5184000 ; pin-sha256="d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=" ; report-uri="http://example.net/pkp-report"']
+	}
+
+	@EnableWebSecurity
+	static class HpkpConfigWithReportURI extends WebSecurityConfigurerAdapter {
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			http
+					.headers()
+					.defaultsDisabled()
+					.httpPublicKeyPinning()
+					.addSha256Pins("d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=")
+					.reportUri(new URI("http://example.net/pkp-report"))
+		}
+	}
+
+	def "headers.hpkp with report URI as String"() {
+		setup:
+			loadConfig(HpkpConfigWithReportURIAsString)
+			request.secure = true
+		when:
+			springSecurityFilterChain.doFilter(request,response,chain)
+		then:
+			responseHeaders == ['Public-Key-Pins-Report-Only' : 'max-age=5184000 ; pin-sha256="d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=" ; report-uri="http://example.net/pkp-report"']
+	}
+
+	@EnableWebSecurity
+	static class HpkpConfigWithReportURIAsString extends WebSecurityConfigurerAdapter {
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			http
+					.headers()
+					.defaultsDisabled()
+					.httpPublicKeyPinning()
+					.addSha256Pins("d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=")
+					.reportUri("http://example.net/pkp-report")
 		}
 	}
 }

--- a/config/src/test/groovy/org/springframework/security/config/doc/XsdDocumentedTests.groovy
+++ b/config/src/test/groovy/org/springframework/security/config/doc/XsdDocumentedTests.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2011-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -33,7 +33,7 @@ class XsdDocumentedTests extends Specification {
 	@Shared def reference = new File('../docs/manual/src/docs/asciidoc/index.adoc')
 
 	@Shared File schema31xDocument = new File('src/main/resources/org/springframework/security/config/spring-security-3.1.xsd')
-	@Shared File schemaDocument = new File('src/main/resources/org/springframework/security/config/spring-security-4.0.xsd')
+	@Shared File schemaDocument = new File('src/main/resources/org/springframework/security/config/spring-security-4.1.xsd')
 	@Shared Map<String,Element> elementNameToElement
 	@Shared GPathResult schemaRootElement
 
@@ -90,7 +90,7 @@ class XsdDocumentedTests extends Specification {
 		when: 'all the schemas are found'
 		def schemas = schemaDocument.getParentFile().list().findAll { it.endsWith('.xsd') }
 		then: 'the count is equal to 8, if not then schemaDocument needs updated'
-		schemas.size() == 9
+		schemas.size() == 10
 	}
 
 	/**

--- a/config/src/test/java/org/springframework/security/config/util/InMemoryXmlApplicationContext.java
+++ b/config/src/test/java/org/springframework/security/config/util/InMemoryXmlApplicationContext.java
@@ -41,11 +41,11 @@ public class InMemoryXmlApplicationContext extends AbstractXmlApplicationContext
 	Resource inMemoryXml;
 
 	public InMemoryXmlApplicationContext(String xml) {
-		this(xml, "4.0", null);
+		this(xml, "4.1", null);
 	}
 
 	public InMemoryXmlApplicationContext(String xml, ApplicationContext parent) {
-		this(xml, "4.0", parent);
+		this(xml, "4.1", parent);
 	}
 
 	public InMemoryXmlApplicationContext(String xml, String secVersion,

--- a/config/src/test/resources/org/springframework/security/config/method/PreAuthorizeTests-context.xml
+++ b/config/src/test/resources/org/springframework/security/config/method/PreAuthorizeTests-context.xml
@@ -3,7 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
 	xmlns:c="http://www.springframework.org/schema/c"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.0.xsd
+	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<global-method-security pre-post-annotations="enabled"/>

--- a/config/src/test/resources/org/springframework/security/config/method/SecuredTests-context.xml
+++ b/config/src/test/resources/org/springframework/security/config/method/SecuredTests-context.xml
@@ -3,7 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
 	xmlns:c="http://www.springframework.org/schema/c"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.0.xsd
+	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<global-method-security secured-annotations="enabled"/>

--- a/docs/manual/src/docs/asciidoc/index.adoc
+++ b/docs/manual/src/docs/asciidoc/index.adoc
@@ -3809,6 +3809,70 @@ protected void configure(HttpSecurity http) throws Exception {
 }
 ----
 
+[[headers-hpkp]]
+==== HTTP Public Key Pinning (HPKP)
+HTTP Public Key Pinning (HPKP) is a security feature that tells a web client to associate a specific cryptographic public key with a certain web server to prevent Man in the Middle (MITM) attacks with forged certificates.
+
+To ensure the authenticity of a server's public key used in TLS sessions, this public key is wrapped into a X.509 certificate which is usually signed by a certificate authority (CA). Web clients such as browsers trust a lot of these CAs, which can all create certificates for arbitrary domain names.
+If an attacker is able to compromise a single CA, they can perform MITM attacks on various TLS connections. HPKP can circumvent this threat for the HTTPS protocol by telling the client which public key belongs to a certain web server.
+HPKP is a Trust on First Use (TOFU) technique. The first time a web server tells a client via a special HTTP header which public keys belong to it, the client stores this information for a given period of time.
+When the client visits the server again, it expects a certificate containing a public key whose fingerprint is already known via HPKP. If the server delivers an unknown public key, the client should present a warning to the user.
+
+[NOTE]
+====
+Because the UA needs to validate the pins against the SSL certificate chain, the HPKP header is only injected into HTTPS responses.
+====
+
+Enabling this feature for your site is as simple as returning the Public-Key-Pins HTTP header when your site is accessed over HTTPS. For example the following would instruct the browser to only report pin validation failures to a given URI for 2 pins:
+
+[source]
+----
+Public-Key-Pins-Report-Only: max-age=5184000 ; pin-sha256="d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=" ; pin-sha256="E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g=" ; report-uri="http://example.net/pkp-report" ; includeSubDomains
+----
+
+The optional includeSubDomains directive instructs the browser to also validate subdomains with the given pins.
+
+Opposed to the other headers, Spring Security does not add HPKP by default. You can customize HPKP headers with the <<nsa-hpkp,<hpkp>>> element as shown below:
+
+[source,xml]
+----
+<http>
+	<!-- ... -->
+
+	<headers>
+		<hpkp
+			include-subdomains="true"
+			report-uri="http://example.net/pkp-report">
+			<pins>
+			    <pin algorithm="sha256">d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=</pin>
+			    <pin algorithm="sha256">E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g=</pin>
+			</pins>
+		</hpkp>
+	</headers>
+</http>
+----
+
+Similarly, you can enable HPKP headers with Java Configuration:
+
+[source,java]
+----
+@EnableWebSecurity
+public class WebSecurityConfig extends
+WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+        // ...
+        .headers()
+            .httpPublicKeyPinning()
+                .includeSubdomains(true)
+                .reportUri("http://example.net/pkp-report")
+                .addSha256Pins("d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=", "E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g=";
+    }
+}
+----
+
 [[headers-frame-options]]
 ==== X-Frame-Options
 Allowing your website to be added to a frame can be a security issue. For example, using clever CSS styling users could be tricked into clicking on something that they were not intending (http://www.youtube.com/watch?v=3mk0RySeNsU[video demo]). For example, a user that is logged into their bank might click a button that grants access to other users. This sort of attack is known as http://en.wikipedia.org/wiki/Clickjacking[Clickjacking].
@@ -6894,7 +6958,7 @@ END;
 
 [[appendix-namespace]]
 == The Security Namespace
-This appendix provides a reference to the elements available in the security namespace and information on the underlying beans they create (a knowledge of the individual classes and how they work together is assumed - you can find more information in the project Javadoc and elsewhere in this document). If you haven't used the namespace before, please read the <<ns-config,introductory chapter>> on namespace configuration, as this is intended as a supplement to the information there. Using a good quality XML editor while editing a configuration based on the schema is recommended as this will provide contextual information on which elements and attributes are available as well as comments explaining their purpose. The namespace is written in http://www.relaxng.org/[RELAX NG] Compact format and later converted into an XSD schema. If you are familiar with this format, you may wish to examine the https://raw.githubusercontent.com/spring-projects/spring-security/master/config/src/main/resources/org/springframework/security/config/spring-security-4.0.rnc[schema file] directly.
+This appendix provides a reference to the elements available in the security namespace and information on the underlying beans they create (a knowledge of the individual classes and how they work together is assumed - you can find more information in the project Javadoc and elsewhere in this document). If you haven't used the namespace before, please read the <<ns-config,introductory chapter>> on namespace configuration, as this is intended as a supplement to the information there. Using a good quality XML editor while editing a configuration based on the schema is recommended as this will provide contextual information on which elements and attributes are available as well as comments explaining their purpose. The namespace is written in http://www.relaxng.org/[RELAX NG] Compact format and later converted into an XSD schema. If you are familiar with this format, you may wish to examine the https://raw.githubusercontent.com/spring-projects/spring-security/master/config/src/main/resources/org/springframework/security/config/spring-security-4.1.rnc[schema file] directly.
 
 [[nsa-web]]
 === Web Application Security
@@ -7065,6 +7129,7 @@ This element allows for configuring additional (security) headers to be send wit
 ** `X-Frame-Options` - Can be set using the <<nsa-frame-options,frame-options>> element. The http://en.wikipedia.org/wiki/Clickjacking#X-Frame-Options[X-Frame-Options ] header can be used to prevent clickjacking attacks.
 ** `X-XSS-Protection` - Can be set using the <<nsa-xss-protection,xss-protection>> element. The http://en.wikipedia.org/wiki/Cross-site_scripting[X-XSS-Protection ] header can be used by browser to do basic control.
 ** `X-Content-Type-Options` - Can be set using the <<nsa-content-type-options,content-type-options>> element. The http://blogs.msdn.com/b/ie/archive/2008/09/02/ie8-security-part-vi-beta-2-update.aspx[X-Content-Type-Options] header prevents Internet Explorer from MIME-sniffing a response away from the declared content-type. This also applies to Google Chrome, when downloading extensions.
+** `Public-Key-Pinning` or `Public-Key-Pinning-Report-Only` - Can be set using the <<nsa-hpkp,hpkp>> element. This allows HTTPS websites to resist impersonation by attackers using mis-issued or otherwise fraudulent certificates.
 
 [[nsa-headers-attributes]]
 ===== <headers> Attributes
@@ -7095,6 +7160,7 @@ Optional attribute that specifies to disable Spring Security's HTTP response hea
 * <<nsa-content-type-options,content-type-options>>
 * <<nsa-frame-options,frame-options>>
 * <<nsa-header,header>>
+* <<nsa-hpkp,hpkp>>
 * <<nsa-hsts,hsts>>
 * <<nsa-xss-protection,xss-protection>>
 
@@ -7152,6 +7218,74 @@ The RequestMatcher instance to be used to determine if the header should be set.
 ===== Parent Elements of <hsts>
 
 * <<nsa-headers,headers>>
+
+
+
+[[nsa-hpkp]]
+==== <hpkp>
+When enabled adds the https://tools.ietf.org/html/rfc7469[Public Key Pinning Extension for HTTP] header to the response for any secure request. This allows HTTPS websites to resist impersonation by attackers using mis-issued or otherwise fraudulent certificates.
+
+
+[[nsa-hpkp-attributes]]
+===== <hpkp> Attributes
+
+[[nsa-hpkp-disabled]]
+* **disabled**
+Specifies if HTTP Public Key Pinning (HPKP) should be disabled. Default true.
+
+[[nsa-hpkp-include-subdomains]]
+* **include-sub-domains**
+Specifies if subdomains should be included. Default false.
+
+
+[[nsa-hpkp-max-age-seconds]]
+* **max-age-seconds**
+Sets the value for the max-age directive of the Public-Key-Pins header. Default 60 days.
+
+
+[[nsa-hpkp-report-only]]
+* **report-only**
+Specifies if the browser should only report pin validation failures. Default true.
+
+
+[[nsa-hpkp-report-uri]]
+* **report-uri**
+Specifies the URI to which the browser should report pin validation failures.
+
+
+[[nsa-hpkp-parents]]
+===== Parent Elements of <hpkp>
+
+* <<nsa-headers,headers>>
+
+
+[[nsa-pins]]
+==== <pins>
+The list of pins
+
+
+[[nsa-pins-children]]
+===== Child Elements of <pins>
+
+* <<nsa-pin,pin>>
+
+
+[[nsa-pin]]
+==== <pin>
+A pin is specified using the base64-encoded SPKI fingerprint as value and the cryptographic hash algorithm as attribute
+
+[[nsa-pin-attributes]]
+===== <pin> Attributes
+
+[[nsa-pin-algorithm]]
+* **algorithm**
+The cryptographic hash algorithm. Default is SHA256.
+
+
+[[nsa-pin-parents]]
+===== Parent Elements of <pin>
+
+* <<nsa-pins,pins>>
 
 
 

--- a/web/src/main/java/org/springframework/security/web/header/writers/HpkpHeaderWriter.java
+++ b/web/src/main/java/org/springframework/security/web/header/writers/HpkpHeaderWriter.java
@@ -1,0 +1,431 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.web.header.writers;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.security.web.header.HeaderWriter;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.util.Assert;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Provides support for <a href="http://tools.ietf.org/html/rfc7469">HTTP Public Key Pinning (HPKP)</a>.
+ *
+ * <p>
+ * Since <a href="http://tools.ietf.org/html/rfc7469#section-4.1">Section 4.1</a> states
+ * that a value on the order of 60 days (5,184,000 seconds) may be considered a good balance,
+ * we use this value as the default. This can be customized using {@link #setMaxAgeInSeconds(long)}.
+ * </p>
+ *
+ * <p>
+ * Because <a href="http://tools.ietf.org/html/rfc7469#appendix-B">Appendix B</a> recommends
+ * that operators should first deploy public key pinning by using the report-only mode,
+ * we opted to use this mode as default. This can be customized using {@link #setReportOnly(boolean)}.
+ * </p>
+ *
+ * <p>
+ * Since we need to validate a certificate chain, the "Public-Key-Pins" or "Public-Key-Pins-Report-Only" header
+ * will only be added when {@link HttpServletRequest#isSecure()} returns {@code true}.
+ * </p>
+ *
+ * <p>
+ * To set the pins you first need to extract the public key information from your certificate or key file
+ * and encode them using Base64. The following commands will help you extract the Base64 encoded information
+ * from a key file, a certificate signing request, or a certificate.
+ *
+ * openssl rsa -in my-key-file.key -outform der -pubout | openssl dgst -sha256 -binary | openssl enc -base64
+ *
+ * openssl req -in my-signing-request.csr -pubkey -noout | openssl rsa -pubin -outform der | openssl dgst -sha256 -binary | openssl enc -base64
+ *
+ * openssl x509 -in my-certificate.crt -pubkey -noout | openssl rsa -pubin -outform der | openssl dgst -sha256 -binary | openssl enc -base64
+ *
+ *
+ * The following command will extract the Base64 encoded information for a website.
+ *
+ * openssl s_client -servername www.example.com -connect www.example.com:443 | openssl x509 -pubkey -noout | openssl rsa -pubin -outform der | openssl dgst -sha256 -binary | openssl enc -base64
+ * </p>
+ *
+ * <p>
+ * Some examples:
+ *
+ * Public-Key-Pins: max-age=3000;
+ * 		pin-sha256="d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=";
+ * 		pin-sha256="E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g="
+ *
+ * Public-Key-Pins: max-age=5184000;
+ * 		pin-sha256="E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g=";
+ * 		pin-sha256="LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ="
+ *
+ * Public-Key-Pins: max-age=5184000;
+ * 		pin-sha256="E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g=";
+ * 		pin-sha256="LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=";
+ * 		report-uri="http://example.com/pkp-report"
+ *
+ * Public-Key-Pins-Report-Only: max-age=5184000;
+ * 		pin-sha256="E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g=";
+ * 		pin-sha256="LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=";
+ * 		report-uri="https://other.example.net/pkp-report"
+ *
+ * Public-Key-Pins: max-age=5184000;
+ * 		pin-sha256="d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=";
+ * 		pin-sha256="E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g=";
+ * 		pin-sha256="LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=";
+ * 		includeSubDomains
+ * </p>
+ *
+ * @author Tim Ysewyn
+ * @since 4.1
+ */
+public final class HpkpHeaderWriter implements HeaderWriter {
+	private static final long DEFAULT_MAX_AGE_SECONDS = 5184000;
+
+	private static final String HPKP_HEADER_NAME = "Public-Key-Pins";
+
+	private static final String HPKP_RO_HEADER_NAME = "Public-Key-Pins-Report-Only";
+
+	private final Log logger = LogFactory.getLog(getClass());
+
+	private final RequestMatcher requestMatcher = new SecureRequestMatcher();
+
+	private Map<String, String> pins = new LinkedHashMap<String, String>();
+
+	private long maxAgeInSeconds;
+
+	private boolean includeSubDomains;
+
+	private boolean reportOnly;
+
+	private URI reportUri;
+
+	private String hpkpHeaderValue;
+
+	/**
+	 * Creates a new instance
+	 *
+	 * @param maxAgeInSeconds maps to {@link #setMaxAgeInSeconds(long)}
+	 * @param includeSubDomains maps to {@link #setIncludeSubDomains(boolean)}
+	 * @param reportOnly maps to {@link #setReportOnly(boolean)}
+	 */
+	public HpkpHeaderWriter(long maxAgeInSeconds, boolean includeSubDomains, boolean reportOnly) {
+		super();
+		this.maxAgeInSeconds = maxAgeInSeconds;
+		this.includeSubDomains = includeSubDomains;
+		this.reportOnly = reportOnly;
+		updateHpkpHeaderValue();
+	}
+
+	/**
+	 * Creates a new instance
+	 *
+	 * @param maxAgeInSeconds maps to {@link #setMaxAgeInSeconds(long)}
+	 * @param includeSubDomains maps to {@link #setIncludeSubDomains(boolean)}
+	 */
+	public HpkpHeaderWriter(long maxAgeInSeconds, boolean includeSubDomains) {
+		this(maxAgeInSeconds, includeSubDomains, true);
+	}
+
+	/**
+	 * Creates a new instance
+	 *
+	 * @param maxAgeInSeconds maps to {@link #setMaxAgeInSeconds(long)}
+	 */
+	public HpkpHeaderWriter(long maxAgeInSeconds) {
+		this(maxAgeInSeconds, false);
+	}
+
+	/**
+	 * Creates a new instance
+	 */
+	public HpkpHeaderWriter() {
+		this(DEFAULT_MAX_AGE_SECONDS);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.springframework.security.web.headers.HeaderWriter#writeHeaders(javax
+	 * .servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+	 */
+	public void writeHeaders(HttpServletRequest request, HttpServletResponse response) {
+		if (requestMatcher.matches(request)) {
+			if (!pins.isEmpty()) {
+				response.setHeader(reportOnly ? HPKP_RO_HEADER_NAME : HPKP_HEADER_NAME, hpkpHeaderValue);
+			} if (logger.isDebugEnabled()) {
+				logger.debug("Not injecting HPKP header since there aren't any pins");
+			}
+		}
+		else if (logger.isDebugEnabled()) {
+			logger.debug("Not injecting HPKP header since it wasn't a secure connection");
+		}
+	}
+
+	/**
+	 * <p>
+	 * Sets the value for the pin- directive of the Public-Key-Pins header.
+	 * </p>
+	 *
+	 * <p>
+	 * The pin directive specifies a way for web host operators to indicate
+	 * a cryptographic identity that should be bound to a given web host.
+	 * See <a href="http://tools.ietf.org/html/rfc7469#section-2.1.1">Section 2.1.1</a> for additional details.
+	 * </p>
+	 *
+	 * <p>
+	 * To get a pin of
+	 *
+	 * Public-Key-Pins:
+	 * 		pin-sha256="d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=";
+	 * 		pin-sha256="E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g="
+	 *
+	 * Use
+	 *
+	 * Map<String, String> pins = new HashMap<String, String>();
+	 * pins.put("d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=", "sha256");
+	 * pins.put("E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g=", "sha256");
+	 * </p>
+	 *
+	 * @param pins the map of base64-encoded SPKI fingerprint &amp; cryptographic hash algorithm pairs.
+	 * @throws IllegalArgumentException if pins is null
+	 */
+	public void setPins(Map<String, String> pins) {
+		Assert.notNull(pins, "pins cannot be null");
+		this.pins = pins;
+		updateHpkpHeaderValue();
+	}
+
+	/**
+	 * <p>
+	 * Adds a list of SHA256 hashed pins for the pin- directive of the Public-Key-Pins header.
+	 * </p>
+	 *
+	 * <p>
+	 * The pin directive specifies a way for web host operators to indicate
+	 * a cryptographic identity that should be bound to a given web host.
+	 * See <a href="http://tools.ietf.org/html/rfc7469#section-2.1.1">Section 2.1.1</a> for additional details.
+	 * </p>
+	 *
+	 * <p>
+	 * To get a pin of
+	 *
+	 * Public-Key-Pins-Report-Only:
+	 * 		pin-sha256="d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=";
+	 * 		pin-sha256="E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g="
+	 *
+	 * Use
+	 *
+	 * HpkpHeaderWriter hpkpHeaderWriter = new HpkpHeaderWriter();
+	 * hpkpHeaderWriter.addSha256Pins("d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM", "E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g=");
+	 * </p>
+	 *
+	 * @param pins a list of base64-encoded SPKI fingerprints.
+	 * @throws IllegalArgumentException if a pin is null
+	 */
+	public void addSha256Pins(String ... pins) {
+		for (String pin : pins) {
+			Assert.notNull(pin, "pin cannot be null");
+			this.pins.put(pin, "sha256");
+		}
+		updateHpkpHeaderValue();
+	}
+
+	/**
+	 * <p>
+	 * Sets the value (in seconds) for the max-age directive of the Public-Key-Pins header. The default is 60 days.
+	 * </p>
+	 *
+	 * <p>
+	 * This instructs browsers how long they should regard the host (from whom the message was received)
+	 * as a known pinned host. See <a href="http://tools.ietf.org/html/rfc7469#section-2.1.2">Section
+	 * 2.1.2</a> for additional details.
+	 * </p>
+	 *
+	 * <p>
+	 * To get a header like
+	 *
+	 * Public-Key-Pins-Report-Only: max-age=2592000;
+	 * 		pin-sha256="d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=";
+	 * 		pin-sha256="E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g="
+	 *
+	 * Use
+	 *
+	 * HpkpHeaderWriter hpkpHeaderWriter = new HpkpHeaderWriter();
+	 * hpkpHeaderWriter.setMaxAgeInSeconds(TimeUnit.DAYS.toSeconds(30));
+	 * </p>
+	 *
+	 * @param maxAgeInSeconds the maximum amount of time (in seconds) to regard the host
+	 * as a known pinned host. (i.e. TimeUnit.DAYS.toSeconds(30) would set this to 30 days)
+	 * @throws IllegalArgumentException if maxAgeInSeconds is negative
+	 */
+	public void setMaxAgeInSeconds(long maxAgeInSeconds) {
+		if (maxAgeInSeconds < 0) {
+			throw new IllegalArgumentException(
+					"maxAgeInSeconds must be non-negative. Got " + maxAgeInSeconds);
+		}
+		this.maxAgeInSeconds = maxAgeInSeconds;
+		updateHpkpHeaderValue();
+	}
+
+	/**
+	 * <p>
+	 * If true, the pinning policy applies to this pinned host as well as any subdomains
+	 * of the host's domain name. The default is false.
+	 * </p>
+	 *
+	 * <p>
+	 * See <a href="http://tools.ietf.org/html/rfc7469#section-2.1.3">Section 2.1.3</a>
+	 * for additional details.
+	 * </p>
+	 *
+	 * <p>
+	 * To get a header like
+	 *
+	 * Public-Key-Pins-Report-Only: max-age=5184000;
+	 * 		pin-sha256="d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=";
+	 * 		pin-sha256="E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g=";
+	 * 		includeSubDomains
+	 *
+	 * you should set this to true.
+	 * </p>
+	 *
+	 * @param includeSubDomains true to include subdomains, else false
+	 */
+	public void setIncludeSubDomains(boolean includeSubDomains) {
+		this.includeSubDomains = includeSubDomains;
+		updateHpkpHeaderValue();
+	}
+
+	/**
+	 * <p>
+	 * To get a Public-Key-Pins header you should set this to false,
+	 * otherwise the header will be Public-Key-Pins-Report-Only. When in report-only mode,
+	 * the browser should not terminate the connection with the server. By default this is true.
+	 * </p>
+	 *
+	 * <p>
+	 * See <a href="http://tools.ietf.org/html/rfc7469#section-2.1">Section 2.1</a>
+	 * for additional details.
+	 * </p>
+	 *
+	 * <p>
+	 * To get a header like
+	 *
+	 * Public-Key-Pins: max-age=5184000;
+	 * 		pin-sha256="d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=";
+	 * 		pin-sha256="E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g="
+	 *
+	 * you should the this to false.
+	 * </p>
+	 *
+	 * @param reportOnly true to report only, else false
+	 */
+	public void setReportOnly(boolean reportOnly) {
+		this.reportOnly = reportOnly;
+	}
+
+	/**
+	 * <p>
+	 * Sets the URI to which the browser should report pin validation failures.
+	 * </p>
+	 *
+	 * <p>
+	 * See <a href="http://tools.ietf.org/html/rfc7469#section-2.1.4">Section 2.1.4</a>
+	 * for additional details.
+	 * </p>
+	 *
+	 * <p>
+	 * To get a header like
+	 *
+	 * Public-Key-Pins-Report-Only: max-age=5184000;
+	 * 		pin-sha256="E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g=";
+	 * 		pin-sha256="LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=";
+	 * 		report-uri="https://other.example.net/pkp-report"
+	 *
+	 * Use
+	 *
+	 * HpkpHeaderWriter hpkpHeaderWriter = new HpkpHeaderWriter();
+	 * hpkpHeaderWriter.setReportUri(new URI("https://other.example.net/pkp-report"));
+	 * </p>
+	 *
+	 * @param reportUri the URI where the browser should send the report to.
+	 */
+	public void setReportUri(URI reportUri) {
+		this.reportUri = reportUri;
+		updateHpkpHeaderValue();
+	}
+
+	/**
+	 * <p>
+	 * Sets the URI to which the browser should report pin validation failures.
+	 * </p>
+	 *
+	 * <p>
+	 * See <a href="http://tools.ietf.org/html/rfc7469#section-2.1.4">Section 2.1.4</a>
+	 * for additional details.
+	 * </p>
+	 *
+	 * <p>
+	 * To get a header like
+	 *
+	 * Public-Key-Pins-Report-Only: max-age=5184000;
+	 * 		pin-sha256="E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g=";
+	 * 		pin-sha256="LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ=";
+	 * 		report-uri="https://other.example.net/pkp-report"
+	 *
+	 * Use
+	 *
+	 * HpkpHeaderWriter hpkpHeaderWriter = new HpkpHeaderWriter();
+	 * hpkpHeaderWriter.setReportUri("https://other.example.net/pkp-report");
+	 * </p>
+	 *
+	 * @param reportUri the URI where the browser should send the report to.
+	 * @throws IllegalArgumentException if the reportUri is not a valid URI
+	 */
+	public void setReportUri(String reportUri) {
+		try {
+			this.reportUri = new URI(reportUri);
+		} catch (URISyntaxException e) {
+			throw new IllegalArgumentException(e);
+		}
+		updateHpkpHeaderValue();
+	}
+
+	private void updateHpkpHeaderValue() {
+		String headerValue = "max-age=" + maxAgeInSeconds;
+		for (Map.Entry<String, String> pin : pins.entrySet()) {
+			headerValue += " ; pin-" + pin.getValue() + "=\"" + pin.getKey() + "\"";
+		}
+		if (reportUri != null) {
+			headerValue += " ; report-uri=\"" + reportUri.toString() + "\"";
+		}
+		if (includeSubDomains) {
+			headerValue += " ; includeSubDomains";
+		}
+		this.hpkpHeaderValue = headerValue;
+	}
+
+	private static final class SecureRequestMatcher implements RequestMatcher {
+		public boolean matches(HttpServletRequest request) {
+			return request.isSecure();
+		}
+	}
+}

--- a/web/src/test/java/org/springframework/security/web/header/writers/HpkpHeaderWriterTests.java
+++ b/web/src/test/java/org/springframework/security/web/header/writers/HpkpHeaderWriterTests.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.web.header.writers;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Tim Ysewyn
+ *
+ */
+public class HpkpHeaderWriterTests {
+
+	private static final Map<String, String> DEFAULT_PINS;
+	static
+	{
+		Map<String, String> defaultPins = new LinkedHashMap<String, String>();
+		defaultPins.put("d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=", "sha256");
+		DEFAULT_PINS = Collections.unmodifiableMap(defaultPins);
+	}
+
+	private MockHttpServletRequest request;
+	private MockHttpServletResponse response;
+
+	private HpkpHeaderWriter writer;
+
+	@Before
+	public void setup() {
+		request = new MockHttpServletRequest();
+		response = new MockHttpServletResponse();
+
+		writer = new HpkpHeaderWriter();
+
+		Map<String, String> defaultPins = new LinkedHashMap<String, String>();
+		defaultPins.put("d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=", "sha256");
+
+		writer.setPins(defaultPins);
+
+		request.setSecure(true);
+	}
+
+	@Test
+	public void writeHeadersDefaultValues() {
+		writer.writeHeaders(request, response);
+
+		assertThat(response.getHeaderNames().size()).isEqualTo(1);
+		assertThat(response.getHeader("Public-Key-Pins-Report-Only")).isEqualTo(
+				"max-age=5184000 ; pin-sha256=\"d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=\"");
+	}
+
+	@Test
+	public void maxAgeCustomConstructorWriteHeaders() {
+		writer = new HpkpHeaderWriter(2592000);
+		writer.setPins(DEFAULT_PINS);
+
+		writer.writeHeaders(request, response);
+
+		assertThat(response.getHeaderNames().size()).isEqualTo(1);
+		assertThat(response.getHeader("Public-Key-Pins-Report-Only")).isEqualTo(
+				"max-age=2592000 ; pin-sha256=\"d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=\"");
+	}
+
+	@Test
+	public void maxAgeAndIncludeSubdomainsCustomConstructorWriteHeaders() {
+		writer = new HpkpHeaderWriter(2592000, true);
+		writer.setPins(DEFAULT_PINS);
+
+		writer.writeHeaders(request, response);
+
+		assertThat(response.getHeaderNames().size()).isEqualTo(1);
+		assertThat(response.getHeader("Public-Key-Pins-Report-Only")).isEqualTo(
+				"max-age=2592000 ; pin-sha256=\"d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=\" ; includeSubDomains");
+	}
+	@Test
+	public void allArgsCustomConstructorWriteHeaders() {
+		writer = new HpkpHeaderWriter(2592000, true, false);
+		writer.setPins(DEFAULT_PINS);
+
+		writer.writeHeaders(request, response);
+
+		assertThat(response.getHeaderNames().size()).isEqualTo(1);
+		assertThat(response.getHeader("Public-Key-Pins")).isEqualTo(
+				"max-age=2592000 ; pin-sha256=\"d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=\" ; includeSubDomains");
+	}
+
+	@Test
+	public void writeHeadersCustomMaxAgeInSeconds() {
+		writer.setMaxAgeInSeconds(2592000);
+
+		writer.writeHeaders(request, response);
+
+		assertThat(response.getHeaderNames().size()).isEqualTo(1);
+		assertThat(response.getHeader("Public-Key-Pins-Report-Only")).isEqualTo(
+				"max-age=2592000 ; pin-sha256=\"d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=\"");
+	}
+
+	@Test
+	public void writeHeadersIncludeSubDomains() {
+		writer.setIncludeSubDomains(true);
+
+		writer.writeHeaders(request, response);
+
+		assertThat(response.getHeaderNames().size()).isEqualTo(1);
+		assertThat(response.getHeader("Public-Key-Pins-Report-Only")).isEqualTo(
+				"max-age=5184000 ; pin-sha256=\"d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=\" ; includeSubDomains");
+	}
+
+	@Test
+	public void writeHeadersTerminateConnection() {
+		writer.setReportOnly(false);
+
+		writer.writeHeaders(request, response);
+
+		assertThat(response.getHeaderNames().size()).isEqualTo(1);
+		assertThat(response.getHeader("Public-Key-Pins")).isEqualTo(
+				"max-age=5184000 ; pin-sha256=\"d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=\"");
+	}
+
+	@Test
+	public void writeHeadersTerminateConnectionWithURI() throws URISyntaxException {
+		writer.setReportOnly(false);
+		writer.setReportUri(new URI("http://example.com/pkp-report"));
+
+		writer.writeHeaders(request, response);
+
+		assertThat(response.getHeaderNames().size()).isEqualTo(1);
+		assertThat(response.getHeader("Public-Key-Pins")).isEqualTo(
+				"max-age=5184000 ; pin-sha256=\"d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=\" ; report-uri=\"http://example.com/pkp-report\"");
+	}
+
+	@Test
+	public void writeHeadersTerminateConnectionWithURIAsString() throws URISyntaxException {
+		writer.setReportOnly(false);
+		writer.setReportUri("http://example.com/pkp-report");
+
+		writer.writeHeaders(request, response);
+
+		assertThat(response.getHeaderNames().size()).isEqualTo(1);
+		assertThat(response.getHeader("Public-Key-Pins")).isEqualTo(
+				"max-age=5184000 ; pin-sha256=\"d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=\" ; report-uri=\"http://example.com/pkp-report\"");
+	}
+
+	@Test
+	public void writeHeadersAddSha256Pins() {
+		writer.addSha256Pins("d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=", "E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g=");
+		writer.writeHeaders(request, response);
+
+		assertThat(response.getHeaderNames().size()).isEqualTo(1);
+		assertThat(response.getHeader("Public-Key-Pins-Report-Only")).isEqualTo(
+				"max-age=5184000 ; pin-sha256=\"d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=\" ; pin-sha256=\"E9CZ9INDbd+2eRQozYqqbQ2yXLVKB9+xcprMF+44U1g=\"");
+	}
+
+	@Test
+	public void writeHeadersInsecureRequestDoesNotWriteHeader() {
+		request.setSecure(false);
+
+		writer.writeHeaders(request, response);
+
+		assertThat(response.getHeaderNames().isEmpty()).isTrue();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void setMaxAgeInSecondsToNegative() {
+		writer.setMaxAgeInSeconds(-1);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void addSha256PinsWithNullPin() {
+		writer.addSha256Pins("d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=", null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void setIncorrectReportUri() {
+		writer.setReportUri("some url here...");
+	}
+}


### PR DESCRIPTION
HTTP Public Key Pinning (HPKP) is a security mechanism which allows HTTPS websites
to resist impersonation by attackers using mis-issued or otherwise fraudulent certificates.
(For example, sometimes attackers can compromise certificate authorities,
 and then can mis-issue certificates for a web origin.)
The HTTPS web server serves a list of public key hashes, and on subsequent connections
clients expect that server to use 1 or more of those public keys in its certificate chain.

This commit will add this new functionality.

Fixes gh-3706