### PR TITLE
Use bitwise AND to check for perm mask intersect

### DIFF
--- a/acl/src/main/java/org/springframework/security/acls/domain/DefaultPermissionGrantingStrategy.java
+++ b/acl/src/main/java/org/springframework/security/acls/domain/DefaultPermissionGrantingStrategy.java
@@ -71,8 +71,8 @@ public class DefaultPermissionGrantingStrategy implements PermissionGrantingStra
 				boolean scanNextSid = true;
 
 				for (AccessControlEntry ace : aces) {
-
-					if ((ace.getPermission().getMask() & p.getMask()) != 0
+					int targetMask = ace.getPermission().getMask();
+                    			if ((targetMask & p.getMask()) == targetMask && 
 							&& ace.getSid().equals(sid)) {
 						// Found a matching ACE, so its authorization decision will
 						// prevail

--- a/acl/src/main/java/org/springframework/security/acls/domain/DefaultPermissionGrantingStrategy.java
+++ b/acl/src/main/java/org/springframework/security/acls/domain/DefaultPermissionGrantingStrategy.java
@@ -72,7 +72,7 @@ public class DefaultPermissionGrantingStrategy implements PermissionGrantingStra
 
 				for (AccessControlEntry ace : aces) {
 
-					if ((ace.getPermission().getMask() == p.getMask())
+					if ((ace.getPermission().getMask() & p.getMask()) != 0
 							&& ace.getSid().equals(sid)) {
 						// Found a matching ACE, so its authorization decision will
 						// prevail

--- a/acl/src/main/java/org/springframework/security/acls/domain/DefaultPermissionGrantingStrategy.java
+++ b/acl/src/main/java/org/springframework/security/acls/domain/DefaultPermissionGrantingStrategy.java
@@ -71,8 +71,8 @@ public class DefaultPermissionGrantingStrategy implements PermissionGrantingStra
 				boolean scanNextSid = true;
 
 				for (AccessControlEntry ace : aces) {
-					int targetMask = ace.getPermission().getMask();
-                    			if ((targetMask & p.getMask()) == targetMask && 
+					int targetMask = p.getMask();
+                    			if ((targetMask & ace.getPermission().getMask()) == targetMask && 
 							&& ace.getSid().equals(sid)) {
 						// Found a matching ACE, so its authorization decision will
 						// prevail


### PR DESCRIPTION
Otherwise, for example, an ACE that has `RWD` will not pass for a permissions check of `R`. Using the strategy proposed you can now consolidate multiple permissions into one mask instead of having multiple permissions per permissions bit.