### PR TITLE
SpEL variables can be referenced in the expression using the syntax #…

### DIFF
--- a/docs/manual/src/docs/asciidoc/index.adoc
+++ b/docs/manual/src/docs/asciidoc/index.adoc
@@ -4851,7 +4851,7 @@ You could refer to the method using:
 ----
 <http>
 	<intercept-url pattern="/user/{userId}/**"
-		access="@webSecurity.checkUserId(authentication,userId)"/>
+		access="@webSecurity.checkUserId(authentication,#userId)"/>
 	...
 </http>
 ----
@@ -4862,7 +4862,7 @@ or in Java configuration
 ----
 http
 		.authorizeUrls()
-				.antMatchers("/user/{userId}/**").access("@webSecurity.checkUserId(authentication,userId)")
+				.antMatchers("/user/{userId}/**").access("@webSecurity.checkUserId(authentication,#userId)")
 				...
 ----
 


### PR DESCRIPTION
…variableName.

Leading # has been left out in code example in 23.2.2 Path Variables in Web Security Expressions.

Fixes gh-3781

I have signed and agree to the terms of the Spring Individual Contributor License Agreement.