### PR TITLE
SecurityMockMvcResultMatchers.withAuthorities(Collection<? extends GrantedAuthority>)

### DIFF
--- a/test/src/main/java/org/springframework/security/test/web/servlet/response/SecurityMockMvcResultMatchers.java
+++ b/test/src/main/java/org/springframework/security/test/web/servlet/response/SecurityMockMvcResultMatchers.java
@@ -36,6 +36,7 @@ import org.springframework.test.web.servlet.ResultMatcher;
  * Security related {@link MockMvc} {@link ResultMatcher}s.
  *
  * @author Rob Winch
+ * @author Eddú Meléndez
  * @since 4.0
  */
 public final class SecurityMockMvcResultMatchers {
@@ -84,7 +85,7 @@ public final class SecurityMockMvcResultMatchers {
 		private Authentication expectedAuthentication;
 		private Object expectedAuthenticationPrincipal;
 		private String expectedAuthenticationName;
-		private Collection<GrantedAuthority> expectedGrantedAuthorities;
+		private Collection<? extends GrantedAuthority> expectedGrantedAuthorities;
 
 		public void match(MvcResult result) throws Exception {
 			SecurityContext context = load(result);
@@ -194,7 +195,7 @@ public final class SecurityMockMvcResultMatchers {
 		 * @param expected the {@link Authentication#getAuthorities()}
 		 * @return the {@link AuthenticatedMatcher} for further customization
 		 */
-		public AuthenticatedMatcher withAuthorities(Collection<GrantedAuthority> expected) {
+		public AuthenticatedMatcher withAuthorities(Collection<? extends GrantedAuthority> expected) {
 			this.expectedGrantedAuthorities = expected;
 			return this;
 		}

--- a/test/src/test/java/org/springframework/security/test/web/servlet/response/SecurityMockWithAuthoritiesMvcResultMatchersTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/response/SecurityMockWithAuthoritiesMvcResultMatchersTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.test.web.servlet.response;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.formLogin;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = SecurityMockWithAuthoritiesMvcResultMatchersTests.Config.class)
+@WebAppConfiguration
+public class SecurityMockWithAuthoritiesMvcResultMatchersTests {
+	@Autowired
+	private WebApplicationContext context;
+
+	private MockMvc mockMvc;
+
+	@Before
+	public void setup() {
+		mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity())
+				.build();
+	}
+
+	@Test
+	public void withAuthoritiesNotOrderSensitive() throws Exception {
+		List<SimpleGrantedAuthority> grantedAuthorities = new ArrayList<SimpleGrantedAuthority>();
+		grantedAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+		grantedAuthorities.add(new SimpleGrantedAuthority("ROLE_SELLER"));
+		mockMvc.perform(formLogin())
+				.andExpect(authenticated().withAuthorities(grantedAuthorities));
+	}
+
+	@Test(expected = AssertionError.class)
+	public void withAuthoritiesFailsIfNotAllRoles() throws Exception {
+		List<SimpleGrantedAuthority> grantedAuthorities = new ArrayList<SimpleGrantedAuthority>();
+		grantedAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+		mockMvc.perform(formLogin()).andExpect(authenticated().withAuthorities(grantedAuthorities));
+	}
+
+	@EnableWebSecurity
+	@EnableWebMvc
+	static class Config extends WebSecurityConfigurerAdapter {
+
+		// @formatter:off
+		@Autowired
+		public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
+			auth
+				.inMemoryAuthentication()
+					.withUser("user").authorities("ROLE_ADMIN", "ROLE_SELLER").password("password");
+		}
+		// @formatter:on
+
+		@RestController
+		static class Controller {
+			@RequestMapping("/")
+			public String ok() {
+				return "ok";
+			}
+		}
+	}
+}


### PR DESCRIPTION
Support Collection<? extends GrantedAuthority> for SecurityMockMvcResultMatchers.withAuthorities

See gh-3791