### PR TITLE
Fix typo in setMessageExpessionHandler

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/socket/AbstractSecurityWebSocketMessageBrokerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/socket/AbstractSecurityWebSocketMessageBrokerConfigurer.java
@@ -206,8 +206,13 @@ public abstract class AbstractSecurityWebSocketMessageBrokerConfigurer extends
 		this.context = context;
 	}
 
-	@Autowired(required = false)
+	@Deprecated
 	public void setMessageExpessionHandler(List<SecurityExpressionHandler<Message<Object>>> expressionHandlers) {
+		setMessageExpressionHandler(expressionHandlers);
+	}
+
+	@Autowired(required = false)
+	public void setMessageExpressionHandler(List<SecurityExpressionHandler<Message<Object>>> expressionHandlers) {
 		if(expressionHandlers.size() == 1) {
 			this.expressionHandler = expressionHandlers.get(0);
 		}


### PR DESCRIPTION
I noticed there is a small typo. However, I'm not sure the fix is correct like this.