### PR TITLE
Configuration of session management strategies

### DIFF
--- a/config/src/main/java/org/springframework/security/config/http/HttpConfigurationBuilder.java
+++ b/config/src/main/java/org/springframework/security/config/http/HttpConfigurationBuilder.java
@@ -15,13 +15,9 @@
  */
 package org.springframework.security.config.http;
 
-import static org.springframework.security.config.http.HttpSecurityBeanDefinitionParser.*;
-import static org.springframework.security.config.http.SecurityFilters.*;
-
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 
@@ -69,6 +65,7 @@ import org.springframework.security.web.savedrequest.RequestCacheAwareFilter;
 import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter;
 import org.springframework.security.web.session.ConcurrentSessionFilter;
 import org.springframework.security.web.session.SessionManagementFilter;
+import org.springframework.security.web.session.SimpleRedirectExpiredSessionStrategy;
 import org.springframework.security.web.session.SimpleRedirectInvalidSessionStrategy;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.util.ClassUtils;
@@ -76,6 +73,9 @@ import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
 import org.w3c.dom.Element;
+
+import static org.springframework.security.config.http.HttpSecurityBeanDefinitionParser.*;
+import static org.springframework.security.config.http.SecurityFilters.*;
 
 /**
  * Stateful class which helps HttpSecurityBDP to create the configuration for the
@@ -97,7 +97,7 @@ class HttpConfigurationBuilder {
 	private static final String ATT_SESSION_AUTH_STRATEGY_REF = "session-authentication-strategy-ref";
 	private static final String ATT_SESSION_AUTH_ERROR_URL = "session-authentication-error-url";
 	private static final String ATT_SECURITY_CONTEXT_REPOSITORY = "security-context-repository-ref";
-
+	private static final String ATT_INVALID_SESSION_STRATEGY_REF = "invalid-session-strategy-ref";
 	private static final String ATT_DISABLE_URL_REWRITING = "disable-url-rewriting";
 
 	private static final String ATT_ACCESS_MGR = "access-decision-manager-ref";
@@ -287,6 +287,7 @@ class HttpConfigurationBuilder {
 
 		String sessionFixationAttribute = null;
 		String invalidSessionUrl = null;
+		String invalidSessionStrategyRef = null;
 		String sessionAuthStratRef = null;
 		String errorUrl = null;
 
@@ -302,12 +303,19 @@ class HttpConfigurationBuilder {
 			sessionFixationAttribute = sessionMgmtElt
 					.getAttribute(ATT_SESSION_FIXATION_PROTECTION);
 			invalidSessionUrl = sessionMgmtElt.getAttribute(ATT_INVALID_SESSION_URL);
+			invalidSessionStrategyRef = sessionMgmtElt.getAttribute(ATT_INVALID_SESSION_STRATEGY_REF);
+
 			sessionAuthStratRef = sessionMgmtElt
 					.getAttribute(ATT_SESSION_AUTH_STRATEGY_REF);
 			errorUrl = sessionMgmtElt.getAttribute(ATT_SESSION_AUTH_ERROR_URL);
 			sessionCtrlElt = DomUtils.getChildElementByTagName(sessionMgmtElt,
 					Elements.CONCURRENT_SESSIONS);
 			sessionControlEnabled = sessionCtrlElt != null;
+
+			if (StringUtils.hasText(invalidSessionUrl) && StringUtils.hasText(invalidSessionStrategyRef)) {
+				pc.getReaderContext().error(ATT_INVALID_SESSION_URL + " attribute cannot be used in combination with" +
+						" the " + ATT_INVALID_SESSION_STRATEGY_REF + " attribute.", sessionMgmtElt);
+			}
 
 			if (sessionControlEnabled) {
 				if (StringUtils.hasText(sessionAuthStratRef)) {
@@ -436,12 +444,16 @@ class HttpConfigurationBuilder {
 
 		}
 
+
+
 		if (StringUtils.hasText(invalidSessionUrl)) {
 			BeanDefinitionBuilder invalidSessionBldr = BeanDefinitionBuilder
 					.rootBeanDefinition(SimpleRedirectInvalidSessionStrategy.class);
 			invalidSessionBldr.addConstructorArgValue(invalidSessionUrl);
 			invalidSession = invalidSessionBldr.getBeanDefinition();
 			sessionMgmtFilter.addPropertyValue("invalidSessionStrategy", invalidSession);
+		} else if (StringUtils.hasText(invalidSessionStrategyRef)) {
+			sessionMgmtFilter.addPropertyReference("invalidSessionStrategy", invalidSessionStrategyRef);
 		}
 
 		sessionMgmtFilter.addConstructorArgReference(sessionAuthStratRef);
@@ -452,6 +464,7 @@ class HttpConfigurationBuilder {
 
 	private void createConcurrencyControlFilterAndSessionRegistry(Element element) {
 		final String ATT_EXPIRY_URL = "expired-url";
+		final String ATT_EXPIRED_SESSION_STRATEGY_REF = "expired-session-strategy-ref";
 		final String ATT_SESSION_REGISTRY_ALIAS = "session-registry-alias";
 		final String ATT_SESSION_REGISTRY_REF = "session-registry-ref";
 
@@ -487,10 +500,20 @@ class HttpConfigurationBuilder {
 		filterBuilder.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
 
 		String expiryUrl = element.getAttribute(ATT_EXPIRY_URL);
+		String expiredSessionStrategyRef = element.getAttribute(ATT_EXPIRED_SESSION_STRATEGY_REF);
+
+		if (StringUtils.hasText(expiryUrl) && StringUtils.hasText(expiredSessionStrategyRef)) {
+			pc.getReaderContext().error("Cannot use 'expired-url' attribute and 'expired-session-strategy-ref'" +
+					" attribute together.", source);
+		}
 
 		if (StringUtils.hasText(expiryUrl)) {
-			WebConfigUtils.validateHttpRedirect(expiryUrl, pc, source);
-			filterBuilder.addConstructorArgValue(expiryUrl);
+			BeanDefinitionBuilder expiredSessionBldr = BeanDefinitionBuilder
+					.rootBeanDefinition(SimpleRedirectExpiredSessionStrategy.class);
+			expiredSessionBldr.addConstructorArgValue(expiryUrl);
+			filterBuilder.addPropertyValue("expiredSessionStrategy", expiredSessionBldr.getBeanDefinition());
+		} else if (StringUtils.hasText(expiredSessionStrategyRef)) {
+			filterBuilder.addPropertyReference("expiredSessionStrategy", expiredSessionStrategyRef);
 		}
 
 		pc.popAndRegisterContainingComponent();

--- a/config/src/main/resources/org/springframework/security/config/spring-security-4.1.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-4.1.rnc
@@ -533,6 +533,9 @@ session-management.attlist &=
 	## The URL to which a user will be redirected if they submit an invalid session indentifier. Typically used to detect session timeouts.
 	attribute invalid-session-url {xsd:token}?
 session-management.attlist &=
+	## Allows injection of the InvalidSessionStrategy instance used by the SessionManagementFilter
+	attribute invalid-session-strategy-ref {xsd:token}?
+session-management.attlist &=
 	## Allows injection of the SessionAuthenticationStrategy instance used by the SessionManagementFilter
 	attribute session-authentication-strategy-ref {xsd:token}?
 session-management.attlist &=
@@ -550,6 +553,9 @@ concurrency-control.attlist &=
 concurrency-control.attlist &=
 	## The URL a user will be redirected to if they attempt to use a session which has been "expired" because they have logged in again.
 	attribute expired-url {xsd:token}?
+concurrency-control.attlist &=
+	## Allows injection of the ExpiredSessionStrategy instance used by the ConcurrentSessionFilter
+	attribute expired-session-strategy-ref {xsd:token}?
 concurrency-control.attlist &=
 	## Specifies that an unauthorized error should be reported when a user attempts to login when they already have the maximum configured sessions open. The default behaviour is to expire the original session. If the session-authentication-error-url attribute is set on the session-management URL, the user will be redirected to this URL.
 	attribute error-if-maximum-exceeded {xsd:boolean}?

--- a/config/src/main/resources/org/springframework/security/config/spring-security-4.1.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-4.1.xsd
@@ -1728,6 +1728,13 @@
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="invalid-session-strategy-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows injection of the InvalidSessionStrategy instance used by the
+                SessionManagementFilter
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
       <xs:attribute name="session-authentication-strategy-ref" type="xs:token">
          <xs:annotation>
             <xs:documentation>Allows injection of the SessionAuthenticationStrategy instance used by the
@@ -1759,6 +1766,13 @@
          <xs:annotation>
             <xs:documentation>The URL a user will be redirected to if they attempt to use a session which has been
                 "expired" because they have logged in again.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="expired-session-strategy-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows injection of the ExpiredSessionStrategy instance used by the
+                ConcurrentSessionFilter
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>

--- a/config/src/test/groovy/org/springframework/security/config/annotation/web/configurers/NamespaceSessionManagementTests.groovy
+++ b/config/src/test/groovy/org/springframework/security/config/annotation/web/configurers/NamespaceSessionManagementTests.groovy
@@ -66,7 +66,7 @@ class NamespaceSessionManagementTests extends BaseSpringSpec {
 			concurrentStrategy.maximumSessions == 1
 			concurrentStrategy.exceptionIfMaximumExceeded
 			concurrentStrategy.sessionRegistry == CustomSessionManagementConfig.SR
-			findFilter(ConcurrentSessionFilter).expiredUrl == "/expired-session"
+			findFilter(ConcurrentSessionFilter).expiredSessionStrategy.destinationUrl == "/expired-session"
 	}
 
 	@EnableWebSecurity

--- a/config/src/test/groovy/org/springframework/security/config/http/SessionManagementConfigTests.groovy
+++ b/config/src/test/groovy/org/springframework/security/config/http/SessionManagementConfigTests.groovy
@@ -15,13 +15,6 @@
  */
 package org.springframework.security.config.http
 
-import static org.junit.Assert.assertSame
-import static org.mockito.Mockito.*
-
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
-
-import org.mockito.Mockito
 import org.springframework.mock.web.MockFilterChain
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
@@ -41,7 +34,6 @@ import org.springframework.security.web.authentication.logout.CookieClearingLogo
 import org.springframework.security.web.authentication.logout.LogoutFilter
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler
 import org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationFilter
-import org.springframework.security.web.authentication.session.SessionAuthenticationException
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy
 import org.springframework.security.web.context.NullSecurityContextRepository
 import org.springframework.security.web.context.SaveContextOnUpdateOrErrorResponseWrapper
@@ -49,6 +41,13 @@ import org.springframework.security.web.context.SecurityContextPersistenceFilter
 import org.springframework.security.web.savedrequest.RequestCacheAwareFilter
 import org.springframework.security.web.session.ConcurrentSessionFilter
 import org.springframework.security.web.session.SessionManagementFilter
+
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+import static org.junit.Assert.assertSame
+import static org.mockito.Matchers.any
+import static org.mockito.Mockito.verify
 
 /**
  * Tests session-related functionality for the &lt;http&gt; namespace element and &lt;session-management&gt;
@@ -164,7 +163,7 @@ class SessionManagementConfigTests extends AbstractHttpConfigTests {
 
 		then:
 		concurrentSessionFilter instanceof ConcurrentSessionFilter
-		concurrentSessionFilter.expiredUrl == '/expired'
+		concurrentSessionFilter.expiredSessionStrategy.destinationUrl == '/expired'
 		appContext.getBean("sr") != null
 		getFilter(SessionManagementFilter.class) != null
 		sessionRegistryIsValid();
@@ -271,7 +270,7 @@ class SessionManagementConfigTests extends AbstractHttpConfigTests {
 		List filters = getFilters("/someurl");
 
 		expect:
-		filters.get(1).expiredUrl == null
+		filters.get(1).expiredSessionStrategy == null
 	}
 
 	def externalSessionStrategyIsSupported() {

--- a/docs/manual/src/docs/asciidoc/index.adoc
+++ b/docs/manual/src/docs/asciidoc/index.adoc
@@ -8294,6 +8294,9 @@ Session-management related functionality is implemented by the addition of a `Se
 * **invalid-session-url**
 Setting this attribute will inject the `SessionManagementFilter` with a `SimpleRedirectInvalidSessionStrategy` configured with the attribute value. When an invalid session ID is submitted, the strategy will be invoked, redirecting to the configured URL.
 
+[[nsa-session-management-invalid-session-strategy-ref]]
+* **invalid-session-url**
+Allows injection of the InvalidSessionStrategy instance used by the SessionManagementFilter. Use either this or the `invalid-session-url` attribute but not both.
 
 [[nsa-session-management-session-authentication-error-url]]
 * **session-authentication-error-url**
@@ -8348,6 +8351,9 @@ If set to "true" a `SessionAuthenticationException` will be raised when a user a
 * **expired-url**
 The URL a user will be redirected to if they attempt to use a session which has been "expired" by the concurrent session controller because the user has exceeded the number of allowed sessions and has logged in again elsewhere. Should be set unless `exception-if-maximum-exceeded` is set. If no value is supplied, an expiry message will just be written directly back to the response.
 
+[[nsa-concurrency-control-expired-session-strategy-ref]]
+* **expired-url**
+Allows injection of the ExpiredSessionStrategy instance used by the ConcurrentSessionFilter
 
 [[nsa-concurrency-control-max-sessions]]
 * **max-sessions**

--- a/itest/web/itest-web.gradle
+++ b/itest/web/itest-web.gradle
@@ -11,7 +11,7 @@ dependencies {
 				"org.springframework:spring-beans:$springVersion",
 				"org.springframework:spring-webmvc:$springVersion",
 				"org.mortbay.jetty:jetty-util:$jettyVersion",
-				"org.testng:testng:5.11:jdk15"
+				"org.testng:testng:6.8.21"
 	testCompile ("org.mortbay.jetty:jetty:$jettyVersion") {
 		exclude group: 'org.mortbay.jetty', module: 'servlet-api'
 	}

--- a/itest/web/itest-web.gradle
+++ b/itest/web/itest-web.gradle
@@ -11,7 +11,7 @@ dependencies {
 				"org.springframework:spring-beans:$springVersion",
 				"org.springframework:spring-webmvc:$springVersion",
 				"org.mortbay.jetty:jetty-util:$jettyVersion",
-				"org.testng:testng:6.8.21"
+				"org.testng:testng:5.11:jdk15"
 	testCompile ("org.mortbay.jetty:jetty:$jettyVersion") {
 		exclude group: 'org.mortbay.jetty', module: 'servlet-api'
 	}

--- a/web/src/main/java/org/springframework/security/web/session/ConcurrentSessionFilter.java
+++ b/web/src/main/java/org/springframework/security/web/session/ConcurrentSessionFilter.java
@@ -17,7 +17,6 @@
 package org.springframework.security.web.session;
 
 import java.io.IOException;
-
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
@@ -30,11 +29,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.session.SessionInformation;
 import org.springframework.security.core.session.SessionRegistry;
-import org.springframework.security.web.DefaultRedirectStrategy;
-import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
-import org.springframework.security.web.util.UrlUtils;
 import org.springframework.util.Assert;
 import org.springframework.web.filter.GenericFilterBean;
 
@@ -50,8 +46,8 @@ import org.springframework.web.filter.GenericFilterBean;
  * as expired. If it has been marked as expired, the configured logout handlers will be
  * called (as happens with
  * {@link org.springframework.security.web.authentication.logout.LogoutFilter}), typically
- * to invalidate the session. A redirect to the expiredURL specified will be performed,
- * and the session invalidation will cause an
+ * to invalidate the session. To handle the expired session a call to the {@link ExpiredSessionStrategy} is made.
+ * The session invalidation will cause an
  * {@link org.springframework.security.web.session.HttpSessionDestroyedEvent} to be
  * published via the
  * {@link org.springframework.security.web.session.HttpSessionEventPublisher} registered
@@ -59,15 +55,15 @@ import org.springframework.web.filter.GenericFilterBean;
  * </p>
  *
  * @author Ben Alex
+ * @author Marten Deinum
  */
 public class ConcurrentSessionFilter extends GenericFilterBean {
 	// ~ Instance fields
 	// ================================================================================================
 
-	private SessionRegistry sessionRegistry;
-	private String expiredUrl;
+	private final SessionRegistry sessionRegistry;
 	private LogoutHandler[] handlers = new LogoutHandler[] { new SecurityContextLogoutHandler() };
-	private RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
+	private ExpiredSessionStrategy expiredSessionStrategy;
 
 	// ~ Methods
 	// ========================================================================================================
@@ -79,17 +75,13 @@ public class ConcurrentSessionFilter extends GenericFilterBean {
 
 	public ConcurrentSessionFilter(SessionRegistry sessionRegistry, String expiredUrl) {
 		Assert.notNull(sessionRegistry, "SessionRegistry required");
-		Assert.isTrue(expiredUrl == null || UrlUtils.isValidRedirectUrl(expiredUrl),
-				expiredUrl + " isn't a valid redirect URL");
 		this.sessionRegistry = sessionRegistry;
-		this.expiredUrl = expiredUrl;
+		this.expiredSessionStrategy = new SimpleRedirectExpiredSessionStrategy(expiredUrl);
 	}
 
 	@Override
 	public void afterPropertiesSet() {
 		Assert.notNull(sessionRegistry, "SessionRegistry required");
-		Assert.isTrue(expiredUrl == null || UrlUtils.isValidRedirectUrl(expiredUrl),
-				expiredUrl + " isn't a valid redirect URL");
 	}
 
 	public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
@@ -106,12 +98,14 @@ public class ConcurrentSessionFilter extends GenericFilterBean {
 			if (info != null) {
 				if (info.isExpired()) {
 					// Expired - abort processing
+					if (logger.isDebugEnabled()) {
+						logger.debug("Requested session ID "
+								+ request.getRequestedSessionId() + " has expired.");
+					}
 					doLogout(request, response);
 
-					String targetUrl = determineExpiredUrl(request, info);
-
-					if (targetUrl != null) {
-						redirectStrategy.sendRedirect(request, response, targetUrl);
+					if (this.expiredSessionStrategy != null) {
+						this.expiredSessionStrategy.onExpiredSessionDetected(request, response);
 
 						return;
 					}
@@ -134,10 +128,6 @@ public class ConcurrentSessionFilter extends GenericFilterBean {
 		chain.doFilter(request, response);
 	}
 
-	protected String determineExpiredUrl(HttpServletRequest request,
-			SessionInformation info) {
-		return expiredUrl;
-	}
 
 	private void doLogout(HttpServletRequest request, HttpServletResponse response) {
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
@@ -152,7 +142,7 @@ public class ConcurrentSessionFilter extends GenericFilterBean {
 		this.handlers = handlers;
 	}
 
-	public void setRedirectStrategy(RedirectStrategy redirectStrategy) {
-		this.redirectStrategy = redirectStrategy;
+	public void setExpiredSessionStrategy(ExpiredSessionStrategy expiredSessionStrategy) {
+		this.expiredSessionStrategy=expiredSessionStrategy;
 	}
 }

--- a/web/src/main/java/org/springframework/security/web/session/ExpiredSessionStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/session/ExpiredSessionStrategy.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.web.session;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Determines the behaviour of the {@code ConcurrentSessionFilter} when an expired session
+ * is detected in the {@code ConcurrentSessionFilter}.
+ *
+ * @author Marten Deinum
+ * @since 4.1.0
+ */
+public interface ExpiredSessionStrategy {
+
+	void onExpiredSessionDetected(HttpServletRequest request, HttpServletResponse response)
+			throws IOException, ServletException;
+
+}

--- a/web/src/main/java/org/springframework/security/web/session/SimpleRedirectExpiredSessionStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/session/SimpleRedirectExpiredSessionStrategy.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.web.session;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.security.web.DefaultRedirectStrategy;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.security.web.util.UrlUtils;
+import org.springframework.util.Assert;
+
+/**
+ * Performs a redirect to a fixed URL when an expired session is detected by the
+ * {@code ConcurrentSessionFilter}.
+ *
+ * @author Marten Deinum
+ * @since 4.1.0
+ */
+public final class SimpleRedirectExpiredSessionStrategy implements ExpiredSessionStrategy {
+	private final Log logger = LogFactory.getLog(getClass());
+	private final String destinationUrl;
+	private final RedirectStrategy redirectStrategy;
+
+	public SimpleRedirectExpiredSessionStrategy(String invalidSessionUrl) {
+		this(invalidSessionUrl, new DefaultRedirectStrategy());
+	}
+
+	public SimpleRedirectExpiredSessionStrategy(String invalidSessionUrl, RedirectStrategy redirectStrategy) {
+		Assert.isTrue(UrlUtils.isValidRedirectUrl(invalidSessionUrl),
+				"url must start with '/' or with 'http(s)'");
+		this.destinationUrl=invalidSessionUrl;
+		this.redirectStrategy=redirectStrategy;
+	}
+
+	public void onExpiredSessionDetected(HttpServletRequest request,
+			HttpServletResponse response) throws IOException {
+		logger.debug("Redirecting to '" + destinationUrl + "'");
+		redirectStrategy.sendRedirect(request, response, destinationUrl);
+	}
+
+}


### PR DESCRIPTION
This commit adds an ExpiredSessionStrategy for the ConcurrentSessionFilter
analogous to the InvalidSessionStrategy for the SessionManagementFilter. It also
adds a configuration option for both the InvalidSessionStrategy and
ExpiredSessionStrategy to the XML namespace and Java configuration.

Fixes: gh-3794, gh-3795

- [X] I have signed the CLA
