### PR TITLE
Update TestNG

### DIFF
--- a/itest/web/itest-web.gradle
+++ b/itest/web/itest-web.gradle
@@ -11,7 +11,7 @@ dependencies {
 				"org.springframework:spring-beans:$springVersion",
 				"org.springframework:spring-webmvc:$springVersion",
 				"org.mortbay.jetty:jetty-util:$jettyVersion",
-				"org.testng:testng:5.11:jdk15"
+				"org.testng:testng:6.8.21"
 	testCompile ("org.mortbay.jetty:jetty:$jettyVersion") {
 		exclude group: 'org.mortbay.jetty', module: 'servlet-api'
 	}


### PR DESCRIPTION
This commit updates the TestNG dependency to 6.8.21. This
is the last JDK 1.6 supporting version. The update of TestNG
makes it possible to run the integration tests from within
Intellij allowing for easier debugging and troubleshooting.

- [X] I have signed the CLA
