### PR TITLE
HeaderWriterFilter: Fix Javadoc.

### DIFF
--- a/web/src/main/java/org/springframework/security/web/header/HeaderWriterFilter.java
+++ b/web/src/main/java/org/springframework/security/web/header/HeaderWriterFilter.java
@@ -28,7 +28,7 @@ import org.springframework.util.Assert;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
- * Filter implementation to add headers to the current request. Can be useful to add
+ * Filter implementation to add headers to the current response. Can be useful to add
  * certain headers which enable browser protection. Like X-Frame-Options, X-XSS-Protection
  * and X-Content-Type-Options.
  *
@@ -40,7 +40,7 @@ public class HeaderWriterFilter extends OncePerRequestFilter {
 
 	/**
 	 * Collection of {@link HeaderWriter} instances to write out the headers to the
-	 * response .
+	 * response.
 	 */
 	private final List<HeaderWriter> headerWriters;
 


### PR DESCRIPTION
HeaderWriterFilter is there for adding headers to the response, not the request.

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

