### PR TITLE
Refactor test assumptions about JCE to common class.

### DIFF
--- a/crypto/crypto.gradle
+++ b/crypto/crypto.gradle
@@ -1,16 +1,3 @@
-// crypto module build file
-
-// jdkVersion = System.properties['java.version']
-// isJdk6 = jdkVersion >= '1.6'
-int maxAESKeySize = javax.crypto.Cipher.getMaxAllowedKeyLength('AES')
-
-configure(project.tasks.withType(Test)) {
-	if (maxAESKeySize < 256) {
-		println "AES keysize limited to $maxAESKeySize, skipping EncryptorsTests"
-		exclude '**/EncryptorsTests.class'
-	}
-}
-
 dependencies {
 	optional 'org.bouncycastle:bcpkix-jdk15on:1.54'
 }

--- a/crypto/src/test/java/org/springframework/security/crypto/encrypt/BouncyCastleAesBytesEncryptorEquivalencyTest.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/encrypt/BouncyCastleAesBytesEncryptorEquivalencyTest.java
@@ -15,17 +15,11 @@
  */
 package org.springframework.security.crypto.encrypt;
 
-import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Random;
 import java.util.UUID;
 
-import javax.crypto.Cipher;
-import javax.crypto.NoSuchPaddingException;
-
 import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.security.crypto.codec.Hex;
@@ -53,7 +47,7 @@ public class BouncyCastleAesBytesEncryptorEquivalencyTest {
 
 	@Test
 	public void bouncyCastleAesCbcWithPredictableIvEquvalent() throws Exception {
-		assumeAes256Available(CipherAlgorithm.CBC);
+		CryptoAssumptions.assumeCBCJCE();
 		BytesEncryptor bcEncryptor = new BouncyCastleAesCbcBytesEncryptor(password, salt,
 				new PredictableRandomBytesKeyGenerator(16));
 		BytesEncryptor jceEncryptor = new AesBytesEncryptor(password, salt,
@@ -63,7 +57,7 @@ public class BouncyCastleAesBytesEncryptorEquivalencyTest {
 
 	@Test
 	public void bouncyCastleAesCbcWithSecureIvCompatible() throws Exception {
-		assumeAes256Available(CipherAlgorithm.CBC);
+		CryptoAssumptions.assumeCBCJCE();
 		BytesEncryptor bcEncryptor = new BouncyCastleAesCbcBytesEncryptor(password, salt,
 				KeyGenerators.secureRandom(16));
 		BytesEncryptor jceEncryptor = new AesBytesEncryptor(password, salt,
@@ -73,7 +67,7 @@ public class BouncyCastleAesBytesEncryptorEquivalencyTest {
 
 	@Test
 	public void bouncyCastleAesGcmWithPredictableIvEquvalent() throws Exception {
-		assumeAes256Available(CipherAlgorithm.GCM);
+		CryptoAssumptions.assumeGCMJCE();
 		BytesEncryptor bcEncryptor = new BouncyCastleAesGcmBytesEncryptor(password, salt,
 				new PredictableRandomBytesKeyGenerator(16));
 		BytesEncryptor jceEncryptor = new AesBytesEncryptor(password, salt,
@@ -83,7 +77,7 @@ public class BouncyCastleAesBytesEncryptorEquivalencyTest {
 
 	@Test
 	public void bouncyCastleAesGcmWithSecureIvCompatible() throws Exception {
-		assumeAes256Available(CipherAlgorithm.GCM);
+		CryptoAssumptions.assumeGCMJCE();
 		BytesEncryptor bcEncryptor = new BouncyCastleAesGcmBytesEncryptor(password, salt,
 				KeyGenerators.secureRandom(16));
 		BytesEncryptor jceEncryptor = new AesBytesEncryptor(password, salt,
@@ -116,25 +110,6 @@ public class BouncyCastleAesBytesEncryptorEquivalencyTest {
 		Assert.assertArrayEquals(testData, rightDecrypted);
 	}
 
-	private void assumeAes256Available(CipherAlgorithm cipherAlgorithm) {
-		boolean aes256Available = false;
-		try {
-			Cipher.getInstance(cipherAlgorithm.toString());
-			aes256Available = Cipher.getMaxAllowedKeyLength("AES") >= 256;
-		}
-		catch (NoSuchAlgorithmException e) {
-			throw new AssumptionViolatedException(
-					cipherAlgorithm + " not available, skipping test", e);
-		}
-		catch (NoSuchPaddingException e) {
-			throw new AssumptionViolatedException(
-					cipherAlgorithm + " padding not available, skipping test", e);
-		}
-		Assume.assumeTrue(
-				"AES key length of 256 not allowed, skipping test",
-				aes256Available);
-
-	}
 
 	/**
 	 * A BytesKeyGenerator that always generates the same sequence of values

--- a/crypto/src/test/java/org/springframework/security/crypto/encrypt/CryptoAssumptions.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/encrypt/CryptoAssumptions.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2011-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.crypto.encrypt;
+
+import java.security.NoSuchAlgorithmException;
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+
+import org.junit.Assume;
+import org.junit.AssumptionViolatedException;
+import org.springframework.security.crypto.encrypt.AesBytesEncryptor.CipherAlgorithm;
+
+public class CryptoAssumptions {
+
+	public static void assumeGCMJCE() {
+		assumeAes256(CipherAlgorithm.GCM);
+	}
+
+	public static void assumeCBCJCE() {
+		assumeAes256(CipherAlgorithm.CBC);
+	}
+
+	private static void assumeAes256(CipherAlgorithm cipherAlgorithm) {
+		boolean aes256Available = false;
+		try {
+			Cipher.getInstance(cipherAlgorithm.toString());
+			aes256Available = Cipher.getMaxAllowedKeyLength("AES") >= 256;
+		}
+		catch (NoSuchAlgorithmException e) {
+			throw new AssumptionViolatedException(
+					cipherAlgorithm + " not available, skipping test", e);
+		}
+		catch (NoSuchPaddingException e) {
+			throw new AssumptionViolatedException(
+					cipherAlgorithm + " padding not available, skipping test", e);
+		}
+		Assume.assumeTrue(
+				"AES key length of 256 not allowed, skipping test",
+				aes256Available);
+
+	}
+
+}

--- a/crypto/src/test/java/org/springframework/security/crypto/encrypt/EncryptorsTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/encrypt/EncryptorsTests.java
@@ -17,19 +17,13 @@ package org.springframework.security.crypto.encrypt;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.security.GeneralSecurityException;
-
-import javax.crypto.Cipher;
-
-import org.junit.Assume;
 import org.junit.Test;
 
 public class EncryptorsTests {
 
 	@Test
 	public void stronger() throws Exception {
-		Assume.assumeTrue("GCM must be available for this test", isAesGcmAvailable());
-
+		CryptoAssumptions.assumeGCMJCE();
 		BytesEncryptor encryptor = Encryptors.stronger("password", "5c0744940b5c369b");
 		byte[] result = encryptor.encrypt("text".getBytes("UTF-8"));
 		assertThat(result).isNotNull();
@@ -41,6 +35,7 @@ public class EncryptorsTests {
 
 	@Test
 	public void standard() throws Exception {
+		CryptoAssumptions.assumeCBCJCE();
 		BytesEncryptor encryptor = Encryptors.standard("password", "5c0744940b5c369b");
 		byte[] result = encryptor.encrypt("text".getBytes("UTF-8"));
 		assertThat(result).isNotNull();
@@ -52,8 +47,7 @@ public class EncryptorsTests {
 
 	@Test
 	public void preferred() {
-		Assume.assumeTrue("GCM must be available for this test", isAesGcmAvailable());
-
+		CryptoAssumptions.assumeGCMJCE();
 		TextEncryptor encryptor = Encryptors.delux("password", "5c0744940b5c369b");
 		String result = encryptor.encrypt("text");
 		assertThat(result).isNotNull();
@@ -64,6 +58,7 @@ public class EncryptorsTests {
 
 	@Test
 	public void text() {
+		CryptoAssumptions.assumeCBCJCE();
 		TextEncryptor encryptor = Encryptors.text("password", "5c0744940b5c369b");
 		String result = encryptor.encrypt("text");
 		assertThat(result).isNotNull();
@@ -74,6 +69,7 @@ public class EncryptorsTests {
 
 	@Test
 	public void queryableText() {
+		CryptoAssumptions.assumeCBCJCE();
 		TextEncryptor encryptor = Encryptors.queryableText("password",
 				"5c0744940b5c369b");
 		String result = encryptor.encrypt("text");
@@ -90,13 +86,4 @@ public class EncryptorsTests {
 		assertThat(encryptor.decrypt("text")).isEqualTo("text");
 	}
 
-	private boolean isAesGcmAvailable() {
-		try {
-			Cipher.getInstance("AES/GCM/NoPadding");
-			return true;
-		}
-		catch (GeneralSecurityException e) {
-			return false;
-		}
-	}
 }


### PR DESCRIPTION
Apply assumptions directly to test methods instead of checking for key
length in crypto.gradle.