### PR TITLE
Only use methods present in Bouncy Castle 1.47.

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/encrypt/BouncyCastleAesBytesEncryptor.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/encrypt/BouncyCastleAesBytesEncryptor.java
@@ -15,11 +15,8 @@
  */
 package org.springframework.security.crypto.encrypt;
 
-import java.io.ByteArrayOutputStream;
-
 import org.bouncycastle.crypto.PBEParametersGenerator;
 import org.bouncycastle.crypto.generators.PKCS5S2ParametersGenerator;
-import org.bouncycastle.crypto.io.CipherOutputStream;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.springframework.security.crypto.codec.Hex;
 import org.springframework.security.crypto.keygen.BytesKeyGenerator;
@@ -52,26 +49,4 @@ abstract class BouncyCastleAesBytesEncryptor implements BytesEncryptor {
 		keyGenerator.init(pkcs12PasswordBytes, Hex.decode(salt), 1024);
 		this.secretKey = (KeyParameter) keyGenerator.generateDerivedParameters(256);
 	}
-
-	byte[] process(CipherOutputStream cipherOutputStream,
-			ByteArrayOutputStream byteArrayOutputStream, byte[] bytes) {
-		try {
-			cipherOutputStream.write(bytes);
-			// close() invokes the  doFinal method of the encapsulated cipher object
-			// and flushes to the underlying outputStream. It must be called before
-			// we get the output.
-			cipherOutputStream.close();
-			return byteArrayOutputStream.toByteArray();
-		}
-		catch (Throwable e) {
-			try {
-				// attempt release of resources
-				cipherOutputStream.close();
-			}
-			catch (Throwable e1) {
-			}
-			throw new IllegalStateException("unable to encrypt/decrypt", e);
-		}
-	}
-
 }

--- a/crypto/src/test/java/org/springframework/security/crypto/encrypt/BouncyCastleAesBytesEncryptorEquivalencyTest.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/encrypt/BouncyCastleAesBytesEncryptorEquivalencyTest.java
@@ -32,17 +32,15 @@ public class BouncyCastleAesBytesEncryptorEquivalencyTest {
 	private byte[] testData;
 	private String password;
 	private String salt;
+	private SecureRandom secureRandom = new SecureRandom();
 
 	@Before
 	public void setup() {
 		// generate random password, salt, and test data
-		SecureRandom secureRandom = new SecureRandom();
 		password = UUID.randomUUID().toString();
 		byte[] saltBytes = new byte[16];
 		secureRandom.nextBytes(saltBytes);
 		salt = new String(Hex.encode(saltBytes));
-		testData = new byte[1024 * 1024];
-		secureRandom.nextBytes(testData);
 	}
 
 	@Test
@@ -87,29 +85,37 @@ public class BouncyCastleAesBytesEncryptorEquivalencyTest {
 
 	private void testEquivalence(BytesEncryptor left, BytesEncryptor right)
 			throws Exception {
-		// tests that right and left generate the same encrypted bytes
-		// and can decrypt back to the original input
-		byte[] leftEncrypted = left.encrypt(testData);
-		byte[] rightEncrypted = right.encrypt(testData);
-		Assert.assertArrayEquals(leftEncrypted, rightEncrypted);
-		byte[] leftDecrypted = left.decrypt(leftEncrypted);
-		byte[] rightDecrypted = right.decrypt(rightEncrypted);
-		Assert.assertArrayEquals(testData, leftDecrypted);
-		Assert.assertArrayEquals(testData, rightDecrypted);
+		for (int size = 1; size < 2048; size++) {
+			testData = new byte[size];
+			secureRandom.nextBytes(testData);
+			// tests that right and left generate the same encrypted bytes
+			// and can decrypt back to the original input
+			byte[] leftEncrypted = left.encrypt(testData);
+			byte[] rightEncrypted = right.encrypt(testData);
+			Assert.assertArrayEquals(leftEncrypted, rightEncrypted);
+			byte[] leftDecrypted = left.decrypt(leftEncrypted);
+			byte[] rightDecrypted = right.decrypt(rightEncrypted);
+			Assert.assertArrayEquals(testData, leftDecrypted);
+			Assert.assertArrayEquals(testData, rightDecrypted);
+		}
+
 	}
 
 	private void testCompatibility(BytesEncryptor left, BytesEncryptor right)
 			throws Exception {
 		// tests that right can decrypt what left encrypted and vice versa
 		// and that the decypted data is the same as the original
-		byte[] leftEncrypted = left.encrypt(testData);
-		byte[] rightEncrypted = right.encrypt(testData);
-		byte[] leftDecrypted = left.decrypt(rightEncrypted);
-		byte[] rightDecrypted = right.decrypt(leftEncrypted);
-		Assert.assertArrayEquals(testData, leftDecrypted);
-		Assert.assertArrayEquals(testData, rightDecrypted);
+		for (int size = 1; size < 2048; size++) {
+			testData = new byte[size];
+			secureRandom.nextBytes(testData);
+			byte[] leftEncrypted = left.encrypt(testData);
+			byte[] rightEncrypted = right.encrypt(testData);
+			byte[] leftDecrypted = left.decrypt(rightEncrypted);
+			byte[] rightDecrypted = right.decrypt(leftEncrypted);
+			Assert.assertArrayEquals(testData, leftDecrypted);
+			Assert.assertArrayEquals(testData, rightDecrypted);
+		}
 	}
-
 
 	/**
 	 * A BytesKeyGenerator that always generates the same sequence of values


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [] I have signed the CLA

This forces us to avoid using CipherOutputStream, and instead use the
BlockCiphers directly. As an extra measure for correctness, test the
equivalence of the BC implementations against data sizes from 1 to 2048
bytes.

Fixes gh-2917