### PR TITLE
Fix NPE in OnCommittedResponseWrapper trackContentLength

### DIFF
--- a/web/src/main/java/org/springframework/security/web/util/OnCommittedResponseWrapper.java
+++ b/web/src/main/java/org/springframework/security/web/util/OnCommittedResponseWrapper.java
@@ -194,7 +194,8 @@ public abstract class OnCommittedResponseWrapper extends HttpServletResponseWrap
 	}
 
 	private void trackContentLength(String content) {
-		checkContentLength(content.length());
+		int contentLength = content == null ? 4 : content.length();
+		checkContentLength(contentLength);
 	}
 
 	/**

--- a/web/src/test/java/org/springframework/security/web/util/OnCommittedResponseWrapperTests.java
+++ b/web/src/test/java/org/springframework/security/web/util/OnCommittedResponseWrapperTests.java
@@ -545,6 +545,21 @@ public class OnCommittedResponseWrapperTests {
 	// The amount of content specified in the setContentLength method of the response
 	// has been greater than zero and has been written to the response.
 
+	// gh-3823
+	@Test
+	public void contentLengthPrintWriterWriteNullCommits() throws Exception {
+		String expected = null;
+		this.response.setContentLength(String.valueOf(expected).length() + 1);
+
+		this.response.getWriter().write(expected);
+
+		assertThat(this.committed).isFalse();
+
+		this.response.getWriter().write("a");
+
+		assertThat(this.committed).isTrue();
+	}
+
 	@Test
 	public void contentLengthPrintWriterWriteIntCommits() throws Exception {
 		int expected = 1;


### PR DESCRIPTION
OnCommittedResponseWrapper trackContentLength will throw a
NullPointerException when the content length passed in is null.

This commit properly tracks the null value as a length of 4.

Fixes gh-3823