### PR TITLE
Check RememberMe in ExceptionTranslationFilter

### DIFF
--- a/config/src/test/groovy/org/springframework/security/config/annotation/web/configurers/ExpressionUrlAuthorizationsTests.groovy
+++ b/config/src/test/groovy/org/springframework/security/config/annotation/web/configurers/ExpressionUrlAuthorizationsTests.groovy
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.security.config.annotation.web.configurers;
+package org.springframework.security.config.annotation.web.configurers
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 
 import static org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurerConfigs.*
 
@@ -293,7 +295,7 @@ public class ExpressionUrlAuthorizationConfigurerTests extends BaseSpringSpec {
 			response.status == HttpServletResponse.SC_UNAUTHORIZED
 		when:
 			super.setup()
-			login(new RememberMeAuthenticationToken("key", "user", AuthorityUtils.createAuthorityList("ROLE_USER")))
+			login(new UsernamePasswordAuthenticationToken("key", "user", AuthorityUtils.createAuthorityList("ROLE_USER")))
 			springSecurityFilterChain.doFilter(request,response,chain)
 		then:
 			response.status == HttpServletResponse.SC_FORBIDDEN
@@ -340,15 +342,11 @@ public class ExpressionUrlAuthorizationConfigurerTests extends BaseSpringSpec {
 		setup:
 			loadConfig(FullyAuthenticatedConfig)
 		when:
-			springSecurityFilterChain.doFilter(request,response,chain)
+		super.setup()
+		login(new RememberMeAuthenticationToken("key", "user", AuthorityUtils.createAuthorityList("ROLE_USER")))
+		springSecurityFilterChain.doFilter(request,response,chain)
 		then:
 			response.status == HttpServletResponse.SC_UNAUTHORIZED
-		when:
-			super.setup()
-			login(new RememberMeAuthenticationToken("key", "user", AuthorityUtils.createAuthorityList("ROLE_USER")))
-			springSecurityFilterChain.doFilter(request,response,chain)
-		then:
-			response.status == HttpServletResponse.SC_FORBIDDEN
 		when:
 			super.setup()
 			login()

--- a/web/src/main/java/org/springframework/security/web/access/ExceptionTranslationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/access/ExceptionTranslationFilter.java
@@ -29,6 +29,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationTrustResolver;
 import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -169,10 +170,10 @@ public class ExceptionTranslationFilter extends GenericFilterBean {
 					(AuthenticationException) exception);
 		}
 		else if (exception instanceof AccessDeniedException) {
-			if (authenticationTrustResolver.isAnonymous(SecurityContextHolder
-					.getContext().getAuthentication())) {
+			Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+			if (authenticationTrustResolver.isAnonymous(auth) || authenticationTrustResolver.isRememberMe(auth)) {
 				logger.debug(
-						"Access is denied (user is anonymous); redirecting to authentication entry point",
+						"Access is denied (user is "+ (authenticationTrustResolver.isAnonymous(auth) ? "anonymous" : "not fully authenticated")+"); redirecting to authentication entry point",
 						exception);
 
 				sendStartAuthentication(


### PR DESCRIPTION
This commit adds a check for rememberme to the ExceptionTranslationFilter.
Using this when someone isn't fully authenticated he will be prompted with a
login screen and after that will be redirected to the original requested URI.

Fixes: gh-2427

- [X] I have signed the CLA
