### PR TITLE
fix(testing): change the way to detect the springSecurityFilterChain …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: java
 
 jdk:
@@ -16,5 +17,6 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+    - $HOME/.m2
 
 script: ./gradlew build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: java
 
 jdk:
@@ -17,6 +16,5 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
-    - $HOME/.m2
 
 script: ./gradlew build

--- a/test/src/main/java/org/springframework/security/test/web/support/WebTestUtils.java
+++ b/test/src/main/java/org/springframework/security/test/web/support/WebTestUtils.java
@@ -21,7 +21,7 @@ import javax.servlet.Filter;
 import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.springframework.security.web.FilterChainProxy;
+import org.springframework.security.web.context.AbstractSecurityWebApplicationInitializer;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.security.web.context.SecurityContextPersistenceFilter;
 import org.springframework.security.web.context.SecurityContextRepository;
@@ -98,8 +98,7 @@ public abstract class WebTestUtils {
 	}
 
 	/**
-	 * Sets the {@link CsrfTokenRepository} for the specified
-	 * {@link HttpServletRequest}.
+	 * Sets the {@link CsrfTokenRepository} for the specified {@link HttpServletRequest}.
 	 *
 	 * @param request the {@link HttpServletRequest} to obtain the
 	 * {@link CsrfTokenRepository}
@@ -121,17 +120,17 @@ public abstract class WebTestUtils {
 		if (webApplicationContext == null) {
 			return null;
 		}
-		FilterChainProxy springSecurityFilterChain = null;
+		Filter springSecurityFilterChain = null;
 		try {
-			springSecurityFilterChain = webApplicationContext
-					.getBean(FilterChainProxy.class);
+			springSecurityFilterChain = (Filter) webApplicationContext.getBean(
+					AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME);
 		}
 		catch (NoSuchBeanDefinitionException notFound) {
 			return null;
 		}
-		List<Filter> filters = (List<Filter>) ReflectionTestUtils.invokeMethod(
-				springSecurityFilterChain, "getFilters", request);
-		if(filters == null) {
+		List<Filter> filters = (List<Filter>) ReflectionTestUtils
+				.invokeMethod(springSecurityFilterChain, "getFilters", request);
+		if (filters == null) {
 			return null;
 		}
 		for (Filter filter : filters) {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsCsrfDebugFilterTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsCsrfDebugFilterTests.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.test.web.servlet.request;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.test.web.support.WebTestUtils;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+@WebAppConfiguration
+/**
+ * https://github.com/spring-projects/spring-security/pull/3836
+ */
+public class SecurityMockMvcRequestPostProcessorsCsrfDebugFilterTests {
+
+    @Autowired
+	WebApplicationContext wac;
+
+	MockMvc mockMvc;
+
+	@Before
+	public void setup() {
+		mockMvc = MockMvcBuilders
+				.webAppContextSetup(wac)
+				.apply(springSecurity())
+				.build();
+	}
+
+    @Test
+    public void csrfWithParam() throws Exception {
+        MvcResult result = mockMvc.perform(post("/").with(csrf()))
+                .andExpect(status().is2xxSuccessful()).andReturn();
+
+        CsrfTokenRepository csrfTokenRepository = WebTestUtils.getCsrfTokenRepository(result.getRequest());
+        assertThat(csrfTokenRepository).isInstanceOf(CookieCsrfTokenRepository.class);
+
+    }
+
+	@EnableWebSecurity
+	static class Config extends WebSecurityConfigurerAdapter {
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			http.csrf().csrfTokenRepository(new CookieCsrfTokenRepository());
+		}
+
+		@Override
+		public void configure(WebSecurity web) throws Exception {
+			// enable the debugfilter
+			web.debug(true);
+		}
+
+		@Bean
+		public TheController controller() {
+			return new TheController();
+		}
+
+		@RestController
+		static class TheController {
+			@RequestMapping("/")
+			String index() {
+				return "Hi";
+			}
+		}
+	}
+}

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsCsrfDebugFilterTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsCsrfDebugFilterTests.java
@@ -21,7 +21,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -33,31 +32,19 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.OncePerRequestFilter;
-
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 @WebAppConfiguration
+
 /**
  * https://github.com/spring-projects/spring-security/pull/3836
  */
@@ -66,22 +53,14 @@ public class SecurityMockMvcRequestPostProcessorsCsrfDebugFilterTests {
     @Autowired
 	WebApplicationContext wac;
 
-	MockMvc mockMvc;
-
-	@Before
-	public void setup() {
-		mockMvc = MockMvcBuilders
-				.webAppContextSetup(wac)
-				.apply(springSecurity())
-				.build();
-	}
-
     @Test
-    public void csrfWithParam() throws Exception {
-        MvcResult result = mockMvc.perform(post("/").with(csrf()))
-                .andExpect(status().is2xxSuccessful()).andReturn();
+    public void shouldFindCookieCsrfTokenRepository() throws Exception {
 
-        CsrfTokenRepository csrfTokenRepository = WebTestUtils.getCsrfTokenRepository(result.getRequest());
+		// do
+		MockHttpServletRequest request = post("/").buildRequest(wac.getServletContext());
+		CsrfTokenRepository csrfTokenRepository = WebTestUtils.getCsrfTokenRepository(request);
+
+		// expect
         assertThat(csrfTokenRepository).isInstanceOf(CookieCsrfTokenRepository.class);
 
     }


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

- [X] I have signed the CLA

…in WebTestUtils

When enabling debug for spring security, the FilterChainProxy will be wrapped by the DebugFilter.
This debugfilter will be registered as bean springSecurityFilterChain. The WebTestUtils will now search for the bean by name instead of the hardcoded class.
In this case we have to cast to a Java ServletFilter to support both filter...

No testcases so far...

fixes the bug discussed on gitter
https://gitter.im/spring-projects/spring-security?at=5718e2d3b129b59c56da3a80