### PR TITLE
Provide editor config for spring-security

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig for Spring Security
+# see https://github.com/spring-projects/spring-security/blob/master/CONTRIBUTING.md#mind-the-whitespace
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = latin1
+
+# 4 tabs indentation
+indent_style = tab
+tab_width = 4
+
+trim_trailing_whitespace = true


### PR DESCRIPTION
This commit provides following editor config:
- Tabs, not spaces
- Unix (LF), not dos (CRLF) line endings
- Eliminate all trailing whitespace
- Latin-1 (ISO-8859-1) encoding for Java sources; use native2ascii to convert if necessary

Following convention cannot be set by editorconfig (only vim and emacs support maxline length of editorconfig):
- Aim to wrap code at 120 characters, but favor readability over wrapping

fixes #3845

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

