### PR TITLE
argument order for passwordencoder

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/dao/DaoAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/dao/DaoAuthenticationProvider.java
@@ -92,8 +92,7 @@ public class DaoAuthenticationProvider extends AbstractUserDetailsAuthentication
 
 		String presentedPassword = authentication.getCredentials().toString();
 
-		if (!passwordEncoder.isPasswordValid(userDetails.getPassword(),
-				presentedPassword, salt)) {
+		if (!passwordEncoder.isPasswordValid(presentedPassword, userDetails.getPassword(), salt)) {
 			logger.debug("Authentication failed: password does not match stored value");
 
 			throw new BadCredentialsException(messages.getMessage(


### PR DESCRIPTION
passwordencoder declares the arguments as encodedpassword and rawpassword, but here it seems to be getting called in reverse order

- [X] I have signed the CLA