### PR TITLE
Fix test .standaloneSetup

### DIFF
--- a/test/src/main/java/org/springframework/security/test/web/servlet/setup/SecurityMockMvcConfigurer.java
+++ b/test/src/main/java/org/springframework/security/test/web/servlet/setup/SecurityMockMvcConfigurer.java
@@ -68,6 +68,8 @@ final class SecurityMockMvcConfigurer extends MockMvcConfigurerAdapter {
 		}
 
 		builder.addFilters(this.springSecurityFilterChain);
+		context.getServletContext().setAttribute(BeanIds.SPRING_SECURITY_FILTER_CHAIN,
+				this.springSecurityFilterChain);
 
 		return testSecurityContext();
 	}

--- a/test/src/main/java/org/springframework/security/test/web/servlet/setup/SecurityMockMvcConfigurer.java
+++ b/test/src/main/java/org/springframework/security/test/web/servlet/setup/SecurityMockMvcConfigurer.java
@@ -15,13 +15,13 @@
  */
 package org.springframework.security.test.web.servlet.setup;
 
+import javax.servlet.Filter;
+
 import org.springframework.security.config.BeanIds;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.test.web.servlet.setup.ConfigurableMockMvcBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcConfigurerAdapter;
 import org.springframework.web.context.WebApplicationContext;
-
-import javax.servlet.Filter;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.testSecurityContext;
 
@@ -54,18 +54,20 @@ final class SecurityMockMvcConfigurer extends MockMvcConfigurerAdapter {
 	public RequestPostProcessor beforeMockMvcCreated(
 			ConfigurableMockMvcBuilder<?> builder, WebApplicationContext context) {
 		String securityBeanId = BeanIds.SPRING_SECURITY_FILTER_CHAIN;
-		if (springSecurityFilterChain == null && context.containsBean(securityBeanId)) {
-			springSecurityFilterChain = context.getBean(securityBeanId, Filter.class);
+		if (this.springSecurityFilterChain == null
+				&& context.containsBean(securityBeanId)) {
+			this.springSecurityFilterChain = context.getBean(securityBeanId,
+					Filter.class);
 		}
 
-		if (springSecurityFilterChain == null) {
+		if (this.springSecurityFilterChain == null) {
 			throw new IllegalStateException(
 					"springSecurityFilterChain cannot be null. Ensure a Bean with the name "
 							+ securityBeanId
 							+ " implementing Filter is present or inject the Filter to be used.");
 		}
 
-		builder.addFilters(springSecurityFilterChain);
+		builder.addFilters(this.springSecurityFilterChain);
 
 		return testSecurityContext();
 	}

--- a/test/src/main/java/org/springframework/security/test/web/support/WebTestUtils.java
+++ b/test/src/main/java/org/springframework/security/test/web/support/WebTestUtils.java
@@ -123,13 +123,14 @@ public abstract class WebTestUtils {
 		Filter springSecurityFilterChain = null;
 		try {
 			springSecurityFilterChain = webApplicationContext.getBean(
-					AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME, Filter.class);
+					AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME,
+					Filter.class);
 		}
 		catch (NoSuchBeanDefinitionException notFound) {
 			return null;
 		}
-		List<Filter> filters = (List<Filter>) ReflectionTestUtils.invokeMethod(
-				springSecurityFilterChain, "getFilters", request);
+		List<Filter> filters = (List<Filter>) ReflectionTestUtils
+				.invokeMethod(springSecurityFilterChain, "getFilters", request);
 		if (filters == null) {
 			return null;
 		}

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsCsrfTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsCsrfTests.java
@@ -27,6 +27,7 @@ import javax.servlet.http.HttpSession;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -34,6 +35,8 @@ import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessorsCsrfTests.Config.TheController;
+import org.springframework.security.web.FilterChainProxy;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -58,6 +61,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class SecurityMockMvcRequestPostProcessorsCsrfTests {
 	@Autowired
 	WebApplicationContext wac;
+	@Autowired
+	TheController controller;
+	@Autowired
+	FilterChainProxy springSecurityFilterChain;
 
 	MockMvc mockMvc;
 
@@ -69,7 +76,20 @@ public class SecurityMockMvcRequestPostProcessorsCsrfTests {
 			.apply(springSecurity())
 			.build();
 		// @formatter:on
+	}
+
+	// gh-3881
+	@Test
+	public void csrfWithStandalone() throws Exception {
+		// @formatter:off
+		this.mockMvc = MockMvcBuilders
+				.standaloneSetup(this.controller)
+				.apply(springSecurity(this.springSecurityFilterChain))
 				.build();
+		this.mockMvc.perform(post("/").with(csrf()))
+			.andExpect(status().is2xxSuccessful())
+			.andExpect(csrfAsParam());
+		// @formatter:on
 	}
 
 	@Test

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsCsrfTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsCsrfTests.java
@@ -15,12 +15,6 @@
  */
 package org.springframework.security.test.web.servlet.request;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import java.io.IOException;
 
 import javax.servlet.FilterChain;
@@ -52,6 +46,12 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
 @WebAppConfiguration
@@ -63,52 +63,64 @@ public class SecurityMockMvcRequestPostProcessorsCsrfTests {
 
 	@Before
 	public void setup() {
-		mockMvc = MockMvcBuilders
-				.webAppContextSetup(wac)
-				.apply(springSecurity())
+		// @formatter:off
+		this.mockMvc = MockMvcBuilders
+			.webAppContextSetup(this.wac)
+			.apply(springSecurity())
+			.build();
+		// @formatter:on
 				.build();
 	}
 
 	@Test
 	public void csrfWithParam() throws Exception {
-		mockMvc.perform(post("/").with(csrf()))
+		// @formatter:off
+		this.mockMvc.perform(post("/").with(csrf()))
 			.andExpect(status().is2xxSuccessful())
 			.andExpect(csrfAsParam());
+		// @formatter:on
 	}
 
 	@Test
 	public void csrfWithHeader() throws Exception {
-		mockMvc.perform(post("/").with(csrf().asHeader()))
+		// @formatter:off
+		this.mockMvc.perform(post("/").with(csrf().asHeader()))
 			.andExpect(status().is2xxSuccessful())
 			.andExpect(csrfAsHeader());
+		// @formatter:on
 	}
 
 	@Test
 	public void csrfWithInvalidParam() throws Exception {
-		mockMvc.perform(post("/").with(csrf().useInvalidToken()))
-				.andExpect(status().isForbidden())
-				.andExpect(csrfAsParam());
+		// @formatter:off
+		this.mockMvc.perform(post("/").with(csrf().useInvalidToken()))
+			.andExpect(status().isForbidden())
+			.andExpect(csrfAsParam());
+		// @formatter:on
 	}
 
 	@Test
 	public void csrfWithInvalidHeader() throws Exception {
-		mockMvc.perform(post("/").with(csrf().asHeader().useInvalidToken()))
+		// @formatter:off
+		this.mockMvc.perform(post("/").with(csrf().asHeader().useInvalidToken()))
 			.andExpect(status().isForbidden())
 			.andExpect(csrfAsHeader());
+		// @formatter:on
 	}
 
 	// SEC-3097
 	@Test
 	public void csrfWithWrappedRequest() throws Exception {
-		mockMvc = MockMvcBuilders
-				.webAppContextSetup(wac)
+		// @formatter:off
+		this.mockMvc = MockMvcBuilders
+				.webAppContextSetup(this.wac)
 				.addFilter(new SessionRepositoryFilter())
 				.apply(springSecurity())
 				.build();
-
-		mockMvc.perform(post("/").with(csrf()))
+		this.mockMvc.perform(post("/").with(csrf()))
 				.andExpect(status().is2xxSuccessful())
 				.andExpect(csrfAsParam());
+		// @formatter:on
 	}
 
 	public static ResultMatcher csrfAsParam() {
@@ -117,6 +129,7 @@ public class SecurityMockMvcRequestPostProcessorsCsrfTests {
 
 	static class CsrfParamResultMatcher implements ResultMatcher {
 
+		@Override
 		public void match(MvcResult result) throws Exception {
 			MockHttpServletRequest request = result.getRequest();
 			assertThat(request.getParameter("_csrf")).isNotNull();
@@ -130,6 +143,7 @@ public class SecurityMockMvcRequestPostProcessorsCsrfTests {
 
 	static class CsrfHeaderResultMatcher implements ResultMatcher {
 
+		@Override
 		public void match(MvcResult result) throws Exception {
 			MockHttpServletRequest request = result.getRequest();
 			assertThat(request.getParameter("_csrf")).isNull();
@@ -140,9 +154,10 @@ public class SecurityMockMvcRequestPostProcessorsCsrfTests {
 	static class SessionRepositoryFilter extends OncePerRequestFilter {
 
 		@Override
-		protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-				throws ServletException, IOException {
-			filterChain.doFilter(new SessionRequestWrapper(request) , response);
+		protected void doFilterInternal(HttpServletRequest request,
+				HttpServletResponse response, FilterChain filterChain)
+						throws ServletException, IOException {
+			filterChain.doFilter(new SessionRequestWrapper(request), response);
 		}
 
 		static class SessionRequestWrapper extends HttpServletRequestWrapper {
@@ -154,12 +169,12 @@ public class SecurityMockMvcRequestPostProcessorsCsrfTests {
 
 			@Override
 			public HttpSession getSession(boolean create) {
-				return session;
+				return this.session;
 			}
 
 			@Override
 			public HttpSession getSession() {
-				return session;
+				return this.session;
 			}
 		}
 	}

--- a/test/src/test/java/org/springframework/security/test/web/servlet/setup/SecurityMockMvcConfigurerTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/setup/SecurityMockMvcConfigurerTests.java
@@ -15,14 +15,15 @@
  */
 package org.springframework.security.test.web.servlet.setup;
 
+import javax.servlet.Filter;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
 import org.springframework.test.web.servlet.setup.ConfigurableMockMvcBuilder;
 import org.springframework.web.context.WebApplicationContext;
-
-import javax.servlet.Filter;
 
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -36,18 +37,18 @@ public class SecurityMockMvcConfigurerTests {
 	@Mock
 	private Filter beanFilter;
 	@Mock
-	private ConfigurableMockMvcBuilder builder;
+	private ConfigurableMockMvcBuilder<?> builder;
 	@Mock
 	private WebApplicationContext context;
 
 	@Test
 	public void beforeMockMvcCreatedOverrideBean() throws Exception {
 		returnFilterBean();
-		SecurityMockMvcConfigurer configurer = new SecurityMockMvcConfigurer(filter);
+		SecurityMockMvcConfigurer configurer = new SecurityMockMvcConfigurer(this.filter);
 
-		configurer.beforeMockMvcCreated(builder, context);
+		configurer.beforeMockMvcCreated(this.builder, this.context);
 
-		verify(builder).addFilters(filter);
+		verify(this.builder).addFilters(this.filter);
 	}
 
 	@Test
@@ -55,29 +56,30 @@ public class SecurityMockMvcConfigurerTests {
 		returnFilterBean();
 		SecurityMockMvcConfigurer configurer = new SecurityMockMvcConfigurer();
 
-		configurer.beforeMockMvcCreated(builder, context);
+		configurer.beforeMockMvcCreated(this.builder, this.context);
 
-		verify(builder).addFilters(beanFilter);
+		verify(this.builder).addFilters(this.beanFilter);
 	}
 
 	@Test
 	public void beforeMockMvcCreatedNoBean() throws Exception {
-		SecurityMockMvcConfigurer configurer = new SecurityMockMvcConfigurer(filter);
+		SecurityMockMvcConfigurer configurer = new SecurityMockMvcConfigurer(this.filter);
 
-		configurer.beforeMockMvcCreated(builder, context);
+		configurer.beforeMockMvcCreated(this.builder, this.context);
 
-		verify(builder).addFilters(filter);
+		verify(this.builder).addFilters(this.filter);
 	}
 
 	@Test(expected = IllegalStateException.class)
 	public void beforeMockMvcCreatedNoFilter() throws Exception {
 		SecurityMockMvcConfigurer configurer = new SecurityMockMvcConfigurer();
 
-		configurer.beforeMockMvcCreated(builder, context);
+		configurer.beforeMockMvcCreated(this.builder, this.context);
 	}
 
 	private void returnFilterBean() {
-		when(context.containsBean(anyString())).thenReturn(true);
-		when(context.getBean(anyString(), eq(Filter.class))).thenReturn(beanFilter);
+		when(this.context.containsBean(anyString())).thenReturn(true);
+		when(this.context.getBean(anyString(), eq(Filter.class)))
+				.thenReturn(this.beanFilter);
 	}
 }

--- a/test/src/test/java/org/springframework/security/test/web/servlet/setup/SecurityMockMvcConfigurerTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/setup/SecurityMockMvcConfigurerTests.java
@@ -16,12 +16,15 @@
 package org.springframework.security.test.web.servlet.setup;
 
 import javax.servlet.Filter;
+import javax.servlet.ServletContext;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import org.springframework.security.config.BeanIds;
 import org.springframework.test.web.servlet.setup.ConfigurableMockMvcBuilder;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -40,6 +43,13 @@ public class SecurityMockMvcConfigurerTests {
 	private ConfigurableMockMvcBuilder<?> builder;
 	@Mock
 	private WebApplicationContext context;
+	@Mock
+	private ServletContext servletContext;
+
+	@Before
+	public void setup() {
+		when(this.context.getServletContext()).thenReturn(this.servletContext);
+	}
 
 	@Test
 	public void beforeMockMvcCreatedOverrideBean() throws Exception {
@@ -49,6 +59,8 @@ public class SecurityMockMvcConfigurerTests {
 		configurer.beforeMockMvcCreated(this.builder, this.context);
 
 		verify(this.builder).addFilters(this.filter);
+		verify(this.servletContext).setAttribute(BeanIds.SPRING_SECURITY_FILTER_CHAIN,
+				this.filter);
 	}
 
 	@Test

--- a/test/src/test/java/org/springframework/security/test/web/support/WebTestUtilsTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/support/WebTestUtilsTests.java
@@ -15,16 +15,13 @@
  */
 package org.springframework.security.test.web.support;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.security.test.web.support.WebTestUtils.getCsrfTokenRepository;
-import static org.springframework.security.test.web.support.WebTestUtils.getSecurityContextRepository;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -39,6 +36,10 @@ import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.support.WebTestUtils.getCsrfTokenRepository;
+import static org.springframework.security.test.web.support.WebTestUtils.getSecurityContextRepository;
+
 @RunWith(MockitoJUnitRunner.class)
 public class WebTestUtilsTests {
 	@Mock
@@ -51,72 +52,72 @@ public class WebTestUtilsTests {
 
 	@Before
 	public void setup() {
-		request = new MockHttpServletRequest();
+		this.request = new MockHttpServletRequest();
 	}
 
 	@After
 	public void cleanup() {
-		if (context != null) {
-			context.close();
+		if (this.context != null) {
+			this.context.close();
 		}
 	}
 
 	@Test
 	public void getCsrfTokenRepositorytNoWac() {
-		assertThat(getCsrfTokenRepository(request)).isInstanceOf(
-				HttpSessionCsrfTokenRepository.class);
+		assertThat(getCsrfTokenRepository(this.request))
+				.isInstanceOf(HttpSessionCsrfTokenRepository.class);
 	}
 
 	@Test
 	public void getCsrfTokenRepositorytNoSecurity() {
 		loadConfig(Config.class);
-		assertThat(getCsrfTokenRepository(request)).isInstanceOf(
-				HttpSessionCsrfTokenRepository.class);
+		assertThat(getCsrfTokenRepository(this.request))
+				.isInstanceOf(HttpSessionCsrfTokenRepository.class);
 	}
 
 	@Test
 	public void getCsrfTokenRepositorytSecurityNoCsrf() {
 		loadConfig(SecurityNoCsrfConfig.class);
-		assertThat(getCsrfTokenRepository(request)).isInstanceOf(
-				HttpSessionCsrfTokenRepository.class);
+		assertThat(getCsrfTokenRepository(this.request))
+				.isInstanceOf(HttpSessionCsrfTokenRepository.class);
 	}
 
 	@Test
 	public void getCsrfTokenRepositorytSecurityCustomRepo() {
-		CustomSecurityConfig.CONTEXT_REPO = contextRepo;
-		CustomSecurityConfig.CSRF_REPO = csrfRepo;
+		CustomSecurityConfig.CONTEXT_REPO = this.contextRepo;
+		CustomSecurityConfig.CSRF_REPO = this.csrfRepo;
 		loadConfig(CustomSecurityConfig.class);
-		assertThat(getCsrfTokenRepository(request)).isSameAs(csrfRepo);
+		assertThat(getCsrfTokenRepository(this.request)).isSameAs(this.csrfRepo);
 	}
 
 	// getSecurityContextRepository
 
 	@Test
 	public void getSecurityContextRepositoryNoWac() {
-		assertThat(getSecurityContextRepository(request)).isInstanceOf(
-				HttpSessionSecurityContextRepository.class);
+		assertThat(getSecurityContextRepository(this.request))
+				.isInstanceOf(HttpSessionSecurityContextRepository.class);
 	}
 
 	@Test
 	public void getSecurityContextRepositoryNoSecurity() {
 		loadConfig(Config.class);
-		assertThat(getSecurityContextRepository(request)).isInstanceOf(
-				HttpSessionSecurityContextRepository.class);
+		assertThat(getSecurityContextRepository(this.request))
+				.isInstanceOf(HttpSessionSecurityContextRepository.class);
 	}
 
 	@Test
 	public void getSecurityContextRepositorySecurityNoCsrf() {
 		loadConfig(SecurityNoCsrfConfig.class);
-		assertThat(getSecurityContextRepository(request)).isInstanceOf(
-				HttpSessionSecurityContextRepository.class);
+		assertThat(getSecurityContextRepository(this.request))
+				.isInstanceOf(HttpSessionSecurityContextRepository.class);
 	}
 
 	@Test
 	public void getSecurityContextRepositorySecurityCustomRepo() {
-		CustomSecurityConfig.CONTEXT_REPO = contextRepo;
-		CustomSecurityConfig.CSRF_REPO = csrfRepo;
+		CustomSecurityConfig.CONTEXT_REPO = this.contextRepo;
+		CustomSecurityConfig.CSRF_REPO = this.csrfRepo;
 		loadConfig(CustomSecurityConfig.class);
-		assertThat(getSecurityContextRepository(request)).isSameAs(contextRepo);
+		assertThat(getSecurityContextRepository(this.request)).isSameAs(this.contextRepo);
 	}
 
 	// gh-3343
@@ -124,7 +125,8 @@ public class WebTestUtilsTests {
 	public void findFilterNoMatchingFilters() {
 		loadConfig(PartialSecurityConfig.class);
 
-		assertThat(WebTestUtils.findFilter(request, SecurityContextPersistenceFilter.class)).isNull();
+		assertThat(WebTestUtils.findFilter(this.request,
+				SecurityContextPersistenceFilter.class)).isNull();
 	}
 
 	private void loadConfig(Class<?> config) {
@@ -132,7 +134,7 @@ public class WebTestUtilsTests {
 		context.register(config);
 		context.refresh();
 		this.context = context;
-		request.getServletContext().setAttribute(
+		this.request.getServletContext().setAttribute(
 				WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, context);
 	}
 
@@ -166,8 +168,6 @@ public class WebTestUtilsTests {
 		}
 		// @formatter:on
 	}
-
-
 
 	@EnableWebSecurity
 	static class PartialSecurityConfig extends WebSecurityConfigurerAdapter {


### PR DESCRIPTION
Previously, Spring Security's test support did not work well with the
standalone setup. This was because the springSecurityFilterChain was not
found by the WebTestUtils.

This commit ensures that the springSecurityFilterChain is added as a
servlet attribute if it is explicitly defined. WebTestUtils can then
find the springSecurityFilterChain in the ServletContext.

Fixes gh-3881