### PR TITLE
Fix Assert usage

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.java
@@ -162,10 +162,6 @@ public abstract class AbstractAuthenticationProcessingFilter extends GenericFilt
 	@Override
 	public void afterPropertiesSet() {
 		Assert.notNull(authenticationManager, "authenticationManager must be specified");
-
-		if (rememberMeServices == null) {
-			rememberMeServices = new NullRememberMeServices();
-		}
 	}
 
 	/**

--- a/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.java
@@ -38,12 +38,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.SpringSecurityMessageSource;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.WebAttributes;
 import org.springframework.security.web.authentication.session.NullAuthenticatedSessionStrategy;
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
-import org.springframework.security.web.util.UrlUtils;
 import org.springframework.util.Assert;
 import org.springframework.web.filter.GenericFilterBean;
 
@@ -387,7 +385,7 @@ public abstract class AbstractAuthenticationProcessingFilter extends GenericFilt
 	}
 
 	public void setRememberMeServices(RememberMeServices rememberMeServices) {
-		Assert.notNull("rememberMeServices cannot be null");
+		Assert.notNull(rememberMeServices, "rememberMeServices cannot be null");
 		this.rememberMeServices = rememberMeServices;
 	}
 

--- a/web/src/test/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilterTests.java
@@ -418,6 +418,15 @@ public class AbstractAuthenticationProcessingFilterTests {
 		assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
 	}
 
+	/**
+	 * https://github.com/spring-projects/spring-security/pull/3905
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void setRememberMeServicesShouldntAllowNulls() {
+		AbstractAuthenticationProcessingFilter filter = new MockAuthenticationFilter();
+		filter.setRememberMeServices(null);
+	}
+
 	// ~ Inner Classes
 	// ==================================================================================================
 


### PR DESCRIPTION
This changes the `Assert.notNull()` to not operate on the message, which is never null.

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [x] I have signed the CLA, previously on Spring Boot, with [knowledge of it on the spring-framework repo](https://github.com/spring-projects/spring-framework/pull/986#issuecomment-192209403).

```
Thank you but our records indicate that you have already accepted the individual contributor agreement.
If you are interested in participating in an additional Spring project, please contact the appropriate project lead and indicate that you have already signed the Spring Contributor Agreement.
Once signed agreement covers participating in as many Spring projects as you need.
```

