### PR TITLE
Avoid duplicate attribute search

### DIFF
--- a/ldap/src/integration-test/java/org/springframework/security/ldap/authentication/BindAuthenticatorTests.java
+++ b/ldap/src/integration-test/java/org/springframework/security/ldap/authentication/BindAuthenticatorTests.java
@@ -30,6 +30,7 @@ import org.springframework.security.ldap.search.FilterBasedLdapUserSearch;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
+
 /**
  * Tests for {@link BindAuthenticator}.
  *
@@ -90,7 +91,9 @@ public class BindAuthenticatorTests extends AbstractLdapIntegrationTests {
 		this.authenticator.setUserSearch(new FilterBasedLdapUserSearch("ou=people",
 				"(uid={0})", getContextSource()));
 		this.authenticator.afterPropertiesSet();
-		this.authenticator.authenticate(this.bob);
+		DirContextOperations result = this.authenticator.authenticate(this.bob);
+		//ensure we are getting the same attributes back
+		assertThat(result.getStringAttribute("cn")).isEqualTo("Bob Hamilton");
 		// SEC-1444
 		this.authenticator.setUserSearch(new FilterBasedLdapUserSearch("ou=people",
 				"(cn={0})", getContextSource()));


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [] I have signed the CLA

When using search-and-bind strategy, the user attributes are already returned in the first search.
If the user happens to not have privileges to perform a search, the second search may fail.
(user only has bind privileges)
See https://github.com/cloudfoundry/uaa/issues/342