### PR TITLE
Added accept method call to buildRequest in SecurityMockMvcRequestBuilders with default of MediaType.APPLICATION_FORM_URLENCODED

### DIFF
--- a/test/src/main/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestBuilders.java
+++ b/test/src/main/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestBuilders.java
@@ -20,6 +20,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 
 import javax.servlet.ServletContext;
 
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.test.web.servlet.MockMvc;
@@ -118,10 +119,13 @@ public final class SecurityMockMvcRequestBuilders {
 		private String username = "user";
 		private String password = "password";
 		private String loginProcessingUrl = "/login";
+		private MediaType acceptMediaType = MediaType.APPLICATION_FORM_URLENCODED;
+
 		private RequestPostProcessor postProcessor = csrf();
 
 		public MockHttpServletRequest buildRequest(ServletContext servletContext) {
 			MockHttpServletRequest request = post(loginProcessingUrl)
+					.accept(acceptMediaType)
 					.param(usernameParam, username).param(passwordParam, password)
 					.buildRequest(servletContext);
 			return postProcessor.postProcessRequest(request);
@@ -207,6 +211,18 @@ public final class SecurityMockMvcRequestBuilders {
 			this.username = username;
 			return this;
 		}
+
+        /**
+         * Specify a media type to to set as the Accept header in the request.
+         *
+         * @param acceptMediaType the {@link MediaType} to set the Accept header to.
+         * Default is: MediaType.APPLICATION_FORM_URLENCODED
+         * @return the {@link FormLoginRequestBuilder} for additional customizations
+         */
+        public FormLoginRequestBuilder acceptMediaType(MediaType acceptMediaType) {
+            this.acceptMediaType = acceptMediaType;
+            return this;
+        }
 
 		private FormLoginRequestBuilder() {
 		}


### PR DESCRIPTION
In cases where a custom content negotiation handler is in play, it may default to JSON processing in the absence of an Accept header that indicates a type of `application/x-www-form-urlencoded`. For `formLogin()`, it's appropriate (although not required) to set the Accept header this way.

It can also be overridden by the `acceptMediaType` method call.

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [X] I have signed the CLA

