### PR TITLE
#3930 removed double salt in result password hash

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/password/Pbkdf2PasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password/Pbkdf2PasswordEncoder.java
@@ -101,7 +101,7 @@ public class Pbkdf2PasswordEncoder implements PasswordEncoder {
 	}
 
 	private byte[] encodeAndConcatenate(CharSequence rawPassword, byte[] salt) {
-		return concatenate(salt, encode(rawPassword, salt));
+		return encode(rawPassword, salt);
 	}
 
 	/**


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

there was a double hash at the salt.

