### PR TITLE
Propagate rolePrefix to LdapAuthoritiesPopulator

### DIFF
--- a/config/src/integration-test/groovy/org/springframework/security/config/annotation/authentication/ldap/LdapAuthenticationProviderConfigurerTests.groovy
+++ b/config/src/integration-test/groovy/org/springframework/security/config/annotation/authentication/ldap/LdapAuthenticationProviderConfigurerTests.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,24 +15,17 @@
  */
 package org.springframework.security.config.annotation.authentication.ldap
 
-import org.springframework.context.annotation.Configuration
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.config.annotation.BaseSpringSpec
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
-import org.springframework.security.config.annotation.authentication.ldap.NamespaceLdapAuthenticationProviderTestsConfigs.LdapAuthenticationProviderConfig
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
-import org.springframework.security.ldap.authentication.LdapAuthenticationProvider
-import org.springframework.security.ldap.authentication.PasswordComparisonAuthenticator
-import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator
-import org.springframework.security.ldap.userdetails.PersonContextMapper
-import org.springframework.test.util.ReflectionTestUtils
-
-import static org.springframework.security.config.annotation.authentication.ldap.NamespaceLdapAuthenticationProviderTestsConfigs.*
+import org.springframework.security.core.authority.SimpleGrantedAuthority
 
 /**
  *
  * @author Rob Winch
+ * @author Eddú Meléndez
  *
  */
 class LdapAuthenticationProviderConfigurerTests extends BaseSpringSpec {
@@ -44,17 +37,54 @@ class LdapAuthenticationProviderConfigurerTests extends BaseSpringSpec {
 			authenticationManager.authenticate(new UsernamePasswordAuthenticationToken("bob","bobspassword"))
 	}
 
+	def "authentication-manager support multiple ldap context with default role prefix" () {
+		when:
+		loadConfig(MultiLdapAuthenticationProvidersConfig)
+		then:
+		def authenticate = authenticationManager.authenticate(new UsernamePasswordAuthenticationToken("bob", "bobspassword"))
+		authenticate.authorities.contains(new SimpleGrantedAuthority("ROLE_DEVELOPERS"))
+	}
+
+	def "authentication-manager support multiple ldap context with custom role prefix"() {
+		when:
+		loadConfig(MultiLdapWithCustomRolePrefixAuthenticationProvidersConfig)
+		then:
+		def authenticate = authenticationManager.authenticate(new UsernamePasswordAuthenticationToken("bob", "bobspassword"))
+		authenticate.authorities.contains(new SimpleGrantedAuthority("ROL_DEVELOPERS"))
+	}
+
 	@EnableWebSecurity
 	static class MultiLdapAuthenticationProvidersConfig extends WebSecurityConfigurerAdapter {
 		protected void configure(AuthenticationManagerBuilder auth) throws Exception {
 			auth
 				.ldapAuthentication()
 					.groupSearchBase("ou=groups")
+					.groupSearchFilter("(member={0})")
 					.userDnPatterns("uid={0},ou=people")
 					.and()
 				.ldapAuthentication()
 					.groupSearchBase("ou=groups")
+					.groupSearchFilter("(member={0})")
 					.userDnPatterns("uid={0},ou=people")
+		}
+	}
+
+	@EnableWebSecurity
+	static class MultiLdapWithCustomRolePrefixAuthenticationProvidersConfig extends
+			WebSecurityConfigurerAdapter {
+		protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+			auth
+				.ldapAuthentication()
+					.groupSearchBase("ou=groups")
+					.groupSearchFilter("(member={0})")
+					.userDnPatterns("uid={0},ou=people")
+					.rolePrefix("ROL_")
+					.and()
+				.ldapAuthentication()
+					.groupSearchBase("ou=groups")
+					.groupSearchFilter("(member={0})")
+					.userDnPatterns("uid={0},ou=people")
+					.rolePrefix("RUOLO_")
 		}
 	}
 }

--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/ldap/LdapAuthenticationProviderConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/ldap/LdapAuthenticationProviderConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ import java.net.ServerSocket;
  * @param <B> the {@link ProviderManagerBuilder} type that this is configuring.
  *
  * @author Rob Winch
+ * @author Eddú Meléndez
  * @since 3.2
  */
 public class LdapAuthenticationProviderConfigurer<B extends ProviderManagerBuilder<B>>
@@ -128,6 +129,7 @@ public class LdapAuthenticationProviderConfigurer<B extends ProviderManagerBuild
 				contextSource, groupSearchBase);
 		defaultAuthoritiesPopulator.setGroupRoleAttribute(groupRoleAttribute);
 		defaultAuthoritiesPopulator.setGroupSearchFilter(groupSearchFilter);
+		defaultAuthoritiesPopulator.setRolePrefix(rolePrefix);
 
 		this.ldapAuthoritiesPopulator = defaultAuthoritiesPopulator;
 		return defaultAuthoritiesPopulator;


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

Previous to this commit, custom rolePrefix was not propagated to
LdapAuthoritiesPopulator populating  a wrong authority. Now, rolePrefix
is propagated and the authority is as expected.

Fixes gh-3921