### PR TITLE
Allow using username in Active Directory LDAP search filter

### DIFF
--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/ad/ActiveDirectoryLdapAuthenticationProvider.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/ad/ActiveDirectoryLdapAuthenticationProvider.java
@@ -312,7 +312,7 @@ public final class ActiveDirectoryLdapAuthenticationProvider extends
 		try {
 			return SpringSecurityLdapTemplate.searchForSingleEntryInternal(context,
 					searchControls, searchRoot, searchFilter,
-					new Object[] { bindPrincipal });
+					new Object[] { bindPrincipal, username });
 		}
 		catch (IncorrectResultSizeDataAccessException incorrectResults) {
 			// Search should never return multiple results if properly configured - just


### PR DESCRIPTION
When customizing the LDAP search filter used by `ActiveDirectoryLdapAuthenticationProvider` I have a need to reference just the username. The default `{0}` is `username@domain`. This small change will allow filters to reference the username with `{1}`

Example:

```
userPrincipalName = someUser@bar.com
sAMAccountName = someUser
Domain Name: foo
```

Trying to set the filter to use sAMAccountName instead of userPrincipalName results in the domain name being included.

```
provider.setSearchFilter("(&(objectClass=user)(sAMAccountName={0}))");
```

Results in `(&(objectClass=user)(sAMAccountName=someUser@bar.com))`

This code change will let me use `{1}` in the filter instead so the search will be: `(&(objectClass=user)(sAMAccountName=someUser))`

I was unable to simply extend `ActiveDirectoryLdapAuthenticationProvider` because it is marked final.