### PR TITLE
Make single definition of `defaultRolePrefix` and `rolePrefix`

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/ldap/LdapAuthenticationProviderConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/ldap/LdapAuthenticationProviderConfigurer.java
@@ -15,11 +15,15 @@
  */
 package org.springframework.security.config.annotation.authentication.configurers.ldap;
 
+import java.io.IOException;
+import java.net.ServerSocket;
+
 import org.springframework.ldap.core.support.BaseLdapPathContextSource;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.encoding.PasswordEncoder;
 import org.springframework.security.authentication.encoding.PlaintextPasswordEncoder;
+import org.springframework.security.config.GrantedAuthorityDefaults;
 import org.springframework.security.config.annotation.ObjectPostProcessor;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.authentication.ProviderManagerBuilder;
@@ -43,9 +47,6 @@ import org.springframework.security.ldap.userdetails.PersonContextMapper;
 import org.springframework.security.ldap.userdetails.UserDetailsContextMapper;
 import org.springframework.util.Assert;
 
-import java.io.IOException;
-import java.net.ServerSocket;
-
 /**
  * Configures LDAP {@link AuthenticationProvider} in the {@link ProviderManagerBuilder}.
  *
@@ -60,7 +61,7 @@ public class LdapAuthenticationProviderConfigurer<B extends ProviderManagerBuild
 	private String groupRoleAttribute = "cn";
 	private String groupSearchBase = "";
 	private String groupSearchFilter = "(uniqueMember={0})";
-	private String rolePrefix = "ROLE_";
+	private GrantedAuthorityDefaults rolePrefix = new GrantedAuthorityDefaults("ROLE_");
 	private String userSearchBase = ""; // only for search
 	private String userSearchFilter = null;// "uid={0}"; // only for search
 	private String[] userDnPatterns;
@@ -128,7 +129,7 @@ public class LdapAuthenticationProviderConfigurer<B extends ProviderManagerBuild
 				contextSource, groupSearchBase);
 		defaultAuthoritiesPopulator.setGroupRoleAttribute(groupRoleAttribute);
 		defaultAuthoritiesPopulator.setGroupSearchFilter(groupSearchFilter);
-		defaultAuthoritiesPopulator.setRolePrefix(rolePrefix);
+		defaultAuthoritiesPopulator.setRolePrefix(this.rolePrefix.getRolePrefix());
 
 		this.ldapAuthoritiesPopulator = defaultAuthoritiesPopulator;
 		return defaultAuthoritiesPopulator;
@@ -161,7 +162,7 @@ public class LdapAuthenticationProviderConfigurer<B extends ProviderManagerBuild
 		}
 
 		SimpleAuthorityMapper simpleAuthorityMapper = new SimpleAuthorityMapper();
-		simpleAuthorityMapper.setPrefix(rolePrefix);
+		simpleAuthorityMapper.setPrefix(this.rolePrefix.getRolePrefix());
 		simpleAuthorityMapper.afterPropertiesSet();
 		this.authoritiesMapper = simpleAuthorityMapper;
 		return simpleAuthorityMapper;
@@ -356,7 +357,7 @@ public class LdapAuthenticationProviderConfigurer<B extends ProviderManagerBuild
 	 * @see SimpleAuthorityMapper#setPrefix(String)
 	 */
 	public LdapAuthenticationProviderConfigurer<B> rolePrefix(String rolePrefix) {
-		this.rolePrefix = rolePrefix;
+		this.rolePrefix = new GrantedAuthorityDefaults(rolePrefix);
 		return this;
 	}
 

--- a/config/src/test/groovy/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfigurationTests.groovy
+++ b/config/src/test/groovy/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfigurationTests.groovy
@@ -17,7 +17,8 @@ package org.springframework.security.config.annotation.method.configuration
 
 
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
-import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl
+import org.springframework.security.config.GrantedAuthorityDefaults;
 
 import java.lang.reflect.Proxy;
 
@@ -494,6 +495,29 @@ public class GlobalMethodSecurityConfigurationTests extends BaseSpringSpec {
 		@Bean
 		RoleHierarchy roleHierarchy() {
 			return new RoleHierarchyImpl(hierarchy:"ROLE_USER > ROLE_ADMIN")
+		}
+	}
+
+	def "GrantedAuthorityDefaults autowires"() {
+		when:
+			loadConfig(CustomGrantedAuthorityConfig)
+			def preAdviceVoter = context.getBean(MethodInterceptor).accessDecisionManager.decisionVoters.find { it instanceof PreInvocationAuthorizationAdviceVoter}
+		then:
+		preAdviceVoter.preAdvice.expressionHandler.defaultRolePrefix == "ROLE:"
+	}
+
+	@EnableGlobalMethodSecurity(prePostEnabled = true)
+	static class CustomGrantedAuthorityConfig extends GlobalMethodSecurityConfiguration {
+
+		@Override
+		protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+			auth
+				.inMemoryAuthentication()
+		}
+
+		@Bean
+		public GrantedAuthorityDefaults ga() {
+			return new GrantedAuthorityDefaults("ROLE:")
 		}
 	}
 }

--- a/core/src/main/java/org/springframework/security/config/GrantedAuthorityDefaults.java
+++ b/core/src/main/java/org/springframework/security/config/GrantedAuthorityDefaults.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.config;
+
+/**
+ * @author Eddú Meléndez
+ * @since 4.2.0
+ */
+public class GrantedAuthorityDefaults {
+
+	private String rolePrefix = "ROLE_";
+
+	public GrantedAuthorityDefaults(String rolePrefix) {
+		this.rolePrefix = rolePrefix;
+	}
+
+	public String getRolePrefix() {
+		return this.rolePrefix;
+	}
+
+	public void setRolePrefix(String rolePrefix) {
+		this.rolePrefix = rolePrefix;
+	}
+
+}

--- a/ldap/src/main/java/org/springframework/security/ldap/userdetails/DefaultLdapAuthoritiesPopulator.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/userdetails/DefaultLdapAuthoritiesPopulator.java
@@ -16,6 +16,10 @@
 
 package org.springframework.security.ldap.userdetails;
 
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.security.config.GrantedAuthorityDefaults;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.ldap.SpringSecurityLdapTemplate;
@@ -97,7 +101,7 @@ import java.util.Set;
  * @author Luke Taylor
  * @author Filip Hanik
  */
-public class DefaultLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator {
+public class DefaultLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator, ApplicationContextAware {
 	// ~ Static fields/initializers
 	// =====================================================================================
 
@@ -140,7 +144,7 @@ public class DefaultLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
 	/**
 	 * The role prefix that will be prepended to each role name
 	 */
-	private String rolePrefix = "ROLE_";
+	private GrantedAuthorityDefaults rolePrefix = new GrantedAuthorityDefaults("ROLE_");
 	/**
 	 * Should we convert the role name to uppercase
 	 */
@@ -250,7 +254,7 @@ public class DefaultLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
 				role = role.toUpperCase();
 			}
 
-			authorities.add(new SimpleGrantedAuthority(rolePrefix + role));
+			authorities.add(new SimpleGrantedAuthority(rolePrefix.getRolePrefix() + role));
 		}
 
 		return authorities;
@@ -297,7 +301,7 @@ public class DefaultLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
 	 */
 	public void setRolePrefix(String rolePrefix) {
 		Assert.notNull(rolePrefix, "rolePrefix must not be null");
-		this.rolePrefix = rolePrefix;
+		this.rolePrefix = new GrantedAuthorityDefaults(rolePrefix);
 	}
 
 	/**
@@ -360,7 +364,7 @@ public class DefaultLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
 	 * @see #setRolePrefix(String)
 	 */
 	protected final String getRolePrefix() {
-		return rolePrefix;
+		return this.rolePrefix.getRolePrefix();
 	}
 
 	/**
@@ -391,4 +395,14 @@ public class DefaultLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
 	private SearchControls getSearchControls() {
 		return searchControls;
 	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext context) throws
+			BeansException {
+		String[] beanNames = context.getBeanNamesForType(GrantedAuthorityDefaults.class);
+		if (beanNames.length == 1) {
+			this.rolePrefix = context.getBean(beanNames[0], GrantedAuthorityDefaults.class);
+		}
+	}
+
 }

--- a/ldap/src/test/java/org/springframework/security/ldap/userdetails/DefaultLdapAuthoritiesPopulatorTests.java
+++ b/ldap/src/test/java/org/springframework/security/ldap/userdetails/DefaultLdapAuthoritiesPopulatorTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.ldap.userdetails;
+
+import org.junit.Test;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.ldap.core.ContextSource;
+import org.springframework.security.config.GrantedAuthorityDefaults;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Eddú Meléndez
+ */
+public class DefaultLdapAuthoritiesPopulatorTests {
+
+	@Test
+	public void testDefaultRolePrefix() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		context.register(LdapAuthoritiesPopulatorConfiguration.class);
+		context.refresh();
+
+		DefaultLdapAuthoritiesPopulator ldapPopulator = context.getBean(DefaultLdapAuthoritiesPopulator.class);
+		assertThat(ldapPopulator.getRolePrefix()).isEqualTo("ROL_");
+	}
+
+	@Configuration
+	static class LdapAuthoritiesPopulatorConfiguration {
+
+		@Bean
+		public GrantedAuthorityDefaults authorityDefaults() {
+			return new GrantedAuthorityDefaults("ROL_");
+		}
+
+		@Bean
+		public DefaultLdapAuthoritiesPopulator ldapAuthoritiesPopulator() {
+			ContextSource contextSource = mock(ContextSource.class);
+			return new DefaultLdapAuthoritiesPopulator(contextSource, "ou=groups");
+		}
+
+	}
+
+}

--- a/ldap/src/test/java/org/springframework/security/ldap/userdetails/LdapUserDetailsMapperTests.java
+++ b/ldap/src/test/java/org/springframework/security/ldap/userdetails/LdapUserDetailsMapperTests.java
@@ -21,9 +21,14 @@ import javax.naming.directory.BasicAttributes;
 
 import org.junit.Test;
 
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.ldap.core.DirContextAdapter;
 import org.springframework.ldap.core.DistinguishedName;
+import org.springframework.security.config.GrantedAuthorityDefaults;
 import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -94,4 +99,32 @@ public class LdapUserDetailsMapperTests {
 
 		assertThat(user.getPassword()).isEqualTo("mypassword");
 	}
+
+	@Test
+	public void testDefaultRolePrefix() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		context.register(LdapUserDetailsMapperConfiguration.class);
+		context.refresh();
+
+		LdapUserDetailsMapper ldapUserDetailsMapper = context.getBean(LdapUserDetailsMapper.class);
+
+		GrantedAuthorityDefaults rolePrefix = (GrantedAuthorityDefaults) ReflectionTestUtils.getField(ldapUserDetailsMapper, "rolePrefix");
+		assertThat(rolePrefix.getRolePrefix()).isEqualTo("ROL_");
+	}
+
+	@Configuration
+	static class LdapUserDetailsMapperConfiguration {
+
+		@Bean
+		public GrantedAuthorityDefaults authorityDefaults() {
+			return new GrantedAuthorityDefaults("ROL_");
+		}
+
+		@Bean
+		public LdapUserDetailsMapper ldapUserDetailsMapper() {
+			return new LdapUserDetailsMapper();
+		}
+
+	}
+
 }

--- a/web/src/main/java/org/springframework/security/web/access/expression/DefaultWebSecurityExpressionHandler.java
+++ b/web/src/main/java/org/springframework/security/web/access/expression/DefaultWebSecurityExpressionHandler.java
@@ -15,11 +15,14 @@
  */
 package org.springframework.security.web.access.expression;
 
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
 import org.springframework.security.access.expression.AbstractSecurityExpressionHandler;
 import org.springframework.security.access.expression.SecurityExpressionHandler;
 import org.springframework.security.access.expression.SecurityExpressionOperations;
 import org.springframework.security.authentication.AuthenticationTrustResolver;
 import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
+import org.springframework.security.config.GrantedAuthorityDefaults;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.FilterInvocation;
 import org.springframework.util.Assert;
@@ -27,6 +30,7 @@ import org.springframework.util.Assert;
 /**
  *
  * @author Luke Taylor
+ * @author Eddú Meléndez
  * @since 3.0
  */
 public class DefaultWebSecurityExpressionHandler extends
@@ -34,7 +38,7 @@ public class DefaultWebSecurityExpressionHandler extends
 		SecurityExpressionHandler<FilterInvocation> {
 
 	private AuthenticationTrustResolver trustResolver = new AuthenticationTrustResolverImpl();
-	private String defaultRolePrefix = "ROLE_";
+	private GrantedAuthorityDefaults defaultRolePrefix = new GrantedAuthorityDefaults("ROLE_");
 
 	@Override
 	protected SecurityExpressionOperations createSecurityExpressionRoot(
@@ -43,7 +47,7 @@ public class DefaultWebSecurityExpressionHandler extends
 		root.setPermissionEvaluator(getPermissionEvaluator());
 		root.setTrustResolver(trustResolver);
 		root.setRoleHierarchy(getRoleHierarchy());
-		root.setDefaultRolePrefix(defaultRolePrefix);
+		root.setDefaultRolePrefix(this.defaultRolePrefix.getRolePrefix());
 		return root;
 	}
 
@@ -74,6 +78,16 @@ public class DefaultWebSecurityExpressionHandler extends
 	 * @param defaultRolePrefix the default prefix to add to roles. Default "ROLE_".
 	 */
 	public void setDefaultRolePrefix(String defaultRolePrefix) {
-		this.defaultRolePrefix = defaultRolePrefix;
+		this.defaultRolePrefix = new GrantedAuthorityDefaults(defaultRolePrefix);
 	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext context) {
+		super.setApplicationContext(context);
+		String[] beanNames = context.getBeanNamesForType(GrantedAuthorityDefaults.class);
+		if (beanNames.length == 1) {
+			this.defaultRolePrefix = context.getBean(beanNames[0], GrantedAuthorityDefaults.class);
+		}
+	}
+
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

Previous to this commit, role prefix had to be set in every class
causing repetition. Now, bean `GrantedAuthorityDefaults` can be used to
define the role prefix in a single point.

Fixes gh-3701