### PR TITLE
fix issue #2969: SEC-2744: BasicAuthenticationFilter decodes the Passwords with UTF-8

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilter.java
@@ -196,7 +196,7 @@ public class BasicAuthenticationFilter extends OncePerRequestFilter {
 			/*
 			 * https://tools.ietf.org/id/draft-reschke-basicauth-enc-00.html
 			 * > On the other hand, the strategy below may already improve the user-visible behavior today:
-			 * > 
+			 * >
 			 * > In the first authentication request, choose the character encoding based on the user's credentials: if they
 			 * > do not need any characters outside the ISO-8859-1 character set, default to ISO-8859-1, otherwise use UTF-8.
 			 * > If the first attempt failed and the encoding used was ISO-8859-1, retry once with UTF-8 encoding instead.

--- a/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilter.java
@@ -192,6 +192,27 @@ public class BasicAuthenticationFilter extends OncePerRequestFilter {
 
 		}
 		catch (AuthenticationException failed) {
+
+			/*
+			 * https://tools.ietf.org/id/draft-reschke-basicauth-enc-00.html
+			 * > On the other hand, the strategy below may already improve the user-visible behavior today:
+			 * > 
+			 * > In the first authentication request, choose the character encoding based on the user's credentials: if they
+			 * > do not need any characters outside the ISO-8859-1 character set, default to ISO-8859-1, otherwise use UTF-8.
+			 * > If the first attempt failed and the encoding used was ISO-8859-1, retry once with UTF-8 encoding instead.
+			 */
+			if (failed instanceof BadCredentialsException && "UTF-8".equals(getCredentialsCharset(request))) {
+
+				try {
+					setCredentialsCharset("ISO-8859-1");
+					doFilterInternal(request, response, chain);
+					return;
+				} finally {
+					setCredentialsCharset("UTF-8");
+				}
+
+			}
+
 			SecurityContextHolder.clearContext();
 
 			if (debug) {


### PR DESCRIPTION
fix issue #2969: SEC-2744: BasicAuthenticationFilter decodes the Passwords with UTF-8