### PR TITLE
DummyRequest supports methods for MvcRequestMatcher

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/HttpSecurityRequestMatchersTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/HttpSecurityRequestMatchersTests.java
@@ -95,6 +95,13 @@ public class HttpSecurityRequestMatchersTests {
 				.isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
 	}
 
+	@Test
+	public void mvcMatcherGetFiltersNoUnsupportedMethodExceptionFromDummyRequest() {
+		loadConfig(MvcMatcherConfig.class);
+
+		assertThat(springSecurityFilterChain.getFilters("/path")).isNotEmpty();
+	}
+
 	@EnableWebSecurity
 	@Configuration
 	@EnableWebMvc

--- a/web/src/main/java/org/springframework/security/web/FilterInvocation.java
+++ b/web/src/main/java/org/springframework/security/web/FilterInvocation.java
@@ -167,6 +167,14 @@ class DummyRequest extends HttpServletRequestWrapper {
 		super(UNSUPPORTED_REQUEST);
 	}
 
+	public String getCharacterEncoding() {
+		return "UTF-8";
+	}
+
+	public Object getAttribute(String attributeName) {
+		return null;
+	}
+
 	public void setRequestURI(String requestURI) {
 		this.requestURI = requestURI;
 	}


### PR DESCRIPTION
To support MvcRequestMatcher DummyRequest needs to support
`getCharacterEncoding()` and `getAttribute(String)`. Otherwise the following exception is thrown:

```
java.lang.UnsupportedOperationException: public abstract java.lang.Object javax.servlet.ServletRequest.getAttribute(java.lang.String) is not supported
	at org.springframework.security.web.UnsupportedOperationExceptionInvocationHandler.invoke(FilterInvocation.java:227)
	at com.sun.proxy.$Proxy66.getAttribute(Unknown Source)
	at javax.servlet.ServletRequestWrapper.getAttribute(ServletRequestWrapper.java:120)
	at javax.servlet.ServletRequestWrapper.getAttribute(ServletRequestWrapper.java:120)
	at org.springframework.web.util.UrlPathHelper.getContextPath(UrlPathHelper.java:323)
	at org.springframework.web.util.UrlPathHelper.getPathWithinApplication(UrlPathHelper.java:224)
	at org.springframework.web.util.UrlPathHelper.getPathWithinServletMapping(UrlPathHelper.java:177)
	at org.springframework.web.util.UrlPathHelper.getLookupPathForRequest(UrlPathHelper.java:154)
	at org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher$DefaultMatcher.matches(MvcRequestMatcher.java:108)
	at org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher.matches(MvcRequestMatcher.java:61)
	at org.springframework.security.web.util.matcher.OrRequestMatcher.matches(OrRequestMatcher.java:67)
	at org.springframework.security.web.DefaultSecurityFilterChain.matches(DefaultSecurityFilterChain.java:57)
	at org.springframework.security.web.FilterChainProxy.getFilters(FilterChainProxy.java:225)
	at org.springframework.security.web.FilterChainProxy.getFilters(FilterChainProxy.java:240)
```