### PR TITLE
Fix <headers defaults-disabled=true> with no children

### DIFF
--- a/web/src/main/java/org/springframework/security/web/header/HeaderWriterFilter.java
+++ b/web/src/main/java/org/springframework/security/web/header/HeaderWriterFilter.java
@@ -51,7 +51,7 @@ public class HeaderWriterFilter extends OncePerRequestFilter {
 	 * {@link HttpServletResponse}.
 	 */
 	public HeaderWriterFilter(List<HeaderWriter> headerWriters) {
-		Assert.notEmpty(headerWriters, "headerWriters cannot be null or empty");
+		Assert.notNull(headerWriters, "headerWriters cannot be null");
 		this.headerWriters = headerWriters;
 	}
 

--- a/web/src/test/java/org/springframework/security/web/header/HeaderWriterFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/header/HeaderWriterFilterTests.java
@@ -57,10 +57,11 @@ public class HeaderWriterFilterTests {
 	@Mock
 	private HeaderWriter writer2;
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void noHeadersConfigured() throws Exception {
 		List<HeaderWriter> headerWriters = new ArrayList<HeaderWriter>();
 		new HeaderWriterFilter(headerWriters);
+		// empty writers list is ok ...
 	}
 
 	@Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
The online docs
     http://docs.spring.io/spring-security/site/docs/current/reference/html/headers.html
suggest that

```xml
     <headers defaults-disabled="true"/>
```

ought to disable the default security headers, but the HeaderWriterFilter has an assertion that its header-writer list is non empty.  This patch just changes Assert.notEmpty to Assert.notNull
