### PR TITLE
Fix Issue 4001: CSRF tokens are vulnerable to a BREACH attack

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configuration/WebMvcSecurityConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configuration/WebMvcSecurityConfigurationTests.java
@@ -89,7 +89,7 @@ public class WebMvcSecurityConfigurationTests {
 
 	@Test
 	public void csrfToken() throws Exception {
-		CsrfToken csrfToken = new DefaultCsrfToken("headerName", "paramName", "token");
+		CsrfToken csrfToken = new DefaultCsrfToken("headerName", "paramName");
 		MockHttpServletRequestBuilder request = get("/csrf").requestAttr(
 				CsrfToken.class.getName(), csrfToken);
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/socket/AbstractSecurityWebSocketMessageBrokerConfigurerDocTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/socket/AbstractSecurityWebSocketMessageBrokerConfigurerDocTests.java
@@ -60,7 +60,7 @@ public class AbstractSecurityWebSocketMessageBrokerConfigurerDocTests {
 
 	@Before
 	public void setup() {
-		token = new DefaultCsrfToken("header", "param", "token");
+		token = new DefaultCsrfToken("header", "param");
 		sessionAttr = "sessionAttr";
 		messageUser = new TestingAuthenticationToken("user", "pass", "ROLE_USER");
 	}

--- a/config/src/test/java/org/springframework/security/config/annotation/web/socket/AbstractSecurityWebSocketMessageBrokerConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/socket/AbstractSecurityWebSocketMessageBrokerConfigurerTests.java
@@ -82,7 +82,7 @@ public class AbstractSecurityWebSocketMessageBrokerConfigurerTests {
 
 	@Before
 	public void setup() {
-		token = new DefaultCsrfToken("header", "param", "token");
+		token = new DefaultCsrfToken("header", "param");
 		sessionAttr = "sessionAttr";
 		messageUser = new TestingAuthenticationToken("user", "pass", "ROLE_USER");
 	}

--- a/messaging/src/main/java/org/springframework/security/messaging/web/csrf/CsrfChannelInterceptor.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/web/csrf/CsrfChannelInterceptor.java
@@ -58,7 +58,7 @@ public final class CsrfChannelInterceptor extends ChannelInterceptorAdapter {
 		String actualTokenValue = SimpMessageHeaderAccessor.wrap(message)
 				.getFirstNativeHeader(expectedToken.getHeaderName());
 
-		boolean csrfCheckPassed = expectedToken.getToken().equals(actualTokenValue);
+		boolean csrfCheckPassed = expectedToken.isValid(actualTokenValue);
 		if (csrfCheckPassed) {
 			return message;
 		}

--- a/messaging/src/test/java/org/springframework/security/messaging/web/csrf/CsrfChannelInterceptorTests.java
+++ b/messaging/src/test/java/org/springframework/security/messaging/web/csrf/CsrfChannelInterceptorTests.java
@@ -46,7 +46,7 @@ public class CsrfChannelInterceptorTests {
 
 	@Before
 	public void setup() {
-		token = new DefaultCsrfToken("header", "param", "token");
+		token = new DefaultCsrfToken("header", "param");
 		interceptor = new CsrfChannelInterceptor();
 
 		messageHeaders = SimpMessageHeaderAccessor.create(SimpMessageType.CONNECT);
@@ -126,7 +126,7 @@ public class CsrfChannelInterceptorTests {
 	@Test(expected = InvalidCsrfTokenException.class)
 	public void preSendInvalidToken() {
 		messageHeaders.setNativeHeader(token.getHeaderName(), token.getToken()
-				+ "invalid");
+			.replaceAll("^.{10}","INVALID000"));
 
 		interceptor.preSend(message(), channel);
 	}

--- a/messaging/src/test/java/org/springframework/security/messaging/web/socket/server/CsrfTokenHandshakeInterceptorTests.java
+++ b/messaging/src/test/java/org/springframework/security/messaging/web/socket/server/CsrfTokenHandshakeInterceptorTests.java
@@ -70,7 +70,7 @@ public class CsrfTokenHandshakeInterceptorTests {
 
 	@Test
 	public void beforeHandshake() throws Exception {
-		CsrfToken token = new DefaultCsrfToken("header", "param", "token");
+		CsrfToken token = new DefaultCsrfToken("header", "param");
 		httpRequest.setAttribute(CsrfToken.class.getName(), token);
 
 		interceptor.beforeHandshake(request, response, wsHandler, attributes);

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestBuildersFormLoginTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestBuildersFormLoginTests.java
@@ -44,8 +44,7 @@ public class SecurityMockMvcRequestBuildersFormLoginTests {
 		assertThat(request.getParameter("username")).isEqualTo("user");
 		assertThat(request.getParameter("password")).isEqualTo("password");
 		assertThat(request.getMethod()).isEqualTo("POST");
-		assertThat(request.getParameter(token.getParameterName()))
-				.isEqualTo(token.getToken());
+		assertThat(token.isValid(request.getParameter(token.getParameterName())));
 		assertThat(request.getRequestURI()).isEqualTo("/login");
 		assertThat(request.getParameter("_csrf")).isNotNull();
 	}
@@ -61,8 +60,7 @@ public class SecurityMockMvcRequestBuildersFormLoginTests {
 		assertThat(request.getParameter("username")).isEqualTo("admin");
 		assertThat(request.getParameter("password")).isEqualTo("secret");
 		assertThat(request.getMethod()).isEqualTo("POST");
-		assertThat(request.getParameter(token.getParameterName()))
-				.isEqualTo(token.getToken());
+		assertThat(token.isValid(request.getParameter(token.getParameterName())));
 		assertThat(request.getRequestURI()).isEqualTo("/login");
 	}
 

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestBuildersFormLogoutTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestBuildersFormLogoutTests.java
@@ -40,8 +40,7 @@ public class SecurityMockMvcRequestBuildersFormLogoutTests {
 		CsrfToken token = (CsrfToken) request.getAttribute(CsrfRequestPostProcessor.TestCsrfTokenRepository.ATTR_NAME);
 
 		assertThat(request.getMethod()).isEqualTo("POST");
-		assertThat(request.getParameter(token.getParameterName())).isEqualTo(
-				token.getToken());
+		assertThat(token.isValid(request.getParameter(token.getParameterName())));
 		assertThat(request.getRequestURI()).isEqualTo("/logout");
 	}
 
@@ -53,8 +52,7 @@ public class SecurityMockMvcRequestBuildersFormLogoutTests {
 		CsrfToken token = (CsrfToken) request.getAttribute(CsrfRequestPostProcessor.TestCsrfTokenRepository.ATTR_NAME);
 
 		assertThat(request.getMethod()).isEqualTo("POST");
-		assertThat(request.getParameter(token.getParameterName())).isEqualTo(
-				token.getToken());
+		assertThat(token.isValid(request.getParameter(token.getParameterName())));
 		assertThat(request.getRequestURI()).isEqualTo("/admin/logout");
 	}
 

--- a/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
@@ -62,8 +62,7 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 
 	@Override
 	public CsrfToken generateToken(HttpServletRequest request) {
-		return new DefaultCsrfToken(this.headerName, this.parameterName,
-				createNewToken());
+		return new DefaultCsrfToken(this.headerName, this.parameterName);
 	}
 
 	@Override
@@ -96,7 +95,7 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 		if (!StringUtils.hasLength(token)) {
 			return null;
 		}
-		return new DefaultCsrfToken(this.headerName, this.parameterName, token);
+		return new DefaultCsrfToken(this.headerName, this.parameterName);
 	}
 
 	/**
@@ -164,9 +163,5 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 		CookieCsrfTokenRepository result = new CookieCsrfTokenRepository();
 		result.setCookieHttpOnly(false);
 		return result;
-	}
-
-	private String createNewToken() {
-		return UUID.randomUUID().toString();
 	}
 }

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
@@ -105,7 +105,7 @@ public final class CsrfFilter extends OncePerRequestFilter {
 		if (actualToken == null) {
 			actualToken = request.getParameter(csrfToken.getParameterName());
 		}
-		if (!csrfToken.getToken().equals(actualToken)) {
+		if (!csrfToken.isValid(actualToken)) {
 			if (this.logger.isDebugEnabled()) {
 				this.logger.debug("Invalid CSRF token found for "
 						+ UrlUtils.buildFullRequestUrl(request));

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfToken.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfToken.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
  * @see DefaultCsrfToken
  *
  * @author Rob Winch
+ * @author John Ray
  * @since 3.2
  *
  */
@@ -49,4 +50,9 @@ public interface CsrfToken extends Serializable {
 	 */
 	String getToken();
 
+	/**
+	 * Check if a value returned by a previous call to getToken() matches this token.
+	 * @return true if the token is Valid
+	 */
+	boolean isValid(String value);
 }

--- a/web/src/main/java/org/springframework/security/web/csrf/HttpSessionCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/HttpSessionCsrfTokenRepository.java
@@ -15,8 +15,6 @@
  */
 package org.springframework.security.web.csrf;
 
-import java.util.UUID;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -87,8 +85,7 @@ public final class HttpSessionCsrfTokenRepository implements CsrfTokenRepository
 	 * servlet .http.HttpServletRequest)
 	 */
 	public CsrfToken generateToken(HttpServletRequest request) {
-		return new DefaultCsrfToken(this.headerName, this.parameterName,
-				createNewToken());
+		return new DefaultCsrfToken(this.headerName, this.parameterName);
 	}
 
 	/**
@@ -122,7 +119,4 @@ public final class HttpSessionCsrfTokenRepository implements CsrfTokenRepository
 		this.sessionAttributeName = sessionAttributeName;
 	}
 
-	private String createNewToken() {
-		return UUID.randomUUID().toString();
-	}
 }

--- a/web/src/main/java/org/springframework/security/web/csrf/LazyCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/LazyCsrfTokenRepository.java
@@ -130,6 +130,11 @@ public final class LazyCsrfTokenRepository implements CsrfTokenRepository {
 		}
 
 		@Override
+		public boolean isValid(String value) {
+			return delegate.isValid(value);
+		}
+
+		@Override
 		public String toString() {
 			return "SaveOnAccessCsrfToken [delegate=" + this.delegate + "]";
 		}

--- a/web/src/test/java/org/springframework/security/web/csrf/CookieCsrfTokenRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CookieCsrfTokenRepositoryTests.java
@@ -82,7 +82,7 @@ public class CookieCsrfTokenRepositoryTests {
 				.isEqualTo(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
 		assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
 		assertThat(tokenCookie.getSecure()).isEqualTo(this.request.isSecure());
-		assertThat(tokenCookie.getValue()).isEqualTo(token.getToken());
+		assertThat(token.isValid(tokenCookie.getValue()));
 		assertThat(tokenCookie.isHttpOnly()).isEqualTo(true);
 	}
 
@@ -204,7 +204,7 @@ public class CookieCsrfTokenRepositoryTests {
 		assertThat(loadToken).isNotNull();
 		assertThat(loadToken.getHeaderName()).isEqualTo(headerName);
 		assertThat(loadToken.getParameterName()).isEqualTo(parameterName);
-		assertThat(loadToken.getToken()).isEqualTo(value);
+		assertThat(loadToken.isValid(value));
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/web/src/test/java/org/springframework/security/web/csrf/CsrfAuthenticationStrategyTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CsrfAuthenticationStrategyTests.java
@@ -60,8 +60,8 @@ public class CsrfAuthenticationStrategyTests {
 		this.request = new MockHttpServletRequest();
 		this.request.setAttribute(HttpServletResponse.class.getName(), this.response);
 		this.strategy = new CsrfAuthenticationStrategy(this.csrfTokenRepository);
-		this.existingToken = new DefaultCsrfToken("_csrf", "_csrf", "1");
-		this.generatedToken = new DefaultCsrfToken("_csrf", "_csrf", "2");
+		this.existingToken = new DefaultCsrfToken("_csrf", "_csrf");
+		this.generatedToken = new DefaultCsrfToken("_csrf", "_csrf");
 	}
 
 	@Test(expected = IllegalArgumentException.class)
@@ -85,7 +85,7 @@ public class CsrfAuthenticationStrategyTests {
 		// SEC-2404, SEC-2832
 		CsrfToken tokenInRequest = (CsrfToken) this.request
 				.getAttribute(CsrfToken.class.getName());
-		assertThat(tokenInRequest.getToken()).isSameAs(this.generatedToken.getToken());
+		assertThat(tokenInRequest.isValid(this.generatedToken.getToken()));
 		assertThat(tokenInRequest.getHeaderName())
 				.isSameAs(this.generatedToken.getHeaderName());
 		assertThat(tokenInRequest.getParameterName())

--- a/web/src/test/java/org/springframework/security/web/csrf/CsrfFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CsrfFilterTests.java
@@ -69,7 +69,7 @@ public class CsrfFilterTests {
 
 	@Before
 	public void setup() {
-		this.token = new DefaultCsrfToken("headerName", "paramName", "csrfTokenValue");
+		this.token = new DefaultCsrfToken("headerName", "paramName");
 		resetRequestResponse();
 		this.filter = createCsrfFilter(this.tokenRepository);
 	}
@@ -140,7 +140,7 @@ public class CsrfFilterTests {
 		when(this.requestMatcher.matches(this.request)).thenReturn(true);
 		when(this.tokenRepository.loadToken(this.request)).thenReturn(this.token);
 		this.request.setParameter(this.token.getParameterName(),
-				this.token.getToken() + " INVALID");
+				this.token.getToken().replaceAll("^.{10}","INVALID000"));
 
 		this.filter.doFilter(this.request, this.response, this.filterChain);
 
@@ -160,7 +160,7 @@ public class CsrfFilterTests {
 		when(this.requestMatcher.matches(this.request)).thenReturn(true);
 		when(this.tokenRepository.loadToken(this.request)).thenReturn(this.token);
 		this.request.addHeader(this.token.getHeaderName(),
-				this.token.getToken() + " INVALID");
+			this.token.getToken().replaceAll("^.{10}","INVALID000"));
 
 		this.filter.doFilter(this.request, this.response, this.filterChain);
 
@@ -181,7 +181,7 @@ public class CsrfFilterTests {
 		when(this.tokenRepository.loadToken(this.request)).thenReturn(this.token);
 		this.request.setParameter(this.token.getParameterName(), this.token.getToken());
 		this.request.addHeader(this.token.getHeaderName(),
-				this.token.getToken() + " INVALID");
+			this.token.getToken().replaceAll("^.{10}","INVALID000"));
 
 		this.filter.doFilter(this.request, this.response, this.filterChain);
 
@@ -420,7 +420,7 @@ public class CsrfFilterTests {
 			assertThat(this.actual.getHeaderName()).isEqualTo(expected.getHeaderName());
 			assertThat(this.actual.getParameterName())
 					.isEqualTo(expected.getParameterName());
-			assertThat(this.actual.getToken()).isEqualTo(expected.getToken());
+			assertThat(this.actual.isValid(expected.getToken()));
 			return this;
 		}
 	}

--- a/web/src/test/java/org/springframework/security/web/csrf/DefaultCsrfTokenTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/DefaultCsrfTokenTests.java
@@ -16,6 +16,7 @@
 package org.springframework.security.web.csrf;
 
 import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Rob Winch
@@ -24,35 +25,41 @@ import org.junit.Test;
 public class DefaultCsrfTokenTests {
 	private final String headerName = "headerName";
 	private final String parameterName = "parameterName";
-	private final String tokenValue = "tokenValue";
 
 	@Test(expected = IllegalArgumentException.class)
 	public void constructorNullHeaderName() {
-		new DefaultCsrfToken(null, parameterName, tokenValue);
+		new DefaultCsrfToken(null, parameterName);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void constructorEmptyHeaderName() {
-		new DefaultCsrfToken("", parameterName, tokenValue);
+		new DefaultCsrfToken("", parameterName);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void constructorNullParameterName() {
-		new DefaultCsrfToken(headerName, null, tokenValue);
+		new DefaultCsrfToken(headerName, null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void constructorEmptyParameterName() {
-		new DefaultCsrfToken(headerName, "", tokenValue);
+		new DefaultCsrfToken(headerName, "");
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void constructorNullTokenValue() {
-		new DefaultCsrfToken(headerName, parameterName, null);
+	@Test
+	public void testIsValid() {
+		DefaultCsrfToken token = new DefaultCsrfToken(headerName, parameterName);
+
+		String value1 = token.getToken();
+		assertThat(value1).isNotEmpty();
+		String value2 = token.getToken();
+		assertThat(value2).isNotEmpty();
+
+		assertThat(value1).doesNotMatch(value2);
+
+		assertThat(token.isValid(value1)).isTrue();
+		assertThat(token.isValid(value2)).isTrue();
+		assertThat(token.isValid(value2.replaceAll("^.{10}","INVALID000"))).isFalse();
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void constructorEmptyTokenValue() {
-		new DefaultCsrfToken(headerName, parameterName, "");
-	}
 }

--- a/web/src/test/java/org/springframework/security/web/csrf/HttpSessionCsrfTokenRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/HttpSessionCsrfTokenRepositoryTests.java
@@ -89,7 +89,7 @@ public class HttpSessionCsrfTokenRepositoryTests {
 
 	@Test
 	public void saveToken() {
-		CsrfToken tokenToSave = new DefaultCsrfToken("123", "abc", "def");
+		CsrfToken tokenToSave = new DefaultCsrfToken("123", "abc");
 		repo.saveToken(tokenToSave, request, response);
 
 		String attrName = request.getSession().getAttributeNames().nextElement();
@@ -100,7 +100,7 @@ public class HttpSessionCsrfTokenRepositoryTests {
 
 	@Test
 	public void saveTokenCustomSessionAttribute() {
-		CsrfToken tokenToSave = new DefaultCsrfToken("123", "abc", "def");
+		CsrfToken tokenToSave = new DefaultCsrfToken("123", "abc");
 		String sessionAttributeName = "custom";
 		repo.setSessionAttributeName(sessionAttributeName);
 		repo.saveToken(tokenToSave, request, response);

--- a/web/src/test/java/org/springframework/security/web/csrf/LazyCsrfTokenRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/LazyCsrfTokenRepositoryTests.java
@@ -51,7 +51,7 @@ public class LazyCsrfTokenRepositoryTests {
 
 	@Before
 	public void setup() {
-		this.token = new DefaultCsrfToken("header", "param", "token");
+		this.token = new DefaultCsrfToken("header", "param");
 		when(this.delegate.generateToken(this.request)).thenReturn(this.token);
 		when(this.request.getAttribute(HttpServletResponse.class.getName()))
 				.thenReturn(this.response);

--- a/web/src/test/java/org/springframework/security/web/method/annotation/CsrfTokenArgumentResolverTests.java
+++ b/web/src/test/java/org/springframework/security/web/method/annotation/CsrfTokenArgumentResolverTests.java
@@ -55,7 +55,7 @@ public class CsrfTokenArgumentResolverTests {
 
 	@Before
 	public void setup() {
-		token = new DefaultCsrfToken("X-CSRF-TOKEN", "_csrf", "secret");
+		token = new DefaultCsrfToken("X-CSRF-TOKEN", "_csrf");
 		resolver = new CsrfTokenArgumentResolver();
 		request = new MockHttpServletRequest();
 		webRequest = new ServletWebRequest(request);

--- a/web/src/test/java/org/springframework/security/web/servlet/support/csrf/CsrfRequestDataValueProcessorTests.java
+++ b/web/src/test/java/org/springframework/security/web/servlet/support/csrf/CsrfRequestDataValueProcessorTests.java
@@ -46,7 +46,7 @@ public class CsrfRequestDataValueProcessorTests {
 		request = new MockHttpServletRequest();
 		processor = new CsrfRequestDataValueProcessor();
 
-		token = new DefaultCsrfToken("1", "a", "b");
+		token = new DefaultCsrfToken("1", "a");
 		request.setAttribute(CsrfToken.class.getName(), token);
 
 		expected.put(token.getParameterName(), token.getToken());
@@ -127,7 +127,7 @@ public class CsrfRequestDataValueProcessorTests {
 
 	@Test
 	public void createGetExtraHiddenFieldsHasCsrfToken() {
-		CsrfToken token = new DefaultCsrfToken("1", "a", "b");
+		CsrfToken token = new DefaultCsrfToken("1", "a");
 		request.setAttribute(CsrfToken.class.getName(), token);
 		Map<String, String> expected = new HashMap<String, String>();
 		expected.put(token.getParameterName(), token.getToken());


### PR DESCRIPTION
This is to fix issue 4001. The changes are:
- add an isValid() method to the CsrfToken interface to compare a String value from a HTTP request to a CsrfToken object.
- Modify DefaultCsrfToken
    - The constructor now generate it's own CSRF token instead of having it passed in
    - getToken() always return a different value. 
    - Implement the isValid() method to check if a value is valid.
- The remainder of the changes were needed because of the DefaultCsrfToken constructor change and that isValid() must be called instead of the caller doing it's own string compare.
