### PR TITLE
Fix typo in autowiring warning

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfiguration.java
@@ -400,7 +400,7 @@ public class GlobalMethodSecurityConfiguration
 	public void setMethodSecurityExpressionHandler(
 			List<MethodSecurityExpressionHandler> handlers) {
 		if (handlers.size() != 1) {
-			logger.debug("Not autwiring PermissionEvaluator since size != 1. Got "
+			logger.debug("Not autowiring MethodSecurityExpressionHandler since size != 1. Got "
 					+ handlers);
 			return;
 		}


### PR DESCRIPTION
Fixes a misleading message that warns about PermissionEvaluator when MethodSecurityExpressionHandler should be mentioned instead.

Fixes #3402