### PR TITLE
LdapUserDetails extends CredentialsContainer

### DIFF
--- a/ldap/src/main/java/org/springframework/security/ldap/userdetails/LdapUserDetails.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/userdetails/LdapUserDetails.java
@@ -16,6 +16,7 @@
 
 package org.springframework.security.ldap.userdetails;
 
+import org.springframework.security.core.CredentialsContainer;
 import org.springframework.security.core.userdetails.UserDetails;
 
 /**
@@ -23,7 +24,7 @@ import org.springframework.security.core.userdetails.UserDetails;
  *
  * @author Luke Taylor
  */
-public interface LdapUserDetails extends UserDetails {
+public interface LdapUserDetails extends UserDetails, CredentialsContainer {
 	// ~ Methods
 	// ========================================================================================================
 

--- a/ldap/src/main/java/org/springframework/security/ldap/userdetails/LdapUserDetailsImpl.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/userdetails/LdapUserDetailsImpl.java
@@ -106,6 +106,11 @@ public class LdapUserDetailsImpl implements LdapUserDetails, PasswordPolicyData 
 	public boolean isEnabled() {
 		return enabled;
 	}
+	
+	@Override
+	public void eraseCredentials() {
+		password = null;
+	}
 
 	public int getTimeBeforeExpiration() {
 		return timeBeforeExpiration;


### PR DESCRIPTION
Now, LdapUserDetails extends CredentialsContainer for clear LDAP passwords when erase-credentials is true.

Fixes #4029