### PR TITLE
AcegiSecurity - Tomcat8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+.metadata/
+.recommenders/
+.settings/
+.externalToolBuilders/
+.factorypath/
+.idea/
+bin/
+tmp/
+target/
+*.tmp
+*.bak
+*.swp
+*.launch
+.classpath
+.project
+*.iml
+src/local/*

--- a/adapters/pom.xml
+++ b/adapters/pom.xml
@@ -26,5 +26,6 @@
     <module>jboss</module>
     <module>jetty</module>
     <module>resin</module>
+    <module>tomcat8</module>
   </modules>
 </project>

--- a/adapters/tomcat8/.cvsignore
+++ b/adapters/tomcat8/.cvsignore
@@ -1,0 +1,5 @@
+target
+.settings
+.classpath
+.project
+.wtpmodules

--- a/adapters/tomcat8/pom.xml
+++ b/adapters/tomcat8/pom.xml
@@ -1,0 +1,17 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.acegisecurity</groupId>
+        <artifactId>acegi-security-adapters</artifactId>
+        <version>1.0.7</version>
+    </parent>
+    <artifactId>acegi-security-tomcat8</artifactId>
+    <name>Acegi Security System for Spring - Tomcat 8 adapter</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-catalina</artifactId>
+            <version>8.5.4</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/adapters/tomcat8/src/main/java/org/acegisecurity/adapters/tomcat8/Tomcat8AcegiUserRealm.java
+++ b/adapters/tomcat8/src/main/java/org/acegisecurity/adapters/tomcat8/Tomcat8AcegiUserRealm.java
@@ -1,0 +1,219 @@
+/* Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.acegisecurity.adapters.tomcat8;
+
+import org.acegisecurity.Authentication;
+import org.acegisecurity.AuthenticationException;
+import org.acegisecurity.AuthenticationManager;
+import org.acegisecurity.GrantedAuthority;
+import org.acegisecurity.adapters.PrincipalAcegiUserToken;
+import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
+import org.apache.catalina.Container;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.realm.GenericPrincipal;
+import org.apache.catalina.realm.RealmBase;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.context.support.FileSystemXmlApplicationContext;
+
+import java.io.File;
+import java.security.Principal;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Adapter to enable Catalina (Tomcat) to authenticate via the Acegi Security System for Spring.<p>Returns a {@link
+ * PrincipalAcegiUserToken} to Catalina's authentication system, which is subsequently available via
+ * <code>HttpServletRequest.getUserPrincipal()</code>.</p>
+ *
+ * @author Ben Alex
+ * @version $Id$
+ */
+public class Tomcat8AcegiUserRealm extends RealmBase {
+	//~ Static fields/initializers =====================================================================================
+
+	private static final Log logger = LogFactory.getLog(Tomcat8AcegiUserRealm.class);
+
+	//~ Instance fields ================================================================================================
+
+	private AuthenticationManager authenticationManager;
+	private Container container;
+	private String appContextLocation;
+	private String key;
+	protected final String name = "Tomcat8SpringUserRealm / $Id$";
+
+	//~ Methods ========================================================================================================
+
+	public Principal authenticate(String username, String credentials) {
+		if (username == null) {
+			return null;
+		}
+
+		if (credentials == null) {
+			credentials = "";
+		}
+
+		Authentication request = new UsernamePasswordAuthenticationToken(username, credentials);
+		Authentication response = null;
+
+		try {
+			response = authenticationManager.authenticate(request);
+		} catch (AuthenticationException failed) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Authentication request for user: " + username + " failed: " + failed.toString());
+			}
+
+			return null;
+		}
+
+		final PrincipalAcegiUserToken principalAcegiUserToken = new PrincipalAcegiUserToken(this.key, response.getPrincipal().toString(), response.getCredentials().toString(), response.getAuthorities(), response.getPrincipal());
+
+		final List roles = new ArrayList();
+
+		for (int i = 0; i < response.getAuthorities().length; i++) {
+			roles.add(response.getAuthorities()[i].toString());
+		}
+
+		return new GenericPrincipal(username, credentials, roles, principalAcegiUserToken);
+	}
+
+	public Principal authenticate(String username, byte[] credentials) {
+		return authenticate(username, new String(credentials));
+	}
+
+	/**
+	 * Not supported, returns null
+	 *
+	 * @param username DOCUMENT ME!
+	 * @param digest DOCUMENT ME!
+	 * @param nonce DOCUMENT ME!
+	 * @param nc DOCUMENT ME!
+	 * @param cnonce DOCUMENT ME!
+	 * @param qop DOCUMENT ME!
+	 * @param realm DOCUMENT ME!
+	 * @param md5a2 DOCUMENT ME!
+	 *
+	 * @return DOCUMENT ME!
+	 */
+	public Principal authenticate(String username, String digest, String nonce, String nc, String cnonce, String qop, String realm, String md5a2) {
+		return null;
+	}
+
+	/**
+	 * Not supported, returns null
+	 *
+	 * @param x509Certificates DOCUMENT ME!
+	 *
+	 * @return DOCUMENT ME!
+	 */
+	public Principal authenticate(X509Certificate[] x509Certificates) {
+		return null;
+	}
+
+	public String getAppContextLocation() {
+		return appContextLocation;
+	}
+
+	public String getKey() {
+		return key;
+	}
+
+	protected String getName() {
+		return this.name;
+	}
+
+	/**
+	 * Always returns null (we override authenticate methods)
+	 *
+	 * @param arg0 DOCUMENT ME!
+	 *
+	 * @return DOCUMENT ME!
+	 */
+	protected String getPassword(String arg0) {
+		return null;
+	}
+
+	/**
+	 * Always returns null (we override authenticate methods)
+	 *
+	 * @param arg0 DOCUMENT ME!
+	 *
+	 * @return DOCUMENT ME!
+	 */
+	protected Principal getPrincipal(String arg0) {
+		return null;
+	}
+
+	public boolean hasRole(Principal principal, String role) {
+		if ((principal == null) || (role == null)) {
+			return false;
+		}
+
+		if (!(principal instanceof PrincipalAcegiUserToken)) {
+			logger.warn("Expected passed principal to be of type PrincipalAcegiUserToken but was " + principal.getClass().getName());
+
+			return false;
+		}
+
+		PrincipalAcegiUserToken test = (PrincipalAcegiUserToken) principal;
+
+		return test.isUserInRole(role);
+	}
+
+	public void setAppContextLocation(String appContextLocation) {
+		this.appContextLocation = appContextLocation;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+	}
+
+	/**
+	 * Provides the method that Catalina will use to start the container.
+	 *
+	 * @throws LifecycleException if a problem is detected
+	 */
+	public void startInternal() throws LifecycleException {
+		super.startInternal();
+
+		if ((appContextLocation == null) || "".equals(appContextLocation)) {
+			throw new LifecycleException("appContextLocation must be defined");
+		}
+
+		if ((key == null) || "".equals(key)) {
+			throw new LifecycleException("key must be defined");
+		}
+
+		File xml = new File(System.getProperty("catalina.base"), appContextLocation);
+
+		if (!xml.exists()) {
+			throw new LifecycleException("appContextLocation does not seem to exist in " + xml.toString());
+		}
+
+		FileSystemXmlApplicationContext ctx = new FileSystemXmlApplicationContext("file:" + xml.getAbsolutePath());
+		Map beans = ctx.getBeansOfType(AuthenticationManager.class, true, true);
+
+		if (beans.size() == 0) {
+			throw new IllegalArgumentException("Bean context must contain at least one bean of type AuthenticationManager");
+		}
+
+		String beanName = (String) beans.keySet().iterator().next();
+		authenticationManager = (AuthenticationManager) beans.get(beanName);
+		logger.info("Tomcat8AcegiUserRealm Started");
+	}
+}


### PR DESCRIPTION
Acegi security does not work with Tomcat8. This implementation can make it work. It's a new module based on Catalina adapter using a new version of tomcat-catalina lib.

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
