### PR TITLE
Improve exception message on Hex#decode

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/codec/Hex.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/codec/Hex.java
@@ -59,7 +59,8 @@ public final class Hex {
 			int lsb = Character.digit(s.charAt(i + 1), 16);
 
 			if (msb < 0 || lsb < 0) {
-				throw new IllegalArgumentException("Non-hex character in input: " + s);
+				throw new IllegalArgumentException(
+					"Detected a Non-hex character at " + (i + 1) + " or " + (i + 2) + " position");
 			}
 			result[i / 2] = (byte) ((msb << 4) | lsb);
 		}

--- a/crypto/src/test/java/org/springframework/security/crypto/codec/HexTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/codec/HexTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.crypto.codec;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test cases for {@link Hex}.
+ *
+ * @author Kazuki Shimizu
+ */
+public class HexTests {
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	@Test
+	public void encode() {
+		assertThat(Hex.encode(new byte[] { (byte) 'A', (byte) 'B', (byte) 'C',
+				(byte) 'D' })).isEqualTo(new char[] {'4','1','4','2','4','3','4','4'});
+	}
+
+	@Test
+	public void encodeEmptyByteArray() {
+		assertThat(Hex.encode(new byte[] {})).isEmpty();
+	}
+
+	@Test
+	public void decode() {
+		assertThat(Hex.decode("41424344")).isEqualTo(new byte[] { (byte) 'A', (byte) 'B', (byte) 'C',
+			(byte) 'D' });
+	}
+
+	@Test
+	public void decodeEmptyString() {
+		assertThat(Hex.decode("")).isEmpty();
+	}
+
+	@Test
+	public void decodeNotEven() {
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("Hex-encoded string must have an even number of characters");
+		Hex.decode("414243444");
+	}
+
+	@Test
+	public void decodeExistNonHexCharAtFirst() {
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("Detected a Non-hex character at 1 or 2 position");
+		Hex.decode("G0");
+	}
+
+	@Test
+	public void decodeExistNonHexCharAtSecond() {
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("Detected a Non-hex character at 3 or 4 position");
+		Hex.decode("410G");
+	}
+
+	@Test
+	public void decodeExistNonHexCharAtBoth() {
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("Detected a Non-hex character at 5 or 6 position");
+		Hex.decode("4142GG");
+	}
+
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
I've backported gh-4043 to 4.1.x line.