### PR TITLE
Add cookiePath to CookieCsrfTokenRepository

### DIFF
--- a/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
@@ -53,7 +53,7 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 
 	private boolean cookieHttpOnly;
 
-  private String cookiePath;
+	private String cookiePath;
 
 	public CookieCsrfTokenRepository() {
 		this.setHttpOnlyMethod = ReflectionUtils.findMethod(Cookie.class, "setHttpOnly", boolean.class);
@@ -74,11 +74,11 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 		String tokenValue = token == null ? "" : token.getToken();
 		Cookie cookie = new Cookie(this.cookieName, tokenValue);
 		cookie.setSecure(request.isSecure());
-    if ( this.cookiePath != null && !this.cookiePath.isEmpty()) {
-		  cookie.setPath(this.cookiePath);
-    } else {
-		  cookie.setPath(this.getRequestContext(request));
-    }
+		if ( this.cookiePath != null && !this.cookiePath.isEmpty()) {
+				cookie.setPath(this.cookiePath);
+		} else {
+				cookie.setPath(this.getRequestContext(request));
+		}
 		if (token == null) {
 			cookie.setMaxAge(0);
 		}
@@ -176,11 +176,11 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 		return UUID.randomUUID().toString();
 	}
 
-  public void setCookiePath(String path) {
-    this.cookiePath = path;
-  }
-  
-  public void getCookiePath() {
-    return this.cookiePath;
-  }
+		public void setCookiePath(String path) {
+				this.cookiePath = path;
+		}
+
+		public void getCookiePath() {
+				return this.cookiePath;
+		}
 }

--- a/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
@@ -176,10 +176,21 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 		return UUID.randomUUID().toString();
 	}
 
+	/**
+	 * Set the path that the Cookie will be created with. This will will override the default functionality which uses the
+	 * request context as the path.
+	 *
+	 * @param path the path to use
+	 */
 	public void setCookiePath(String path) {
 		this.cookiePath = path;
 	}
 
+	/**
+	 * Get the path that the CSRF cookie will be set to.
+	 *
+	 * @return the path to be used.
+	 */
 	public String getCookiePath() {
 		return this.cookiePath;
 	}

--- a/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
@@ -74,7 +74,7 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 		String tokenValue = token == null ? "" : token.getToken();
 		Cookie cookie = new Cookie(this.cookieName, tokenValue);
 		cookie.setSecure(request.isSecure());
-		if ( this.cookiePath != null && !this.cookiePath.isEmpty()) {
+		if (this.cookiePath != null && !this.cookiePath.isEmpty()) {
 				cookie.setPath(this.cookiePath);
 		} else {
 				cookie.setPath(this.getRequestContext(request));
@@ -176,11 +176,11 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 		return UUID.randomUUID().toString();
 	}
 
-		public void setCookiePath(String path) {
-				this.cookiePath = path;
-		}
+	public void setCookiePath(String path) {
+		this.cookiePath = path;
+	}
 
-		public void getCookiePath() {
-				return this.cookiePath;
-		}
+	public void getCookiePath() {
+		return this.cookiePath;
+	}
 }

--- a/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
@@ -180,7 +180,7 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 		this.cookiePath = path;
 	}
 
-	public void getCookiePath() {
+	public String getCookiePath() {
 		return this.cookiePath;
 	}
 }

--- a/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
@@ -53,6 +53,8 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 
 	private boolean cookieHttpOnly;
 
+  private String cookiePath;
+
 	public CookieCsrfTokenRepository() {
 		this.setHttpOnlyMethod = ReflectionUtils.findMethod(Cookie.class, "setHttpOnly", boolean.class);
 		if (this.setHttpOnlyMethod != null) {
@@ -72,7 +74,11 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 		String tokenValue = token == null ? "" : token.getToken();
 		Cookie cookie = new Cookie(this.cookieName, tokenValue);
 		cookie.setSecure(request.isSecure());
-		cookie.setPath(getCookiePath(request));
+    if ( this.cookiePath != null && !this.cookiePath.isEmpty()) {
+		  cookie.setPath(this.cookiePath);
+    } else {
+		  cookie.setPath(this.getRequestContext(request));
+    }
 		if (token == null) {
 			cookie.setMaxAge(0);
 		}
@@ -148,7 +154,7 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 		this.cookieHttpOnly = cookieHttpOnly;
 	}
 
-	private String getCookiePath(HttpServletRequest request) {
+	private String getRequestContext(HttpServletRequest request) {
 		String contextPath = request.getContextPath();
 		return contextPath.length() > 0 ? contextPath : "/";
 	}
@@ -169,4 +175,12 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 	private String createNewToken() {
 		return UUID.randomUUID().toString();
 	}
+
+  public void setCookiePath(String path) {
+    this.cookiePath = path;
+  }
+  
+  public void getCookiePath() {
+    return this.cookiePath;
+  }
 }

--- a/web/src/test/java/org/springframework/security/web/csrf/CookieCsrfTokenRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CookieCsrfTokenRepositoryTests.java
@@ -149,10 +149,10 @@ public class CookieCsrfTokenRepositoryTests {
 
 		assertThat(tokenCookie.isHttpOnly()).isFalse();
 	}
-  
-  @Test
+
+	@Test
 	public void saveTokenCustomPath() {
-    String customPath = "/custompath";
+		String customPath = "/custompath";
 		this.repository.setCookiePath(customPath);
 		CsrfToken token = this.repository.generateToken(this.request);
 		this.repository.saveToken(token, this.request, this.response);
@@ -162,10 +162,10 @@ public class CookieCsrfTokenRepositoryTests {
 
 		assertThat(tokenCookie.getPath()).isEqualTo(this.repository.getCookiePath());
 	}
-  
-  @Test
+
+	@Test
 	public void saveTokenEmptyCustomPath() {
-    String customPath = "";
+		String customPath = "";
 		this.repository.setCookiePath(customPath);
 		CsrfToken token = this.repository.generateToken(this.request);
 		this.repository.saveToken(token, this.request, this.response);
@@ -175,10 +175,10 @@ public class CookieCsrfTokenRepositoryTests {
 
 		assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
 	}
-  
-  @Test
+
+	@Test
 	public void saveTokenNullCustomPath() {
-    String customPath = null;
+		String customPath = null;
 		this.repository.setCookiePath(customPath);
 		CsrfToken token = this.repository.generateToken(this.request);
 		this.repository.saveToken(token, this.request, this.response);

--- a/web/src/test/java/org/springframework/security/web/csrf/CookieCsrfTokenRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CookieCsrfTokenRepositoryTests.java
@@ -149,6 +149,45 @@ public class CookieCsrfTokenRepositoryTests {
 
 		assertThat(tokenCookie.isHttpOnly()).isFalse();
 	}
+  
+  @Test
+	public void saveTokenCustomPath() {
+    String customPath = "/custompath";
+		this.repository.setCookiePath(customPath);
+		CsrfToken token = this.repository.generateToken(this.request);
+		this.repository.saveToken(token, this.request, this.response);
+
+		Cookie tokenCookie = this.response
+				.getCookie(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+		assertThat(tokenCookie.getPath()).isEqualTo(this.repository.getCookiePath());
+	}
+  
+  @Test
+	public void saveTokenEmptyCustomPath() {
+    String customPath = "";
+		this.repository.setCookiePath(customPath);
+		CsrfToken token = this.repository.generateToken(this.request);
+		this.repository.saveToken(token, this.request, this.response);
+
+		Cookie tokenCookie = this.response
+				.getCookie(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+		assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
+	}
+  
+  @Test
+	public void saveTokenNullCustomPath() {
+    String customPath = null;
+		this.repository.setCookiePath(customPath);
+		CsrfToken token = this.repository.generateToken(this.request);
+		this.repository.saveToken(token, this.request, this.response);
+
+		Cookie tokenCookie = this.response
+				.getCookie(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+		assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
+	}
 
 	@Test
 	public void loadTokenNoCookiesNull() {


### PR DESCRIPTION
When using Spring Security to secure a REST API and a JS frontend I run the REST API using Tomcat and the frontend using NPM. Both tomcat and NPM are exposed via an NGINX reverse proxy which forwards / to NPM and /api to tomcat.

I ran into an issue implementing CSRF protection with an AngularJS app in which making a request to tomcat at /api the CSRF cookie's path would be set to /api. In order for Angular to be able to see the cookie the path needs to be set to /. This pull request would allow for the CSRF cookie's path to be set explicitly instead of being derived from the request context and would only set the path if the developer explicitly wanted to otherwise it will default to using the request context. 