### PR TITLE
Wording fixes: Obvious Fix

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/WebSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/WebSecurity.java
@@ -113,7 +113,7 @@ public final class WebSecurity extends
 
 	/**
 	 * <p>
-	 * Allows adding {@link RequestMatcher} instances that should that Spring Security
+	 * Allows adding {@link RequestMatcher} instances that Spring Security
 	 * should ignore. Web Security provided by Spring Security (including the
 	 * {@link SecurityContext}) will not be available on {@link HttpServletRequest} that
 	 * match. Typically the requests that are registered should be that of only static

--- a/docs/manual/src/docs/asciidoc/index.adoc
+++ b/docs/manual/src/docs/asciidoc/index.adoc
@@ -4089,7 +4089,7 @@ protected void configure(HttpSecurity http) throws Exception {
 
 [[headers-xss-protection]]
 ==== X-XSS-Protection
-Some browsers have built in support for filtering out https://www.owasp.org/index.php/Testing_for_Reflected_Cross_site_scripting_(OWASP-DV-001)[reflected XSS attacks]. This is by no means full proof, but does assist in XSS protection.
+Some browsers have built in support for filtering out https://www.owasp.org/index.php/Testing_for_Reflected_Cross_site_scripting_(OWASP-DV-001)[reflected XSS attacks]. This is by no means foolproof, but does assist in XSS protection.
 
 The filtering is typically enabled by default, so adding the header typically just ensures it is enabled and instructs the browser what to do when a XSS attack is detected. For example, the filter might try to change the content in the least invasive way to still render everything. At times, this type of replacement can become a http://hackademix.net/2009/11/21/ies-xss-filter-creates-xss-vulnerabilities/[XSS vulnerability in itself]. Instead, it is best to block the content rather than attempt to fix it. To do this we can add the following header:
 


### PR DESCRIPTION
Fix some appalling English :-) There was one more thing that I can't fix:

docs/manual/src/docs/asciidoc/index.adoc:4041:Another modern approach to dealing with clickjacking is to use <<headers-content-security-policy>>.

Perhaps that reference is not alive? Shows up as ??? in 20.1.5 of http://docs.spring.io/spring-security/site/docs/current/reference/html/headers.html