### PR TITLE
Add open redirect prevention

### DIFF
--- a/taglibs/src/main/java/org/springframework/security/taglibs/redirect/RedirectorTag.java
+++ b/taglibs/src/main/java/org/springframework/security/taglibs/redirect/RedirectorTag.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.taglibs.redirect;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.tagext.TagSupport;
+
+import org.springframework.security.web.redirect.SignCalculator;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * A JSP tag to generate hidden field for signature of redirect target URL.
+ *
+ * @author Takuya Iwatsuka
+ */
+@SuppressWarnings("serial")
+public class RedirectorTag extends TagSupport {
+
+	private String redirectorUrl;
+
+	private String text;
+
+	private String targetUrl;
+
+	private boolean hidden = false;
+
+	public void setRedirectorUrl(String redirectorUrl) {
+		this.redirectorUrl = redirectorUrl;
+	}
+
+	public String getRedirectorUrl() {
+		return redirectorUrl;
+	}
+
+	public void setText(String text) {
+		this.text = text;
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public void setTargetUrl(String targetUrl) {
+		Assert.hasLength(targetUrl);
+		this.targetUrl = targetUrl;
+	}
+
+	public String getTargetUrl() {
+		return targetUrl;
+	}
+
+	public void setHidden(boolean hidden) {
+		this.hidden = hidden;
+	}
+
+	public boolean isHidden() {
+		return hidden;
+	}
+
+	@Override
+	public int doEndTag() throws JspException {
+		if(!hidden && !StringUtils.hasLength(redirectorUrl)){
+			throw new JspException("The value of redirectorUrl must not be empty.");
+		}
+
+		ServletRequest request = pageContext.getRequest();
+		SignCalculator signCalculator = (SignCalculator) request
+				.getAttribute("_signCalculator");
+		String redirectParameter = (String) request
+				.getAttribute("_redirectParameter");
+		String signParameter = (String) request.getAttribute("_signParameter");
+		String sign = signCalculator.calculateSign(targetUrl);
+
+		StringBuilder builder;
+		if(hidden){
+			builder = new StringBuilder(
+					"<input type=\"hidden\" name=\"").append(redirectParameter)
+					.append("\" value=\"").append(targetUrl).append("\" />\n")
+					.append("<input type=\"hidden\" name=\"").append(signParameter)
+					.append("\" value=\"")
+					.append(sign)
+					.append("\" />");
+		} else {
+			UriComponents uriComponent = UriComponentsBuilder.fromUriString(redirectorUrl)
+					.queryParam(redirectParameter, targetUrl)
+					.queryParam(signParameter, sign).build();
+			builder = new StringBuilder("<a href=\"")
+					.append(uriComponent.toUriString())
+					.append("\">");
+			if(StringUtils.hasLength(text)){
+				builder.append(text);
+			}else{
+				builder.append(redirectorUrl);
+			}
+			builder.append("</a>");
+		}
+
+		try {
+			pageContext.getOut().write(builder.toString());
+		} catch (Exception e) {
+			throw new JspException(e);
+		}
+
+		return EVAL_PAGE;
+	}
+}

--- a/taglibs/src/main/resources/META-INF/security.tld
+++ b/taglibs/src/main/resources/META-INF/security.tld
@@ -192,4 +192,52 @@
         <body-content>empty</body-content>
     </tag>
 
+
+    <tag>
+        <description>
+            If Open Redirect protection is enabled, this tag calculate the signature for the redirect's target URL which
+            is specified as a value of the attribute.
+            The URL and the signature are inserted to the page as hidden form fields or query strings to the redirector.
+        </description>
+        <name>redirector</name>
+        <tag-class>org.springframework.security.taglibs.redirect.RedirectorTag</tag-class>
+        <body-content>empty</body-content>
+
+        <attribute>
+            <description>
+                A redirect's target URL. The signature calculated from this URL will be embedded in the page.
+            </description>
+            <name>targetUrl</name>
+            <required>true</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <description>
+                A redirector's URL. If the "hidden" attribute is set false, the tag generate link to this URL.
+                The generated link contains the redirect's target URL and the signature as query strings.
+            </description>
+            <name>redirectorUrl</name>
+            <required>false</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <description>
+                A text for a link that the tag generate. If this attribute does not be set, the value of
+                the "redirectorUrl" attribute is used as the text.
+            </description>
+            <name>text</name>
+            <required>false</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <description>
+                A flag to decide whether the redirect's target URL and the signature will be embedded as hidden field.
+                If the value of this attribute is set true, the tag will not generate a link.
+                The default value is false.
+            </description>
+            <name>hidden</name>
+            <required>false</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+    </tag>
 </taglib>

--- a/taglibs/src/test/java/org/springframework/security/taglibs/redirect/RedirectorTagTests.java
+++ b/taglibs/src/test/java/org/springframework/security/taglibs/redirect/RedirectorTagTests.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.taglibs.redirect;
+
+import java.io.UnsupportedEncodingException;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.tagext.TagSupport;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockPageContext;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.security.web.redirect.SignCalculator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RedirectorTagTests {
+
+	@Mock
+	private SignCalculator signCalculator;
+
+	private MockHttpServletRequest request;
+
+	private MockHttpServletResponse response;
+
+	private RedirectorTag redirectorTag;
+
+	@Before
+	public void setup() {
+		this.request = new MockHttpServletRequest();
+		this.response = new MockHttpServletResponse();
+		this.redirectorTag = new RedirectorTag();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void setTargetUrlNull(){
+		this.redirectorTag.setTargetUrl(null);
+	}
+
+	@Test(expected = JspException.class)
+	public void setRedirectorUrlNull() throws JspException{
+		this.redirectorTag.setRedirectorUrl(null);
+		this.redirectorTag.setHidden(false);
+		this.redirectorTag.doEndTag();
+	}
+
+	@Test
+	public void doEndTagRendersHiddenFields() throws JspException,
+			UnsupportedEncodingException {
+		String targetUrl = "https://spring.io";
+		when(this.signCalculator.calculateSign(targetUrl)).thenReturn(
+				"calculated_sign");
+
+		MockServletContext servletContext = new MockServletContext();
+		this.request.setAttribute("_redirectParameter", "redirectTo");
+		this.request.setAttribute("_signParameter", "sign");
+		this.request.setAttribute("_signCalculator", this.signCalculator);
+		MockPageContext pageContext = new MockPageContext(servletContext,
+				this.request, this.response);
+		this.redirectorTag.setPageContext(pageContext);
+		this.redirectorTag.setTargetUrl(targetUrl);
+		this.redirectorTag.setHidden(true);
+
+		assertThat(this.redirectorTag.doEndTag()).isEqualTo(
+				TagSupport.EVAL_PAGE);
+		assertThat(this.response.getContentAsString())
+				.isEqualTo(
+						"<input type=\"hidden\" name=\"redirectTo\" "
+						+ "value=\"https://spring.io\" />\n"
+						+ "<input type=\"hidden\" name=\"sign\" "
+						+ "value=\"calculated_sign\" />");
+	}
+
+	@Test
+	public void doEndTagRendersLinkToRedirector() throws JspException,
+			UnsupportedEncodingException {
+		String targetUrl = "https://spring.io";
+		when(this.signCalculator.calculateSign(targetUrl)).thenReturn(
+				"calculated_sign");
+
+		MockServletContext servletContext = new MockServletContext();
+		this.request.setAttribute("_redirectParameter", "redirectTo");
+		this.request.setAttribute("_signParameter", "sign");
+		this.request.setAttribute("_signCalculator", this.signCalculator);
+		MockPageContext pageContext = new MockPageContext(servletContext,
+				this.request, this.response);
+		this.redirectorTag.setPageContext(pageContext);
+		this.redirectorTag.setTargetUrl(targetUrl);
+		this.redirectorTag.setRedirectorUrl("redirector");
+		this.redirectorTag.setHidden(false);
+		this.redirectorTag.setText("link");
+
+		assertThat(this.redirectorTag.doEndTag()).isEqualTo(
+				TagSupport.EVAL_PAGE);
+		assertThat(this.response.getContentAsString())
+				.isEqualTo(
+						"<a href=\"redirector?redirectTo=https://spring.io"
+						+ "&sign=calculated_sign\">link</a>");
+	}
+
+}

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -49,6 +49,12 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.10</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
       <version>4.2.0.M1</version>
@@ -127,12 +133,6 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>1.1.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>1.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/web/src/main/java/org/springframework/security/web/redirect/AbstractSignCalculator.java
+++ b/web/src/main/java/org/springframework/security/web/redirect/AbstractSignCalculator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.redirect;
+
+/**
+ * Provides an abstract superclass for {@link SignCalculator} implementations.
+ *
+ * @author Takuya Iwatsuka
+ */
+public abstract class AbstractSignCalculator implements SignCalculator {
+
+	@Override
+	abstract public String calculateSign(String source);
+
+	@Override
+	public boolean validateSign(String source, String sign) {
+		return sign.equals(calculateSign(source));
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/redirect/HmacSignCalculator.java
+++ b/web/src/main/java/org/springframework/security/web/redirect/HmacSignCalculator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.redirect;
+
+import org.apache.commons.codec.digest.HmacUtils;
+import org.springframework.util.Assert;
+
+/**
+ * A implementation of {@link SignCalculator} which uses HMAC to calculate
+ * signature.
+ *
+ * @author Takuya Iwatsuka
+ */
+public class HmacSignCalculator extends AbstractSignCalculator {
+
+	protected final String key;
+
+	/**
+	 * Specifies a secret key for calculate signature.
+	 *
+	 * @param key a secret key for calculate signature
+	 */
+	public HmacSignCalculator(String key) {
+		Assert.hasLength(key);
+		this.key = key;
+	}
+
+	@Override
+	public String calculateSign(String source) {
+		return HmacUtils.hmacSha256Hex(key, source);
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/redirect/InvalidRedirectException.java
+++ b/web/src/main/java/org/springframework/security/web/redirect/InvalidRedirectException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.redirect;
+
+/**
+ * Thrown when an expected signature for redirect target URL is missing, or it
+ * does not match the value present on the {@link HttpServletRequest}
+ *
+ * @author Takuya Iwatsuka
+ */
+@SuppressWarnings("serial")
+public class InvalidRedirectException extends RuntimeException {
+
+	public InvalidRedirectException(String message) {
+		super(message);
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/redirect/RedirectValidationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/redirect/RedirectValidationFilter.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.redirect;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * <p>
+ * A servlet filter which provides <a href="https://www.owasp.org/index.php/Open_redirect">Open Redirect</a>
+ * protection.
+ * </p>
+ *
+ * <p>
+ * When a redirect target URL is passed as a request parameter by specific
+ * parameter name, this filter explore the signature of the URL for validation
+ * from the request.
+ * This filter wraps the request with {@link SignedRedirectHttpServletResponse}.
+ * It validate the redirect target URL with the signature when a redirect occurs.
+ * If you have to redirect to other URL than the one passed as the request
+ * parameter, you can exclude the URL from the target of the validation.
+ * </p>
+ *
+ * @author Takuya Iwatsuka
+ */
+public class RedirectValidationFilter extends OncePerRequestFilter {
+
+	private String signParameter = "sign";
+
+	private String redirectParameter = "redirectTo";
+
+	private final SignCalculator signCalculator;
+
+	private Set<String> excludedURLs = Collections.emptySet();
+
+	/**
+	 * Specifies a request parameter name to pass a signature for the redirect
+	 * target URL. The default value is "sign".
+	 *
+	 * @param signParameter a parameter name for the signature
+	 */
+	public void setSignParameter(String signParameter) {
+		Assert.hasLength(signParameter);
+		this.signParameter = signParameter;
+	}
+
+	/**
+	 * Specifies a parameter name to pass a redirect target URL. The default
+	 * value is "redirectTo".
+	 *
+	 * @param redirectParameter a parameter name for the redirect target URL
+	 */
+	public void setRedirectParameter(String redirectParameter) {
+		Assert.hasLength(redirectParameter);
+		this.redirectParameter = redirectParameter;
+	}
+
+	/**
+	 * @param signCalculator a {@link SingCalculator} which is used for actual validation
+	 */
+	public RedirectValidationFilter(SignCalculator signCalculator) {
+		Assert.notNull(signCalculator, "signCalculator cannot be null");
+		this.signCalculator = signCalculator;
+	}
+
+	/**
+	 * @param excludedURLs a set of URLs which are not the target of the validation
+	 */
+	public void setExcludedURLs(Set<String> excludedURLs) {
+		Assert.notNull(excludedURLs);
+		this.excludedURLs = excludedURLs;
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request,
+			HttpServletResponse response, FilterChain filterChain)
+			throws ServletException, IOException {
+		request.setAttribute("_signParameter", signParameter);
+		request.setAttribute("_redirectParameter", redirectParameter);
+		request.setAttribute("_signCalculator", signCalculator);
+
+		if (StringUtils.hasLength(request.getParameter(redirectParameter))) {
+			String sign = request.getParameter(signParameter);
+			HttpServletResponse signedResponse = new SignedRedirectHttpServletResponse(
+					response, sign, signCalculator, excludedURLs);
+			filterChain.doFilter(request, signedResponse);
+		} else {
+			filterChain.doFilter(request, response);
+		}
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/redirect/SignCalculator.java
+++ b/web/src/main/java/org/springframework/security/web/redirect/SignCalculator.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.redirect;
+
+/**
+ *  A component to calculate signature for redirect target URL.
+ *
+ * @author Takuya Iwatsuka
+ */
+public interface SignCalculator {
+
+	String calculateSign(String source);
+
+	boolean validateSign(String source, String sign);
+
+}

--- a/web/src/main/java/org/springframework/security/web/redirect/SignedRedirectHttpServletResponse.java
+++ b/web/src/main/java/org/springframework/security/web/redirect/SignedRedirectHttpServletResponse.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.redirect;
+
+import java.io.IOException;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * A HttpServletResponseWrapper to validate redirect target URL with given
+ * signature.
+ * If the signature is invalid, an exception is thrown because the URL
+ * might have been falsified.
+ *
+ * @author Takuya Iwatsuka
+ */
+public class SignedRedirectHttpServletResponse extends
+		HttpServletResponseWrapper {
+
+	private String sign;
+	private SignCalculator signCalculator;
+	private Set<String> excludedURLs;
+
+	public SignedRedirectHttpServletResponse(HttpServletResponse response,
+			String sign, SignCalculator signCalculator, Set<String> excludedURLs) {
+		super(response);
+		this.sign = sign;
+		this.signCalculator = signCalculator;
+		this.excludedURLs = excludedURLs;
+	}
+
+	@Override
+	public void sendRedirect(String location) throws IOException {
+		if (!excludedURLs.contains(location)) {
+			if (!StringUtils.hasLength(sign)) {
+				throw new InvalidRedirectException(
+						"A signature for the url is missing.");
+			} else if (!signCalculator.validateSign(location, sign)) {
+				throw new InvalidRedirectException(
+						"A signature for the url is invalid.");
+			}
+		}
+		super.sendRedirect(location);
+	}
+
+}

--- a/web/src/test/java/org/springframework/security/web/redirect/HmacSignCalculatorTests.java
+++ b/web/src/test/java/org/springframework/security/web/redirect/HmacSignCalculatorTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.web.redirect;
+
+import org.apache.commons.codec.digest.HmacUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Takuya Iwatsuka
+ *
+ */
+public class HmacSignCalculatorTests {
+
+	private HmacSignCalculator signCalculator;
+
+	private String key = "secret_key";
+
+	@Before
+	public void setup() {
+		this.signCalculator = new HmacSignCalculator(this.key);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void constructorNullKey(){
+		new HmacSignCalculator(null);
+	}
+
+	@Test
+	public void validateSignReturnFalseIfSignIsInvalid() {
+		assertThat(this.signCalculator.validateSign("source", "sign"))
+				.isFalse();
+	}
+
+	@Test
+	public void validateSignReturnTrueIfSignIsCalculatedByHMAC() {
+		assertThat(
+				this.signCalculator.validateSign("source",
+						HmacUtils.hmacSha256Hex(this.key, "source"))).isTrue();
+	}
+}

--- a/web/src/test/java/org/springframework/security/web/redirect/RedirectValidationFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/redirect/RedirectValidationFilterTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.web.redirect;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Matchers.any;
+
+/**
+ * @author Takuya Iwatsuka
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RedirectValidationFilterTests {
+
+	@Captor
+	private ArgumentCaptor<HttpServletResponse> responseCaptor;
+
+	@Mock
+	private SignCalculator signCalculator;
+
+	@Mock
+	private FilterChain filterChain;
+
+	private MockHttpServletRequest request;
+
+	private MockHttpServletResponse response;
+
+	private RedirectValidationFilter filter;
+
+	@Before
+	public void setup() {
+		this.request = new MockHttpServletRequest();
+		this.response = new MockHttpServletResponse();
+		this.filter = new RedirectValidationFilter(this.signCalculator);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void constructorNullSignCalculator() {
+		new RedirectValidationFilter(null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void setRedirectParameterNull() {
+		this.filter.setRedirectParameter(null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void setSignParameterNull() {
+		this.filter.setSignParameter(null);
+	}
+
+	@Test
+	public void doFilterSetRequestAttributes() throws ServletException,
+			IOException {
+		this.filter.doFilter(this.request, this.response, this.filterChain);
+		assertThat(this.request.getAttribute("_redirectParameter")).isEqualTo(
+				"redirectTo");
+		assertThat(this.request.getAttribute("_signParameter")).isEqualTo(
+				"sign");
+		assertThat(this.request.getAttribute("_signCalculator")).isEqualTo(
+				this.signCalculator);
+	}
+
+	@Test
+	public void doFilterDoesNotWrapResponseIfRedirectParameterIsNotContained()
+			throws ServletException, IOException{
+		this.filter.doFilter(this.request, this.response, this.filterChain);
+		verify(this.filterChain).doFilter(any(HttpServletRequest.class), this.responseCaptor.capture());
+		assertThat(this.responseCaptor.getValue()).isNotInstanceOf(SignedRedirectHttpServletResponse.class);
+	}
+
+	@Test
+	public void doFilterWrapResponseIfRedirectParameterIsContained()
+			throws ServletException, IOException{
+		this.request.setParameter("redirectTo", "https://spring.io/");
+		this.filter.doFilter(this.request, this.response, this.filterChain);
+		verify(this.filterChain).doFilter(any(HttpServletRequest.class), this.responseCaptor.capture());
+		assertThat(this.responseCaptor.getValue()).isInstanceOf(SignedRedirectHttpServletResponse.class);
+	}
+}

--- a/web/src/test/java/org/springframework/security/web/redirect/SignedRedirectHttpServletResponseTests.java
+++ b/web/src/test/java/org/springframework/security/web/redirect/SignedRedirectHttpServletResponseTests.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.web.redirect;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+/**
+ * @author Takuya Iwatsuka
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SignedRedirectHttpServletResponseTests {
+
+	@Mock
+	SignCalculator signCalculator;
+
+	MockHttpServletResponse response;
+
+	Set<String> excludedURLs;
+
+	@Before
+	public void SetupBlock(){
+		this.response = new MockHttpServletResponse();
+		this.excludedURLs = Collections.emptySet();
+	}
+
+	@Test(expected = InvalidRedirectException.class)
+	public void sendRedirectThrowsExceptionIfSignIsMissing() throws IOException {
+		String targetURL = "https://spring.io";
+		SignedRedirectHttpServletResponse signedResponse = new SignedRedirectHttpServletResponse(
+				this.response, null, signCalculator, excludedURLs);
+		signedResponse.sendRedirect(targetURL);
+	}
+
+	@Test(expected = InvalidRedirectException.class)
+	public void sendRedirectThrowsExceptionIfSignIsInvalid() throws IOException {
+		String targetURL = "https://spring.io";
+		String sign = "invalid_sign";
+		when(this.signCalculator.validateSign(targetURL, sign)).thenReturn(false);
+
+		SignedRedirectHttpServletResponse signedResponse = new SignedRedirectHttpServletResponse(
+				this.response, sign, this.signCalculator, excludedURLs);
+		signedResponse.sendRedirect(targetURL);
+	}
+
+	@Test
+	public void sendRedirectIfSignIsValid() throws IOException {
+		String targetURL = "https://spring.io";
+		String sign = "valid_sign";
+		when(this.signCalculator.validateSign(targetURL, sign)).thenReturn(true);
+
+		SignedRedirectHttpServletResponse signedResponse = new SignedRedirectHttpServletResponse(
+				this.response, sign, this.signCalculator, excludedURLs);
+		signedResponse.sendRedirect(targetURL);
+
+		verify(this.signCalculator, times(1)).validateSign(targetURL, sign);
+	}
+
+	@Test(expected = InvalidRedirectException.class)
+	public void sendRedirectThrowsExceptionIfTargetURLIsNotMatch() throws IOException {
+		String targetURL = "https://spring.io";
+		String sign = "invalid_sign";
+		when(this.signCalculator.validateSign(targetURL, sign)).thenReturn(false);
+
+		String location = "https://some.location";
+		SignedRedirectHttpServletResponse signedResponse = new SignedRedirectHttpServletResponse(
+				this.response, sign, this.signCalculator, excludedURLs);
+		signedResponse.sendRedirect(location);
+	}
+
+	@Test
+	public void sendRedirectDoesNotVelifyIfTargetURLIsExcluded() throws IOException {
+		String targetURL = "https://spring.io";
+		String sign = "invalid_sign";
+		when(this.signCalculator.validateSign(targetURL, sign)).thenReturn(false);
+
+		String location = "https://some.location";
+		this.excludedURLs = new HashSet<String>(Arrays.asList(location));
+		SignedRedirectHttpServletResponse signedResponse = new SignedRedirectHttpServletResponse(
+				this.response, sign, this.signCalculator, excludedURLs);
+		signedResponse.sendRedirect(location);
+
+		verify(this.signCalculator, times(0)).validateSign(location, sign);
+	}
+}

--- a/web/web.gradle
+++ b/web/web.gradle
@@ -4,6 +4,7 @@ dependencies {
 	compile project(':spring-security-core'),
 			springCoreDependency,
 			'aopalliance:aopalliance:1.0',
+			'commons-codec:commons-codec:1.10',
 			"org.springframework:spring-beans:$springVersion",
 			"org.springframework:spring-context:$springVersion",
 			"org.springframework:spring-expression:$springVersion",
@@ -17,7 +18,6 @@ dependencies {
 	provided "javax.servlet:javax.servlet-api:$servletApiVersion"
 
 	testCompile project(':spring-security-core').sourceSets.test.output,
-				'commons-codec:commons-codec:1.3',
 				"org.slf4j:jcl-over-slf4j:$slf4jVersion",
 				"org.codehaus.groovy:groovy-all:$groovyVersion",
 				powerMockDependencies,


### PR DESCRIPTION
To prevent open redirect by checking signature of the target URL of redirects, this PR add some classes described below.
- RedirectCheckFilter : A servlet filter to wrap responses with SignedRedirectHttpServletResponse
- SignedRedirectHttpServletResponse : A wrapper of servlet response to validate redirect target URL by using signature
- SignCalculator : An interface which executes actual calculation of the signature
- HmacSignCalculator : An implementation of SignCalculator
- RedirectorTag : A JSP tag to generate signature in the page

Issue #3352
