### PR TITLE
UnmodifiableSet Deserializer added to support Jackson 2.7+ 

### DIFF
--- a/core/src/main/java/org/springframework/security/jackson2/UnmodifiableSetDeserializer.java
+++ b/core/src/main/java/org/springframework/security/jackson2/UnmodifiableSetDeserializer.java
@@ -39,23 +39,23 @@ import java.util.Set;
  */
 class UnmodifiableSetDeserializer extends JsonDeserializer<Set> {
 
-    @Override
-    public Set deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-        ObjectMapper mapper = (ObjectMapper) jp.getCodec();
-        JsonNode node = mapper.readTree(jp);
-        Set<Object> resultSet = new HashSet<Object>();
-        if (node != null) {
-            if (node instanceof ArrayNode) {
-                ArrayNode arrayNode = (ArrayNode) node;
-                Iterator<JsonNode> nodeIterator = arrayNode.iterator();
-                while (nodeIterator.hasNext()) {
-                    JsonNode elementNode = nodeIterator.next();
-                    resultSet.add(mapper.readValue(elementNode.toString(), Object.class));
-                }
-            } else {
-                resultSet.add(mapper.readValue(node.toString(), Object.class));
-            }
-        }
-        return Collections.unmodifiableSet(resultSet);
-    }
+	@Override
+	public Set deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+		ObjectMapper mapper = (ObjectMapper) jp.getCodec();
+		JsonNode node = mapper.readTree(jp);
+		Set<Object> resultSet = new HashSet<Object>();
+		if (node != null) {
+			if (node instanceof ArrayNode) {
+				ArrayNode arrayNode = (ArrayNode) node;
+				Iterator<JsonNode> nodeIterator = arrayNode.iterator();
+				while (nodeIterator.hasNext()) {
+					JsonNode elementNode = nodeIterator.next();
+					resultSet.add(mapper.readValue(elementNode.toString(), Object.class));
+				}
+			} else {
+				resultSet.add(mapper.readValue(node.toString(), Object.class));
+			}
+		}
+		return Collections.unmodifiableSet(resultSet);
+	}
 }

--- a/core/src/main/java/org/springframework/security/jackson2/UnmodifiableSetDeserializer.java
+++ b/core/src/main/java/org/springframework/security/jackson2/UnmodifiableSetDeserializer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson2;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * Custom deserializer for {@link UnmodifiableSetMixin}.
+ *
+ * @author Jitendra Singh
+ * @see UnmodifiableSetMixin
+ * @since 4.2
+ */
+class UnmodifiableSetDeserializer extends JsonDeserializer<Set> {
+
+    @Override
+    public Set deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        ObjectMapper mapper = (ObjectMapper) jp.getCodec();
+        JsonNode node = mapper.readTree(jp);
+        Set<Object> resultSet = new HashSet<Object>();
+        if (node != null) {
+            if (node instanceof ArrayNode) {
+                ArrayNode arrayNode = (ArrayNode) node;
+                Iterator<JsonNode> nodeIterator = arrayNode.iterator();
+                while (nodeIterator.hasNext()) {
+                    JsonNode elementNode = nodeIterator.next();
+                    resultSet.add(mapper.readValue(elementNode.toString(), Object.class));
+                }
+            } else {
+                resultSet.add(mapper.readValue(node.toString(), Object.class));
+            }
+        }
+        return Collections.unmodifiableSet(resultSet);
+    }
+}

--- a/core/src/main/java/org/springframework/security/jackson2/UnmodifiableSetMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson2/UnmodifiableSetMixin.java
@@ -18,6 +18,7 @@ package org.springframework.security.jackson2;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import java.util.Set;
 
@@ -31,11 +32,13 @@ import java.util.Set;
  * </pre>
  *
  * @author Jitendra Singh
+ * @see UnmodifiableSetDeserializer
  * @see CoreJackson2Module
  * @see SecurityJacksonModules
  * @since 4.2
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
+@JsonDeserialize(using = UnmodifiableSetDeserializer.class)
 class UnmodifiableSetMixin {
 
 	/**


### PR DESCRIPTION
Hi @rwinch when updating `jackson-databind` to 2.7+ somehow Jackson is not picking our `UnmodifiableSetMixin` at the time of deserialization.  I've added CustomDeserializer for the same and tested it w/ 2.7+ and older versions.   #4073 