### PR TITLE
Add useful configuration methods for Referrer Policy header

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HeadersConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HeadersConfigurer.java
@@ -827,6 +827,14 @@ public class HeadersConfigurer<H extends HttpSecurityBuilder<H>> extends
 	 * </ul>
 	 *
 	 * @see ReferrerPolicyHeaderWriter
+	 * @see ReferrerPolicyConfig#noReferrer
+	 * @see ReferrerPolicyConfig#noReferrerWhenDowngrade
+	 * @see ReferrerPolicyConfig#sameOrigin
+	 * @see ReferrerPolicyConfig#origin
+	 * @see ReferrerPolicyConfig#strictOrigin
+	 * @see ReferrerPolicyConfig#originWhenCrossOrigin
+	 * @see ReferrerPolicyConfig#strictOriginWhenCrossOrigin
+	 * @see ReferrerPolicyConfig#unsafeUrl
 	 * @since 4.2
 	 * @return the ReferrerPolicyConfig for additional configuration
 	 * @throws IllegalArgumentException if policy is null or empty
@@ -843,6 +851,100 @@ public class HeadersConfigurer<H extends HttpSecurityBuilder<H>> extends
 		private ReferrerPolicyConfig() {
 		}
 
+		/**
+		 * Specify to 'no-referrer' policy.
+		 *
+		 * @return the {@link HeadersConfigurer} for additional customization.
+		 * @since 4.2.1
+		 */
+		public HeadersConfigurer<H> noReferrer() {
+			writer = new ReferrerPolicyHeaderWriter(ReferrerPolicy.NO_REFERRER);
+			return and();
+		}
+
+		/**
+		 * Specify to 'no-referrer-when-downgrade' policy.
+		 *
+		 * @return the {@link HeadersConfigurer} for additional customization.
+		 * @since 4.2.1
+		 */
+		public HeadersConfigurer<H> noReferrerWhenDowngrade() {
+			writer = new ReferrerPolicyHeaderWriter(ReferrerPolicy.NO_REFERRER_WHEN_DOWNGRADE);
+			return and();
+		}
+
+		/**
+		 * Specify to 'same-origin' policy.
+		 *
+		 * @return the {@link HeadersConfigurer} for additional customization.
+		 * @since 4.2.1
+		 */
+		public HeadersConfigurer<H> sameOrigin() {
+			writer = new ReferrerPolicyHeaderWriter(ReferrerPolicy.SAME_ORIGIN);
+			return and();
+		}
+
+		/**
+		 * Specify to 'origin' policy.
+		 *
+		 * @return the {@link HeadersConfigurer} for additional customization.
+		 * @since 4.2.1
+		 */
+		public HeadersConfigurer<H> origin() {
+			writer = new ReferrerPolicyHeaderWriter(ReferrerPolicy.ORIGIN);
+			return and();
+		}
+
+		/**
+		 * Specify to 'strict-origin' policy.
+		 *
+		 * @return the {@link HeadersConfigurer} for additional customization.
+		 * @since 4.2.1
+		 */
+		public HeadersConfigurer<H> strictOrigin() {
+			writer = new ReferrerPolicyHeaderWriter(ReferrerPolicy.STRICT_ORIGIN);
+			return and();
+		}
+
+		/**
+		 * Specify to 'origin-when-cross-origin' policy.
+		 *
+		 * @return the {@link HeadersConfigurer} for additional customization.
+		 * @since 4.2.1
+		 */
+		public HeadersConfigurer<H> originWhenCrossOrigin() {
+			writer = new ReferrerPolicyHeaderWriter(ReferrerPolicy.ORIGIN_WHEN_CROSS_ORIGIN);
+			return and();
+		}
+
+		/**
+		 * Specify to 'strict-origin-when-cross-origin' policy.
+		 *
+		 * @return the {@link HeadersConfigurer} for additional customization.
+		 * @since 4.2.1
+		 */
+		public HeadersConfigurer<H> strictOriginWhenCrossOrigin() {
+			writer = new ReferrerPolicyHeaderWriter(ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN);
+			return and();
+		}
+
+		/**
+		 * Specify to 'unsafe-url' policy.
+		 *
+		 * @return the {@link HeadersConfigurer} for additional customization.
+		 * @since 4.2.1
+		 */
+		public HeadersConfigurer<H> unsafeUrl() {
+			writer = new ReferrerPolicyHeaderWriter(ReferrerPolicy.UNSAFE_URL);
+			return and();
+		}
+
+		/**
+		 * Allows completing configuration of Referrer Policy and continuing
+		 * configuration of headers.
+		 *
+		 * @return the {@link HeadersConfigurer} for additional configuration
+		 */
 		public HeadersConfigurer<H> and() {
 			return HeadersConfigurer.this;
 		}

--- a/config/src/test/groovy/org/springframework/security/config/annotation/web/configurers/HeadersConfigurerTests.groovy
+++ b/config/src/test/groovy/org/springframework/security/config/annotation/web/configurers/HeadersConfigurerTests.groovy
@@ -28,6 +28,7 @@ import static org.springframework.security.web.header.writers.ReferrerPolicyHead
  * @author Tim Ysewyn
  * @author Joe Grandja
  * @author Eddú Meléndez
+ * @author Kazuki Shimizu
  */
 class HeadersConfigurerTests extends BaseSpringSpec {
 
@@ -494,6 +495,174 @@ class HeadersConfigurerTests extends BaseSpringSpec {
 					.headers()
 					.defaultsDisabled()
 					.referrerPolicy(ReferrerPolicy.SAME_ORIGIN);
+		}
+	}
+
+	def "headers.referrerPolicy with noReferrer"() {
+		setup:
+		loadConfig(ReferrerPolicyNoReferrerConfig)
+		when:
+		springSecurityFilterChain.doFilter(request,response,chain)
+		then:
+		responseHeaders == ['Referrer-Policy': 'no-referrer']
+	}
+
+	@EnableWebSecurity
+	static class ReferrerPolicyNoReferrerConfig extends WebSecurityConfigurerAdapter {
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			http
+					.headers()
+					.defaultsDisabled()
+					.referrerPolicy().noReferrer();
+		}
+	}
+
+	def "headers.referrerPolicy with noReferrerWhenDowngrade"() {
+		setup:
+		loadConfig(ReferrerPolicyNoReferrerWhenDowngradeConfig)
+		when:
+		springSecurityFilterChain.doFilter(request,response,chain)
+		then:
+		responseHeaders == ['Referrer-Policy': 'no-referrer-when-downgrade']
+	}
+
+	@EnableWebSecurity
+	static class ReferrerPolicyNoReferrerWhenDowngradeConfig extends WebSecurityConfigurerAdapter {
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			http
+					.headers()
+					.defaultsDisabled()
+					.referrerPolicy().noReferrerWhenDowngrade();
+		}
+	}
+
+	def "headers.referrerPolicy with sameOrigin"() {
+		setup:
+		loadConfig(ReferrerPolicySameOriginConfig)
+		when:
+		springSecurityFilterChain.doFilter(request,response,chain)
+		then:
+		responseHeaders == ['Referrer-Policy': 'same-origin']
+	}
+
+	@EnableWebSecurity
+	static class ReferrerPolicySameOriginConfig extends WebSecurityConfigurerAdapter {
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			http
+					.headers()
+					.defaultsDisabled()
+					.referrerPolicy().sameOrigin();
+		}
+	}
+
+	def "headers.referrerPolicy with origin"() {
+		setup:
+		loadConfig(ReferrerPolicyOriginConfig)
+		when:
+		springSecurityFilterChain.doFilter(request,response,chain)
+		then:
+		responseHeaders == ['Referrer-Policy': 'origin']
+	}
+
+	@EnableWebSecurity
+	static class ReferrerPolicyOriginConfig extends WebSecurityConfigurerAdapter {
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			http
+					.headers()
+					.defaultsDisabled()
+					.referrerPolicy().origin();
+		}
+	}
+
+	def "headers.referrerPolicy with strictOrigin"() {
+		setup:
+		loadConfig(ReferrerPolicyStrictOriginConfig)
+		when:
+		springSecurityFilterChain.doFilter(request,response,chain)
+		then:
+		responseHeaders == ['Referrer-Policy': 'strict-origin']
+	}
+
+	@EnableWebSecurity
+	static class ReferrerPolicyStrictOriginConfig extends WebSecurityConfigurerAdapter {
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			http
+					.headers()
+					.defaultsDisabled()
+					.referrerPolicy().strictOrigin();
+		}
+	}
+
+	def "headers.referrerPolicy with originWhenCrossOrigin"() {
+		setup:
+		loadConfig(ReferrerPolicyOriginWhenCrossOriginConfig)
+		when:
+		springSecurityFilterChain.doFilter(request,response,chain)
+		then:
+		responseHeaders == ['Referrer-Policy': 'origin-when-cross-origin']
+	}
+
+	@EnableWebSecurity
+	static class ReferrerPolicyOriginWhenCrossOriginConfig extends WebSecurityConfigurerAdapter {
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			http
+					.headers()
+					.defaultsDisabled()
+					.referrerPolicy().originWhenCrossOrigin();
+		}
+	}
+
+	def "headers.referrerPolicy with strictOriginWhenCrossOrigin"() {
+		setup:
+		loadConfig(ReferrerPolicyStrictOriginWhenCrossOriginConfig)
+		when:
+		springSecurityFilterChain.doFilter(request,response,chain)
+		then:
+		responseHeaders == ['Referrer-Policy': 'strict-origin-when-cross-origin']
+	}
+
+	@EnableWebSecurity
+	static class ReferrerPolicyStrictOriginWhenCrossOriginConfig extends WebSecurityConfigurerAdapter {
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			http
+					.headers()
+					.defaultsDisabled()
+					.referrerPolicy().strictOriginWhenCrossOrigin();
+		}
+	}
+
+	def "headers.referrerPolicy with unsafeUrl"() {
+		setup:
+		loadConfig(ReferrerPolicyUnsafeUrlConfig)
+		when:
+		springSecurityFilterChain.doFilter(request,response,chain)
+		then:
+		responseHeaders == ['Referrer-Policy': 'unsafe-url']
+	}
+
+	@EnableWebSecurity
+	static class ReferrerPolicyUnsafeUrlConfig extends WebSecurityConfigurerAdapter {
+
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			http
+					.headers()
+					.defaultsDisabled()
+					.referrerPolicy().unsafeUrl();
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

I've added some configuration method like the `FrameOptionsConfig` (`deny()`, `sameOrigin()`).
This changes allow the following configuration.

```java
@Override
protected void configure(HttpSecurity http) throws Exception {
    http.headers()
            .referrerPolicy().sameOrigin();
}
```

What do you think ?

## Related issues

* gh-4110