### PR TITLE
DefaultRedirectStrategy should not calculate relative url if it does not contain the context-path

### DIFF
--- a/web/src/main/java/org/springframework/security/web/DefaultRedirectStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/DefaultRedirectStrategy.java
@@ -73,6 +73,10 @@ public class DefaultRedirectStrategy implements RedirectStrategy {
 			return url;
 		}
 
+		if (!url.contains(contextPath)) {
+			return "";
+		}
+
 		// Calculate the relative URL from the fully qualified URL, minus the last
 		// occurrence of the scheme and base context.
 		url = url.substring(url.lastIndexOf("://") + 3); // strip off scheme

--- a/web/src/test/java/org/springframework/security/web/DefaultRedirectStrategyTests.java
+++ b/web/src/test/java/org/springframework/security/web/DefaultRedirectStrategyTests.java
@@ -56,4 +56,19 @@ public class DefaultRedirectStrategyTests {
 
 		assertThat(response.getRedirectedUrl()).isEqualTo("remainder");
 	}
+
+	@Test
+	public void contextRelativeShouldRedirectToRootIfURLDoesNotContainContextPath()
+		throws Exception {
+		DefaultRedirectStrategy rds = new DefaultRedirectStrategy();
+		rds.setContextRelative(true);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setContextPath("/context");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		rds.sendRedirect(request, response,
+			"https://redirectme.somewhere.else");
+
+		assertThat(response.getRedirectedUrl()).isEqualTo("");
+	}
 }


### PR DESCRIPTION
Hello,

When defining a redirect strategy, after a logout for example, you can force the redirection to be context relative, by ``setContextRelative(true)``.

If by mistake (or not), you want the redirect target to be an absolute url completely outside of your context-path (eg: http://www.google.com), this url obviously does not contain your context-path.

This lead to ``DefaultRedirectStrategy#calculateRedirectUrl`` silently calculating a completely wrong URL if ``contextRelative`` is ``true``

This PR  checks is the URL contains the context-path. If not, it early returns the untouched url.

Another possibility would be to throw an ``IllegalArgumentException`` if ``contextRelative`` is true BUT url is absolute AND does not contain the context-path.