### PR TITLE
Prevent BCrypt NPE

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCrypt.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCrypt.java
@@ -532,14 +532,19 @@ public class BCrypt {
 	 * @param password the password to hash
 	 * @param salt the salt to hash with (perhaps generated using BCrypt.gensalt)
 	 * @return the hashed password
+	 * @throws IllegalArgumentException if invalid salt is passed
 	 */
-	public static String hashpw(String password, String salt) {
+	public static String hashpw(String password, String salt) throws IllegalArgumentException {
 		BCrypt B;
 		String real_salt;
 		byte passwordb[], saltb[], hashed[];
 		char minor = (char) 0;
 		int rounds, off = 0;
 		StringBuilder rs = new StringBuilder();
+
+		if (salt == null) {
+			throw new IllegalArgumentException("Invalid salt");
+		}
 
 		int saltLength = salt.length();
 

--- a/crypto/src/test/java/org/springframework/security/crypto/bcrypt/BCryptTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/bcrypt/BCryptTests.java
@@ -14,10 +14,11 @@
 
 package org.springframework.security.crypto.bcrypt;
 
+import org.junit.Test;
+
 import java.util.Arrays;
 
-import org.junit.Test;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * JUnit unit tests for BCrypt routines
@@ -269,6 +270,11 @@ public class BCryptTests {
 	public void genSaltGeneratesCorrectSaltPrefix() {
 		assertThat(BCrypt.gensalt(4).startsWith("$2a$04$")).isTrue();
 		assertThat(BCrypt.gensalt(31).startsWith("$2a$31$")).isTrue();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void hashpwFailsWhenSaltIsNull() {
+		BCrypt.hashpw("password", null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
This PR introduces a simple null check within BCrypt.hashpw(String password, String salt) to properly handle null-value salts in a consistent way and prevent NPEs. 

Fixes #4147 

