### PR TITLE
Xenoterracide nullsafe equals

### DIFF
--- a/core/src/main/java/org/springframework/security/core/userdetails/User.java
+++ b/core/src/main/java/org/springframework/security/core/userdetails/User.java
@@ -200,7 +200,7 @@ public class User implements UserDetails, CredentialsContainer {
 	@Override
 	public boolean equals(Object rhs) {
 		if (rhs instanceof User) {
-			return ObjectUtils.nullSafeEquals(this.username, (User) rhs).username);
+			return ObjectUtils.nullSafeEquals(this.username, ((User) rhs).username);
 		}
 		return false;
 	}

--- a/core/src/main/java/org/springframework/security/core/userdetails/User.java
+++ b/core/src/main/java/org/springframework/security/core/userdetails/User.java
@@ -33,6 +33,7 @@ import org.springframework.security.core.SpringSecurityCoreVersion;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 
 /**
  * Models core user information retrieved by a {@link UserDetailsService}.
@@ -199,7 +200,7 @@ public class User implements UserDetails, CredentialsContainer {
 	@Override
 	public boolean equals(Object rhs) {
 		if (rhs instanceof User) {
-			return username.equals(((User) rhs).username);
+			return ObjectUtils.nullSafeEquals(this.username, (User) rhs).username);
 		}
 		return false;
 	}
@@ -209,7 +210,7 @@ public class User implements UserDetails, CredentialsContainer {
 	 */
 	@Override
 	public int hashCode() {
-		return username.hashCode();
+		return ObjectUtils.nullSafeHashCode(this.username);
 	}
 
 	@Override


### PR DESCRIPTION
provide a nullsafe implimenation of equals and hashcode. Although these are never null, when subclassing and testing equals some 3rd party testing utilities such as equalsverifier may not be aware of this (see https://github.com/jqno/equalsverifier/issues/164)

side note, I'm using 4.1.x can backport. Also I created the branch using githubs online editor, so happy to clean up patches as necessary, if the change is otherwise acceptable.