### PR TITLE
principals and sessionIds should be set using constructor so that can be shared across node in cluster

### DIFF
--- a/core/src/main/java/org/springframework/security/core/session/SessionRegistryImpl.java
+++ b/core/src/main/java/org/springframework/security/core/session/SessionRegistryImpl.java
@@ -48,11 +48,22 @@ public class SessionRegistryImpl implements SessionRegistry,
 	protected final Log logger = LogFactory.getLog(SessionRegistryImpl.class);
 
 	/** <principal:Object,SessionIdSet> */
-	private final ConcurrentMap<Object, Set<String>> principals = new ConcurrentHashMap<Object, Set<String>>();
-	/** <sessionId:Object,SessionInformation> */
-	private final Map<String, SessionInformation> sessionIds = new ConcurrentHashMap<String, SessionInformation>();
+    private final ConcurrentMap<Object, Set<String>> principals;
+    /** <sessionId:Object,SessionInformation> */
+    private final Map<String, SessionInformation> sessionIds;
 
-	// ~ Methods
+    public SessionRegistryImpl() {
+    	this.principals = new ConcurrentHashMap<Object, Set<String>>();
+    	this.sessionIds = new ConcurrentHashMap<String, SessionInformation>();
+	}
+
+    
+    public SessionRegistryImpl(ConcurrentMap<Object, Set<String>> principals,Map<String, SessionInformation> sessionIds) {
+		this.principals=principals;
+		this.sessionIds=sessionIds;
+	}
+
+    // ~ Methods
 	// ========================================================================================================
 
 	public List<Object> getAllPrincipals() {


### PR DESCRIPTION


As principals and sessionIds are set in class itself so one can't share session count of user across nodes(Cluster). By setting principals and sessionIds we can pass Cache map to constructor which can enable common session count in cluster otherwise user would be allowed to logged in with multiple sessions. There is no point keeping principals and sessionIds completely internal.

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
