### PR TITLE
prevent NPE in case of null BeanDefinition bean class name

### DIFF
--- a/config/src/main/java/org/springframework/security/config/websocket/WebSocketMessageBrokerSecurityBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/websocket/WebSocketMessageBrokerSecurityBeanDefinitionParser.java
@@ -255,8 +255,8 @@ public final class WebSocketMessageBrokerSecurityBeanDefinitionParser implements
 			for (String beanName : beanNames) {
 				BeanDefinition bd = registry.getBeanDefinition(beanName);
 				String beanClassName = bd.getBeanClassName();
-				if (beanClassName.equals(SimpAnnotationMethodMessageHandler.class
-						.getName()) || beanClassName.equals(WEB_SOCKET_AMMH_CLASS_NAME)) {
+				if (SimpAnnotationMethodMessageHandler.class.getName().equals(beanClassName) ||
+						WEB_SOCKET_AMMH_CLASS_NAME.equals(beanClassName)) {
 					PropertyValue current = bd.getPropertyValues().getPropertyValue(
 							CUSTOM_ARG_RESOLVERS_PROP);
 					ManagedList<Object> argResolvers = new ManagedList<Object>();
@@ -275,16 +275,16 @@ public final class WebSocketMessageBrokerSecurityBeanDefinitionParser implements
 						}
 					}
 				}
-				else if (beanClassName
-						.equals("org.springframework.web.socket.server.support.WebSocketHttpRequestHandler")) {
+				else if ("org.springframework.web.socket.server.support.WebSocketHttpRequestHandler"
+						.equals(beanClassName)) {
 					addCsrfTokenHandshakeInterceptor(bd);
 				}
-				else if (beanClassName
-						.equals("org.springframework.web.socket.sockjs.transport.TransportHandlingSockJsService")) {
+				else if ("org.springframework.web.socket.sockjs.transport.TransportHandlingSockJsService"
+						.equals(beanClassName)) {
 					addCsrfTokenHandshakeInterceptor(bd);
 				}
-				else if (beanClassName
-						.equals("org.springframework.web.socket.sockjs.transport.handler.DefaultSockJsService")) {
+				else if ("org.springframework.web.socket.sockjs.transport.handler.DefaultSockJsService"
+						.equals(beanClassName)) {
 					addCsrfTokenHandshakeInterceptor(bd);
 				}
 			}

--- a/config/src/test/java/org/springframework/security/config/websocket/MessageSecurityPostProcessorTest.java
+++ b/config/src/test/java/org/springframework/security/config/websocket/MessageSecurityPostProcessorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.security.config.websocket;
 
 import org.junit.Test;

--- a/config/src/test/java/org/springframework/security/config/websocket/MessageSecurityPostProcessorTest.java
+++ b/config/src/test/java/org/springframework/security/config/websocket/MessageSecurityPostProcessorTest.java
@@ -1,0 +1,19 @@
+package org.springframework.security.config.websocket;
+
+import org.junit.Test;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.GenericBeanDefinition;
+import org.springframework.beans.factory.support.SimpleBeanDefinitionRegistry;
+
+public class MessageSecurityPostProcessorTest {
+
+	private WebSocketMessageBrokerSecurityBeanDefinitionParser.MessageSecurityPostProcessor postProcessor =
+		new WebSocketMessageBrokerSecurityBeanDefinitionParser.MessageSecurityPostProcessor("id", false);
+
+	@Test
+	public void handlesBeansWithoutClass() {
+		BeanDefinitionRegistry registry = new SimpleBeanDefinitionRegistry();
+		registry.registerBeanDefinition("beanWithoutClass", new GenericBeanDefinition());
+		postProcessor.postProcessBeanDefinitionRegistry(registry);
+	}
+}

--- a/core/src/test/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyUtilsTests.java
+++ b/core/src/test/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyUtilsTests.java
@@ -38,7 +38,7 @@ public class RoleHierarchyUtilsTests {
 		roleHierarchyMap.put("ROLE_B", asList("ROLE_D"));
 		roleHierarchyMap.put("ROLE_C", asList("ROLE_D"));
 
-		String roleHierarchy = RoleHierarchyUtils.roleHierarchyFromMap(roleHierarchyMap);
+		String roleHierarchy = RoleHierarchyUtils.roleHierarchyFromMap(roleHierarchyMap).replace("\r", "");
 
 		assertThat(roleHierarchy).isEqualTo(expectedRoleHierarchy);
 	}


### PR DESCRIPTION
This fixes #4112, which can occur for a number of reasons. It's completely trivial, it just turns the `beanClassName`, which can be `null`, into the operand of the `equals()` invocations to make them null-safe.

I was surprised to see that this hadn't been fixed yet, so I'm assuming the issue was simply overlooked. We ran into this as well, and AFAICT it's simply valid for a bean definition's bean class name to be `null`. 
