### PR TITLE
* removing MaxPermSize

### DIFF
--- a/gradle/javaprojects.gradle
+++ b/gradle/javaprojects.gradle
@@ -134,7 +134,7 @@ project.conf2ScopeMappings.addMapping(MavenPlugin.TEST_COMPILE_PRIORITY + 2, pro
 check.dependsOn integrationTest
 
 task springSnapshotTest(type: Test) {
-	jvmArgs = ['-ea', '-Xmx500m', '-XX:MaxPermSize=128M']
+	jvmArgs = ['-ea', '-Xmx500m']
 	classpath = sourceSets.test.output + sourceSets.main.output + configurations.springSnapshotTestRuntime
 	reports {
 		html.destination = project.file("$buildDir/spring-snapshot-test-results/")
@@ -168,7 +168,7 @@ configurations.all {
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 project.tasks.matching { it instanceof Test && it.name != 'integrationTest' }.all {
-	jvmArgs = ['-ea', '-Xmx500m', '-XX:MaxPermSize=512m']
+	jvmArgs = ['-ea', '-Xmx500m']
 	maxParallelForks = guessMaxForks()
 	logging.captureStandardOutput(LogLevel.INFO)
 }

--- a/gradlew
+++ b/gradlew
@@ -7,7 +7,7 @@
 ##############################################################################
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS="-Xmx2048M -XX:MaxPermSize=512M"
+DEFAULT_JVM_OPTS="-Xmx2048M"
 export GRADLE_OPTS='-Dorg.gradle.daemon=false'
 
 APP_NAME="Gradle"


### PR DESCRIPTION
I have removed MaxPermSize from the JVM options because Travis logged warnings about it
 
<!--
Travis logged warnings because of usage of MaxPermSize option in the build system  because if it's deprecation synce jdk8
-->
