### PR TITLE
Fix class name in comment

### DIFF
--- a/config/src/main/java/org/springframework/security/config/http/FilterInvocationSecurityMetadataSourceParser.java
+++ b/config/src/main/java/org/springframework/security/config/http/FilterInvocationSecurityMetadataSourceParser.java
@@ -194,7 +194,7 @@ public class FilterInvocationSecurityMetadataSourceParser implements BeanDefinit
 				logger.info("Creating access control expression attribute '" + access
 						+ "' for " + path);
 				// The single expression will be parsed later by the
-				// ExpressionFilterInvocationSecurityMetadataSource
+				// ExpressionBasedFilterInvocationSecurityMetadataSource
 				attributeBuilder.addConstructorArgValue(new String[] { access });
 				attributeBuilder.setFactoryMethod("createList");
 


### PR DESCRIPTION
Obvious Fix:
The class `ExpressionFilterInvocationSecurityMetadataSource` does not exist.
The `ExpressionBasedFilterInvocationSecurityMetadataSource` should be mentioned instead.