### PR TITLE
Change a default realm name to 'Realm'

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
@@ -943,7 +943,7 @@ public final class HttpSecurity extends
 	 * <h2>Example Configuration</h2>
 	 *
 	 * The example below demonstrates how to configure HTTP Basic authentication for an
-	 * application. The default realm is "Spring Security Application", but can be
+	 * application. The default realm is "Realm", but can be
 	 * customized using {@link HttpBasicConfigurer#realmName(String)}.
 	 *
 	 * <pre>

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HttpBasicConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HttpBasicConfigurer.java
@@ -125,7 +125,7 @@ public final class HttpBasicConfigurer<B extends HttpSecurityBuilder<B>> extends
 	 * The {@link AuthenticationEntryPoint} to be populated on
 	 * {@link BasicAuthenticationFilter} in the event that authentication fails. The
 	 * default to use {@link BasicAuthenticationEntryPoint} with the realm
-	 * "Spring Security Application".
+	 * "Realm".
 	 *
 	 * @param authenticationEntryPoint the {@link AuthenticationEntryPoint} to use
 	 * @return {@link HttpBasicConfigurer} for additional customization

--- a/config/src/main/java/org/springframework/security/config/http/AuthenticationConfigBuilder.java
+++ b/config/src/main/java/org/springframework/security/config/http/AuthenticationConfigBuilder.java
@@ -70,7 +70,7 @@ final class AuthenticationConfigBuilder {
 	private final Log logger = LogFactory.getLog(getClass());
 
 	private static final String ATT_REALM = "realm";
-	private static final String DEF_REALM = "Spring Security Application";
+	private static final String DEF_REALM = "Realm";
 
 	static final String OPEN_ID_AUTHENTICATION_PROCESSING_FILTER_CLASS = "org.springframework.security.openid.OpenIDAuthenticationFilter";
 	static final String OPEN_ID_AUTHENTICATION_PROVIDER_CLASS = "org.springframework.security.openid.OpenIDAuthenticationProvider";

--- a/config/src/main/resources/org/springframework/security/config/spring-security-4.2.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-4.2.rnc
@@ -336,7 +336,7 @@ http.attlist &=
 	## Optional attribute specifying the ID of the AccessDecisionManager implementation which should be used for authorizing HTTP requests.
 	attribute access-decision-manager-ref {xsd:token}?
 http.attlist &=
-	## Optional attribute specifying the realm name that will be used for all authentication features that require a realm name (eg BASIC and Digest authentication). If unspecified, defaults to "Spring Security Application".
+	## Optional attribute specifying the realm name that will be used for all authentication features that require a realm name (eg BASIC and Digest authentication). If unspecified, defaults to "Realm".
 	attribute realm {xsd:token}?
 http.attlist &=
 	## Allows a customized AuthenticationEntryPoint to be set on the ExceptionTranslationFilter.

--- a/config/src/main/resources/org/springframework/security/config/spring-security-4.2.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-4.2.xsd
@@ -1228,7 +1228,7 @@
          <xs:annotation>
             <xs:documentation>Optional attribute specifying the realm name that will be used for all authentication
                 features that require a realm name (eg BASIC and Digest authentication). If unspecified,
-                defaults to "Spring Security Application".
+                defaults to "Realm".
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>

--- a/config/src/test/java/org/springframework/security/config/http/NamespaceHttpBasicTests.java
+++ b/config/src/test/java/org/springframework/security/config/http/NamespaceHttpBasicTests.java
@@ -94,6 +94,24 @@ public class NamespaceHttpBasicTests {
 		assertThat(this.response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
 	}
 
+	// gh-4220
+	@Test
+	public void httpBasicUnauthorizedOnDefault() throws Exception {
+		// @formatter:off
+		loadContext("<http>\n" +
+			"		<intercept-url pattern=\"/**\" access=\"hasRole('USER')\" />\n" +
+			"		<http-basic />\n" +
+			"	</http>\n" +
+			"\n" +
+			"	<authentication-manager />");
+		// @formatter:on
+
+		this.springSecurityFilterChain.doFilter(this.request, this.response, this.chain);
+
+		assertThat(this.response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+		assertThat(this.response.getHeader("WWW-Authenticate")).isEqualTo("Basic realm=\"Realm\"");
+	}
+
 	private void loadContext(String context) {
 		this.context = new InMemoryXmlApplicationContext(context);
 		this.springSecurityFilterChain = this.context.getBean("springSecurityFilterChain",


### PR DESCRIPTION
Change a default realm name of Basic Authentication for XML namespace to 'Realm'.

Fixes gh-4220

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
