### PR TITLE
Fix broken test

### DIFF
--- a/core/src/test/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyUtilsTests.java
+++ b/core/src/test/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,30 +15,78 @@
  */
 package org.springframework.security.access.hierarchicalroles;
 
-import org.junit.Test;
-
-import java.util.*;
-
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 /**
  * Tests for {@link RoleHierarchyUtils}.
  *
  * @author Joe Grandja
  */
+@RunWith(Parameterized.class)
 public class RoleHierarchyUtilsTests {
+
+	/**
+	 * Provide the data to be injected into {@link RoleHierarchyUtilsTests} to be used by
+	 * {@link RoleHierarchyUtilsTests#roleHierarchyFromMapWhenMapValidThenConvertsCorrectly()}
+	 * in order to test a number of different role hierarchies.
+	 * @return the data for {@link RoleHierarchyUtilsTests#roleHierarchyFromMapWhenMapValidThenConvertsCorrectly()}
+	 */
+	@Parameters
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][] {
+			{
+				new TreeMap<String, List<String>>() {
+					{ put("ROLE_A", asList("ROLE_B", "ROLE_C")); }
+					{ put("ROLE_B", asList("ROLE_D")); }
+					{ put("ROLE_C", asList("ROLE_D")); }
+				}
+			},
+			{
+				new TreeMap<String, List<String>>() {
+					{ put("ROLE_A", asList("ROLE_B")); }
+					{ put("ROLE_B", asList("ROLE_C")); }
+					{ put("ROLE_C", asList("ROLE_D", "ROLE_E")); }
+				}
+			},
+		});
+	}
+
+	@Parameter
+	public Map<String, List<String>> roleHierarchyMap;
 
 	@Test
 	public void roleHierarchyFromMapWhenMapValidThenConvertsCorrectly() throws Exception {
-		String expectedRoleHierarchy = "ROLE_A > ROLE_B\nROLE_A > ROLE_C\nROLE_B > ROLE_D\nROLE_C > ROLE_D\n";
+		StringWriter roleHierarchyBuffer = new StringWriter();
+		PrintWriter roleHierarchyWriter = new PrintWriter(roleHierarchyBuffer);
 
-		Map<String, List<String>> roleHierarchyMap = new TreeMap<String, List<String>>();
-		roleHierarchyMap.put("ROLE_A", asList("ROLE_B", "ROLE_C"));
-		roleHierarchyMap.put("ROLE_B", asList("ROLE_D"));
-		roleHierarchyMap.put("ROLE_C", asList("ROLE_D"));
+		for (Map.Entry<String, List<String>> entry: this.roleHierarchyMap.entrySet()) {
+			String role = entry.getKey();
+			for (String impliedRole: entry.getValue()) {
+				String roleMapping = String.format("%s > %s", role, impliedRole);
+				roleHierarchyWriter.println(roleMapping);
+			}
+		}
 
-		String roleHierarchy = RoleHierarchyUtils.roleHierarchyFromMap(roleHierarchyMap);
+		String expectedRoleHierarchy = roleHierarchyBuffer.toString();
+
+		String roleHierarchy = RoleHierarchyUtils.roleHierarchyFromMap(this.roleHierarchyMap);
 
 		assertThat(roleHierarchy).isEqualTo(expectedRoleHierarchy);
 	}


### PR DESCRIPTION
It seems that the RoleHierarchyUtilsTests has only been tested in the
unix-like enviroments where the lines ends with lf. But on windows
computers they end with crlf. PrintWriter knows about it and ends lines
with crlf on windows and lf on unix.

The expected result was crafted with \n which caused the test fail in
windows, because the result PrintWriter generates contains \r\n, hence
the expected and actual results didn't match.

Now in order to build an expected result PrintWriter is employed and
both the expected and actual results match each other.

fixes gh-4227

Signed-off-by: Nikita Eshkeev <kastolom@gmail.com>

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
