### PR TITLE
Fully customizable PBKDF2 password encoder

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/codec/Codec.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/codec/Codec.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.crypto.codec;
+
+/**
+ * A {@code Codec} is responsible for translating byte array into {@link String} and a {@link String} back into byte array in a compatible manner.
+ * <p>
+ * Compatible manner means:
+ * <dl>
+ *     <dt>given {@code codec} as a {@link Codec} implementation and {@code array} as a byte array</dt>
+ *     <dd>{@code java.util.Arrays.equals( codec.decode( codec.encode( array ) ), array ) == true}</dd>
+ *     <dt>given {@code codec} as a {@link Codec} implementation and {@code string} as a String</dt>
+ *     <dd>{@code string.equals( codec.encode( codec.decode( string ) ) ) == true}</dd>
+ * </dl>
+ *
+ * @author Guillaume Wallet
+ * @since 4.2.2
+ * @see Codecs
+ */
+public interface Codec {
+	/**
+	 * Produces a {@link String} from a byte array.
+	 *
+	 * @param source source byte array.
+	 * @return String representation of the byte array.
+	 */
+	String encode(byte[] source);
+
+	/**
+	 * Produces a byte array from a {@link String} representation.
+	 *
+	 * @param source the string representation.
+	 * @return Returns the byte array represented in the {@link String}.
+	 */
+	byte[] decode(String source);
+}

--- a/crypto/src/main/java/org/springframework/security/crypto/codec/Codecs.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/codec/Codecs.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.crypto.codec;
+
+/**
+ * Quick access facility to some {@link Codec} implementations.
+ *
+ * @author Guillaume Wallet
+ * @since 4.2.2
+ */
+public final class Codecs {
+	private static Codec BASE64 = new Codec() {
+		@Override
+		public String encode(byte[] source) {
+			return Utf8.decode(Base64.encode(source));
+		}
+
+		@Override
+		public byte[] decode(String source) {
+			return Base64.decode(Utf8.encode(source));
+		}
+	};
+
+	public static Codec base64() {
+		return BASE64;
+	}
+
+	private static Codec HEXADECIMAL = new Codec() {
+		@Override
+		public String encode(byte[] source) {
+			return new String(Hex.encode(source));
+		}
+
+		@Override
+		public byte[] decode(String source) {
+			return Hex.decode(source);
+		}
+	};
+
+	public static Codec hexadecimal() {
+		return HEXADECIMAL;
+	}
+}

--- a/crypto/src/main/java/org/springframework/security/crypto/password/Pbkdf2PasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password/Pbkdf2PasswordEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,8 +38,11 @@ import static org.springframework.security.crypto.util.EncodingUtils.subArray;
  *
  * @author Rob Worsnop
  * @author Rob Winch
+ * @author Guillaume Wallet
  * @since 4.1
+ * @deprecated Deprecated in 4.2.2, please use {@link org.springframework.security.crypto.pbkdf2.PBKDF2PasswordEncoder} instead.
  */
+@Deprecated
 public class Pbkdf2PasswordEncoder implements PasswordEncoder {
 	private static final String PBKDF2_ALGORITHM = "PBKDF2WithHmacSHA1";
 	private static final int DEFAULT_HASH_WIDTH = 256;

--- a/crypto/src/main/java/org/springframework/security/crypto/pbkdf2/PBKDF2.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/pbkdf2/PBKDF2.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.crypto.pbkdf2;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+/**
+ * Password Based Key Derivation Function 2.
+ *
+ * @author Guillaume Wallet
+ * @since 4.2.2
+ * @see <a href="https://tools.ietf.org/html/rfc2898">Password-Based Cryptography Specification Version 2.0</a>
+ */
+public final class PBKDF2 {
+	/**
+	 * @see <a href="http://docs.oracle.com/javase/6/docs/technotes/guides/security/StandardNames.html#SecretKeyFactory">Java 6 runtime's SecretKeyFactory</a>
+	 * @see <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#SecretKeyFactory">Java 7 runtime's SecretKeyFactory</a>
+	 */
+	public static final String WITH_HMAC_SHA1 = "PBKDF2WithHmacSHA1";
+	/**
+	 * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#SecretKeyFactory">Java 8 runtime's SecretKeyFactory</a>
+	 */
+	public static final String WITH_HMAC_SHA256 = "PBKDF2WithHmacSHA256";
+	/**
+	 * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#SecretKeyFactory">Java 8 runtime's SecretKeyFactory</a>
+	 */
+	public static final String WITH_HMAC_SHA512 = "PBKDF2WithHmacSHA512";
+
+	private final SecretKeyFactory secretKeyFactory;
+
+	/**
+	 * Constructs a key derivation function with HMAC-SHA1 as the underlying pseudo-random function.
+	 *
+	 * @see #WITH_HMAC_SHA1
+	 */
+	public PBKDF2() {
+		this(WITH_HMAC_SHA1);
+	}
+
+	/**
+	 * Constructs a key derivation function with the given underlying pseudo-random function.
+	 *
+	 * @param algorithm the secret key factory algorithm, can be one of {@code "PBKDF2WithHmacSHA1"} (default),
+	 * 			{@code "PBKDF2WithHmacSHA256"}, {@code "PBKDF2WithHmacSHA512"}, depending on the target runtime version.
+	 *
+	 * @see #WITH_HMAC_SHA1
+	 * @see #WITH_HMAC_SHA256
+	 * @see #WITH_HMAC_SHA512
+	 * @see <a href="http://docs.oracle.com/javase/6/docs/technotes/guides/security/StandardNames.html#SecretKeyFactory">Java 6 runtime's SecretKeyFactory</a>
+	 * @see <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#SecretKeyFactory">Java 7 runtime's SecretKeyFactory</a>
+	 * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#SecretKeyFactory">Java 8 runtime's SecretKeyFactory</a>
+	 */
+	public PBKDF2(String algorithm) {
+		try {
+			this.secretKeyFactory = SecretKeyFactory.getInstance(algorithm);
+		} catch (NoSuchAlgorithmException cause) {
+			throw new IllegalArgumentException("Could not create PBKDF2 instance " + algorithm, cause);
+		}
+	}
+
+	public byte[] encode(String password, byte[] salt, int iterations, int hashLengthInByte) {
+		PBEKeySpec spec = new PBEKeySpec(password.toCharArray(), salt, iterations, hashLengthInByte * 8);
+		try {
+			return secretKeyFactory.generateSecret(spec).getEncoded();
+		} catch (InvalidKeySpecException cause) { throw new IllegalStateException("Can not create hash", cause); } // Should never happen
+	}
+}

--- a/crypto/src/main/java/org/springframework/security/crypto/pbkdf2/PBKDF2PasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/pbkdf2/PBKDF2PasswordEncoder.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.crypto.pbkdf2;
+
+import org.springframework.security.crypto.codec.Codec;
+import org.springframework.security.crypto.codec.Codecs;
+import org.springframework.security.crypto.keygen.BytesKeyGenerator;
+import org.springframework.security.crypto.keygen.KeyGenerators;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.springframework.security.crypto.pbkdf2.PBKDF2.WITH_HMAC_SHA1;
+import static org.springframework.security.crypto.util.EncodingUtils.concatenate;
+import static org.springframework.security.crypto.util.EncodingUtils.subArray;
+import static org.springframework.security.crypto.util.EncodingUtils.timeConstantArrayEquals;
+
+/**
+ * A {@link PasswordEncoder} implementation that rely on {@link PBKDF2} and is fully customizable.
+ * <p>
+ * The hash length can be configured, default value is 32 bytes (256 bits) long.<br/>
+ * The salt length can be configured, default value is 8 bytes (64 bits) long.<br/>
+ * The iteration count can be configured, default value is 185,000.<br/>
+ * The key derivation function used can be configured, default value is {@code HmacSHA1}.<br/>
+ * The default hash's {@link String} representation is {@link Codecs#hexadecimal() hexadecimal}.
+ * <p>
+ *
+ * @author Guillaume Wallet
+ * @since 4.2.2
+ * @see <a href="https://tools.ietf.org/html/rfc2898">Password-Based Cryptography Specification Version 2.0</a>
+ * @see PBKDF2
+ * @see Codec
+ */
+public class PBKDF2PasswordEncoder implements PasswordEncoder {
+	/** The default hash length is 32 bytes (256 bits) long. */
+	public static final int DEFAULT_HASH_LENGTH = 32;
+	/** The default salt length is 8 bytes (64 bits) long. */
+	public static final int DEFAULT_SALT_LENGTH = 8;
+	/** The default iterations count is 185,000. */
+	public static final int DEFAULT_ITERATION_COUNT = 185000;
+	private BytesKeyGenerator saltGenerator;
+	private int hashLength;
+	private int iterations;
+	private PBKDF2 keyDerivationFunction;
+	private Codec codec;
+
+	/**
+	 * Constructs a password encoder with defined settings and produces hexadecimal footprint
+	 * using HMAC-SHA1 as key derivation function.
+	 * The salt will be 8 bytes long (64 bits), the hash will be 32 bytes long (256 bits) produced
+	 * by iterating 185 000 times.
+	 */
+	public PBKDF2PasswordEncoder() {
+		this(DEFAULT_SALT_LENGTH, DEFAULT_HASH_LENGTH, DEFAULT_ITERATION_COUNT);
+	}
+
+	/**
+	 * Constructs a password encoder with defined settings and produces hexadecimal footprint
+	 * using HmacSHA1 as key derivation function.
+	 *
+	 * @param saltLength Length in bytes of the generated salt.
+	 * @param hashLength Length in bytes of the produced hash.
+	 * @param iterations Number of iterations to produce the hash.
+	 */
+	public PBKDF2PasswordEncoder(int saltLength, int hashLength, int iterations) {
+		this(saltLength, hashLength, iterations, new PBKDF2(WITH_HMAC_SHA1));
+	}
+
+	/**
+	 * Constructs a password encoder with defined settings and produces hexadecimal footprint.
+	 *
+	 * @param saltLength Length in bytes of the generated salt.
+	 * @param hashLength Length in bytes of the produced hash.
+	 * @param iterations Number of iterations to produce the hash.
+	 * @param keyDerivationFunction The key derivation function to use.
+	 */
+	public PBKDF2PasswordEncoder(int saltLength, int hashLength, int iterations, PBKDF2 keyDerivationFunction) {
+		this(saltLength, hashLength, iterations, keyDerivationFunction, Codecs.hexadecimal());
+	}
+
+	/**
+	 * Constructs a password encoder with defined settings.
+	 *
+	 * @param saltLength Length in bytes of the generated salt.
+	 * @param hashLength Length in bytes of the produced hash.
+	 * @param iterations Number of iterations to produce the hash.
+	 * @param keyDerivationFunction The key derivation function to use.
+	 * @param codec The codec to use when encoding into {@code java.lang.String}.
+	 */
+	public PBKDF2PasswordEncoder(int saltLength, int hashLength, int iterations, PBKDF2 keyDerivationFunction, Codec codec) {
+		this.iterations = iterations;
+		this.hashLength = hashLength;
+		this.saltGenerator = KeyGenerators.secureRandom(saltLength);
+		this.keyDerivationFunction = keyDerivationFunction;
+		this.codec = codec;
+	}
+
+	@Override
+	public String encode(CharSequence rawPassword) {
+		byte[] salt = saltGenerator.generateKey();
+		byte[] encoded = doEncode(rawPassword, salt);
+		return codec.encode(concatenate(salt, encoded));
+	}
+
+	/*
+	 * Execute the same algorithm for #encode(CharSequence) and #matches(CharSequence, String)
+	 */
+	protected byte[] doEncode(CharSequence rawPassword, byte[] salt) {
+		return keyDerivationFunction.encode(rawPassword.toString(), salt, iterations, hashLength);
+	}
+
+	@Override
+	public boolean matches(CharSequence rawPassword, String encodedPassword) {
+		byte[] footprint = codec.decode(encodedPassword);
+		byte[] salt = subArray(footprint, 0, saltGenerator.getKeyLength());
+		byte[] encoded = subArray(footprint, salt.length, footprint.length);
+		return timeConstantArrayEquals(encoded, doEncode(rawPassword, salt));
+	}
+}

--- a/crypto/src/main/java/org/springframework/security/crypto/util/EncodingUtils.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/util/EncodingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ package org.springframework.security.crypto.util;
  * For internal use only.
  *
  * @author Keith Donald
+ * @author Guillaume Wallet
  */
 public class EncodingUtils {
 
@@ -57,4 +58,20 @@ public class EncodingUtils {
 	private EncodingUtils() {
 	}
 
+	/**
+	 * Constant time comparison to prevent against timing attacks.
+	 * @param expected the expected array
+	 * @param actual the given array to compare
+	 */
+	public static boolean timeConstantArrayEquals(byte[] expected, byte[] actual) {
+		if (expected.length != actual.length) {
+			return false;
+		}
+
+		int result = 0;
+		for (int i = 0; i < expected.length; i++) {
+			result |= expected[i] ^ actual[i];
+		}
+		return result == 0;
+	}
 }

--- a/crypto/src/test/java/org/springframework/security/crypto/codec/CodecsTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/codec/CodecsTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.crypto.codec;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CodecsTests {
+
+	public static final String SOURCE = "Hi!";
+	public static final String BASE64_STRING = "SGkh";
+	public static final String HEXA_STRING = "486921";
+	public static final byte[] BYTE_ARRAY = {0x1, 0x2, 0x3};
+
+	@Test
+	public void shouldSatisfyCodecContract() throws Exception {
+		Codec codec = Codecs.base64();
+		assertThat(Arrays.equals(codec.decode(codec.encode(BYTE_ARRAY)), BYTE_ARRAY))
+			.isTrue();
+		assertThat(BASE64_STRING.equals(codec.encode(codec.decode(BASE64_STRING))))
+			.isTrue();
+
+		codec = Codecs.hexadecimal();
+		assertThat(Arrays.equals(codec.decode(codec.encode(BYTE_ARRAY)), BYTE_ARRAY))
+			.isTrue();
+		assertThat(HEXA_STRING.equals(codec.encode(codec.decode(HEXA_STRING))))
+			.isTrue();
+	}
+
+	@Test
+	public void shouldEncodeInBase64() throws Exception {
+		assertThat(Codecs.base64().encode(SOURCE.getBytes()))
+			.isEqualToIgnoringCase(BASE64_STRING);
+	}
+
+	@Test
+	public void shouldDecodeBase64() throws Exception {
+		assertThat(Codecs.base64().decode(BASE64_STRING))
+			.isEqualTo(SOURCE.getBytes());
+	}
+
+	@Test
+	public void shouldEncodeInHexadecimal() throws Exception {
+		assertThat(Codecs.hexadecimal().encode(SOURCE.getBytes()))
+			.isEqualToIgnoringCase(HEXA_STRING);
+	}
+
+	@Test
+	public void shouldDecodeHexadecimal() throws Exception {
+		assertThat(Codecs.hexadecimal().decode(HEXA_STRING))
+			.isEqualTo(SOURCE.getBytes());
+	}
+}

--- a/crypto/src/test/java/org/springframework/security/crypto/pbkdf2/PBKDF2PasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/pbkdf2/PBKDF2PasswordEncoderTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2011-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.crypto.pbkdf2;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.crypto.codec.Codecs;
+
+import java.security.NoSuchAlgorithmException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PBKDF2PasswordEncoderTests {
+	private static final String PASS = "quick brown fox jumps over the lazy dog";
+	private static final String GOOD = "ec87602c076fc532689027d236ded368d000f70216e9c4338d6e5d0d98295190ff1b5e554b5d9542";
+	private static final String CAFE = "cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe";
+
+	private PBKDF2PasswordEncoder encoder;
+
+	@Before
+	public void setUp() throws Exception {
+		encoder = new PBKDF2PasswordEncoder();
+	}
+
+	@Test
+	public void shouldMatch() throws Exception {
+		assertThat(encoder.matches(PASS, GOOD))
+			.isTrue();
+	}
+
+	@Test
+	public void shouldNotMatch() throws Exception {
+		assertThat(encoder.matches(PASS, CAFE))
+			.isFalse();
+	}
+
+	@Test
+	public void shouldGenerateUniqueFootprint() throws Exception {
+		String encoded = encoder.encode(PASS);
+		assertThat(encoder.matches(PASS, encoded))
+			.isTrue();
+		assertThat(encoded).isNotEqualToIgnoringCase(GOOD);
+	}
+
+	@Test
+	public void shouldHaveTheGoodLengthInHexadecimal() throws Exception {
+		String encoded = encoder.encode(PASS);
+		int saltLength = 8;
+		int hashLength = 32;
+		assertThat(encoded).hasSize(hexaLength(saltLength + hashLength));
+	}
+
+	private int hexaLength(int lengthInBytes) {
+		return lengthInBytes * 2;
+	}
+
+	@Test
+	public void shouldHaveTheGoodLengthInBase64() throws Exception {
+		int saltLength = 8;
+		int hashLength = 32;
+		encoder = new PBKDF2PasswordEncoder(saltLength, hashLength, PBKDF2PasswordEncoder.DEFAULT_ITERATION_COUNT, new PBKDF2(PBKDF2.WITH_HMAC_SHA1), Codecs.base64());
+		String encoded = encoder.encode(PASS);
+		assertThat(encoded).hasSize(base64Length(saltLength + hashLength));
+	}
+
+	private int base64Length(int lengthInBytes) {
+		double length = lengthInBytes * 4.0 / 3.0;
+		return ((int) (length / 4)) * 4 + 4;
+	}
+
+	@Test
+	public void hmacSHA256IsNotSupportedBeforeJava8() throws Exception {
+		try {
+			assertThat(new PBKDF2(PBKDF2.WITH_HMAC_SHA256)).isNotNull(); // Only true on JDK 8 and later
+			assertThat(Double.valueOf(System.getProperty("java.specification.version")))
+				.isGreaterThanOrEqualTo(1.8);
+		} catch (IllegalArgumentException exception) {
+			assertThat(exception)
+				.hasMessage("Could not create PBKDF2 instance PBKDF2WithHmacSHA256")
+				.hasCauseInstanceOf(NoSuchAlgorithmException.class);
+			assertThat(Double.valueOf(System.getProperty("java.specification.version")))
+				.isLessThan(1.8);
+		}
+	}
+}


### PR DESCRIPTION
Hi,

I had once to implement a new org.springframework.security.crypto.password.PasswordEncoder to fulfill the following security requirements:
- Hash algorithm: PBKDF2
- PRF: HMAC-SHA256
- Hash length: 256 bits
- Salt length: 64 bits
- Iteration count: 100,000

Keeping an eye on the project to migrate on an existing one, I find out the new one org.springframework.security.crypto.password.Pbkdf2PasswordEncoder was close to fit but suffer from a lack of customization regarding to the above requirements.

Here comes a suggestion to enable the use of PBKDF2 as password encoder algorithm (like mentioned in #2383) with some settings improvement.
The new PBKDF2 password encoder :
- makes PBKDF2 algorithm a first class citizen (like BCrypt)
- uses one of the PBKDF2 flavor supported by the platform (like HMAC-SHA256 and HMAC-SHA512 [starting from JDK 8](http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#SecretKeyFactory))
- uses the given salt/hash length, iterations count
- uses the given codec in order to represent the hash as Base64 or Hexadecimal, ... or whatever

Because it's not fully backward compatible with the previous one (no secret key), I choose to  deprecate it in and create a new dedicated package.

I tried to follow coding guideline, to test it and to document as much as possible, any review's feedback will be welcome.
