### PR TITLE
Avoid multiple X-Frame-Options headers

### DIFF
--- a/web/src/main/java/org/springframework/security/web/header/writers/frameoptions/XFrameOptionsHeaderWriter.java
+++ b/web/src/main/java/org/springframework/security/web/header/writers/frameoptions/XFrameOptionsHeaderWriter.java
@@ -74,16 +74,22 @@ public final class XFrameOptionsHeaderWriter implements HeaderWriter {
 		this.allowFromStrategy = allowFromStrategy;
 	}
 
+	/**
+	 * Writes the X-Frame-Options header value, overwritting any previous value.
+	 *
+	 * @param request the servlet request
+	 * @param response the servlet response
+	 */
 	public void writeHeaders(HttpServletRequest request, HttpServletResponse response) {
 		if (XFrameOptionsMode.ALLOW_FROM.equals(frameOptionsMode)) {
 			String allowFromValue = allowFromStrategy.getAllowFromValue(request);
 			if (allowFromValue != null) {
-				response.addHeader(XFRAME_OPTIONS_HEADER,
+				response.setHeader(XFRAME_OPTIONS_HEADER,
 						XFrameOptionsMode.ALLOW_FROM.getMode() + " " + allowFromValue);
 			}
 		}
 		else {
-			response.addHeader(XFRAME_OPTIONS_HEADER, frameOptionsMode.getMode());
+			response.setHeader(XFRAME_OPTIONS_HEADER, frameOptionsMode.getMode());
 		}
 	}
 

--- a/web/src/test/java/org/springframework/security/web/header/writers/frameoptions/FrameOptionsHeaderWriterTests.java
+++ b/web/src/test/java/org/springframework/security/web/header/writers/frameoptions/FrameOptionsHeaderWriterTests.java
@@ -108,4 +108,17 @@ public class FrameOptionsHeaderWriterTests {
 		assertThat(response.getHeader(XFrameOptionsHeaderWriter.XFRAME_OPTIONS_HEADER))
 				.isEqualTo("SAMEORIGIN");
 	}
+
+	@Test
+	public void writeHeadersTwiceLastWins() {
+		writer = new XFrameOptionsHeaderWriter(XFrameOptionsMode.SAMEORIGIN);
+		writer.writeHeaders(request, response);
+		
+		writer = new XFrameOptionsHeaderWriter(XFrameOptionsMode.DENY);
+		writer.writeHeaders(request, response);
+
+		assertThat(response.getHeaderNames().size()).isEqualTo(1);
+		assertThat(response.getHeader(XFrameOptionsHeaderWriter.XFRAME_OPTIONS_HEADER))
+				.isEqualTo("DENY");
+	}
 }

--- a/web/src/test/java/org/springframework/security/web/header/writers/frameoptions/FrameOptionsHeaderWriterTests.java
+++ b/web/src/test/java/org/springframework/security/web/header/writers/frameoptions/FrameOptionsHeaderWriterTests.java
@@ -113,7 +113,7 @@ public class FrameOptionsHeaderWriterTests {
 	public void writeHeadersTwiceLastWins() {
 		writer = new XFrameOptionsHeaderWriter(XFrameOptionsMode.SAMEORIGIN);
 		writer.writeHeaders(request, response);
-		
+
 		writer = new XFrameOptionsHeaderWriter(XFrameOptionsMode.DENY);
 		writer.writeHeaders(request, response);
 


### PR DESCRIPTION
XFrameOptionsHeaderWriter should not *add*, but *set* the X-Frame-Options header.
According to https://tools.ietf.org/html/rfc7034#section-2.1, having multiple values for the header is disallowed:

> There are three different values for the header field.  These values are mutually exclusive; that is, the header field MUST be set to exactly one of the three values.

With this change, only the latest XFrameOptionsHeaderWriter will remain.
