### PR TITLE
SEC-2026: MethodSecurityExpressionRoot should be a public class

### DIFF
--- a/core/src/main/java/org/springframework/security/access/expression/method/MethodSecurityExpressionRoot.java
+++ b/core/src/main/java/org/springframework/security/access/expression/method/MethodSecurityExpressionRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.springframework.security.core.Authentication;
  * @author Luke Taylor
  * @since 3.0
  */
-class MethodSecurityExpressionRoot extends SecurityExpressionRoot implements
+public class MethodSecurityExpressionRoot extends SecurityExpressionRoot implements
 		MethodSecurityExpressionOperations {
 	private Object filterObject;
 	private Object returnObject;


### PR DESCRIPTION
changed class accessor from package-private to public

#2251 SEC-2026: MethodSecurityExpressionRoot should be a public class
Changed class accessor to public as requested. It is anoying to have to copy the code just because its package-private.
#SEC-2026: 