### PR TITLE
Provide AuthenticatedPrincipal abstraction

### DIFF
--- a/acl/pom.xml
+++ b/acl/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-acl</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-acl</name>
   <description>spring-security-acl</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -51,7 +56,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -114,7 +119,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -162,8 +167,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/aspects/pom.xml
+++ b/aspects/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-aspects</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-aspects</name>
   <description>spring-security-aspects</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -45,7 +50,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -104,7 +109,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -141,8 +146,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/cas/pom.xml
+++ b/cas/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-cas</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-cas</name>
   <description>spring-security-cas</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -51,13 +56,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -128,7 +133,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -166,8 +171,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-config</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-config</name>
   <description>spring-security-config</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -51,7 +56,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -97,28 +102,28 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-ldap</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-messaging</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-openid</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
@@ -161,7 +166,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
-      <version>3.1</version>
+      <version>3.2.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -227,7 +232,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -275,7 +280,7 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -287,31 +292,31 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-support</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-core</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4-common</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-reflect</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -365,13 +370,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-aspects</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-cas</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -401,8 +406,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-core</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-core</name>
   <description>spring-security-core</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -159,7 +164,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -189,7 +194,7 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -201,7 +206,7 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-support</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -213,7 +218,7 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-core</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -225,7 +230,7 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -237,7 +242,7 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4-common</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -249,7 +254,7 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-reflect</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -305,8 +310,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/core/src/main/java/org/springframework/security/authentication/AbstractAuthenticationToken.java
+++ b/core/src/main/java/org/springframework/security/authentication/AbstractAuthenticationToken.java
@@ -24,8 +24,8 @@ import java.util.Collections;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.CredentialsContainer;
+import org.springframework.security.core.AuthenticatedPrincipal;
 import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.security.core.userdetails.UserDetails;
 
 /**
  * Base class for <code>Authentication</code> objects.
@@ -79,8 +79,8 @@ public abstract class AbstractAuthenticationToken implements Authentication,
 	}
 
 	public String getName() {
-		if (this.getPrincipal() instanceof UserDetails) {
-			return ((UserDetails) this.getPrincipal()).getUsername();
+		if (this.getPrincipal() instanceof AuthenticatedPrincipal) {
+			return ((AuthenticatedPrincipal) this.getPrincipal()).getName();
 		}
 
 		if (getPrincipal() instanceof Principal) {

--- a/core/src/main/java/org/springframework/security/core/AuthenticatedPrincipal.java
+++ b/core/src/main/java/org/springframework/security/core/AuthenticatedPrincipal.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.core;
+
+import org.springframework.security.authentication.AuthenticationManager;
+
+/**
+ * Representation of an authenticated <code>Principal</code> once an
+ * {@link Authentication} request has been successfully authenticated
+ * by the {@link AuthenticationManager#authenticate(Authentication)} method.
+ *
+ * Implementors typically provide their own representation of a <code>Principal</code>,
+ * which usually contains information describing the <code>Principal</code> entity,
+ * such as, first/middle/last name, address, email, phone, id, etc.
+ *
+ * This interface allows implementors to expose specific attributes
+ * of their custom representation of <code>Principal</code> in a generic way.
+ *
+ * @author Joe Grandja
+ * @since 5.0
+ * @see Authentication#getPrincipal()
+ * @see org.springframework.security.core.userdetails.UserDetails
+ */
+public interface AuthenticatedPrincipal {
+
+	/**
+	 * Returns the name of the authenticated <code>Principal</code>. Never <code>null</code>.
+	 *
+	 * @return the name of the authenticated <code>Principal</code>
+	 */
+	String getName();
+
+}

--- a/core/src/main/java/org/springframework/security/core/userdetails/UserDetails.java
+++ b/core/src/main/java/org/springframework/security/core/userdetails/UserDetails.java
@@ -18,6 +18,7 @@ package org.springframework.security.core.userdetails;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.AuthenticatedPrincipal;
 
 import java.io.Serializable;
 import java.util.Collection;
@@ -41,7 +42,7 @@ import java.util.Collection;
  *
  * @author Ben Alex
  */
-public interface UserDetails extends Serializable {
+public interface UserDetails extends AuthenticatedPrincipal, Serializable {
 	// ~ Methods
 	// ========================================================================================================
 
@@ -60,8 +61,7 @@ public interface UserDetails extends Serializable {
 	String getPassword();
 
 	/**
-	 * Returns the username used to authenticate the user. Cannot return <code>null</code>
-	 * .
+	 * Returns the username used to authenticate the user. Cannot return <code>null</code>.
 	 *
 	 * @return the username (never <code>null</code>)
 	 */
@@ -100,4 +100,14 @@ public interface UserDetails extends Serializable {
 	 * @return <code>true</code> if the user is enabled, <code>false</code> otherwise
 	 */
 	boolean isEnabled();
+
+	/**
+	 * Returns the name of the user. Cannot return <code>null</code>.
+	 * The default implementation of this method returns {@link #getUsername()}.
+	 *
+	 * @return the name of the user (never <code>null</code>)
+	 */
+	default String getName() {
+		return getUsername();
+	}
 }

--- a/core/src/test/java/org/springframework/security/authentication/AbstractAuthenticationTokenTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/AbstractAuthenticationTokenTests.java
@@ -17,8 +17,10 @@
 package org.springframework.security.authentication;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import org.junit.*;
+import org.springframework.security.core.AuthenticatedPrincipal;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -133,6 +135,18 @@ public class AbstractAuthenticationTokenTests {
 		MockAuthenticationImpl token = new MockAuthenticationImpl("Test", "Password",
 				null);
 		assertThat(token.toString().lastIndexOf("Not granted any authorities") != -1).isTrue();
+	}
+
+	@Test
+	public void testGetNameWhenPrincipalIsAuthenticatedPrincipal() {
+		String principalName = "test";
+
+		AuthenticatedPrincipal principal = mock(AuthenticatedPrincipal.class);
+		when(principal.getName()).thenReturn(principalName);
+
+		MockAuthenticationImpl token = new MockAuthenticationImpl(principal, "Password", authorities);
+		assertThat(token.getName()).isEqualTo(principalName);
+		verify(principal, times(1)).getName();
 	}
 
 	// ~ Inner Classes

--- a/core/src/test/java/org/springframework/security/core/JavaVersionTests.java
+++ b/core/src/test/java/org/springframework/security/core/JavaVersionTests.java
@@ -15,10 +15,10 @@
  */
 package org.springframework.security.core;
 
+import org.junit.Test;
+
 import java.io.DataInputStream;
 import java.io.InputStream;
-
-import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class JavaVersionTests {
 
-	private static final int JDK6_CLASS_VERSION = 50;
+	private static final int JDK8_CLASS_VERSION = 52;
 
 	@Test
 	public void authenticationCorrectJdkCompatibility() throws Exception {
@@ -45,7 +45,7 @@ public class JavaVersionTests {
 			data.readInt();
 			data.readShort(); // minor
 			int major = data.readShort();
-			assertThat(major).isEqualTo(JDK6_CLASS_VERSION);
+			assertThat(major).isEqualTo(JDK8_CLASS_VERSION);
 		}
 		finally {
 			try {

--- a/core/src/test/java/org/springframework/security/core/userdetails/UserDetailsTest.java
+++ b/core/src/test/java/org/springframework/security/core/userdetails/UserDetailsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.core.userdetails;
+
+import org.junit.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests {@link UserDetails}
+ *
+ * @author Joe Grandja
+ */
+public class UserDetailsTest {
+
+	@Test
+	public void getNameWhenCalledThenDefaultToGetUsername() {
+		UserDetails userDetails = new MockUserDetails("joeg");
+		assertThat(userDetails.getName()).isEqualTo(userDetails.getUsername());
+	}
+
+	private class MockUserDetails implements UserDetails {
+		private final String username;
+
+		private MockUserDetails(String username) {
+			this.username = username;
+		}
+
+		@Override
+		public Collection<? extends GrantedAuthority> getAuthorities() {
+			return AuthorityUtils.NO_AUTHORITIES;
+		}
+
+		@Override
+		public String getPassword() {
+			return null;
+		}
+
+		@Override
+		public String getUsername() {
+			return this.username;
+		}
+
+		@Override
+		public boolean isAccountNonExpired() {
+			return true;
+		}
+
+		@Override
+		public boolean isAccountNonLocked() {
+			return true;
+		}
+
+		@Override
+		public boolean isCredentialsNonExpired() {
+			return true;
+		}
+
+		@Override
+		public boolean isEnabled() {
+			return true;
+		}
+	}
+}

--- a/crypto/pom.xml
+++ b/crypto/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-crypto</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-crypto</name>
   <description>spring-security-crypto</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -71,7 +76,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -103,8 +108,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-data</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-data</name>
   <description>spring-security-data</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -51,7 +56,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -87,7 +92,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -119,8 +124,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/gradle/javaprojects.gradle
+++ b/gradle/javaprojects.gradle
@@ -5,13 +5,13 @@ apply plugin: 'javadocHotfix'
 apply plugin: 'propdeps'
 apply plugin: 'propdeps-maven'
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 ext.apacheDsVersion = '1.5.5'
 ext.aspectjVersion = '1.8.4'
 ext.casClientVersion = '3.4.1'
-ext.cglibVersion = '3.1'
+ext.cglibVersion = '3.2.5'
 ext.commonsCodecVersion = '1.10'
 ext.commonsCollectionsVersion = '3.2.2'
 ext.commonsLoggingVersion = '1.2'
@@ -27,7 +27,7 @@ ext.jettyVersion = '6.1.26'
 ext.jstlVersion = '1.2.1'
 ext.junitVersion = '4.12'
 ext.logbackVersion = '1.1.2'
-ext.powerMockVersion = '1.6.2'
+ext.powerMockVersion = '1.6.5'
 ext.seleniumVersion = '2.44.0'
 ext.servletApiVersion = '3.1.0'
 ext.slf4jVersion = '1.7.7'
@@ -40,6 +40,7 @@ ext.springBootVersion = '1.5.0.BUILD-SNAPSHOT'
 ext.thymeleafVersion = '3.0.2.RELEASE'
 ext.jsonassertVersion = '1.3.0'
 ext.validationApiVersion = '1.1.0.Final'
+
 
 ext.spockDependencies = [
 	dependencies.create("org.spockframework:spock-spring:$spockVersion") {
@@ -148,7 +149,7 @@ dependencies {
 	testCompile "junit:junit:$junitVersion",
 			'org.mockito:mockito-core:1.10.19',
 			"org.springframework:spring-test:$springVersion",
-			'org.assertj:assertj-core:2.2.0'
+			'org.assertj:assertj-core:3.6.2'
 
 	// Use slf4j/logback for logging
 	testRuntime "org.slf4j:jcl-over-slf4j:$slf4jVersion",

--- a/gradle/maven-deployment.gradle
+++ b/gradle/maven-deployment.gradle
@@ -67,7 +67,12 @@ def customizePom(pom, gradleProject) {
 			developer {
 				id = 'rwinch'
 				name = 'Rob Winch'
-				email = 'rwinch@gopivotal.com'
+				email = 'rwinch@pivotal.io'
+			}
+			developer {
+				id = 'jgrandja'
+				name = 'Joe Grandja'
+				email = 'jgrandja@pivotal.io'
 			}
 		}
 
@@ -113,8 +118,8 @@ def customizePom(pom, gradleProject) {
 			.appendNode('plugin')
 				.appendNode('artifactId','maven-compiler-plugin').parent()
 				.appendNode('configuration')
-					.appendNode('source','1.7').parent()
-					.appendNode('target','1.7')
+					.appendNode('source','1.8').parent()
+					.appendNode('target','1.8')
 		if(isWar) {
 			plugins
 				.appendNode('plugin')

--- a/itest/context/pom.xml
+++ b/itest/context/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>itest-context</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>itest-context</name>
   <description>itest-context</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -57,7 +62,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -114,7 +119,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -132,13 +137,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -163,8 +168,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/itest/web/pom.xml
+++ b/itest/web/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>itest-web</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>itest-web</name>
   <description>itest-web</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -80,7 +85,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -98,31 +103,31 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-ldap</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-test</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -152,8 +157,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/ldap/pom.xml
+++ b/ldap/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-ldap</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-ldap</name>
   <description>spring-security-ldap</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -73,7 +78,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -173,7 +178,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -211,8 +216,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-messaging</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-messaging</name>
   <description>spring-security-messaging</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -51,7 +56,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -102,7 +107,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
@@ -133,7 +138,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -157,7 +162,7 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -169,31 +174,31 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-support</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-core</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4-common</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-reflect</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -243,8 +248,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-openid</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-openid</name>
   <description>spring-security-openid</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -63,13 +68,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -143,7 +148,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -175,8 +180,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/remoting/pom.xml
+++ b/remoting/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-remoting</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-remoting</name>
   <description>spring-security-remoting</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -51,7 +56,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -102,7 +107,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -134,8 +139,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/samples/boot/helloworld/pom.xml
+++ b/samples/boot/helloworld/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-boot-helloworld</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-samples-boot-helloworld</name>
   <description>spring-security-samples-boot-helloworld</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -55,13 +60,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -92,7 +97,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -115,7 +120,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-test</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -135,8 +140,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/samples/boot/insecure/pom.xml
+++ b/samples/boot/insecure/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-boot-insecure</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-samples-boot-insecure</name>
   <description>spring-security-samples-boot-insecure</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -74,7 +79,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -111,8 +116,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/samples/javaconfig/aspectj/pom.xml
+++ b/samples/javaconfig/aspectj/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-javaconfig-aspectj</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-samples-javaconfig-aspectj</name>
   <description>spring-security-samples-javaconfig-aspectj</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -45,13 +50,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -71,7 +76,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-aspects</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -89,7 +94,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -121,8 +126,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/samples/javaconfig/concurrency/pom.xml
+++ b/samples/javaconfig/concurrency/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-javaconfig-concurrency</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-concurrency</name>
   <description>spring-security-samples-javaconfig-concurrency</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -91,25 +96,25 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-samples-javaconfig-messages</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -144,7 +149,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
-      <version>3.1</version>
+      <version>3.2.5</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -168,7 +173,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -194,8 +199,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/javaconfig/data/pom.xml
+++ b/samples/javaconfig/data/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-javaconfig-data</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-samples-javaconfig-data</name>
   <description>spring-security-samples-javaconfig-data</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -81,13 +86,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-data</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -112,7 +117,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -144,8 +149,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/samples/javaconfig/form/pom.xml
+++ b/samples/javaconfig/form/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-javaconfig-form</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-form</name>
   <description>spring-security-samples-javaconfig-form</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -91,25 +96,25 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-samples-javaconfig-messages</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -144,7 +149,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
-      <version>3.1</version>
+      <version>3.2.5</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -174,7 +179,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -248,8 +253,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/javaconfig/hellojs/pom.xml
+++ b/samples/javaconfig/hellojs/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-javaconfig-hellojs</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-hellojs</name>
   <description>spring-security-samples-javaconfig-hellojs</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -97,25 +102,25 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-samples-javaconfig-messages</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -150,7 +155,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
-      <version>3.1</version>
+      <version>3.2.5</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -174,7 +179,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -200,8 +205,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/javaconfig/hellomvc/pom.xml
+++ b/samples/javaconfig/hellomvc/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-javaconfig-hellomvc</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-hellomvc</name>
   <description>spring-security-samples-javaconfig-hellomvc</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -91,25 +96,25 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-samples-javaconfig-messages</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -144,7 +149,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
-      <version>3.1</version>
+      <version>3.2.5</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -168,7 +173,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -180,7 +185,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-test</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -200,8 +205,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/javaconfig/helloworld/pom.xml
+++ b/samples/javaconfig/helloworld/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-javaconfig-helloworld</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-helloworld</name>
   <description>spring-security-samples-javaconfig-helloworld</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -67,13 +72,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -116,7 +121,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -190,8 +195,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/javaconfig/inmemory/pom.xml
+++ b/samples/javaconfig/inmemory/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-javaconfig-inmemory</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-inmemory</name>
   <description>spring-security-samples-javaconfig-inmemory</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -91,25 +96,25 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-samples-javaconfig-messages</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -144,7 +149,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
-      <version>3.1</version>
+      <version>3.2.5</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -168,7 +173,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -180,7 +185,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-test</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -200,8 +205,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/javaconfig/jdbc/pom.xml
+++ b/samples/javaconfig/jdbc/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-javaconfig-jdbc</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-jdbc</name>
   <description>spring-security-samples-javaconfig-jdbc</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -91,25 +96,25 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-samples-javaconfig-messages</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -144,7 +149,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
-      <version>3.1</version>
+      <version>3.2.5</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -174,7 +179,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -248,8 +253,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/javaconfig/ldap/pom.xml
+++ b/samples/javaconfig/ldap/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-javaconfig-ldap</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-ldap</name>
   <description>spring-security-samples-javaconfig-ldap</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -127,31 +132,31 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-ldap</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-samples-javaconfig-messages</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -186,7 +191,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
-      <version>3.1</version>
+      <version>3.2.5</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -216,7 +221,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -290,8 +295,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/javaconfig/messages/pom.xml
+++ b/samples/javaconfig/messages/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-javaconfig-messages</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-samples-javaconfig-messages</name>
   <description>spring-security-samples-javaconfig-messages</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -99,13 +104,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -187,7 +192,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -219,8 +224,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/samples/javaconfig/openid/pom.xml
+++ b/samples/javaconfig/openid/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-javaconfig-openid</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-openid</name>
   <description>spring-security-samples-javaconfig-openid</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -91,31 +96,31 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-openid</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-samples-javaconfig-messages</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -150,7 +155,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
-      <version>3.1</version>
+      <version>3.2.5</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -180,7 +185,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -206,8 +211,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/javaconfig/preauth/pom.xml
+++ b/samples/javaconfig/preauth/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-javaconfig-preauth</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-preauth</name>
   <description>spring-security-samples-javaconfig-preauth</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -91,25 +96,25 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-samples-javaconfig-messages</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -144,7 +149,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
-      <version>3.1</version>
+      <version>3.2.5</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -168,7 +173,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -194,8 +199,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/javaconfig/rememberme/pom.xml
+++ b/samples/javaconfig/rememberme/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-javaconfig-rememberme</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-rememberme</name>
   <description>spring-security-samples-javaconfig-rememberme</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -91,25 +96,25 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-samples-javaconfig-messages</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -144,7 +149,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
-      <version>3.1</version>
+      <version>3.2.5</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -168,7 +173,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -194,8 +199,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/javaconfig/x509/pom.xml
+++ b/samples/javaconfig/x509/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-javaconfig-x509</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-x509</name>
   <description>spring-security-samples-javaconfig-x509</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -91,25 +96,25 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-samples-javaconfig-messages</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -144,7 +149,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
-      <version>3.1</version>
+      <version>3.2.5</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -168,7 +173,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -194,8 +199,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/xml/aspectj/pom.xml
+++ b/samples/xml/aspectj/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-xml-aspectj</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-samples-xml-aspectj</name>
   <description>spring-security-samples-xml-aspectj</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -45,7 +50,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -65,13 +70,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-aspects</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -89,7 +94,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -121,8 +126,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/samples/xml/cas/cassample/pom.xml
+++ b/samples/xml/cas/cassample/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-xml-cassample</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-xml-cassample</name>
   <description>spring-security-samples-xml-cassample</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -55,13 +60,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-cas</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -98,13 +103,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -127,7 +132,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -207,8 +212,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/xml/cas/casserver/pom.xml
+++ b/samples/xml/cas/casserver/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-xml-casserver</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-xml-casserver</name>
   <description>spring-security-samples-xml-casserver</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -68,7 +73,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -100,8 +105,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/xml/contacts/pom.xml
+++ b/samples/xml/contacts/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-xml-contacts</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-xml-contacts</name>
   <description>spring-security-samples-xml-contacts</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -49,13 +54,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-acl</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -145,19 +150,19 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-taglibs</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -180,7 +185,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -254,8 +259,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/xml/dms/pom.xml
+++ b/samples/xml/dms/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-xml-dms</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-samples-xml-dms</name>
   <description>spring-security-samples-xml-dms</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -45,13 +50,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-acl</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -92,7 +97,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -115,7 +120,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -152,8 +157,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/samples/xml/gae/pom.xml
+++ b/samples/xml/gae/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-xml-gae</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-xml-gae</name>
   <description>spring-security-samples-xml-gae</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -73,13 +78,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -147,13 +152,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-taglibs</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -189,7 +194,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -215,8 +220,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/xml/helloworld/pom.xml
+++ b/samples/xml/helloworld/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-xml-helloworld</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-xml-helloworld</name>
   <description>spring-security-samples-xml-helloworld</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -67,13 +72,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -116,7 +121,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -190,8 +195,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/xml/insecure/pom.xml
+++ b/samples/xml/insecure/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-xml-insecure</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-xml-insecure</name>
   <description>spring-security-samples-xml-insecure</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -104,7 +109,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -178,8 +183,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/xml/insecuremvc/pom.xml
+++ b/samples/xml/insecuremvc/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-xml-insecuremvc</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-xml-insecuremvc</name>
   <description>spring-security-samples-xml-insecuremvc</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -91,7 +96,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-samples-javaconfig-messages</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -126,7 +131,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib-nodep</artifactId>
-      <version>3.1</version>
+      <version>3.2.5</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -150,7 +155,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -176,8 +181,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/xml/jaas/pom.xml
+++ b/samples/xml/jaas/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-xml-jaas</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-xml-jaas</name>
   <description>spring-security-samples-xml-jaas</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -49,7 +54,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -107,19 +112,19 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-taglibs</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -142,7 +147,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -216,8 +221,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/xml/ldap/pom.xml
+++ b/samples/xml/ldap/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-xml-ldap</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-xml-ldap</name>
   <description>spring-security-samples-xml-ldap</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -61,7 +66,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-taglibs</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -128,19 +133,19 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-ldap</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -158,7 +163,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -232,8 +237,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/xml/openid/pom.xml
+++ b/samples/xml/openid/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-xml-openid</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-xml-openid</name>
   <description>spring-security-samples-xml-openid</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -49,13 +54,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-openid</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -103,13 +108,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-taglibs</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -121,7 +126,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -147,8 +152,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/xml/preauth/pom.xml
+++ b/samples/xml/preauth/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-xml-preauth</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-xml-preauth</name>
   <description>spring-security-samples-xml-preauth</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -74,13 +79,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -92,7 +97,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -118,8 +123,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/xml/servletapi/pom.xml
+++ b/samples/xml/servletapi/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-xml-servletapi</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-xml-servletapi</name>
   <description>spring-security-samples-xml-servletapi</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -55,13 +60,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -118,13 +123,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-taglibs</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -141,7 +146,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -167,8 +172,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/samples/xml/tutorial/pom.xml
+++ b/samples/xml/tutorial/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-samples-xml-tutorial</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <packaging>war</packaging>
   <name>spring-security-samples-xml-tutorial</name>
   <description>spring-security-samples-xml-tutorial</description>
@@ -23,7 +23,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -55,7 +60,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -119,19 +124,19 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-taglibs</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -143,7 +148,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -169,8 +174,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/taglibs/pom.xml
+++ b/taglibs/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-taglibs</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-taglibs</name>
   <description>spring-security-taglibs</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -45,19 +50,19 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-acl</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -136,7 +141,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -198,8 +203,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-test</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-test</name>
   <description>spring-security-test</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -45,13 +50,13 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -80,7 +85,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
@@ -105,7 +110,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -117,7 +122,7 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -129,31 +134,31 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-support</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-core</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4-common</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-reflect</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -184,8 +189,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.springframework.security</groupId>
   <artifactId>spring-security-web</artifactId>
-  <version>4.2.3.BUILD-SNAPSHOT</version>
+  <version>5.0.0.BUILD-SNAPSHOT</version>
   <name>spring-security-web</name>
   <description>spring-security-web</description>
   <url>http://spring.io/spring-security</url>
@@ -22,7 +22,12 @@
     <developer>
       <id>rwinch</id>
       <name>Rob Winch</name>
-      <email>rwinch@gopivotal.com</email>
+      <email>rwinch@pivotal.io</email>
+    </developer>
+    <developer>
+      <id>jgrandja</id>
+      <name>Joe Grandja</name>
+      <email>jgrandja@pivotal.io</email>
     </developer>
   </developers>
   <scm>
@@ -51,7 +56,7 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
-      <version>4.2.3.BUILD-SNAPSHOT</version>
+      <version>5.0.0.BUILD-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -144,7 +149,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.2.0</version>
+      <version>3.6.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -168,7 +173,7 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -180,31 +185,31 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-support</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-core</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4-common</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-reflect</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -260,8 +265,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>

--- a/web/src/test/java/org/springframework/security/web/servletapi/SecurityContextHolderAwareRequestFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/servletapi/SecurityContextHolderAwareRequestFilterTests.java
@@ -331,9 +331,9 @@ public class SecurityContextHolderAwareRequestFilterTests {
 		DelegatingSecurityContextRunnable wrappedRunnable = (DelegatingSecurityContextRunnable) runnableCaptor
 				.getValue();
 		assertThat(
-				WhiteboxImpl.getInternalState(wrappedRunnable, "delegateSecurityContext"))
+				WhiteboxImpl.<SecurityContext>getInternalState(wrappedRunnable, "delegateSecurityContext"))
 						.isEqualTo(context);
-		assertThat(WhiteboxImpl.getInternalState(wrappedRunnable, "delegate"))
+		assertThat(WhiteboxImpl.<SecurityContext>getInternalState(wrappedRunnable, "delegate"))
 				.isEqualTo(runnable);
 	}
 
@@ -361,9 +361,9 @@ public class SecurityContextHolderAwareRequestFilterTests {
 		DelegatingSecurityContextRunnable wrappedRunnable = (DelegatingSecurityContextRunnable) runnableCaptor
 				.getValue();
 		assertThat(
-				WhiteboxImpl.getInternalState(wrappedRunnable, "delegateSecurityContext"))
+				WhiteboxImpl.<SecurityContext>getInternalState(wrappedRunnable, "delegateSecurityContext"))
 						.isEqualTo(context);
-		assertThat(WhiteboxImpl.getInternalState(wrappedRunnable, "delegate"))
+		assertThat(WhiteboxImpl.<SecurityContext>getInternalState(wrappedRunnable, "delegate"))
 				.isEqualTo(runnable);
 	}
 
@@ -392,9 +392,9 @@ public class SecurityContextHolderAwareRequestFilterTests {
 		DelegatingSecurityContextRunnable wrappedRunnable = (DelegatingSecurityContextRunnable) runnableCaptor
 				.getValue();
 		assertThat(
-				WhiteboxImpl.getInternalState(wrappedRunnable, "delegateSecurityContext"))
+				WhiteboxImpl.<SecurityContext>getInternalState(wrappedRunnable, "delegateSecurityContext"))
 						.isEqualTo(context);
-		assertThat(WhiteboxImpl.getInternalState(wrappedRunnable, "delegate"))
+		assertThat(WhiteboxImpl.<SecurityContext>getInternalState(wrappedRunnable, "delegate"))
 				.isEqualTo(runnable);
 	}
 


### PR DESCRIPTION
The goal for the `AuthenticatedPrincipal` abstraction is to decouple `Principal` type of abstractions from    `AbstractAuthenticationToken`, specifically `AbstractAuthenticationToken.getName()`.

As of now we are referencing `UserDetails` in `AbstractAuthenticationToken.getName()` and it would be nice to abstract this away to a generic interface that would provide the name of the `Principal` for any representation of a `Principal`, for example, `UserDetails`, _OAuth2 User_, _OpenID Connect User_, etc.