### PR TITLE
Extending AuthorityUtils with String list to GrantedAuthority list converter

### DIFF
--- a/core/src/main/java/org/springframework/security/core/authority/AuthorityUtils.java
+++ b/core/src/main/java/org/springframework/security/core/authority/AuthorityUtils.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.util.StringUtils;
@@ -72,5 +73,9 @@ public abstract class AuthorityUtils {
 		}
 
 		return authorities;
+	}
+
+	public static List<GrantedAuthority> createAuthorityList(List<String> roles) {
+		return roles.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList());
 	}
 }


### PR DESCRIPTION
AuthorityUtil suffer from tool that enables conversion from list of strings to GrantedAuthority. Right now it enables only conversion from array of strings which forces user that works with List to use some odd conversions like this

`AuthorityUtils.createAuthorityList(listOfAuthorities.toArray(new String[0]))`