### PR TITLE
Fix Okta documentation and compiler error

### DIFF
--- a/samples/boot/oauth2login/README.adoc
+++ b/samples/boot/oauth2login/README.adoc
@@ -306,8 +306,8 @@ In the next step, we will _assign_ the application to _people_ in order to grant
 [[okta-login-assign-application-people]]
 === Assign Application to People
 
-From the _"General"_ tab of the application, select the _"People"_ tab and then click on the _"Assign to People"_ button.
-Assign your account to the application and then click on the _"Save and Go Back"_ button.
+From the _"General"_ tab of the application, select the _"Assignments"_ tab and then click the _"Assign"_ button.  
+Select _"Assign to People" and assign your account to the application. Then click the _"Save and Go Back"_ button.
 
 [[okta-login-configure-application-yml]]
 === Configuring application.yml

--- a/webflux/src/main/java/org/springframework/security/web/server/util/matcher/PathMatcherServerWebExchangeMatcher.java
+++ b/webflux/src/main/java/org/springframework/security/web/server/util/matcher/PathMatcherServerWebExchangeMatcher.java
@@ -27,6 +27,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.PathMatcher;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.support.HttpRequestPathHelper;
+import org.springframework.web.server.support.LookupPath;
 import reactor.core.publisher.Mono;
 
 /**
@@ -57,12 +58,12 @@ public final class PathMatcherServerWebExchangeMatcher implements ServerWebExcha
 		if(this.method != null && !this.method.equals(request.getMethod())) {
 			return MatchResult.notMatch();
 		}
-		String path = helper.getLookupPathForRequest(exchange);
-		boolean match = pathMatcher.match(pattern, path);
+		LookupPath path = helper.getLookupPathForRequest(exchange);
+		boolean match = pathMatcher.match(pattern, path.getPath());
 		if(!match) {
 			return MatchResult.notMatch();
 		}
-		Map<String,String> pathVariables = pathMatcher.extractUriTemplateVariables(pattern, path);
+		Map<String,String> pathVariables = pathMatcher.extractUriTemplateVariables(pattern, path.getPath());
 		Map<String,Object> variables = new HashMap<>(pathVariables);
 		return MatchResult.match(variables);
 	}


### PR DESCRIPTION
Fixes compiler error:

```
:spring-security-webflux:compileJava
/Users/mraible/dev/spring-security/webflux/src/main/java/org/springframework/security/web/server/util/matcher/PathMatcherServerWebExchangeMatcher.java:60: error: incompatible types: LookupPath cannot be converted to String
                String path = helper.getLookupPathForRequest(exchange);
                                                            ^
1 error
:spring-security-webflux:compileJava FAILED
```

Java and Gradle versions:

```
$ java -version
java version "1.8.0_121"
Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)
$ gradle -version

------------------------------------------------------------
Gradle 3.4.1
------------------------------------------------------------

Build time:   2017-03-03 19:45:41 UTC
Revision:     9eb76efdd3d034dc506c719dac2955efb5ff9a93

Groovy:       2.4.7
Ant:          Apache Ant(TM) version 1.9.6 compiled on June 29 2015
JVM:          1.8.0_121 (Oracle Corporation 25.121-b13)
OS:           Mac OS X 10.12.5 x86_64
```