### PR TITLE
Update AbstractLdapAuthenticationProvider.java

### DIFF
--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/AbstractLdapAuthenticationProvider.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/AbstractLdapAuthenticationProvider.java
@@ -80,8 +80,6 @@ public abstract class AbstractLdapAuthenticationProvider
 					"Empty Password"));
 		}
 
-		Assert.notNull(password, "Null password was supplied in authentication token");
-
 		DirContextOperations userData = doAuthentication(userToken);
 
 		UserDetails user = this.userDetailsContextMapper.mapUserFromContext(userData,


### PR DESCRIPTION
If password == null a BadCredentialsException in line 78 will be thrown.

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
