### PR TITLE
Removed Unicode Character from Parameter Name

### DIFF
--- a/web/src/main/java/org/springframework/security/web/session/SessionInformationExpiredStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/session/SessionInformationExpiredStrategy.java
@@ -29,6 +29,6 @@ import javax.servlet.ServletException;
  */
 public interface SessionInformationExpiredStrategy {
 
-	void onExpiredSessionDetected(SessionInformationExpiredEvent eventØ)
+	void onExpiredSessionDetected(SessionInformationExpiredEvent event)
 			throws IOException, ServletException;
 }


### PR DESCRIPTION
Removed Unicode character from a parameter name that caused compilation errors on Windows.

Fixes #4428 