### PR TITLE
Drop the `aopalliance:aopalliance` dependency

### DIFF
--- a/acl/spring-security-acl.gradle
+++ b/acl/spring-security-acl.gradle
@@ -2,7 +2,6 @@ apply plugin: 'io.spring.convention.spring-module'
 
 dependencies {
 	compile project(':spring-security-core')
-	compile 'aopalliance:aopalliance'
 	compile 'org.springframework:spring-aop'
 	compile 'org.springframework:spring-context'
 	compile 'org.springframework:spring-core'

--- a/aspects/spring-security-aspects.gradle
+++ b/aspects/spring-security-aspects.gradle
@@ -7,6 +7,5 @@ dependencies {
 	compile 'org.springframework:spring-context'
 	compile 'org.springframework:spring-core'
 
-	testCompile 'aopalliance:aopalliance'
 	testCompile 'org.springframework:spring-aop'
 }

--- a/config/spring-security-config.gradle
+++ b/config/spring-security-config.gradle
@@ -4,7 +4,6 @@ apply plugin: 'trang'
 dependencies {
 	// NB: Don't add other compile time dependencies to the config module as this breaks tooling
 	compile project(':spring-security-core')
-	compile 'aopalliance:aopalliance:1.0'
 	compile 'org.springframework:spring-aop'
 	compile 'org.springframework:spring-beans'
 	compile 'org.springframework:spring-context'

--- a/core/spring-security-core.gradle
+++ b/core/spring-security-core.gradle
@@ -8,7 +8,6 @@ configurations {
 }
 
 dependencies {
-	compile 'aopalliance:aopalliance'
 	compile 'org.springframework:spring-aop'
 	compile 'org.springframework:spring-beans'
 	compile 'org.springframework:spring-context'

--- a/docs/manual/src/docs/asciidoc/index.adoc
+++ b/docs/manual/src/docs/asciidoc/index.adoc
@@ -9858,10 +9858,6 @@ The core module must be included in any project using Spring Security.
 |===
 | Dependency | Version | Description
 
-| aopalliance
-| 1.0
-| Required for method security implementation.
-
 | ehcache
 | 1.6.2
 | Required if the Ehcache-based user cache implementation is used (optional).

--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -34,7 +34,6 @@ dependencyManagement {
 dependencyManagement {
 	dependencies {
 		dependency 'antlr:antlr:2.7.7'
-		dependency 'aopalliance:aopalliance:1.0'
 		dependency 'asm:asm:3.1'
 		dependency 'bouncycastle:bcprov-jdk15:140'
 		dependency 'ch.qos.logback:logback-classic:1.2.3'

--- a/itest/context/spring-security-itest-context.gradle
+++ b/itest/context/spring-security-itest-context.gradle
@@ -2,7 +2,6 @@ apply plugin: 'io.spring.convention.spring-test'
 
 dependencies {
 	compile project(':spring-security-core')
-	compile 'aopalliance:aopalliance'
 	compile 'org.python:jython'
 	compile 'org.springframework:spring-aop'
 	compile 'org.springframework:spring-beans'

--- a/messaging/spring-security-messaging.gradle
+++ b/messaging/spring-security-messaging.gradle
@@ -2,7 +2,6 @@ apply plugin: 'io.spring.convention.spring-module'
 
 dependencies {
 	compile project(':spring-security-core')
-	compile 'aopalliance:aopalliance'
 	compile 'org.springframework:spring-beans'
 	compile 'org.springframework:spring-context'
 	compile 'org.springframework:spring-core'

--- a/remoting/spring-security-remoting.gradle
+++ b/remoting/spring-security-remoting.gradle
@@ -2,7 +2,7 @@ apply plugin: 'io.spring.convention.spring-module'
 
 dependencies {
 	compile project(':spring-security-core')
-	compile 'aopalliance:aopalliance'
+	compile 'org.springframework:spring-aop'
 	compile 'org.springframework:spring-beans'
 	compile 'org.springframework:spring-context'
 	compile 'org.springframework:spring-core'

--- a/web/spring-security-web.gradle
+++ b/web/spring-security-web.gradle
@@ -3,7 +3,7 @@ apply plugin: 'io.spring.convention.spring-module'
 dependencies {
 	compile project(':spring-security-core')
 	compile springCoreDependency
-	compile 'aopalliance:aopalliance'
+	compile 'org.springframework:spring-aop'
 	compile 'org.springframework:spring-beans'
 	compile 'org.springframework:spring-context'
 	compile 'org.springframework:spring-expression'


### PR DESCRIPTION
As of Spring 4.3 RC1 the `org.aopalliance` interfaces are once again bundled
with `spring-aop` [1]. Moreover, all modules with a dependency on
`aopalliance:aopalliance` directly or indirectly also depend on `spring-aop`.

This change drops the `aopalliance:aopalliance` dependency in all places it's
declared. Where applicable an explicit dependency on `spring-aop` was added in
its place. (This dependency was already present in most places; in one case the
module didn't require `aopalliance:aopalliance` in the first place.)

The documentation is updated accordingly.

[1] https://jira.spring.io/browse/SPR-13984

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
