### PR TITLE
Fix Typo in Reference Docs

### DIFF
--- a/docs/manual/src/docs/asciidoc/index.adoc
+++ b/docs/manual/src/docs/asciidoc/index.adoc
@@ -6614,7 +6614,7 @@ Use the KeyGenerators.secureRandom factory methods to generate a BytesKeyGenerat
 
 [source,java]
 ----
-KeyGenerator generator = KeyGenerators.secureRandom();
+BytesKeyGenerator generator = KeyGenerators.secureRandom();
 byte[] key = generator.generateKey();
 ----
 


### PR DESCRIPTION
Fixes #4420 by correcting a small typo in the reference docs.

`KeyGenerators` class is a Factory that can return a `BytesKeyGenerator` or `StringKeyGenerator`.

The example code in the docs calls `KeyGenerators.secureRandom()` which returns a `BytesKeyGenerator` not a `KeyGenerator`