### PR TITLE
Pass username as second parameter for search filter.

### DIFF
--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/ad/ActiveDirectoryLdapAuthenticationProvider.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/ad/ActiveDirectoryLdapAuthenticationProvider.java
@@ -312,7 +312,7 @@ public final class ActiveDirectoryLdapAuthenticationProvider extends
 		try {
 			return SpringSecurityLdapTemplate.searchForSingleEntryInternal(context,
 					searchControls, searchRoot, searchFilter,
-					new Object[] { bindPrincipal });
+					new Object[] { bindPrincipal, username });
 		}
 		catch (IncorrectResultSizeDataAccessException incorrectResults) {
 			// Search should never return multiple results if properly configured - just
@@ -383,7 +383,8 @@ public final class ActiveDirectoryLdapAuthenticationProvider extends
 
 	/**
 	 * The LDAP filter string to search for the user being authenticated. Occurrences of
-	 * {0} are replaced with the {@code username@domain}.
+	 * {0} are replaced with the {@code username@domain}. Occurrences of {1} are replaced
+	 * with the {@code username} only.
 	 * <p>
 	 * Defaults to: {@code (&(objectClass=user)(userPrincipalName= 0}))}
 	 * </p>

--- a/ldap/src/test/java/org/springframework/security/ldap/authentication/ad/ActiveDirectoryLdapAuthenticationProviderTests.java
+++ b/ldap/src/test/java/org/springframework/security/ldap/authentication/ad/ActiveDirectoryLdapAuthenticationProviderTests.java
@@ -140,9 +140,9 @@ public class ActiveDirectoryLdapAuthenticationProviderTests {
 				any(Object[].class), any(SearchControls.class));
 	}
 
-	// SEC-2897
+	// SEC-2897,SEC-2224
 	@Test
-	public void bindPrincipalUsed() throws Exception {
+	public void bindPrincipalAndUsernameUsed() throws Exception {
 		// given
 		final String defaultSearchFilter = "(&(objectClass=user)(userPrincipalName={0}))";
 		ArgumentCaptor<Object[]> captor = ArgumentCaptor.forClass(Object[].class);
@@ -166,7 +166,7 @@ public class ActiveDirectoryLdapAuthenticationProviderTests {
 		Authentication result = customProvider.authenticate(joe);
 
 		// then
-		assertThat(captor.getValue()).containsOnly("joe@mydomain.eu");
+		assertThat(captor.getValue()).containsExactly("joe@mydomain.eu", "joe");
 		assertThat(result.isAuthenticated()).isTrue();
 	}
 


### PR DESCRIPTION
Allows the username only (without domain) to be used in custom search filter like "sAMAccountName={1}",
in eg. situations where the userPrincipalName has a different suffix than domain.

Thanks to contributors in issue.

fixes gh-2448

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
