### PR TITLE
Added HttpServletResponse to AuthorizationRequestRepository

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/authentication/AuthorizationCodeRequestRedirectFilter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/authentication/AuthorizationCodeRequestRedirectFilter.java
@@ -130,7 +130,7 @@ public class AuthorizationCodeRequestRedirectFilter extends OncePerRequestFilter
 				.state(this.stateGenerator.generateKey())
 				.build();
 
-		this.authorizationRequestRepository.saveAuthorizationRequest(authorizationRequestAttributes, request);
+		this.authorizationRequestRepository.saveAuthorizationRequest(authorizationRequestAttributes, request, response);
 
 		URI redirectUri = this.authorizationUriBuilder.build(authorizationRequestAttributes);
 		this.authorizationRedirectStrategy.sendRedirect(request, response, redirectUri.toString());

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/authentication/AuthorizationRequestRepository.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/authentication/AuthorizationRequestRepository.java
@@ -18,6 +18,7 @@ package org.springframework.security.oauth2.client.authentication;
 import org.springframework.security.oauth2.core.endpoint.AuthorizationRequestAttributes;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * Implementations of this interface are responsible for the persistence
@@ -38,7 +39,8 @@ public interface AuthorizationRequestRepository {
 
 	AuthorizationRequestAttributes loadAuthorizationRequest(HttpServletRequest request);
 
-	void saveAuthorizationRequest(AuthorizationRequestAttributes authorizationRequest, HttpServletRequest request);
+	void saveAuthorizationRequest(AuthorizationRequestAttributes authorizationRequest, HttpServletRequest request,
+								  HttpServletResponse response);
 
 	AuthorizationRequestAttributes removeAuthorizationRequest(HttpServletRequest request);
 

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/authentication/HttpSessionAuthorizationRequestRepository.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/authentication/HttpSessionAuthorizationRequestRepository.java
@@ -18,6 +18,7 @@ package org.springframework.security.oauth2.client.authentication;
 import org.springframework.security.oauth2.core.endpoint.AuthorizationRequestAttributes;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 /**
@@ -44,7 +45,8 @@ public final class HttpSessionAuthorizationRequestRepository implements Authoriz
 	}
 
 	@Override
-	public void saveAuthorizationRequest(AuthorizationRequestAttributes authorizationRequest, HttpServletRequest request) {
+	public void saveAuthorizationRequest(AuthorizationRequestAttributes authorizationRequest, HttpServletRequest request,
+										 HttpServletResponse response) {
 		if (authorizationRequest == null) {
 			this.removeAuthorizationRequest(request);
 			return;

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/authentication/AuthorizationCodeAuthenticationProcessingFilterTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/authentication/AuthorizationCodeAuthenticationProcessingFilterTests.java
@@ -239,7 +239,9 @@ public class AuthorizationCodeAuthenticationProcessingFilterTests {
 				.state(state)
 				.build();
 
-		authorizationRequestRepository.saveAuthorizationRequest(authorizationRequestAttributes, request);
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		authorizationRequestRepository.saveAuthorizationRequest(authorizationRequestAttributes, request, response);
 	}
 
 	private MockHttpServletRequest setupRequest(ClientRegistration clientRegistration) {


### PR DESCRIPTION
This change enables AuthorizationRequestRepository to possibly save the AuthorizationRequestAttributes to a cookie.

Fixes #4446 
