### PR TITLE
Make `AuthenticatedPrincipal` serializable

### DIFF
--- a/core/src/main/java/org/springframework/security/core/AuthenticatedPrincipal.java
+++ b/core/src/main/java/org/springframework/security/core/AuthenticatedPrincipal.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.security.core;
 
+import java.io.Serializable;
+
 import org.springframework.security.authentication.AuthenticationManager;
 
 /**
@@ -34,7 +36,7 @@ import org.springframework.security.authentication.AuthenticationManager;
  * @see Authentication#getPrincipal()
  * @see org.springframework.security.core.userdetails.UserDetails
  */
-public interface AuthenticatedPrincipal {
+public interface AuthenticatedPrincipal extends Serializable {
 
 	/**
 	 * Returns the name of the authenticated <code>Principal</code>. Never <code>null</code>.

--- a/core/src/main/java/org/springframework/security/core/userdetails/UserDetails.java
+++ b/core/src/main/java/org/springframework/security/core/userdetails/UserDetails.java
@@ -20,7 +20,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.AuthenticatedPrincipal;
 
-import java.io.Serializable;
 import java.util.Collection;
 
 /**
@@ -42,7 +41,7 @@ import java.util.Collection;
  *
  * @author Ben Alex
  */
-public interface UserDetails extends AuthenticatedPrincipal, Serializable {
+public interface UserDetails extends AuthenticatedPrincipal {
 	// ~ Methods
 	// ========================================================================================================
 

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/user/OAuth2User.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/user/OAuth2User.java
@@ -19,7 +19,6 @@ import org.springframework.security.core.AuthenticatedPrincipal;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
 
@@ -47,7 +46,7 @@ import java.util.Map;
  * @see DefaultOAuth2User
  * @see AuthenticatedPrincipal
  */
-public interface OAuth2User extends AuthenticatedPrincipal, Serializable {
+public interface OAuth2User extends AuthenticatedPrincipal {
 
 	Collection<? extends GrantedAuthority> getAuthorities();
 


### PR DESCRIPTION
As a root of principal hierarchy, the `AuthenticatedPrincipal` should extend `Serializable`.