### PR TITLE
Added Unit Tests For oauth2-core

### DIFF
--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/AuthorizationCodeTokenRequestAttributes.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/AuthorizationCodeTokenRequestAttributes.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.security.oauth2.core.endpoint;
 
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.util.Assert;
 
 /**
@@ -28,6 +29,7 @@ public final class AuthorizationCodeTokenRequestAttributes {
 	private String code;
 	private String clientId;
 	private String redirectUri;
+	private AuthorizationGrantType grantType;
 
 	private AuthorizationCodeTokenRequestAttributes() {
 	}
@@ -44,6 +46,10 @@ public final class AuthorizationCodeTokenRequestAttributes {
 		return this.redirectUri;
 	}
 
+	public AuthorizationGrantType getGrantType() {
+		return grantType;
+	}
+
 	public static Builder withCode(String code) {
 		return new Builder(code);
 	}
@@ -55,21 +61,22 @@ public final class AuthorizationCodeTokenRequestAttributes {
 			Assert.hasText(code, "code cannot be empty");
 			this.authorizationCodeTokenRequest = new AuthorizationCodeTokenRequestAttributes();
 			this.authorizationCodeTokenRequest.code = code;
+			this.authorizationCodeTokenRequest.grantType = AuthorizationGrantType.AUTHORIZATION_CODE;
 		}
 
 		public Builder clientId(String clientId) {
-			Assert.hasText(clientId, "clientId cannot be empty");
 			this.authorizationCodeTokenRequest.clientId = clientId;
 			return this;
 		}
 
 		public Builder redirectUri(String redirectUri) {
-			Assert.hasText(redirectUri, "redirectUri cannot be empty");
 			this.authorizationCodeTokenRequest.redirectUri = redirectUri;
 			return this;
 		}
 
 		public AuthorizationCodeTokenRequestAttributes build() {
+			Assert.hasText(this.authorizationCodeTokenRequest.clientId, "clientId cannot be empty");
+			Assert.hasText(this.authorizationCodeTokenRequest.redirectUri, "redirectUri cannot be empty");
 			return this.authorizationCodeTokenRequest;
 		}
 	}

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/AuthorizationCodeTokenRequestAttributes.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/AuthorizationCodeTokenRequestAttributes.java
@@ -29,7 +29,6 @@ public final class AuthorizationCodeTokenRequestAttributes {
 	private String code;
 	private String clientId;
 	private String redirectUri;
-	private AuthorizationGrantType grantType;
 
 	private AuthorizationCodeTokenRequestAttributes() {
 	}
@@ -46,10 +45,6 @@ public final class AuthorizationCodeTokenRequestAttributes {
 		return this.redirectUri;
 	}
 
-	public AuthorizationGrantType getGrantType() {
-		return grantType;
-	}
-
 	public static Builder withCode(String code) {
 		return new Builder(code);
 	}
@@ -61,7 +56,6 @@ public final class AuthorizationCodeTokenRequestAttributes {
 			Assert.hasText(code, "code cannot be empty");
 			this.authorizationCodeTokenRequest = new AuthorizationCodeTokenRequestAttributes();
 			this.authorizationCodeTokenRequest.code = code;
-			this.authorizationCodeTokenRequest.grantType = AuthorizationGrantType.AUTHORIZATION_CODE;
 		}
 
 		public Builder clientId(String clientId) {

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/AuthorizationRequestAttributes.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/AuthorizationRequestAttributes.java
@@ -92,19 +92,16 @@ public final class AuthorizationRequestAttributes implements Serializable {
 		}
 
 		public Builder authorizeUri(String authorizeUri) {
-			Assert.hasText(authorizeUri, "authorizeUri cannot be empty");
 			this.authorizationRequest.authorizeUri = authorizeUri;
 			return this;
 		}
 
 		public Builder clientId(String clientId) {
-			Assert.hasText(clientId, "clientId cannot be empty");
 			this.authorizationRequest.clientId = clientId;
 			return this;
 		}
 
 		public Builder redirectUri(String redirectUri) {
-			Assert.hasText(redirectUri, "redirectUri cannot be empty");
 			this.authorizationRequest.redirectUri = redirectUri;
 			return this;
 		}
@@ -121,6 +118,8 @@ public final class AuthorizationRequestAttributes implements Serializable {
 		}
 
 		public AuthorizationRequestAttributes build() {
+			Assert.hasText(this.authorizationRequest.clientId, "clientId cannot be empty");
+			Assert.hasText(this.authorizationRequest.authorizeUri, "authorizeUri cannot be empty");
 			return this.authorizationRequest;
 		}
 	}

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/AuthorizationCodeAuthorizationResponseAttributesTest.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/AuthorizationCodeAuthorizationResponseAttributesTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.core.endpoint;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link AuthorizationCodeAuthorizationResponseAttributes}
+ *
+ * @author Luander Ribeiro
+ */
+public class AuthorizationCodeAuthorizationResponseAttributesTest {
+
+	@Test(expected = IllegalArgumentException.class)
+	public void constructorWhenCodeIsNullThenThrowIllegalArgumentException() {
+		new AuthorizationCodeAuthorizationResponseAttributes(null, "xyz");
+	}
+}

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/AuthorizationCodeTokenRequestAttributesTest.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/AuthorizationCodeTokenRequestAttributesTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.core.endpoint;
+
+import org.junit.Test;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests {@link AuthorizationCodeTokenRequestAttributes}
+ *
+ * @author Luander Ribeiro
+ */
+public class AuthorizationCodeTokenRequestAttributesTest {
+	private static final String CODE = "code";
+	private static final String CLIENT_ID = "client id";
+	private static final String REDIRECT_URI = "http://redirect.uri/";
+
+	@Test(expected = IllegalArgumentException.class)
+	public void buildWhenCodeIsNullThenThrowIllegalArgumentException() {
+		AuthorizationCodeTokenRequestAttributes
+			.withCode(null)
+			.clientId(CLIENT_ID)
+			.redirectUri(REDIRECT_URI)
+			.build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void buildWhenClientIdIsNullThenThrowIllegalArgumentException() {
+		AuthorizationCodeTokenRequestAttributes
+			.withCode(CODE)
+			.clientId(null)
+			.redirectUri(REDIRECT_URI)
+			.build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void buildWhenRedirectUriIsNullThenThrowIllegalArgumentException() {
+		AuthorizationCodeTokenRequestAttributes
+			.withCode(CODE)
+			.clientId(CLIENT_ID)
+			.redirectUri(null)
+			.build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void buildWhenClientIdIsNotCalledThenThrowIllegalArgumentException() {
+		AuthorizationCodeTokenRequestAttributes
+			.withCode(CODE)
+			.redirectUri(REDIRECT_URI)
+			.build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void buildWhenRedirectUriIsNotCalledThenThrowIllegalArgumentException() {
+		AuthorizationCodeTokenRequestAttributes
+			.withCode(CODE)
+			.clientId(CLIENT_ID)
+			.build();
+	}
+
+	@Test
+	public void buildWhenGetGrantTypeIsCalledThenReturnAuthorizationCodeString() {
+		AuthorizationCodeTokenRequestAttributes attributes;
+		attributes = AuthorizationCodeTokenRequestAttributes
+			.withCode(CODE)
+			.clientId(CLIENT_ID)
+			.redirectUri(REDIRECT_URI)
+			.build();
+
+		assertThat(attributes.getGrantType()).isEqualTo(AuthorizationGrantType.AUTHORIZATION_CODE);
+	}
+}

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/AuthorizationCodeTokenRequestAttributesTest.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/AuthorizationCodeTokenRequestAttributesTest.java
@@ -58,7 +58,7 @@ public class AuthorizationCodeTokenRequestAttributesTest {
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void buildWhenClientIdIsNotCalledThenThrowIllegalArgumentException() {
+	public void buildWhenClientIdNotSetThenThrowIllegalArgumentException() {
 		AuthorizationCodeTokenRequestAttributes
 			.withCode(CODE)
 			.redirectUri(REDIRECT_URI)
@@ -66,22 +66,10 @@ public class AuthorizationCodeTokenRequestAttributesTest {
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void buildWhenRedirectUriIsNotCalledThenThrowIllegalArgumentException() {
+	public void buildWhenRedirectUriNotSetThenThrowIllegalArgumentException() {
 		AuthorizationCodeTokenRequestAttributes
 			.withCode(CODE)
 			.clientId(CLIENT_ID)
 			.build();
-	}
-
-	@Test
-	public void buildWhenGetGrantTypeIsCalledThenReturnAuthorizationCodeString() {
-		AuthorizationCodeTokenRequestAttributes attributes;
-		attributes = AuthorizationCodeTokenRequestAttributes
-			.withCode(CODE)
-			.clientId(CLIENT_ID)
-			.redirectUri(REDIRECT_URI)
-			.build();
-
-		assertThat(attributes.getGrantType()).isEqualTo(AuthorizationGrantType.AUTHORIZATION_CODE);
 	}
 }

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/AuthorizationRequestAttributesTest.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/AuthorizationRequestAttributesTest.java
@@ -47,7 +47,7 @@ public class AuthorizationRequestAttributesTest {
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void buildWhenAuthorizeUriIsNotCalledThenThrowIllegalArgumentException() {
+	public void buildWhenAuthorizeUriNotSetThenThrowIllegalArgumentException() {
 		AuthorizationRequestAttributes.withAuthorizationCode()
 			.clientId(CLIENT_ID)
 			.redirectUri(REDIRECT_URI)
@@ -68,7 +68,7 @@ public class AuthorizationRequestAttributesTest {
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void buildWhenClientIdIsNotCalledThenThrowIllegalArgumentException() {
+	public void buildWhenClientIdNotSetThenThrowIllegalArgumentException() {
 		AuthorizationRequestAttributes.withAuthorizationCode()
 			.authorizeUri(AUTHORIZE_URI)
 			.redirectUri(REDIRECT_URI)
@@ -103,7 +103,7 @@ public class AuthorizationRequestAttributesTest {
 	}
 
 	@Test
-	public void buildWhenRedirectUriIsNotCalledThenDoesNotThrowAnyException() {
+	public void buildWhenRedirectUriNotSetThenDoesNotThrowAnyException() {
 		assertThatCode(() -> AuthorizationRequestAttributes.withAuthorizationCode()
 			.authorizeUri(AUTHORIZE_URI)
 			.clientId(CLIENT_ID)
@@ -124,7 +124,7 @@ public class AuthorizationRequestAttributesTest {
 	}
 
 	@Test
-	public void buildWhenScopesIsNotCalledThenDoesNotThrowAnyException() {
+	public void buildWhenScopesNotSetThenDoesNotThrowAnyException() {
 		assertThatCode(() -> AuthorizationRequestAttributes.withAuthorizationCode()
 			.authorizeUri(AUTHORIZE_URI)
 			.clientId(CLIENT_ID)
@@ -145,7 +145,7 @@ public class AuthorizationRequestAttributesTest {
 	}
 
 	@Test
-	public void buildWhenStateIsNotCalledThenDoesNotThrowAnyException() {
+	public void buildWhenStateNotSetThenDoesNotThrowAnyException() {
 		assertThatCode(() -> AuthorizationRequestAttributes.withAuthorizationCode()
 			.authorizeUri(AUTHORIZE_URI)
 			.clientId(CLIENT_ID)

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/AuthorizationRequestAttributesTest.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/AuthorizationRequestAttributesTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.core.endpoint;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Tests {@link AuthorizationRequestAttributes}
+ *
+ * @author Luander Ribeiro
+ */
+public class AuthorizationRequestAttributesTest {
+	private static final String AUTHORIZE_URI = "http://authorize.uri/";
+	private static final String CLIENT_ID = "client id";
+	private static final String REDIRECT_URI = "http://redirect.uri/";
+	private static final Set<String> SCOPES = Collections.singleton("scope");
+	private static final String STATE = "xyz";
+
+	@Test(expected = IllegalArgumentException.class)
+	public void buildWhenAuthorizationUriIsNullThenThrowIllegalArgumentException() {
+		AuthorizationRequestAttributes.withAuthorizationCode()
+			.authorizeUri(null)
+			.clientId(CLIENT_ID)
+			.redirectUri(REDIRECT_URI)
+			.scopes(SCOPES)
+			.state(STATE)
+			.build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void buildWhenAuthorizeUriIsNotCalledThenThrowIllegalArgumentException() {
+		AuthorizationRequestAttributes.withAuthorizationCode()
+			.clientId(CLIENT_ID)
+			.redirectUri(REDIRECT_URI)
+			.scopes(SCOPES)
+			.state(STATE)
+			.build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void buildWhenClientIdIsNullThenThrowIllegalArgumentException() {
+		AuthorizationRequestAttributes.withAuthorizationCode()
+			.authorizeUri(AUTHORIZE_URI)
+			.clientId(null)
+			.redirectUri(REDIRECT_URI)
+			.scopes(SCOPES)
+			.state(STATE)
+			.build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void buildWhenClientIdIsNotCalledThenThrowIllegalArgumentException() {
+		AuthorizationRequestAttributes.withAuthorizationCode()
+			.authorizeUri(AUTHORIZE_URI)
+			.redirectUri(REDIRECT_URI)
+			.scopes(SCOPES)
+			.state(STATE)
+			.build();
+	}
+
+	@Test
+	public void buildWhenGetResponseTypeIsCalledThenReturnCode() {
+		AuthorizationRequestAttributes attributes;
+		attributes = AuthorizationRequestAttributes.withAuthorizationCode()
+			.authorizeUri(AUTHORIZE_URI)
+			.clientId(CLIENT_ID)
+			.redirectUri(REDIRECT_URI)
+			.scopes(SCOPES)
+			.state(STATE)
+			.build();
+
+		assertThat(attributes.getResponseType()).isEqualTo(ResponseType.CODE);
+	}
+
+	@Test
+	public void buildWhenRedirectUriIsNullThenDoesNotThrowAnyException() {
+		assertThatCode(() -> AuthorizationRequestAttributes.withAuthorizationCode()
+			.authorizeUri(AUTHORIZE_URI)
+			.clientId(CLIENT_ID)
+			.redirectUri(null)
+			.scopes(SCOPES)
+			.state(STATE)
+			.build()).doesNotThrowAnyException();
+	}
+
+	@Test
+	public void buildWhenRedirectUriIsNotCalledThenDoesNotThrowAnyException() {
+		assertThatCode(() -> AuthorizationRequestAttributes.withAuthorizationCode()
+			.authorizeUri(AUTHORIZE_URI)
+			.clientId(CLIENT_ID)
+			.scopes(SCOPES)
+			.state(STATE)
+			.build()).doesNotThrowAnyException();
+	}
+
+	@Test
+	public void buildWhenScopesIsNullThenDoesNotThrowAnyException() {
+		assertThatCode(() -> AuthorizationRequestAttributes.withAuthorizationCode()
+			.authorizeUri(AUTHORIZE_URI)
+			.clientId(CLIENT_ID)
+			.redirectUri(REDIRECT_URI)
+			.scopes(null)
+			.state(STATE)
+			.build()).doesNotThrowAnyException();
+	}
+
+	@Test
+	public void buildWhenScopesIsNotCalledThenDoesNotThrowAnyException() {
+		assertThatCode(() -> AuthorizationRequestAttributes.withAuthorizationCode()
+			.authorizeUri(AUTHORIZE_URI)
+			.clientId(CLIENT_ID)
+			.redirectUri(REDIRECT_URI)
+			.state(STATE)
+			.build()).doesNotThrowAnyException();
+	}
+
+	@Test
+	public void buildWhenStateIsNullThenDoesNotThrowAnyException() {
+		assertThatCode(() -> AuthorizationRequestAttributes.withAuthorizationCode()
+			.authorizeUri(AUTHORIZE_URI)
+			.clientId(CLIENT_ID)
+			.redirectUri(REDIRECT_URI)
+			.scopes(SCOPES)
+			.state(null)
+			.build()).doesNotThrowAnyException();
+	}
+
+	@Test
+	public void buildWhenStateIsNotCalledThenDoesNotThrowAnyException() {
+		assertThatCode(() -> AuthorizationRequestAttributes.withAuthorizationCode()
+			.authorizeUri(AUTHORIZE_URI)
+			.clientId(CLIENT_ID)
+			.redirectUri(REDIRECT_URI)
+			.scopes(SCOPES)
+			.build()).doesNotThrowAnyException();
+	}
+}

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/ErrorResponseAttributesTest.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/ErrorResponseAttributesTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.core.endpoint;
+
+import org.junit.Test;
+
+/**
+ * Tests ${@link ErrorResponseAttributes}
+ *
+ * @author Luander Ribeiro
+ */
+public class ErrorResponseAttributesTest {
+
+	@Test(expected = IllegalArgumentException.class)
+	public void builderWhenCodeIsNullThenThrowIllegalArgumentException() {
+		ErrorResponseAttributes.withErrorCode(null)
+			.build();
+	}
+}

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/ErrorResponseAttributesTest.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/ErrorResponseAttributesTest.java
@@ -18,14 +18,14 @@ package org.springframework.security.oauth2.core.endpoint;
 import org.junit.Test;
 
 /**
- * Tests ${@link ErrorResponseAttributes}
+ * Tests {@link ErrorResponseAttributes}
  *
  * @author Luander Ribeiro
  */
 public class ErrorResponseAttributesTest {
 
 	@Test(expected = IllegalArgumentException.class)
-	public void builderWhenCodeIsNullThenThrowIllegalArgumentException() {
+	public void withErrorCodeWhenCodeIsNullThenThrowIllegalArgumentException() {
 		ErrorResponseAttributes.withErrorCode(null)
 			.build();
 	}

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/TokenResponseAttributesTest.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/TokenResponseAttributesTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.core.endpoint;
+
+import org.junit.Test;
+import org.springframework.security.oauth2.core.AccessToken;
+
+import java.util.Collections;
+
+/**
+ * Tests ${@link TokenResponseAttributes}
+ *
+ * @author Luander Ribeiro
+ */
+public class TokenResponseAttributesTest {
+
+	private static final String TOKEN = "token";
+	private static final long INVALID_EXPIRES_IN = -1L;
+	private static final long EXPIRES_IN = System.currentTimeMillis();
+
+	@Test(expected = IllegalArgumentException.class)
+	public void buildWhenTokenValueIsNullThenThrowIllegalArgumentException() {
+		TokenResponseAttributes.withToken(null)
+			.expiresIn(EXPIRES_IN)
+			.additionalParameters(Collections.emptyMap())
+			.scopes(Collections.emptySet())
+			.tokenType(AccessToken.TokenType.BEARER)
+			.build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void buildWhenExpiresInIsNegativeThenThrowIllegalArgumentException() {
+		TokenResponseAttributes.withToken(TOKEN)
+			.expiresIn(INVALID_EXPIRES_IN)
+			.additionalParameters(Collections.emptyMap())
+			.scopes(Collections.emptySet())
+			.tokenType(AccessToken.TokenType.BEARER)
+			.build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void buildWhenTokenTypeIsInvalidThenThrowIllegalArgumentException() {
+		TokenResponseAttributes.withToken(TOKEN)
+			.expiresIn(EXPIRES_IN)
+			.additionalParameters(Collections.emptyMap())
+			.tokenType(null)
+			.build();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void buildWhenTokeTypeIsNotCalledThenThrowIllegalArgumentException() {
+		TokenResponseAttributes.withToken(TOKEN)
+			.expiresIn(EXPIRES_IN)
+			.additionalParameters(Collections.emptyMap())
+			.build();
+	}
+}

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/TokenResponseAttributesTest.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/TokenResponseAttributesTest.java
@@ -21,7 +21,7 @@ import org.springframework.security.oauth2.core.AccessToken;
 import java.util.Collections;
 
 /**
- * Tests ${@link TokenResponseAttributes}
+ * Tests {@link TokenResponseAttributes}
  *
  * @author Luander Ribeiro
  */
@@ -61,7 +61,7 @@ public class TokenResponseAttributesTest {
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void buildWhenTokeTypeIsNotCalledThenThrowIllegalArgumentException() {
+	public void buildWhenTokenTypeNotSetThenThrowIllegalArgumentException() {
 		TokenResponseAttributes.withToken(TOKEN)
 			.expiresIn(EXPIRES_IN)
 			.additionalParameters(Collections.emptyMap())


### PR DESCRIPTION
I added new tests for the oauth2-core according to the oauth 2 RFC 6749. 
These tests are only for the "endpoint" package. Other tests may be added/required.
In this PR I also included some fixes for the classes tested.

Part of #4298 