### PR TITLE
Add check to see if return value is DENY

### DIFF
--- a/web/src/main/java/org/springframework/security/web/header/writers/frameoptions/XFrameOptionsHeaderWriter.java
+++ b/web/src/main/java/org/springframework/security/web/header/writers/frameoptions/XFrameOptionsHeaderWriter.java
@@ -83,7 +83,7 @@ public final class XFrameOptionsHeaderWriter implements HeaderWriter {
 	public void writeHeaders(HttpServletRequest request, HttpServletResponse response) {
 		if (XFrameOptionsMode.ALLOW_FROM.equals(frameOptionsMode)) {
 			String allowFromValue = allowFromStrategy.getAllowFromValue(request);
-			if (allowFromValue != null) {
+			if (allowFromValue != null && !allowFromValue.equals(XFrameOptionsMode.DENY)) {
 				response.setHeader(XFRAME_OPTIONS_HEADER,
 						XFrameOptionsMode.ALLOW_FROM.getMode() + " " + allowFromValue);
 			}

--- a/web/src/main/java/org/springframework/security/web/header/writers/frameoptions/XFrameOptionsHeaderWriter.java
+++ b/web/src/main/java/org/springframework/security/web/header/writers/frameoptions/XFrameOptionsHeaderWriter.java
@@ -83,7 +83,7 @@ public final class XFrameOptionsHeaderWriter implements HeaderWriter {
 	public void writeHeaders(HttpServletRequest request, HttpServletResponse response) {
 		if (XFrameOptionsMode.ALLOW_FROM.equals(frameOptionsMode)) {
 			String allowFromValue = allowFromStrategy.getAllowFromValue(request);
-			if (allowFromValue != null && !allowFromValue.equals(XFrameOptionsMode.DENY)) {
+			if (allowFromValue != null && !allowFromValue.equals(XFrameOptionsMode.DENY.getMode())) {
 				response.setHeader(XFRAME_OPTIONS_HEADER,
 						XFrameOptionsMode.ALLOW_FROM.getMode() + " " + allowFromValue);
 			}


### PR DESCRIPTION
Originally, if the return from `getAllowFromValue(request)` is `DENY`,
then the X-Frame-Options header's value will proceed to be written as
`ALLOW FROM DENY` - an invalid value.

This commit adds a condition in the if clause that checks whether
allowFromValue is `DENY`. This way, the X-Frame-Options header will be
written as `ALLOW FROM [origin]` or `DENY`.

If `XFrameOptionsHeaderWriter` is used with the strategy `WhiteListedAllowFromStrategy`, then any supplied origin that is not a direct match on the provided white list should result in `DENY` being written. But stepping through the code will show that if there is no match, `getAllowFromValue()` will return `DENY`, then will proceed to be concatenated with `ALLOW FROM`, resulting in `ALLOW FROM DENY`.

If the supplied origin has a match on the white list, then result is as expected.