### PR TITLE
Fix Javadoc of PasswordEncoderFactories#createDelegatingPasswordEncoder

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/factory/PasswordEncoderFactories.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/factory/PasswordEncoderFactories.java
@@ -41,8 +41,9 @@ public class PasswordEncoderFactories {
 	 * updates should not impact users. The mappings current are:
 	 *
 	 * <ul>
+	 * <li>bcrypt - {@link BCryptPasswordEncoder} (Also used for encoding)</li>
 	 * <li>noop - {@link NoOpPasswordEncoder}</li>
-	 * <li>pbkdf2 - {@link Pbkdf2PasswordEncoder} (Also used for encoding)</li>
+	 * <li>pbkdf2 - {@link Pbkdf2PasswordEncoder}</li>
 	 * <li>scrypt - {@link SCryptPasswordEncoder}</li>
 	 * <li>sha256 - {@link StandardPasswordEncoder}</li>
 	 * </ul>


### PR DESCRIPTION
See gh-4666

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

Probably, Javadoc is wrong. In the current implementation, the `BCryptPasswordEncoder` is used for encoding a password. 
Is wrong implementation?
