### PR TITLE
Add new factory method for creating DelegatingPasswordEncoder

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/factory/PasswordEncoderFactories.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/factory/PasswordEncoderFactories.java
@@ -51,15 +51,35 @@ public class PasswordEncoderFactories {
 	 * @return the {@link PasswordEncoder} to use
 	 */
 	public static PasswordEncoder createDelegatingPasswordEncoder() {
-		String encodingId = "bcrypt";
+		return createDelegatingPasswordEncoder("bcrypt");
+	}
+
+	/**
+	 * Creates a {@link DelegatingPasswordEncoder} with default mappings. Additional
+	 * mappings may be added and the encoding will be updated to conform with best
+	 * practices. However, due to the nature of {@link DelegatingPasswordEncoder} the
+	 * updates should not impact users. The mappings current are:
+	 *
+	 * <ul>
+	 * <li>bcrypt - {@link BCryptPasswordEncoder}</li>
+	 * <li>noop - {@link NoOpPasswordEncoder}</li>
+	 * <li>pbkdf2 - {@link Pbkdf2PasswordEncoder}</li>
+	 * <li>scrypt - {@link SCryptPasswordEncoder}</li>
+	 * <li>sha256 - {@link StandardPasswordEncoder}</li>
+	 * </ul>
+	 *
+	 * @param idForEncode the id used to lookup which {@link PasswordEncoder} should be
+	 * used for {@link PasswordEncoder#encode(CharSequence)}
+	 * @return the {@link PasswordEncoder} to use
+	 */
+	public static PasswordEncoder createDelegatingPasswordEncoder(String idForEncode) {
 		Map<String,PasswordEncoder> encoders = new HashMap<>();
-		encoders.put(encodingId, new BCryptPasswordEncoder());
+		encoders.put("bcrypt", new BCryptPasswordEncoder());
 		encoders.put("noop", NoOpPasswordEncoder.getInstance());
 		encoders.put("pbkdf2", new Pbkdf2PasswordEncoder());
 		encoders.put("scrypt", new SCryptPasswordEncoder());
 		encoders.put("sha256", new StandardPasswordEncoder());
-
-		return new DelegatingPasswordEncoder(encodingId, encoders);
+		return new DelegatingPasswordEncoder(idForEncode, encoders);
 	}
 
 	private PasswordEncoderFactories() {}

--- a/crypto/src/test/java/org/springframework/security/crypto/factory/PasswordEncoderFactoriesTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/factory/PasswordEncoderFactoriesTests.java
@@ -68,4 +68,13 @@ public class PasswordEncoderFactoriesTests {
 		assertThat(this.encoder.matches(this.rawPassword, encodedPassword)).isTrue();
 	}
 
+	@Test
+	public void encodeUsingSpecifiedEncoder() {
+		PasswordEncoder passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder("pbkdf2");
+		String encodedPassword = passwordEncoder.encode(this.rawPassword);
+
+		assertThat(encodedPassword).startsWith("{pbkdf2}");
+		assertThat(passwordEncoder.matches(this.rawPassword, encodedPassword)).isTrue();
+	}
+
 }


### PR DESCRIPTION
See gh-4666

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

I will propose to add new factory method that can specify the id of an encoder for encoding password.
What do you think?
