### PR TITLE
Add UnboundId LDAP inmemory support

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/ldap/LdapAuthenticationProviderConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/ldap/LdapAuthenticationProviderConfigurer.java
@@ -39,6 +39,7 @@ import org.springframework.security.ldap.authentication.PasswordComparisonAuthen
 import org.springframework.security.ldap.search.FilterBasedLdapUserSearch;
 import org.springframework.security.ldap.search.LdapUserSearch;
 import org.springframework.security.ldap.server.ApacheDSContainer;
+import org.springframework.security.ldap.server.UnboundIdContainer;
 import org.springframework.security.ldap.userdetails.DefaultLdapAuthoritiesPopulator;
 import org.springframework.security.ldap.userdetails.InetOrgPersonContextMapper;
 import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator;
@@ -46,6 +47,7 @@ import org.springframework.security.ldap.userdetails.LdapUserDetailsMapper;
 import org.springframework.security.ldap.userdetails.PersonContextMapper;
 import org.springframework.security.ldap.userdetails.UserDetailsContextMapper;
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 
 /**
  * Configures LDAP {@link AuthenticationProvider} in the {@link ProviderManagerBuilder}.
@@ -551,9 +553,16 @@ public class LdapAuthenticationProviderConfigurer<B extends ProviderManagerBuild
 			if (url != null) {
 				return contextSource;
 			}
-			ApacheDSContainer apacheDsContainer = new ApacheDSContainer(root, ldif);
-			apacheDsContainer.setPort(getPort());
-			postProcess(apacheDsContainer);
+			if (ClassUtils.isPresent("org.apache.directory.server.core.DefaultDirectoryService", getClass().getClassLoader())) {
+				ApacheDSContainer apacheDsContainer = new ApacheDSContainer(root, ldif);
+				apacheDsContainer.setPort(getPort());
+				postProcess(apacheDsContainer);
+			}
+			else if (ClassUtils.isPresent("com.unboundid.ldap.listener.InMemoryDirectoryServer", getClass().getClassLoader())) {
+				UnboundIdContainer unboundIdContainer = new UnboundIdContainer(root, ldif);
+				unboundIdContainer.setPort(getPort());
+				postProcess(unboundIdContainer);
+			}
 			return contextSource;
 		}
 

--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -49,6 +49,7 @@ dependencyManagement {
 		dependency 'com.nimbusds:oauth2-oidc-sdk:5.38'
 		dependency 'com.squareup.okhttp3:okhttp:3.9.0'
 		dependency 'com.squareup.okio:okio:1.13.0'
+		dependency 'com.unboundid:unboundid-ldapsdk:3.2.0'
 		dependency 'com.vaadin.external.google:android-json:0.0.20131108.vaadin1'
 		dependency 'commons-cli:commons-cli:1.4'
 		dependency 'commons-codec:commons-codec:1.10'

--- a/ldap/spring-security-ldap.gradle
+++ b/ldap/spring-security-ldap.gradle
@@ -11,6 +11,8 @@ dependencies {
 	optional 'ldapsdk:ldapsdk'
 	optional 'org.apache.directory.shared:shared-ldap'
 
+	optional "com.unboundid:unboundid-ldapsdk"
+
 	compile ('org.springframework.ldap:spring-ldap-core') {
 		exclude(group: 'commons-logging', module: 'commons-logging')
 		exclude(group: 'org.springframework', module: 'spring-beans')

--- a/ldap/src/integration-test/java/org/springframework/security/ldap/server/UnboundIdContainerTests.java
+++ b/ldap/src/integration-test/java/org/springframework/security/ldap/server/UnboundIdContainerTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.ldap.server;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Eddú Meléndez
+ */
+public class UnboundIdContainerTests {
+
+	@Test
+	public void startLdapServer() throws IOException {
+		UnboundIdContainer server = new UnboundIdContainer("dc=springframework,dc=org",
+				"classpath:test-server.ldif");
+		List<Integer> ports = getDefaultPorts(1);
+		server.setPort(ports.get(0));
+
+		try {
+			server.afterPropertiesSet();
+			fail("Expected a RuntimeException to be thrown.");
+		} catch (Exception ex) {
+			assertThat(ex).hasMessage("Server startup failed");
+		}
+	}
+
+	private List<Integer> getDefaultPorts(int count) throws IOException {
+		List<ServerSocket> connections = new ArrayList<ServerSocket>();
+		List<Integer> availablePorts = new ArrayList<Integer>(count);
+		try {
+			for (int i = 0; i < count; i++) {
+				ServerSocket socket = new ServerSocket(0);
+				connections.add(socket);
+				availablePorts.add(socket.getLocalPort());
+			}
+			return availablePorts;
+		} finally {
+			for (ServerSocket conn : connections) {
+				conn.close();
+			}
+		}
+	}
+
+}

--- a/ldap/src/main/java/org/springframework/security/ldap/server/UnboundIdContainer.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/server/UnboundIdContainer.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.ldap.server;
+
+import java.io.InputStream;
+
+import com.unboundid.ldap.listener.InMemoryDirectoryServer;
+import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
+import com.unboundid.ldap.listener.InMemoryListenerConfig;
+import com.unboundid.ldap.sdk.DN;
+import com.unboundid.ldap.sdk.Entry;
+import com.unboundid.ldap.sdk.LDAPException;
+import com.unboundid.ldif.LDIFReader;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.Lifecycle;
+import org.springframework.core.io.Resource;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Eddú Meléndez
+ */
+public class UnboundIdContainer implements InitializingBean, DisposableBean, Lifecycle,
+		ApplicationContextAware {
+
+	private InMemoryDirectoryServer directoryServer;
+
+	private String defaultPartitionSuffix;
+
+	private int port = 53389;
+
+	private ApplicationContext context;
+
+	private boolean running;
+
+	private String ldif;
+
+	public UnboundIdContainer(String defaultPartitionSuffix, String ldif) {
+		this.defaultPartitionSuffix = defaultPartitionSuffix;
+		this.ldif = ldif;
+	}
+
+	public int getPort() {
+		return this.port;
+	}
+
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	@Override
+	public void destroy() throws Exception {
+		stop();
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		start();
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.context = applicationContext;
+	}
+
+	@Override
+	public void start() {
+		if (isRunning()) {
+			return;
+		}
+
+		try {
+			InMemoryDirectoryServerConfig config = new InMemoryDirectoryServerConfig(this.defaultPartitionSuffix);
+			config.addAdditionalBindCredentials("uid=admin,ou=system", "secret");
+
+			config.setListenerConfigs(InMemoryListenerConfig.createLDAPConfig("LDAP", this.port));
+			config.setEnforceSingleStructuralObjectClass(false);
+			config.setEnforceAttributeSyntaxCompliance(true);
+
+			DN dn = new DN(this.defaultPartitionSuffix);
+			Entry entry = new Entry(dn);
+			entry.addAttribute("objectClass", "top", "domain", "extensibleObject");
+			entry.addAttribute("dc", dn.getRDN().getAttributeValues()[0]);
+
+			InMemoryDirectoryServer directoryServer = new InMemoryDirectoryServer(config);
+			directoryServer.add(entry);
+			importLdif(directoryServer);
+			directoryServer.startListening();
+			this.directoryServer = directoryServer;
+			this.running = true;
+		} catch (LDAPException ex) {
+			throw new RuntimeException("Server startup failed", ex);
+		}
+
+	}
+
+	private void importLdif(InMemoryDirectoryServer directoryServer) {
+		if (StringUtils.hasText(this.ldif)) {
+			Resource resource = this.context.getResource(this.ldif);
+			try {
+				if (resource.exists()) {
+					try (InputStream inputStream = resource.getInputStream()) {
+						directoryServer.importFromLDIF(false, new LDIFReader(inputStream));
+					}
+				}
+			} catch (Exception ex) {
+				throw new IllegalStateException("Unable to load LDIF " + this.ldif, ex);
+			}
+		}
+	}
+
+	@Override
+	public void stop() {
+		this.directoryServer.shutDown(true);
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.running;
+	}
+}


### PR DESCRIPTION
This commit adds the capability to run a LDAP inmemory different than
apacheds. Both providers `apacheds` and `unboundid` are supported.

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
