### PR TITLE
Use id field instead of name field for GitHub and Facebook providers.

### DIFF
--- a/config/src/main/java/org/springframework/security/config/oauth2/client/CommonOAuth2Provider.java
+++ b/config/src/main/java/org/springframework/security/config/oauth2/client/CommonOAuth2Provider.java
@@ -58,7 +58,7 @@ public enum CommonOAuth2Provider {
 			builder.authorizationUri("https://github.com/login/oauth/authorize");
 			builder.tokenUri("https://github.com/login/oauth/access_token");
 			builder.userInfoUri("https://api.github.com/user");
-			builder.userNameAttributeName("name");
+			builder.userNameAttributeName("id");
 			builder.clientName("GitHub");
 			return builder;
 		}
@@ -74,7 +74,7 @@ public enum CommonOAuth2Provider {
 			builder.authorizationUri("https://www.facebook.com/v2.8/dialog/oauth");
 			builder.tokenUri("https://graph.facebook.com/v2.8/oauth/access_token");
 			builder.userInfoUri("https://graph.facebook.com/me");
-			builder.userNameAttributeName("name");
+			builder.userNameAttributeName("id");
 			builder.clientName("Facebook");
 			return builder;
 		}

--- a/config/src/test/java/org/springframework/security/config/oauth2/client/CommonOAuth2ProviderTests.java
+++ b/config/src/test/java/org/springframework/security/config/oauth2/client/CommonOAuth2ProviderTests.java
@@ -69,7 +69,7 @@ public class CommonOAuth2ProviderTests {
 		assertThat(providerDetails.getUserInfoEndpoint().getUri())
 			.isEqualTo("https://api.github.com/user");
 		assertThat(providerDetails.getUserInfoEndpoint().getUserNameAttributeName())
-			.isEqualTo("name");
+			.isEqualTo("id");
 		assertThat(providerDetails.getJwkSetUri()).isNull();
 		assertThat(registration.getClientAuthenticationMethod())
 			.isEqualTo(ClientAuthenticationMethod.BASIC);
@@ -92,7 +92,7 @@ public class CommonOAuth2ProviderTests {
 		assertThat(providerDetails.getUserInfoEndpoint().getUri())
 			.isEqualTo("https://graph.facebook.com/me");
 		assertThat(providerDetails.getUserInfoEndpoint().getUserNameAttributeName())
-			.isEqualTo("name");
+			.isEqualTo("id");
 		assertThat(providerDetails.getJwkSetUri()).isNull();
 		assertThat(registration.getClientAuthenticationMethod())
 			.isEqualTo(ClientAuthenticationMethod.POST);


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

Pulls a user's "id" field as the unique identifier rather than the "name" field when doing OAuth2 authentication against Facebook and GitHub. Fixes #4763