### PR TITLE
Remove duplicate eruby option in asciidoctor task

### DIFF
--- a/docs/guides/spring-security-docs-guides.gradle
+++ b/docs/guides/spring-security-docs-guides.gradle
@@ -4,7 +4,6 @@ asciidoctor {
 	baseDir = file('src/docs/asciidoc')
 	options = [
 	  eruby: 'erubis',
-	  eruby: 'erubis',
 	  attributes: [
 		  copycss : '',
 		  icons : 'font',


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR removes duplicate `eruby` option in `asciidoctor` task.