### PR TITLE
Update to hibernate-validator 6.0.4.Final

### DIFF
--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -172,7 +172,7 @@ dependencyManagement {
 		dependency 'org.hibernate.javax.persistence:hibernate-jpa-2.1-api:1.0.0.Final'
 		dependency 'org.hibernate:hibernate-core:5.2.12.Final'
 		dependency 'org.hibernate:hibernate-entitymanager:5.2.12.Final'
-		dependency 'org.hibernate:hibernate-validator:5.4.2.Final'
+		dependency 'org.hibernate:hibernate-validator:6.0.4.Final'
 		dependency 'org.hsqldb:hsqldb:2.4.0'
 		dependency 'org.jasig.cas.client:cas-client-core:3.4.1'
 		dependency 'org.javassist:javassist:3.22.0-CR2'


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
`hibernate-validator` has been upgraded to 6.0.2.Final in 21280386a1e1e1333bd74d599f2bcd67fba2612a due to https://github.com/spring-projects/spring-security/issues/4640#issuecomment-338422262 and upgrade to 6.0.4.Final again in fb632624d234cd85d367a036606c032edd1d14f6 but changed to 5.4.2.Final in 6d4b4bf2c785bfbeb7be04a204a97074bf7c71fc.

It looks a accidental change, so this PR updates it back to 6.0.4.Final again.