### PR TITLE
Remove initialization of ServerHttpSecurity.headers

### DIFF
--- a/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
@@ -97,7 +97,7 @@ public class ServerHttpSecurity {
 
 	private AuthorizeExchangeSpec authorizeExchange;
 
-	private HeaderSpec headers = new HeaderSpec();
+	private HeaderSpec headers;
 
 	private CsrfSpec csrf = new CsrfSpec();
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
There is `null` handing for `ServerHttpSecurity.headers` but it can't be `null` unless something similar `CsrfSpec.disable()` should be added.

This PR simply drops its initialization.