### PR TITLE
Improve configuration for ClientRegistration#redirectUriTemplate

### DIFF
--- a/config/src/main/java/org/springframework/security/config/oauth2/client/CommonOAuth2Provider.java
+++ b/config/src/main/java/org/springframework/security/config/oauth2/client/CommonOAuth2Provider.java
@@ -27,6 +27,7 @@ import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
  * builders} pre-configured with sensible defaults.
  *
  * @author Phillip Webb
+ * @author Kazuki Shimizu
  * @since 5.0
  */
 public enum CommonOAuth2Provider {
@@ -36,7 +37,8 @@ public enum CommonOAuth2Provider {
 		@Override
 		public Builder getBuilder(String registrationId) {
 			ClientRegistration.Builder builder = getBuilder(registrationId,
-					ClientAuthenticationMethod.BASIC, DEFAULT_LOGIN_REDIRECT_URL);
+					ClientAuthenticationMethod.BASIC,
+					ClientRegistration.DEFAULT_REDIRECT_URI_TEMPLATE);
 			builder.scope("openid", "profile", "email", "address", "phone");
 			builder.authorizationUri("https://accounts.google.com/o/oauth2/v2/auth");
 			builder.tokenUri("https://www.googleapis.com/oauth2/v4/token");
@@ -53,7 +55,8 @@ public enum CommonOAuth2Provider {
 		@Override
 		public Builder getBuilder(String registrationId) {
 			ClientRegistration.Builder builder = getBuilder(registrationId,
-					ClientAuthenticationMethod.BASIC, DEFAULT_LOGIN_REDIRECT_URL);
+					ClientAuthenticationMethod.BASIC,
+					ClientRegistration.DEFAULT_REDIRECT_URI_TEMPLATE);
 			builder.scope("user");
 			builder.authorizationUri("https://github.com/login/oauth/authorize");
 			builder.tokenUri("https://github.com/login/oauth/access_token");
@@ -69,7 +72,8 @@ public enum CommonOAuth2Provider {
 		@Override
 		public Builder getBuilder(String registrationId) {
 			ClientRegistration.Builder builder = getBuilder(registrationId,
-					ClientAuthenticationMethod.POST, DEFAULT_LOGIN_REDIRECT_URL);
+					ClientAuthenticationMethod.POST,
+					ClientRegistration.DEFAULT_REDIRECT_URI_TEMPLATE);
 			builder.scope("public_profile", "email");
 			builder.authorizationUri("https://www.facebook.com/v2.8/dialog/oauth");
 			builder.tokenUri("https://graph.facebook.com/v2.8/oauth/access_token");
@@ -85,7 +89,8 @@ public enum CommonOAuth2Provider {
 		@Override
 		public Builder getBuilder(String registrationId) {
 			ClientRegistration.Builder builder = getBuilder(registrationId,
-					ClientAuthenticationMethod.BASIC, DEFAULT_LOGIN_REDIRECT_URL);
+					ClientAuthenticationMethod.BASIC,
+					ClientRegistration.DEFAULT_REDIRECT_URI_TEMPLATE);
 			builder.scope("openid", "profile", "email", "address", "phone");
 			builder.userNameAttributeName(IdTokenClaimNames.SUB);
 			builder.clientName("Okta");
@@ -93,14 +98,12 @@ public enum CommonOAuth2Provider {
 		}
 	};
 
-	private static final String DEFAULT_LOGIN_REDIRECT_URL = "{baseUrl}/login/oauth2/code/{registrationId}";
-
 	protected final ClientRegistration.Builder getBuilder(String registrationId,
-															ClientAuthenticationMethod method, String redirectUri) {
+													ClientAuthenticationMethod method, String redirectUriTemplate) {
 		ClientRegistration.Builder builder = ClientRegistration.withRegistrationId(registrationId);
 		builder.clientAuthenticationMethod(method);
 		builder.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE);
-		builder.redirectUriTemplate(redirectUri);
+		builder.redirectUriTemplate(redirectUriTemplate);
 		return builder;
 	}
 

--- a/config/src/test/java/org/springframework/security/config/oauth2/client/CommonOAuth2ProviderTests.java
+++ b/config/src/test/java/org/springframework/security/config/oauth2/client/CommonOAuth2ProviderTests.java
@@ -28,10 +28,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link CommonOAuth2Provider}.
  *
  * @author Phillip Webb
+ * @author Kazuki Shimizu
  */
 public class CommonOAuth2ProviderTests {
 
-	private static final String DEFAULT_LOGIN_REDIRECT_URL = "{baseUrl}/login/oauth2/code/{registrationId}";
+	private static final String DEFAULT_REDIRECT_URL_TEMPLATE = "{baseUrl}/login/oauth2/code/{registrationId}";
 
 	@Test
 	public void getBuilderWhenGoogleShouldHaveGoogleSettings() throws Exception {
@@ -51,7 +52,7 @@ public class CommonOAuth2ProviderTests {
 			.isEqualTo(ClientAuthenticationMethod.BASIC);
 		assertThat(registration.getAuthorizationGrantType())
 			.isEqualTo(AuthorizationGrantType.AUTHORIZATION_CODE);
-		assertThat(registration.getRedirectUriTemplate()).isEqualTo(DEFAULT_LOGIN_REDIRECT_URL);
+		assertThat(registration.getRedirectUriTemplate()).isEqualTo(DEFAULT_REDIRECT_URL_TEMPLATE);
 		assertThat(registration.getScopes()).containsOnly("openid", "profile", "email",
 			"address", "phone");
 		assertThat(registration.getClientName()).isEqualTo("Google");
@@ -75,7 +76,7 @@ public class CommonOAuth2ProviderTests {
 			.isEqualTo(ClientAuthenticationMethod.BASIC);
 		assertThat(registration.getAuthorizationGrantType())
 			.isEqualTo(AuthorizationGrantType.AUTHORIZATION_CODE);
-		assertThat(registration.getRedirectUriTemplate()).isEqualTo(DEFAULT_LOGIN_REDIRECT_URL);
+		assertThat(registration.getRedirectUriTemplate()).isEqualTo(DEFAULT_REDIRECT_URL_TEMPLATE);
 		assertThat(registration.getScopes()).containsOnly("user");
 		assertThat(registration.getClientName()).isEqualTo("GitHub");
 		assertThat(registration.getRegistrationId()).isEqualTo("123");
@@ -98,7 +99,7 @@ public class CommonOAuth2ProviderTests {
 			.isEqualTo(ClientAuthenticationMethod.POST);
 		assertThat(registration.getAuthorizationGrantType())
 			.isEqualTo(AuthorizationGrantType.AUTHORIZATION_CODE);
-		assertThat(registration.getRedirectUriTemplate()).isEqualTo(DEFAULT_LOGIN_REDIRECT_URL);
+		assertThat(registration.getRedirectUriTemplate()).isEqualTo(DEFAULT_REDIRECT_URL_TEMPLATE);
 		assertThat(registration.getScopes()).containsOnly("public_profile", "email");
 		assertThat(registration.getClientName()).isEqualTo("Facebook");
 		assertThat(registration.getRegistrationId()).isEqualTo("123");
@@ -123,7 +124,7 @@ public class CommonOAuth2ProviderTests {
 			.isEqualTo(ClientAuthenticationMethod.BASIC);
 		assertThat(registration.getAuthorizationGrantType())
 			.isEqualTo(AuthorizationGrantType.AUTHORIZATION_CODE);
-		assertThat(registration.getRedirectUriTemplate()).isEqualTo(DEFAULT_LOGIN_REDIRECT_URL);
+		assertThat(registration.getRedirectUriTemplate()).isEqualTo(DEFAULT_REDIRECT_URL_TEMPLATE);
 		assertThat(registration.getScopes()).containsOnly("openid", "profile", "email",
 			"address", "phone");
 		assertThat(registration.getClientName()).isEqualTo("Okta");

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
@@ -29,14 +29,21 @@ import java.util.Set;
  * A representation of a client registration with an OAuth 2.0 / OpenID Connect 1.0 <i>Authorization Server</i>.
  *
  * @author Joe Grandja
+ * @author Kazuki Shimizu
  * @since 5.0
  * @see <a target="_blank" href="https://tools.ietf.org/html/rfc6749#section-2">Section 2 Client Registration</a>
  */
 public final class ClientRegistration {
+
+	/**
+	 * The default URI template for redirecting to the client application when authorization is completed.
+	 */
+	public static final String DEFAULT_REDIRECT_URI_TEMPLATE = "{baseUrl}/login/oauth2/code/{registrationId}";
+
 	private String registrationId;
 	private String clientId;
 	private String clientSecret;
-	private ClientAuthenticationMethod clientAuthenticationMethod = ClientAuthenticationMethod.BASIC;
+	private ClientAuthenticationMethod clientAuthenticationMethod;
 	private AuthorizationGrantType authorizationGrantType;
 	private String redirectUriTemplate;
 	private Set<String> scopes = Collections.emptySet();
@@ -150,7 +157,7 @@ public final class ClientRegistration {
 		private String clientSecret;
 		private ClientAuthenticationMethod clientAuthenticationMethod = ClientAuthenticationMethod.BASIC;
 		private AuthorizationGrantType authorizationGrantType;
-		private String redirectUriTemplate;
+		private String redirectUriTemplate = DEFAULT_REDIRECT_URI_TEMPLATE;
 		private Set<String> scopes;
 		private String authorizationUri;
 		private String tokenUri;

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/ClientRegistrationTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/ClientRegistrationTests.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link ClientRegistration}.
  *
  * @author Joe Grandja
+ * @author Kazuki Shimizu
  */
 public class ClientRegistrationTests {
 	private static final String REGISTRATION_ID = "registration-1";
@@ -150,7 +151,7 @@ public class ClientRegistrationTests {
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void buildWhenAuthorizationCodeGrantRedirectUriIsNullThenThrowIllegalArgumentException() {
+	public void buildWhenAuthorizationCodeGrantRedirectUriTemplateIsNullThenThrowIllegalArgumentException() {
 		ClientRegistration.withRegistrationId(REGISTRATION_ID)
 			.clientId(CLIENT_ID)
 			.clientSecret(CLIENT_SECRET)
@@ -305,7 +306,7 @@ public class ClientRegistrationTests {
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void buildWhenImplicitGrantRedirectUriIsNullThenThrowIllegalArgumentException() {
+	public void buildWhenImplicitGrantRedirectUriTemplateIsNullThenThrowIllegalArgumentException() {
 		ClientRegistration.withRegistrationId(REGISTRATION_ID)
 			.clientId(CLIENT_ID)
 			.authorizationGrantType(AuthorizationGrantType.IMPLICIT)
@@ -351,4 +352,31 @@ public class ClientRegistrationTests {
 			.clientName(null)
 			.build();
 	}
+
+	@Test
+	public void buildOmitDefinitionOnHavingDefaultValue() {
+		ClientRegistration registration = ClientRegistration.withRegistrationId(REGISTRATION_ID)
+			.clientId(CLIENT_ID)
+			.clientSecret(CLIENT_SECRET)
+			.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+			.scope(SCOPES.toArray(new String[0]))
+			.authorizationUri(AUTHORIZATION_URI)
+			.tokenUri(TOKEN_URI)
+			.jwkSetUri(JWK_SET_URI)
+			.clientName(CLIENT_NAME)
+			.build();
+
+		assertThat(registration.getRegistrationId()).isEqualTo(REGISTRATION_ID);
+		assertThat(registration.getClientId()).isEqualTo(CLIENT_ID);
+		assertThat(registration.getClientSecret()).isEqualTo(CLIENT_SECRET);
+		assertThat(registration.getClientAuthenticationMethod()).isEqualTo(ClientAuthenticationMethod.BASIC); // have default value
+		assertThat(registration.getAuthorizationGrantType()).isEqualTo(AuthorizationGrantType.AUTHORIZATION_CODE);
+		assertThat(registration.getRedirectUriTemplate()).isEqualTo("{baseUrl}/login/oauth2/code/{registrationId}"); // have default value
+		assertThat(registration.getScopes()).isEqualTo(SCOPES);
+		assertThat(registration.getProviderDetails().getAuthorizationUri()).isEqualTo(AUTHORIZATION_URI);
+		assertThat(registration.getProviderDetails().getTokenUri()).isEqualTo(TOKEN_URI);
+		assertThat(registration.getProviderDetails().getJwkSetUri()).isEqualTo(JWK_SET_URI);
+		assertThat(registration.getClientName()).isEqualTo(CLIENT_NAME);
+	}
+
 }


### PR DESCRIPTION
* Set default value on ClientRegistration#redirectUriTemplate
* Move the constant for redirectUriTemplate to ClientRegistration as public constant

Fixes gh-4862

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
