### PR TITLE
Remove address and phone from default scope for Google

### DIFF
--- a/config/src/main/java/org/springframework/security/config/oauth2/client/CommonOAuth2Provider.java
+++ b/config/src/main/java/org/springframework/security/config/oauth2/client/CommonOAuth2Provider.java
@@ -37,7 +37,7 @@ public enum CommonOAuth2Provider {
 		public Builder getBuilder(String registrationId) {
 			ClientRegistration.Builder builder = getBuilder(registrationId,
 					ClientAuthenticationMethod.BASIC, DEFAULT_LOGIN_REDIRECT_URL);
-			builder.scope("openid", "profile", "email", "address", "phone");
+			builder.scope("openid", "profile", "email");
 			builder.authorizationUri("https://accounts.google.com/o/oauth2/v2/auth");
 			builder.tokenUri("https://www.googleapis.com/oauth2/v4/token");
 			builder.jwkSetUri("https://www.googleapis.com/oauth2/v3/certs");

--- a/config/src/test/java/org/springframework/security/config/oauth2/client/CommonOAuth2ProviderTests.java
+++ b/config/src/test/java/org/springframework/security/config/oauth2/client/CommonOAuth2ProviderTests.java
@@ -52,8 +52,7 @@ public class CommonOAuth2ProviderTests {
 		assertThat(registration.getAuthorizationGrantType())
 			.isEqualTo(AuthorizationGrantType.AUTHORIZATION_CODE);
 		assertThat(registration.getRedirectUriTemplate()).isEqualTo(DEFAULT_LOGIN_REDIRECT_URL);
-		assertThat(registration.getScopes()).containsOnly("openid", "profile", "email",
-			"address", "phone");
+		assertThat(registration.getScopes()).containsOnly("openid", "profile", "email");
 		assertThat(registration.getClientName()).isEqualTo("Google");
 		assertThat(registration.getRegistrationId()).isEqualTo("123");
 	}


### PR DESCRIPTION
I think the `address` and `phone` are ignored(=not supported) on the userinfo endpoint of Google.
About supported scopes for OpenID Connect refer to [here](https://developers.google.com/identity/protocols/googlescopes#openid_connect).

WDYT?

