### PR TITLE
Improve SessionManagementConfigurer

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -229,7 +229,7 @@ public final class SessionManagementConfigurer<H extends HttpSecurityBuilder<H>>
 	 */
 	public SessionManagementConfigurer<H> sessionAuthenticationStrategy(
 			SessionAuthenticationStrategy sessionAuthenticationStrategy) {
-		this.sessionFixationAuthenticationStrategy = sessionAuthenticationStrategy;
+		this.providedSessionAuthenticationStrategy = sessionAuthenticationStrategy;
 		return this;
 	}
 
@@ -246,6 +246,11 @@ public final class SessionManagementConfigurer<H extends HttpSecurityBuilder<H>>
 		return this;
 	}
 
+	/**
+	 * Allows changing the default {@link SessionFixationProtectionStrategy}.
+	 *
+	 * @return the {@link SessionFixationConfigurer} for further customizations
+	 */
 	public SessionFixationConfigurer sessionFixation() {
 		return new SessionFixationConfigurer();
 	}


### PR DESCRIPTION
The first commit fixes incomplete commit e68d8bfaeaae7e244bf3a27ce6dbec530b0c940c in context with gh-234.
e68d8bfaeaae7e244bf3a27ce6dbec530b0c940c added a private field `providedSessionAuthenticationStrategy` but missed to set it somewhere.

The second commit improves the possibilities to configure session management. 
In my opinion it's kind of surprising that setting session authorization disables session fixation. (although it is documented in `sessionAuthenticationStrategy`s JavaDoc but only mention the default fixation)
Configuring 
```
sessionManagement().sessionFixation().newSession()
                   .sessionAuthenticationStrategy(myStrategy)
```
will result in disabled session fixation.
The commit changes this behavior and allows configuration of all three features (session fixation, maximumSessions and custom session authentication) together.
User can still disable session fixation by setting `sessionFixation().none()`.