### PR TITLE
Metadatasource's attributes default value is an empty collection, not null value.

### DIFF
--- a/config/src/test/groovy/org/springframework/security/config/http/MiscHttpConfigTests.groovy
+++ b/config/src/test/groovy/org/springframework/security/config/http/MiscHttpConfigTests.groovy
@@ -268,7 +268,7 @@ class MiscHttpConfigTests extends AbstractHttpConfigTests {
 		 expect:
 		 attrs.size() == 1
 		 attrs.contains(new SecurityConfig("REQUIRES_SECURE_CHANNEL"))
-		 attrsPost == null
+		 attrsPost != null && attrsPost.isEmpty()
 	 }
 
 	 def httpMethodMatchIsSupportedForRequiresChannelAny() {
@@ -285,7 +285,7 @@ class MiscHttpConfigTests extends AbstractHttpConfigTests {
 		 expect:
 		 attrs.size() == 1
 		 attrs.contains(new SecurityConfig("REQUIRES_SECURE_CHANNEL"))
-		 attrsPost == null
+		 attrsPost != null && attrsPost.isEmpty()
 	 }
 
 	def oncePerRequestAttributeIsSupported() {

--- a/config/src/test/java/org/springframework/security/config/annotation/web/messaging/MessageSecurityMetadataSourceRegistryTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/messaging/MessageSecurityMetadataSourceRegistryTests.java
@@ -296,7 +296,7 @@ public class MessageSecurityMetadataSourceRegistryTests {
 	private String getAttribute() {
 		MessageSecurityMetadataSource source = messages.createMetadataSource();
 		Collection<ConfigAttribute> attrs = source.getAttributes(message);
-		if (attrs == null) {
+		if (attrs.isEmpty()) {
 			return null;
 		}
 		assertThat(attrs).hasSize(1);

--- a/core/src/main/java/org/springframework/security/access/annotation/Jsr250MethodSecurityMetadataSource.java
+++ b/core/src/main/java/org/springframework/security/access/annotation/Jsr250MethodSecurityMetadataSource.java
@@ -20,6 +20,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.security.DenyAll;
@@ -68,7 +69,7 @@ public class Jsr250MethodSecurityMetadataSource extends
 	}
 
 	public Collection<ConfigAttribute> getAllConfigAttributes() {
-		return null;
+		return Collections.emptyList();
 	}
 
 	private List<ConfigAttribute> processAnnotations(Annotation[] annotations) {

--- a/core/src/main/java/org/springframework/security/access/annotation/SecuredAnnotationSecurityMetadataSource.java
+++ b/core/src/main/java/org/springframework/security/access/annotation/SecuredAnnotationSecurityMetadataSource.java
@@ -68,7 +68,7 @@ public class SecuredAnnotationSecurityMetadataSource extends
 	}
 
 	public Collection<ConfigAttribute> getAllConfigAttributes() {
-		return null;
+		return Collections.emptyList();
 	}
 
 	private Collection<ConfigAttribute> processAnnotation(Annotation a) {

--- a/core/src/main/java/org/springframework/security/access/method/AbstractMethodSecurityMetadataSource.java
+++ b/core/src/main/java/org/springframework/security/access/method/AbstractMethodSecurityMetadataSource.java
@@ -17,6 +17,7 @@
 package org.springframework.security.access.method;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import org.aopalliance.intercept.MethodInvocation;
 import org.apache.commons.logging.Log;
@@ -55,6 +56,9 @@ public abstract class AbstractMethodSecurityMetadataSource implements
 			}
 			if (target != null && !(target instanceof Class<?>)) {
 				attrs = getAttributes(mi.getMethod(), target.getClass());
+			}
+			if (attrs == null) {
+				attrs = Collections.emptyList();
 			}
 			return attrs;
 		}

--- a/core/src/main/java/org/springframework/security/access/prepost/PrePostAnnotationSecurityMetadataSource.java
+++ b/core/src/main/java/org/springframework/security/access/prepost/PrePostAnnotationSecurityMetadataSource.java
@@ -106,7 +106,7 @@ public class PrePostAnnotationSecurityMetadataSource extends
 	}
 
 	public Collection<ConfigAttribute> getAllConfigAttributes() {
-		return null;
+		return Collections.emptyList();
 	}
 
 	/**

--- a/core/src/test/java/org/springframework/security/access/annotation/Jsr250MethodSecurityMetadataSourceTests.java
+++ b/core/src/test/java/org/springframework/security/access/annotation/Jsr250MethodSecurityMetadataSourceTests.java
@@ -141,7 +141,7 @@ public class Jsr250MethodSecurityMetadataSourceTests {
 				"notOverriden");
 
 		Collection<ConfigAttribute> accessAttributes = this.mds.getAttributes(mi);
-		assertThat(accessAttributes).isNull();
+		assertThat(accessAttributes).isNotNull().isEmpty();
 	}
 
 	@Test

--- a/core/src/test/java/org/springframework/security/access/annotation/SecuredAnnotationSecurityMetadataSourceTests.java
+++ b/core/src/test/java/org/springframework/security/access/annotation/SecuredAnnotationSecurityMetadataSourceTests.java
@@ -208,6 +208,16 @@ public class SecuredAnnotationSecurityMetadataSourceTests {
 	}
 
 	@Test
+	public void emptyResultIfNoMatching() throws Exception {
+		MockMethodInvocation annotatedAtMethodLevel = new MockMethodInvocation(
+				new NoAnnotatedAnnotationAtAnyLevel(), ReturnVoid.class, "doSomething",
+				List.class);
+		Collection<ConfigAttribute> attrs = mds.getAttributes(annotatedAtMethodLevel);
+
+		assertThat(attrs).isNotNull().isEmpty();
+	}
+
+	@Test
 	public void proxyFactoryInterfaceAttributesFound() throws Exception {
 		MockMethodInvocation mi = MethodInvocationFactory.createSec2150MethodInvocation();
 		Collection<ConfigAttribute> attributes = mds.getAttributes(mi);
@@ -315,4 +325,11 @@ public class SecuredAnnotationSecurityMetadataSourceTests {
 		public void doSomething(List<?> param) {
 		}
 	}
+
+	public static class NoAnnotatedAnnotationAtAnyLevel implements ReturnVoid {
+
+		public void doSomething(List<?> param) {
+		}
+	}
+
 }

--- a/core/src/test/java/org/springframework/security/access/intercept/method/MapBasedMethodSecurityMetadataSourceTests.java
+++ b/core/src/test/java/org/springframework/security/access/intercept/method/MapBasedMethodSecurityMetadataSourceTests.java
@@ -54,6 +54,12 @@ public class MapBasedMethodSecurityMetadataSourceTests {
 	}
 
 	@Test
+	public void returnEmptyAttributesCollectionIfNoMatch() {
+		// no definition of method's configuration attributes.
+		assertThat(mds.getAttributes(someMethodInteger, MockService.class)).isNotNull().isEmpty();
+	}
+
+	@Test
 	public void methodsWithDifferentArgumentsAreMatchedCorrectly() throws Exception {
 		mds.addSecureMethod(MockService.class, someMethodInteger, ROLE_A);
 		mds.addSecureMethod(MockService.class, someMethodString, ROLE_B);

--- a/messaging/src/main/java/org/springframework/security/messaging/access/intercept/DefaultMessageSecurityMetadataSource.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/access/intercept/DefaultMessageSecurityMetadataSource.java
@@ -56,7 +56,7 @@ public final class DefaultMessageSecurityMetadataSource implements
 				return entry.getValue();
 			}
 		}
-		return null;
+		return Collections.emptyList();
 	}
 
 	public Collection<ConfigAttribute> getAllConfigAttributes() {

--- a/messaging/src/test/java/org/springframework/security/messaging/access/expression/ExpressionBasedMessageSecurityMetadataSourceFactoryTests.java
+++ b/messaging/src/test/java/org/springframework/security/messaging/access/expression/ExpressionBasedMessageSecurityMetadataSourceFactoryTests.java
@@ -71,7 +71,7 @@ public class ExpressionBasedMessageSecurityMetadataSourceFactoryTests {
 
 		Collection<ConfigAttribute> attrs = source.getAttributes(message);
 
-		assertThat(attrs).isNull();
+		assertThat(attrs).isNotNull().isEmpty();
 	}
 
 	@Test

--- a/messaging/src/test/java/org/springframework/security/messaging/access/intercept/DefaultMessageSecurityMetadataSourceTests.java
+++ b/messaging/src/test/java/org/springframework/security/messaging/access/intercept/DefaultMessageSecurityMetadataSourceTests.java
@@ -63,7 +63,7 @@ public class DefaultMessageSecurityMetadataSourceTests {
 
 	@Test
 	public void getAttributesNull() {
-		assertThat(source.getAttributes(message)).isNull();
+		assertThat(source.getAttributes(message)).isNotNull().isEmpty();
 	}
 
 	@Test

--- a/web/src/main/java/org/springframework/security/web/access/intercept/DefaultFilterInvocationSecurityMetadataSource.java
+++ b/web/src/main/java/org/springframework/security/web/access/intercept/DefaultFilterInvocationSecurityMetadataSource.java
@@ -17,6 +17,7 @@
 package org.springframework.security.web.access.intercept;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -96,7 +97,7 @@ public class DefaultFilterInvocationSecurityMetadataSource implements
 				return entry.getValue();
 			}
 		}
-		return null;
+		return Collections.emptyList();
 	}
 
 	public boolean supports(Class<?> clazz) {

--- a/web/src/test/java/org/springframework/security/web/access/channel/ChannelProcessingFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/access/channel/ChannelProcessingFilterTests.java
@@ -16,11 +16,12 @@
 
 package org.springframework.security.web.access.channel;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -218,7 +219,7 @@ public class ChannelProcessingFilterTests {
 
 		public Collection<ConfigAttribute> getAllConfigAttributes() {
 			if (!provideIterator) {
-				return null;
+				return Collections.emptyList();
 			}
 
 			return toReturn;

--- a/web/src/test/java/org/springframework/security/web/access/intercept/DefaultFilterInvocationSecurityMetadataSourceTests.java
+++ b/web/src/test/java/org/springframework/security/web/access/intercept/DefaultFilterInvocationSecurityMetadataSourceTests.java
@@ -52,6 +52,16 @@ public class DefaultFilterInvocationSecurityMetadataSourceTests {
 	}
 
 	@Test
+	public void lookupNotNullButEmptyIfNotMatching() {
+		createFids("/foo/**", null);
+
+		FilterInvocation fi = createFilterInvocation("/bar/somefile.html", null,
+				null, null);
+
+		assertThat(this.fids.getAttributes(fi)).isNotNull().isEmpty();;
+	}
+
+	@Test
 	public void lookupNotRequiringExactMatchSucceedsIfNotMatching() {
 		createFids("/secure/super/**", null);
 
@@ -128,7 +138,7 @@ public class DefaultFilterInvocationSecurityMetadataSourceTests {
 
 		FilterInvocation fi = createFilterInvocation("/somepage", null, null, "POST");
 		Collection<ConfigAttribute> attrs = this.fids.getAttributes(fi);
-		assertThat(attrs).isNull();
+		assertThat(attrs).isNotNull().isEmpty();
 	}
 
 	// SEC-1236


### PR DESCRIPTION
As it's specified in the `SecurityMetadataSource` interface's Javadoc.