### PR TITLE
Remove @Nullable annotations in UserDetailsMapFactoryBean

### DIFF
--- a/config/src/main/java/org/springframework/security/config/core/userdetails/UserDetailsMapFactoryBean.java
+++ b/config/src/main/java/org/springframework/security/config/core/userdetails/UserDetailsMapFactoryBean.java
@@ -17,7 +17,6 @@
 package org.springframework.security.config.core.userdetails;
 
 import org.springframework.beans.factory.FactoryBean;
-import org.springframework.lang.Nullable;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.memory.UserAttribute;
@@ -54,7 +53,6 @@ public class UserDetailsMapFactoryBean implements FactoryBean<Collection<UserDet
 		this.userProperties = userProperties;
 	}
 
-	@Nullable
 	@Override
 	public Collection<UserDetails> getObject() throws Exception {
 		Collection<UserDetails> users = new ArrayList<>(this.userProperties.size());
@@ -78,7 +76,6 @@ public class UserDetailsMapFactoryBean implements FactoryBean<Collection<UserDet
 		} return users;
 	}
 
-	@Nullable
 	@Override
 	public Class<?> getObjectType() {
 		return Collection.class;


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
It looks impossible to be `null`, so this PR removes the `@Nullable` annotations.