### PR TITLE
Remove spring-security-bom in dependencyManagement

### DIFF
--- a/bom/spring-security-bom.gradle
+++ b/bom/spring-security-bom.gradle
@@ -5,6 +5,8 @@ sonarqube.skipProject = true
 
 project.rootProject.allprojects.each { p ->
 	p.plugins.withType(io.spring.gradle.convention.SpringMavenPlugin) {
-		project.mavenBom.projects.add(p)
+		if (!project.name.equals(p.name)) {
+			project.mavenBom.projects.add(p)
+		}
 	}
 }


### PR DESCRIPTION
spring-security-bom it provides dependency management for itself. This
commit avoids adding it to the dependency management section.

Fixes gh-4878

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
