### PR TITLE
Remove unused imports and fixes some compile time errors for some tests

### DIFF
--- a/cas/src/test/java/org/springframework/security/cas/jackson2/CasAuthenticationTokenMixinTests.java
+++ b/cas/src/test/java/org/springframework/security/cas/jackson2/CasAuthenticationTokenMixinTests.java
@@ -128,6 +128,7 @@ public class CasAuthenticationTokenMixinTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void deserializeCasAuthenticationTest() throws IOException, JSONException {
 		CasAuthenticationToken token = mapper.readValue(CAS_TOKEN_JSON, CasAuthenticationToken.class);
 		assertThat(token).isNotNull();
@@ -137,7 +138,10 @@ public class CasAuthenticationTokenMixinTests {
 		assertThat(token.getUserDetails()).isNotNull().isInstanceOf(User.class);
 		assertThat(token.getAssertion()).isNotNull().isInstanceOf(AssertionImpl.class);
 		assertThat(token.getKeyHash()).isEqualTo(KEY.hashCode());
-		assertThat(token.getUserDetails().getAuthorities()).hasSize(1).contains(new SimpleGrantedAuthority("ROLE_USER"));
+
+		Collection<GrantedAuthority> authorities = (Collection<GrantedAuthority>) token.getUserDetails().getAuthorities();
+		assertThat(authorities).hasSize(1).contains(new SimpleGrantedAuthority("ROLE_USER"));
+
 		assertThat(token.getAssertion().getAuthenticationDate()).isEqualTo(START_DATE);
 		assertThat(token.getAssertion().getValidFromDate()).isEqualTo(START_DATE);
 		assertThat(token.getAssertion().getValidUntilDate()).isEqualTo(END_DATE);

--- a/config/src/integration-test/groovy/org/springframework/security/config/annotation/authentication/ldap/LdapAuthenticationProviderBuilderSecurityBuilderTests.groovy
+++ b/config/src/integration-test/groovy/org/springframework/security/config/annotation/authentication/ldap/LdapAuthenticationProviderBuilderSecurityBuilderTests.groovy
@@ -28,7 +28,6 @@ import org.springframework.security.authentication.AuthenticationProvider
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.config.annotation.BaseSpringSpec
 import org.springframework.security.config.annotation.SecurityBuilder;
-import org.springframework.security.config.annotation.authentication.AuthenticationManagerBuilder
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
 import org.springframework.security.config.annotation.authentication.configuration.EnableGlobalAuthentication
 import org.springframework.security.config.annotation.configuration.AutowireBeanFactoryObjectPostProcessor

--- a/config/src/test/groovy/org/springframework/security/config/annotation/authentication/BaseAuthenticationConfig.groovy
+++ b/config/src/test/groovy/org/springframework/security/config/annotation/authentication/BaseAuthenticationConfig.groovy
@@ -21,7 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.authentication.AuthenticationManager
-import org.springframework.security.config.annotation.authentication.AuthenticationManagerBuilder
 import org.springframework.security.config.annotation.authentication.configurers.userdetails.UserDetailsServiceConfigurer;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configurers.provisioning.InMemoryUserDetailsManagerConfigurer;

--- a/config/src/test/groovy/org/springframework/security/config/annotation/method/configuration/SampleEnableGlobalMethodSecurityTests.groovy
+++ b/config/src/test/groovy/org/springframework/security/config/annotation/method/configuration/SampleEnableGlobalMethodSecurityTests.groovy
@@ -25,7 +25,6 @@ import org.springframework.security.access.expression.method.MethodSecurityExpre
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.TestingAuthenticationToken
 import org.springframework.security.config.annotation.BaseSpringSpec
-import org.springframework.security.config.annotation.authentication.AuthenticationManagerBuilder
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;

--- a/config/src/test/groovy/org/springframework/security/config/annotation/provisioning/UserDetailsManagerConfigurerTests.groovy
+++ b/config/src/test/groovy/org/springframework/security/config/annotation/provisioning/UserDetailsManagerConfigurerTests.groovy
@@ -15,6 +15,8 @@
  */
 package org.springframework.security.config.annotation.provisioning
 
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
+import org.springframework.security.config.annotation.authentication.configurers.provisioning.InMemoryUserDetailsManagerConfigurer
 import org.springframework.security.config.annotation.authentication.configurers.provisioning.UserDetailsManagerConfigurer;
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
@@ -30,10 +32,8 @@ import spock.lang.Specification
 class UserDetailsManagerConfigurerTests extends Specification {
 
 	def "all attributes supported"() {
-		setup:
-			InMemoryUserDetailsManager userDetailsManager = new InMemoryUserDetailsManager([])
 		when:
-			UserDetails userDetails = new UserDetailsManagerConfigurer<InMemoryUserDetailsManager,UserDetailsManagerConfigurer<InMemoryUserDetailsManager>>(userDetailsManager)
+			UserDetails userDetails = new InMemoryUserDetailsManagerConfigurer<AuthenticationManagerBuilder>()
 				.withUser("user")
 					.password("password")
 					.roles("USER")
@@ -54,10 +54,9 @@ class UserDetailsManagerConfigurerTests extends Specification {
 
 	def "authorities(GrantedAuthorities...) works"() {
 		setup:
-			InMemoryUserDetailsManager userDetailsManager = new InMemoryUserDetailsManager([])
 			SimpleGrantedAuthority authority = new SimpleGrantedAuthority("ROLE_USER")
 		when:
-			UserDetails userDetails = new UserDetailsManagerConfigurer<InMemoryUserDetailsManager,UserDetailsManagerConfigurer<InMemoryUserDetailsManager>>(userDetailsManager)
+			UserDetails userDetails = new InMemoryUserDetailsManagerConfigurer<AuthenticationManagerBuilder>()
 				.withUser("user")
 					.password("password")
 					.authorities(authority)
@@ -68,10 +67,9 @@ class UserDetailsManagerConfigurerTests extends Specification {
 
 	def "authorities(String...) works"() {
 		setup:
-			InMemoryUserDetailsManager userDetailsManager = new InMemoryUserDetailsManager([])
 			String authority = "ROLE_USER"
 		when:
-			UserDetails userDetails = new UserDetailsManagerConfigurer<InMemoryUserDetailsManager,UserDetailsManagerConfigurer<InMemoryUserDetailsManager>>(userDetailsManager)
+			UserDetails userDetails = new InMemoryUserDetailsManagerConfigurer<AuthenticationManagerBuilder>()
 				.withUser("user")
 					.password("password")
 					.authorities(authority)
@@ -83,10 +81,9 @@ class UserDetailsManagerConfigurerTests extends Specification {
 
 	def "authorities(List) works"() {
 		setup:
-			InMemoryUserDetailsManager userDetailsManager = new InMemoryUserDetailsManager([])
 			SimpleGrantedAuthority authority = new SimpleGrantedAuthority("ROLE_USER")
 		when:
-			UserDetails userDetails = new UserDetailsManagerConfigurer<InMemoryUserDetailsManager,UserDetailsManagerConfigurer<InMemoryUserDetailsManager>>(userDetailsManager)
+			UserDetails userDetails = new InMemoryUserDetailsManagerConfigurer<AuthenticationManagerBuilder>()
 				.withUser("user")
 					.password("password")
 					.authorities([authority])

--- a/config/src/test/groovy/org/springframework/security/config/annotation/provisioning/UserDetailsManagerConfigurerTests.groovy
+++ b/config/src/test/groovy/org/springframework/security/config/annotation/provisioning/UserDetailsManagerConfigurerTests.groovy
@@ -32,8 +32,10 @@ import spock.lang.Specification
 class UserDetailsManagerConfigurerTests extends Specification {
 
 	def "all attributes supported"() {
+		setup:
+			InMemoryUserDetailsManager userDetailsManager = new InMemoryUserDetailsManager([])
 		when:
-			UserDetails userDetails = new InMemoryUserDetailsManagerConfigurer<AuthenticationManagerBuilder>()
+			UserDetails userDetails = new UserDetailsManagerConfigurer<AuthenticationManagerBuilder, InMemoryUserDetailsManagerConfigurer<AuthenticationManagerBuilder>>(userDetailsManager)
 				.withUser("user")
 					.password("password")
 					.roles("USER")
@@ -54,9 +56,10 @@ class UserDetailsManagerConfigurerTests extends Specification {
 
 	def "authorities(GrantedAuthorities...) works"() {
 		setup:
+			InMemoryUserDetailsManager userDetailsManager = new InMemoryUserDetailsManager([])
 			SimpleGrantedAuthority authority = new SimpleGrantedAuthority("ROLE_USER")
 		when:
-			UserDetails userDetails = new InMemoryUserDetailsManagerConfigurer<AuthenticationManagerBuilder>()
+			UserDetails userDetails = new UserDetailsManagerConfigurer<AuthenticationManagerBuilder, InMemoryUserDetailsManagerConfigurer<AuthenticationManagerBuilder>>(userDetailsManager)
 				.withUser("user")
 					.password("password")
 					.authorities(authority)
@@ -67,9 +70,10 @@ class UserDetailsManagerConfigurerTests extends Specification {
 
 	def "authorities(String...) works"() {
 		setup:
+		InMemoryUserDetailsManager userDetailsManager = new InMemoryUserDetailsManager([])
 			String authority = "ROLE_USER"
 		when:
-			UserDetails userDetails = new InMemoryUserDetailsManagerConfigurer<AuthenticationManagerBuilder>()
+			UserDetails userDetails = new UserDetailsManagerConfigurer<AuthenticationManagerBuilder, InMemoryUserDetailsManagerConfigurer<AuthenticationManagerBuilder>>(userDetailsManager)
 				.withUser("user")
 					.password("password")
 					.authorities(authority)
@@ -81,9 +85,10 @@ class UserDetailsManagerConfigurerTests extends Specification {
 
 	def "authorities(List) works"() {
 		setup:
+			InMemoryUserDetailsManager userDetailsManager = new InMemoryUserDetailsManager([])
 			SimpleGrantedAuthority authority = new SimpleGrantedAuthority("ROLE_USER")
 		when:
-			UserDetails userDetails = new InMemoryUserDetailsManagerConfigurer<AuthenticationManagerBuilder>()
+			UserDetails userDetails = new UserDetailsManagerConfigurer<AuthenticationManagerBuilder, InMemoryUserDetailsManagerConfigurer<AuthenticationManagerBuilder>>(userDetailsManager)
 				.withUser("user")
 					.password("password")
 					.authorities([authority])

--- a/core/src/test/java/org/springframework/security/jackson2/SecurityContextMixinTests.java
+++ b/core/src/test/java/org/springframework/security/jackson2/SecurityContextMixinTests.java
@@ -21,11 +21,13 @@ import org.json.JSONException;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextImpl;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,6 +54,7 @@ public class SecurityContextMixinTests extends AbstractMixinTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void securityContextDeserializeTest() throws IOException {
 		SecurityContext context = mapper.readValue(SECURITY_CONTEXT_JSON, SecurityContextImpl.class);
 		assertThat(context).isNotNull();
@@ -59,6 +62,8 @@ public class SecurityContextMixinTests extends AbstractMixinTests {
 		assertThat(context.getAuthentication().getPrincipal()).isEqualTo("admin");
 		assertThat(context.getAuthentication().getCredentials()).isEqualTo("1234");
 		assertThat(context.getAuthentication().isAuthenticated()).isTrue();
-		assertThat(context.getAuthentication().getAuthorities()).hasSize(1).contains(new SimpleGrantedAuthority("ROLE_USER"));
+
+		Collection<GrantedAuthority> authorities = (Collection<GrantedAuthority>) context.getAuthentication().getAuthorities();
+		assertThat(authorities).hasSize(1).contains(new SimpleGrantedAuthority("ROLE_USER"));
 	}
 }

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/userinfo/DelegatingOAuth2UserServiceTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/userinfo/DelegatingOAuth2UserServiceTests.java
@@ -44,11 +44,10 @@ public class DelegatingOAuth2UserServiceTests {
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	@SuppressWarnings("unchecked")
 	public void loadUserWhenUserRequestIsNullThenThrowIllegalArgumentException() {
 		DelegatingOAuth2UserService<OAuth2UserRequest, OAuth2User> delegatingUserService =
 			new DelegatingOAuth2UserService<>(
-				Arrays.asList(mock(OAuth2UserService.class), mock(OAuth2UserService.class)));
+				Arrays.asList(mock(DefaultOAuth2UserService.class), mock(DefaultOAuth2UserService.class)));
 		delegatingUserService.loadUser(null);
 	}
 

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/userinfo/DelegatingOAuth2UserServiceTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/userinfo/DelegatingOAuth2UserServiceTests.java
@@ -44,10 +44,10 @@ public class DelegatingOAuth2UserServiceTests {
 	}
 
 	@Test(expected = IllegalArgumentException.class)
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public void loadUserWhenUserRequestIsNullThenThrowIllegalArgumentException() {
 		DelegatingOAuth2UserService<OAuth2UserRequest, OAuth2User> delegatingUserService =
-			new DelegatingOAuth2UserService<>(
-				Arrays.asList(mock(DefaultOAuth2UserService.class), mock(DefaultOAuth2UserService.class)));
+			new DelegatingOAuth2UserService(Arrays.asList(mock(OAuth2UserService.class), mock(OAuth2UserService.class)));
 		delegatingUserService.loadUser(null);
 	}
 

--- a/test/src/test/java/org/springframework/security/test/context/support/WithSecurityContextTestExcecutionListenerTests.java
+++ b/test/src/test/java/org/springframework/security/test/context/support/WithSecurityContextTestExcecutionListenerTests.java
@@ -83,7 +83,7 @@ public class WithSecurityContextTestExcecutionListenerTests {
 	}
 
 	@Test
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings({ "rawtypes" })
 	public void beforeTestMethodNoApplicationContext() throws Exception {
 		Class testClass = FakeTest.class;
 		when(testContext.getApplicationContext()).thenThrow(new IllegalStateException());
@@ -101,7 +101,7 @@ public class WithSecurityContextTestExcecutionListenerTests {
 		SqlScriptsTestExecutionListener sql = new SqlScriptsTestExecutionListener();
 		WithSecurityContextTestExecutionListener security = new WithSecurityContextTestExecutionListener();
 
-		List<? extends TestExecutionListener> listeners = Arrays.asList(security, sql);
+		List<TestExecutionListener> listeners = Arrays.asList(security, sql);
 
 		AnnotationAwareOrderComparator.sort(listeners);
 

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsUserTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsUserTests.java
@@ -24,6 +24,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 
 import java.util.Arrays;
+import java.util.Collection;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -106,6 +107,7 @@ public class SecurityMockMvcRequestPostProcessorsUserTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void userCustomAuthoritiesVarargs() {
 		String username = "customuser";
 
@@ -114,7 +116,11 @@ public class SecurityMockMvcRequestPostProcessorsUserTests {
 		verify(repository).saveContext(contextCaptor.capture(), eq(request),
 				any(HttpServletResponse.class));
 		SecurityContext context = contextCaptor.getValue();
-		assertThat(context.getAuthentication().getAuthorities()).containsOnly(authority1,
+
+		Collection<GrantedAuthority> authorities = (Collection<GrantedAuthority>) context
+				.getAuthentication().getAuthorities();
+
+		assertThat(authorities).containsOnly(authority1,
 				authority2);
 	}
 
@@ -124,6 +130,7 @@ public class SecurityMockMvcRequestPostProcessorsUserTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void userCustomAuthoritiesList() {
 		String username = "customuser";
 
@@ -133,7 +140,10 @@ public class SecurityMockMvcRequestPostProcessorsUserTests {
 		verify(repository).saveContext(contextCaptor.capture(), eq(request),
 				any(HttpServletResponse.class));
 		SecurityContext context = contextCaptor.getValue();
-		assertThat(context.getAuthentication().getAuthorities()).containsOnly(authority1,
+
+		Collection<GrantedAuthority> authorities = (Collection<GrantedAuthority>) context
+				.getAuthentication().getAuthorities();
+		assertThat(authorities).containsOnly(authority1,
 				authority2);
 	}
 


### PR DESCRIPTION
- Remove invalid imports referencing `org.springframework.security.config.annotation.authentication.AuthenticationManagerBuilder`.

- Change the way to use `contains` method from `Asssertions` class from Assertj. When checking
for a concrete class against a generic collection, Eclipse and IntelliJ were presenting compiling time errors. There is an issue regarding the usage of generic types on `contains` method from `Assertions` class as follows:

https://github.com/joel-costigliola/assertj-core/issues/772

- Change `DelegatingOAuth2UserServiceTests` to start using concrete types to create the `ArrayList` of services that are needed to create an instance of `DelegatingOAuth2UserService`.
