### PR TITLE
Add tip to install Groovy Eclipse plugin on newer STS versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,11 @@ The following provides information on setting up a development environment that 
 * Importing the project into Spring Tool Suite
   * File->Import...->Gradle Project
 
+As of new versions of Spring Tool Suite, you might need to install Groovy Eclipse pointing directly to the updates plugin location. To install Groovy Eclipse on Spring Tool Suite based on Eclipse Oxigen you must do the following steps:
+
+Help->Install New Software...->Add the following URL into _Work with_ field:
+http://dist.springsource.org/snapshot/GRECLIPSE/e4.7/
+
 # Understand the basics 
 Not sure what a pull request is, or how to submit one? Take a look at GitHub's excellent [help documentation first](https://help.github.com/articles/using-pull-requests).
 


### PR DESCRIPTION
When trying to install the requirements needed to start contributing to the project, I realized that the last version of Groovy Eclipse plugin isn't available at Eclipse Marketplace. So, to install newer versions I propose the tip added to `CONTRIBUTING.md` file to help other developers.

- Add a tip on `CONTRIBUTING.md` file within the section __Importing into IDE__