### PR TITLE
Catch possible NullPointerException

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/password/DelegatingPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password/DelegatingPasswordEncoder.java
@@ -116,6 +116,7 @@ import java.util.Map;
  * @see org.springframework.security.crypto.factory.PasswordEncoderFactories
  *
  * @author Rob Winch
+ * @author Michael Simons
  * @since 5.0
  */
 public class DelegatingPasswordEncoder implements PasswordEncoder {
@@ -190,7 +191,11 @@ public class DelegatingPasswordEncoder implements PasswordEncoder {
 			return true;
 		}
 		String id = extractId(prefixEncodedPassword);
-		PasswordEncoder delegate = this.idToPasswordEncoder.get(id);
+		PasswordEncoder delegate = null;
+		try {
+			delegate = this.idToPasswordEncoder.get(id);
+		} catch(NullPointerException e) {
+		}
 		if(delegate == null) {
 			return this.defaultPasswordEncoderForMatches
 				.matches(rawPassword, prefixEncodedPassword);


### PR DESCRIPTION
Some maps may throw a NullPointerException when get is called with null. This commit catches the exceptions and just leaves the delegate null.

Fixes gh-4936

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
