### PR TITLE
Enable caching for Test tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,3 +17,16 @@ ext.releaseBuild = version.contains("SNAPSHOT")
 ext.milestoneBuild = !(snapshotBuild || releaseBuild)
 
 dependencyManagementExport.projects = subprojects.findAll { !it.name.contains('-boot') }
+
+// Disable JaCoCo when not explicitly requested to enable caching of test 
+// See https://discuss.gradle.org/t/do-not-cache-if-condition-matched-jacoco-agent-configured-with-append-true-satisfied/23504
+gradle.taskGraph.whenReady { graph ->
+    def enabled = graph.allTasks.any { it instanceof JacocoReport }
+	subprojects { project ->
+		project.plugins.withType(JacocoPlugin) {
+		    project.tasks.withType(Test) {
+		        jacoco.enabled = enabled
+		    }
+		}
+	}
+}


### PR DESCRIPTION
When using Gradle's build cache (`--build-cache`) the `Test` tasks are not loaded from cache because of a JaCoCo issue with caching:

https://discuss.gradle.org/t/do-not-cache-if-condition-matched-jacoco-agent-configured-with-append-true-satisfied/23504

This PR applies the recommended workaround to disable JaCoCo when a report is not explicitly requested.