### PR TITLE
Allow spring-security-core:compileJava to be cached

### DIFF
--- a/core/spring-security-core.gradle
+++ b/core/spring-security-core.gradle
@@ -34,12 +34,7 @@ dependencies {
 	testRuntime 'org.hsqldb:hsqldb'
 }
 
-classes.doLast {
-	copy {
-		from includeProject.sourceSets.main.output
-		into sourceSets.main.java.outputDir
-	}
-}
+tasks.jar.from { includeProject.sourceSets.main.output }
 
 tasks.sourcesJar.from {includeProject.sourceSets.main.java}
 


### PR DESCRIPTION
Instead of copying classes to the compile output, we now add them directly to the JAR. This allows JavaCompile to be cached, since there are no overlapping outputs anymore.