### PR TITLE
Update ExpressionBasedFilterInvocationSecurityMetadataSource.java ,make it easy to use

### DIFF
--- a/web/src/main/java/org/springframework/security/web/access/expression/ExpressionBasedFilterInvocationSecurityMetadataSource.java
+++ b/web/src/main/java/org/springframework/security/web/access/expression/ExpressionBasedFilterInvocationSecurityMetadataSource.java
@@ -32,31 +32,7 @@ public final class ExpressionBasedFilterInvocationSecurityMetadataSource extends
         Assert.notNull(expressionHandler, "A non-null SecurityExpressionHandler is required");
     }
     
-     /**
-     * @param urlMap store url<--> expression
-     */
-    public ExpressionBasedFilterInvocationSecurityMetadataSource(Map<String, String> urlMap ) {
-        loadSecurityMetadataSourceFromUrlMap(urlMap);
-    }
 
-    /**
-     * @param urlMap store url<--> expression
-     */
-    public synchronized void loadSecurityMetadataSourceFromUrlMap(Map<String, String> urlMap) {
-        LinkedHashMap<RequestMatcher, Collection<ConfigAttribute>> requestMap  = new LinkedHashMap(urlMap.size());
-        for (Map.Entry<String, String> entry : urlMap.entrySet()) {
-            RequestMatcher requestMatcher = new AntPathRequestMatcher(entry.getKey());
-            Set<String> set = StringUtils.commaDelimitedListToSet(entry.getValue());
-            Collection<ConfigAttribute> configAttributes = new LinkedHashSet<>(set.size());
-            for (String str : set) {
-                configAttributes.add(new SecurityConfig(str));
-            }
-            requestMap.put(requestMatcher, configAttributes);
-        }
-        FilterInvocationSecurityMetadataSource metadataSource =
-                new ExpressionBasedFilterInvocationSecurityMetadataSource(requestMap, new DefaultWebSecurityExpressionHandler());
-        this.securityMetadataSource = metadataSource;
-    }
 
     private static LinkedHashMap<RequestMatcher, Collection<ConfigAttribute>> processMap(
             LinkedHashMap<RequestMatcher,Collection<ConfigAttribute>> requestMap, ExpressionParser parser) {

--- a/web/src/main/java/org/springframework/security/web/access/expression/ExpressionBasedFilterInvocationSecurityMetadataSource.java
+++ b/web/src/main/java/org/springframework/security/web/access/expression/ExpressionBasedFilterInvocationSecurityMetadataSource.java
@@ -31,6 +31,32 @@ public final class ExpressionBasedFilterInvocationSecurityMetadataSource extends
         super(processMap(requestMap, expressionHandler.getExpressionParser()));
         Assert.notNull(expressionHandler, "A non-null SecurityExpressionHandler is required");
     }
+    
+     /**
+     * @param urlMap store url<--> expression
+     */
+    public ExpressionBasedFilterInvocationSecurityMetadataSource(Map<String, String> urlMap ) {
+        loadSecurityMetadataSourceFromUrlMap(urlMap);
+    }
+
+    /**
+     * @param urlMap store url<--> expression
+     */
+    public synchronized void loadSecurityMetadataSourceFromUrlMap(Map<String, String> urlMap) {
+        LinkedHashMap<RequestMatcher, Collection<ConfigAttribute>> requestMap  = new LinkedHashMap(urlMap.size());
+        for (Map.Entry<String, String> entry : urlMap.entrySet()) {
+            RequestMatcher requestMatcher = new AntPathRequestMatcher(entry.getKey());
+            Set<String> set = StringUtils.commaDelimitedListToSet(entry.getValue());
+            Collection<ConfigAttribute> configAttributes = new LinkedHashSet<>(set.size());
+            for (String str : set) {
+                configAttributes.add(new SecurityConfig(str));
+            }
+            requestMap.put(requestMatcher, configAttributes);
+        }
+        FilterInvocationSecurityMetadataSource metadataSource =
+                new ExpressionBasedFilterInvocationSecurityMetadataSource(requestMap, new DefaultWebSecurityExpressionHandler());
+        this.securityMetadataSource = metadataSource;
+    }
 
     private static LinkedHashMap<RequestMatcher, Collection<ConfigAttribute>> processMap(
             LinkedHashMap<RequestMatcher,Collection<ConfigAttribute>> requestMap, ExpressionParser parser) {

--- a/web/src/main/java/org/springframework/security/web/access/intercept/DelegatingFilterInvocationSecurityMetadataSource.java
+++ b/web/src/main/java/org/springframework/security/web/access/intercept/DelegatingFilterInvocationSecurityMetadataSource.java
@@ -1,0 +1,64 @@
+package org.springframework.security.web.access.intercept;
+
+import org.springframework.security.access.ConfigAttribute;
+import org.springframework.security.access.SecurityConfig;
+import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler;
+import org.springframework.security.web.access.expression.ExpressionBasedFilterInvocationSecurityMetadataSource;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.util.StringUtils;
+
+import java.util.*;
+
+public class DelegatingFilterInvocationSecurityMetadataSource implements FilterInvocationSecurityMetadataSource {
+
+    FilterInvocationSecurityMetadataSource securityMetadataSource;
+
+    @Override
+    public Collection<ConfigAttribute> getAttributes(Object object) throws IllegalArgumentException {
+        return securityMetadataSource.getAttributes(object);
+    }
+
+    @Override
+    public Collection<ConfigAttribute> getAllConfigAttributes() {
+        return securityMetadataSource.getAllConfigAttributes();
+    }
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return securityMetadataSource.supports(clazz );
+    }
+
+    public DelegatingFilterInvocationSecurityMetadataSource(Map<String, String> urlMap ) {
+        loadSecurityMetadataSourceFromUrlMap(urlMap);
+    }
+
+    /**
+     * @param urlMap store url<--> express
+     */
+    public synchronized void loadSecurityMetadataSourceFromUrlMap(Map<String, String> urlMap) {
+        LinkedHashMap<RequestMatcher, Collection<ConfigAttribute>> requestMap  = new LinkedHashMap(urlMap.size());
+        for (Map.Entry<String, String> entry : urlMap
+                .entrySet()) {
+            RequestMatcher requestMatcher = new AntPathRequestMatcher(entry.getKey());
+            Set<String> set = StringUtils.commaDelimitedListToSet(entry.getValue());
+            Collection<ConfigAttribute> configAttributes = new LinkedHashSet<>(set.size());
+            for (String str : set) {
+                configAttributes.add(new SecurityConfig(str));
+            }
+            requestMap.put(requestMatcher, configAttributes);
+
+        }
+        FilterInvocationSecurityMetadataSource metadataSource =
+                new ExpressionBasedFilterInvocationSecurityMetadataSource(requestMap, new DefaultWebSecurityExpressionHandler());
+        this.securityMetadataSource = metadataSource;
+    }
+
+    public DelegatingFilterInvocationSecurityMetadataSource(Set<String> urlSet ) {
+        Map<String, String> urlMap  = new LinkedHashMap(urlSet.size());
+         for (String resource : urlSet) {
+             urlMap.put(resource,resource);
+         }
+         loadSecurityMetadataSourceFromUrlMap(urlMap);
+    }
+}


### PR DESCRIPTION
  ExpressionBasedFilterInvocationSecurityMetadataSource(Map<String, String> urlMap ) make ExpressionBasedFilterInvocationSecurityMetadataSource easy to use.

this change  can load  SecurityMetadataSource  from propertie  config ; then  you can load config from other store like file ,db or other store. 

this change can make security config  like shiro config ;[http://shiro.apache.org/spring.html]
````
<bean id="shiroFilter" class="org.apache.shiro.spring.web.ShiroFilterFactoryBean">
    <property name="securityManager" ref="securityManager"/>
    <!-- override these for application-specific URLs if you like:
    <property name="loginUrl" value="/login.jsp"/>
    <property name="successUrl" value="/home.jsp"/>
    <property name="unauthorizedUrl" value="/unauthorized.jsp"/> -->
    <!-- The 'filters' property is not necessary since any declared javax.servlet.Filter bean  -->
    <!-- defined will be automatically acquired and available via its beanName in chain        -->
    <!-- definitions, but you can perform instance overrides or name aliases here if you like: -->
    <!-- <property name="filters">
        <util:map>
            <entry key="anAlias" value-ref="someFilter"/>
        </util:map>
    </property> -->
    <property name="filterChainDefinitions">
        <value>
            # some example chain definitions:
            /admin/** = authc, roles[admin]
            /docs/** = authc, perms[document:read]
            /** = authc
            # more URL-to-FilterChain definitions here
        </value>
    </property>
</bean>
 
````
<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
