### PR TITLE
Upgrade Nimbus OAuth + OIDC SDK to 5.56

### DIFF
--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -43,7 +43,7 @@ dependencyManagement {
 		dependency 'com.google.inject:guice:3.0'
 		dependency 'com.nimbusds:lang-tag:1.4.3'
 		dependency 'com.nimbusds:nimbus-jose-jwt:5.5'
-		dependency 'com.nimbusds:oauth2-oidc-sdk:5.54'
+		dependency 'com.nimbusds:oauth2-oidc-sdk:5.56'
 		dependency 'com.squareup.okhttp3:okhttp:3.9.0'
 		dependency 'com.squareup.okio:okio:1.13.0'
 		dependency 'com.unboundid:unboundid-ldapsdk:4.0.4'


### PR DESCRIPTION
This upgrades Nimbus OAuth + OIDC SDK from `5.54` to `5.56`.

`5.55` fixes compatibility issue with Nimbus JOSE + JWT `5.5` onward, while `5.56` brings a number of improvements including removal of dependency on Apache Commons Lang and Apache Commons Collections 4.

This should go in `master` and `5.0.x`.