### PR TITLE
Upgrade Nimbus JOSE + JWT to 5.6

### DIFF
--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -42,7 +42,7 @@ dependencyManagement {
 		dependency 'com.google.guava:guava:20.0'
 		dependency 'com.google.inject:guice:3.0'
 		dependency 'com.nimbusds:lang-tag:1.4.3'
-		dependency 'com.nimbusds:nimbus-jose-jwt:5.5'
+		dependency 'com.nimbusds:nimbus-jose-jwt:5.6'
 		dependency 'com.nimbusds:oauth2-oidc-sdk:5.54'
 		dependency 'com.squareup.okhttp3:okhttp:3.9.0'
 		dependency 'com.squareup.okio:okio:1.13.0'


### PR DESCRIPTION
This upgrades Nimbus JOSE + JWT from `5.5` to `5.6`.

This should go in `master` and `5.0.x`.