### PR TITLE
Authorities authenticate TestingAuthenticationToken

### DIFF
--- a/cas/src/test/java/org/springframework/security/cas/web/CasAuthenticationFilterTests.java
+++ b/cas/src/test/java/org/springframework/security/cas/web/CasAuthenticationFilterTests.java
@@ -16,11 +16,6 @@
 
 package org.springframework.security.cas.web;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
-import javax.servlet.FilterChain;
-
 import org.jasig.cas.client.proxy.ProxyGrantingTicketStorage;
 import org.junit.After;
 import org.junit.Test;
@@ -35,8 +30,12 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
-
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import javax.servlet.FilterChain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests {@link CasAuthenticationFilter}.
@@ -146,8 +145,7 @@ public class CasAuthenticationFilterTests {
 						.createAuthorityList("ROLE_ANONYMOUS")));
 		assertThat(filter.requiresAuthentication(request, response)).isTrue();
 		SecurityContextHolder.getContext().setAuthentication(
-				new TestingAuthenticationToken("un", "principal", AuthorityUtils
-						.createAuthorityList("ROLE_ANONYMOUS")));
+				new TestingAuthenticationToken("un", "principal"));
 		assertThat(filter.requiresAuthentication(request, response)).isTrue();
 		SecurityContextHolder.getContext().setAuthentication(
 				new TestingAuthenticationToken("un", "principal", "ROLE_ANONYMOUS"));

--- a/core/src/main/java/org/springframework/security/authentication/TestingAuthenticationToken.java
+++ b/core/src/main/java/org/springframework/security/authentication/TestingAuthenticationToken.java
@@ -16,10 +16,10 @@
 
 package org.springframework.security.authentication;
 
-import java.util.List;
-
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
+
+import java.util.List;
 
 /**
  * An {@link org.springframework.security.core.Authentication} implementation that is
@@ -49,7 +49,6 @@ public class TestingAuthenticationToken extends AbstractAuthenticationToken {
 	public TestingAuthenticationToken(Object principal, Object credentials,
 			String... authorities) {
 		this(principal, credentials, AuthorityUtils.createAuthorityList(authorities));
-		setAuthenticated(true);
 	}
 
 	public TestingAuthenticationToken(Object principal, Object credentials,
@@ -57,6 +56,7 @@ public class TestingAuthenticationToken extends AbstractAuthenticationToken {
 		super(authorities);
 		this.principal = principal;
 		this.credentials = credentials;
+		setAuthenticated(true);
 	}
 
 	// ~ Methods

--- a/core/src/test/java/org/springframework/security/authentication/TestingAuthenticationTokenTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/TestingAuthenticationTokenTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.authentication;
+
+import org.junit.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Josh Cummings
+ */
+public class TestingAuthenticationTokenTests {
+	@Test
+	public void constructorWhenNoAuthoritiesThenUnauthenticated() {
+		TestingAuthenticationToken unauthenticated =
+			new TestingAuthenticationToken("principal", "credentials");
+
+		assertThat(unauthenticated.isAuthenticated()).isFalse();
+	}
+
+	@Test
+	public void constructorWhenArityAuthoritiesThenAuthenticated() {
+		TestingAuthenticationToken authenticated =
+			new TestingAuthenticationToken("principal", "credentials", "authority");
+
+		assertThat(authenticated.isAuthenticated()).isTrue();
+	}
+
+	@Test
+	public void constructorWhenCollectionAuthoritiesThenAuthenticated() {
+		TestingAuthenticationToken authenticated =
+			new TestingAuthenticationToken("principal", "credentials",
+				Arrays.asList(new SimpleGrantedAuthority("authority")));
+
+		assertThat(authenticated.isAuthenticated()).isTrue();
+	}
+}


### PR DESCRIPTION
In other extensions of `AbstractAuthenticationToken`, the constructors
that include `authorities` call `setAuthenticated(true)`. This includes
`PreAuthenticated`-, `UsernamePassword`-, and
`RememberMeAuthenticationToken`.

This change brings `TestingAuthenticationToken` in line with that
convention.

Note that this was done once already to one of the constructors
(ee13be4) in `TestingAuthenticationToken` that takes an arity of
`authorities`. It was not propagated to the constructor that takes a
collection, which is what this commit remedies.

Fixes: gh-5073