### PR TITLE
Advisory to avoid markdown in commit messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,6 +180,7 @@ Fixes gh-123
 2. Do not end the subject line with a period
 3. In the body of the commit message, explain how things worked before this commit, what has changed, and how things work now
 3. Include Fixes gh-<issue-number> at the end if this fixes a GitHub issue  
+5. Avoid markdown, including back-ticks identifying code
 
 # Run all tests prior to submission
 


### PR DESCRIPTION
Today, @rwinch and I were discussing the merits of leaving commit messages free of formatting hints, like back-ticks. Adding this bullet-point brings things into line with expectations.

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
