### PR TITLE
Provide Bearer Token resolving strategy

### DIFF
--- a/oauth2/oauth2-resource-server/spring-security-oauth2-resource-server.gradle
+++ b/oauth2/oauth2-resource-server/spring-security-oauth2-resource-server.gradle
@@ -1,0 +1,13 @@
+apply plugin: 'io.spring.convention.spring-module'
+
+dependencies {
+	compile project(':spring-security-core')
+	compile project(':spring-security-oauth2-core')
+	compile project(':spring-security-web')
+	compile springCoreDependency
+	compile 'com.nimbusds:oauth2-oidc-sdk'
+
+	optional project(':spring-security-oauth2-jose')
+
+	provided 'javax.servlet:javax.servlet-api'
+}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/BearerTokenAuthenticationException.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/BearerTokenAuthenticationException.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.resource;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.util.Assert;
+
+/**
+ * This exception is thrown for all Bearer Token related {@link Authentication} errors.
+ *
+ * @author Vedran Pavic
+ * @since 5.1
+ * @see <a href="https://tools.ietf.org/html/rfc6750#section-3" target="_blank">RFC 6750 Section 3: The WWW-Authenticate Response Header Field</a>
+ */
+public class BearerTokenAuthenticationException extends AuthenticationException {
+
+	private final BearerTokenError error;
+
+	/**
+	 * Create a new {@link BearerTokenAuthenticationException}.
+	 * @param error the {@link BearerTokenError Bearer Token Error}
+	 * @param message the detail message
+	 * @param cause the root cause
+	 */
+	public BearerTokenAuthenticationException(BearerTokenError error, String message, Throwable cause) {
+		super(message, cause);
+		Assert.notNull(error, "error must not be null");
+		this.error = error;
+	}
+
+	/**
+	 * Create a new {@link BearerTokenAuthenticationException}.
+	 * @param error the {@link BearerTokenError Bearer Token Error}
+	 * @param message the detail message
+	 */
+	public BearerTokenAuthenticationException(BearerTokenError error, String message) {
+		super(message);
+		Assert.notNull(error, "error must not be null");
+		this.error = error;
+	}
+
+	/**
+	 * Return the Bearer Token error
+	 * @return the error
+	 */
+	public BearerTokenError getError() {
+		return error;
+	}
+
+}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/BearerTokenError.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/BearerTokenError.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.resource;
+
+import java.io.Serializable;
+
+import org.springframework.security.core.SpringSecurityCoreVersion;
+import org.springframework.util.Assert;
+
+/**
+ * A representation of an Bearer Token Error.
+ *
+ * @author Vedran Pavic
+ * @since 5.1
+ * @see BearerTokenErrorCodes
+ * @see <a href="https://tools.ietf.org/html/rfc6750#section-3" target="_blank">RFC 6750 Section 3: The WWW-Authenticate Response Header Field</a>
+ */
+public final class BearerTokenError implements Serializable {
+
+	private static final long serialVersionUID = SpringSecurityCoreVersion.SERIAL_VERSION_UID;
+
+	private final String errorCode;
+
+	private final String description;
+
+	private final String uri;
+
+	private final String scope;
+
+	/**
+	 * Create a {@code BearerTokenError} using the provided parameters.
+	 * @param errorCode the error code
+	 */
+	public BearerTokenError(String errorCode) {
+		this(errorCode, null, null, null);
+	}
+
+	/**
+	 * Create a {@code BearerTokenError} using the provided parameters.
+	 * @param errorCode the error code
+	 * @param description the description
+	 * @param uri the URI
+	 * @param scope the scope
+	 */
+	public BearerTokenError(String errorCode, String description, String uri, String scope) {
+		Assert.hasText(errorCode, "errorCode must not be empty");
+		this.errorCode = errorCode;
+		this.description = description;
+		this.uri = uri;
+		this.scope = scope;
+	}
+
+	/**
+	 * Return the error code.
+	 * @return the error code
+	 */
+	public String getErrorCode() {
+		return this.errorCode;
+	}
+
+	/**
+	 * Return the description.
+	 * @return the description
+	 */
+	public String getDescription() {
+		return this.description;
+	}
+
+	/**
+	 * Return the URI.
+	 * @return the URI
+	 */
+	public String getUri() {
+		return this.uri;
+	}
+
+	/**
+	 * Return the scope.
+	 * @return the scope
+	 */
+	public String getScope() {
+		return scope;
+	}
+
+	@Override
+	public String toString() {
+		return "[" + this.getErrorCode() + "]" + (this.description != null ? " " + this.description : "");
+	}
+
+}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/BearerTokenErrorCodes.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/BearerTokenErrorCodes.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.resource;
+
+/**
+ * Standard error codes defined by the OAuth 2.0 Authorization Framework: Bearer Token Usage.
+ *
+ * @author Vedran Pavic
+ * @since 5.1
+ * @see <a href="https://tools.ietf.org/html/rfc6750#section-3.1" target="_blank">RFC 6750 Section 3.1: Error Codes</a>
+ */
+public interface BearerTokenErrorCodes {
+
+	/**
+	 * {@code invalid_request} - The request is missing a required parameter, includes an unsupported parameter or
+	 * parameter value, repeats the same parameter, uses more than one method for including an access token, or is
+	 * otherwise malformed.
+	 */
+	String INVALID_REQUEST = "invalid_request";
+
+	/**
+	 * {@code invalid_token} - The access token provided is expired, revoked, malformed, or invalid for other
+	 * reasons.
+	 */
+	String INVALID_TOKEN = "invalid_token";
+
+	/**
+	 * {@code insufficient_scope} - The request requires higher privileges than provided by the access token.
+	 */
+	String INSUFFICIENT_SCOPE = "insufficient_scope";
+
+}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/package-info.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * OAuth 2.0 Resource Server core classes and interfaces providing support.
+ */
+package org.springframework.security.oauth2.server.resource;

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/BearerTokenResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/BearerTokenResolver.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.resource.web;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * A strategy for resolving Bearer Token from the {@link HttpServletRequest}.
+ *
+ * @author Vedran Pavic
+ * @since 5.1
+ * @see <a href="https://tools.ietf.org/html/rfc6750#section-2" target="_blank">RFC 6750 Section 2: Authenticated Requests</a>
+ */
+public interface BearerTokenResolver {
+
+	/**
+	 * Resolve the Bearer Token value from the request.
+	 * @param request the request
+	 * @return the Bearer Token value
+	 */
+	String resolve(HttpServletRequest request);
+
+}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.resource.web;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationException;
+import org.springframework.security.oauth2.server.resource.BearerTokenError;
+import org.springframework.security.oauth2.server.resource.BearerTokenErrorCodes;
+import org.springframework.util.StringUtils;
+
+/**
+ * The default {@link BearerTokenResolver} implementation based on RFC 6750.
+ *
+ * @author Vedran Pavic
+ * @since 5.1
+ * @see <a href="https://tools.ietf.org/html/rfc6750#section-2" target="_blank">RFC 6750 Section 2: Authenticated Requests</a>
+ */
+public final class DefaultBearerTokenResolver implements BearerTokenResolver {
+
+	private static final Pattern authorizationPattern = Pattern.compile("^Bearer (?<token>[^\\s]+)*$");
+
+	private boolean useFormEncodedBodyParameter = false;
+
+	private boolean useUriQueryParameter = false;
+
+	@Override
+	public String resolve(HttpServletRequest request) {
+		String authorizationHeaderToken = resolveFromAuthorizationHeader(request);
+		String parameterToken = request.getParameter("access_token");
+		if (authorizationHeaderToken != null) {
+			if (parameterToken != null) {
+				BearerTokenError error = new BearerTokenError(BearerTokenErrorCodes.INVALID_REQUEST);
+				throw new BearerTokenAuthenticationException(error, error.toString());
+			}
+			return authorizationHeaderToken;
+		}
+		else if (parameterToken != null && isParameterTokenSupportedForRequest(request)) {
+			return parameterToken;
+		}
+		return null;
+	}
+
+	/**
+	 * Set if transport of access token using form-encoded body parameter is supported. Defaults to {@code false}.
+	 * @param useFormEncodedBodyParameter if the form-encoded body parameter is supported
+	 */
+	public void setUseFormEncodedBodyParameter(boolean useFormEncodedBodyParameter) {
+		this.useFormEncodedBodyParameter = useFormEncodedBodyParameter;
+	}
+
+	/**
+	 * Set if transport of access token using URI query parameter is supported. Defaults to {@code false}.
+	 * @param useUriQueryParameter if the URI query parameter is supported
+	 */
+	public void setUseUriQueryParameter(boolean useUriQueryParameter) {
+		this.useUriQueryParameter = useUriQueryParameter;
+	}
+
+	private static String resolveFromAuthorizationHeader(HttpServletRequest request) {
+		String authorization = request.getHeader("Authorization");
+		if (StringUtils.hasText(authorization)) {
+			Matcher matcher = authorizationPattern.matcher(authorization);
+			if (matcher.matches()) {
+				return matcher.group("token");
+			}
+		}
+		return null;
+	}
+
+	private boolean isParameterTokenSupportedForRequest(HttpServletRequest request) {
+		return ((this.useFormEncodedBodyParameter && "POST".equals(request.getMethod()))
+				|| (this.useUriQueryParameter && "GET".equals(request.getMethod())));
+	}
+
+}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/package-info.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * OAuth 2.0 Resource Server {@code Filter}'s and supporting classes and interfaces.
+ */
+package org.springframework.security.oauth2.server.resource.web;

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/BearerTokenAuthenticationExceptionTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/BearerTokenAuthenticationExceptionTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.resource;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link BearerTokenAuthenticationException}.
+ *
+ * @author Vedran Pavic
+ */
+public class BearerTokenAuthenticationExceptionTests {
+
+	private static final BearerTokenError TEST_ERROR = new BearerTokenError("test-code");
+
+	private static final String TEST_MESSAGE = "test-message";
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void constructorWithAllParametersWhenErrorIsValidThenCreated() {
+		BearerTokenAuthenticationException exception = new BearerTokenAuthenticationException(TEST_ERROR, TEST_MESSAGE,
+			new Throwable());
+
+		assertThat(exception.getError()).isEqualTo(TEST_ERROR);
+	}
+
+	@Test
+	public void constructorWithAllParametersWhenErrorIsNullThenThrowIllegalArgumentException() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("error must not be null");
+
+		new BearerTokenAuthenticationException(null, TEST_MESSAGE, new Throwable());
+	}
+
+	@Test
+	public void constructorWithErrorAndMessageWhenErrorIsValidThenCreated() {
+		BearerTokenAuthenticationException exception = new BearerTokenAuthenticationException(TEST_ERROR, TEST_MESSAGE);
+
+		assertThat(exception.getError()).isEqualTo(TEST_ERROR);
+	}
+
+	@Test
+	public void constructorWithErrorAndMessageWhenErrorIsNullThenThrowIllegalArgumentException() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("error must not be null");
+
+		new BearerTokenAuthenticationException(null, TEST_MESSAGE);
+	}
+
+}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/BearerTokenErrorTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/BearerTokenErrorTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.resource;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link BearerTokenError}.
+ *
+ * @author Vedran Pavic
+ */
+public class BearerTokenErrorTests {
+
+	private static final String TEST_ERROR_CODE = "test-code";
+
+	private static final String TEST_DESCRIPTION = "test-description";
+
+	private static final String TEST_URI = "http://example.com";
+
+	private static final String TEST_SCOPE = "test-scope";
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void constructorWithErrorCodeWhenErrorCodeIsValidThenCreated() {
+		BearerTokenError error = new BearerTokenError(TEST_ERROR_CODE);
+
+		assertThat(error.getErrorCode()).isEqualTo(TEST_ERROR_CODE);
+		assertThat(error.getDescription()).isNull();
+		assertThat(error.getUri()).isNull();
+		assertThat(error.getScope()).isNull();
+	}
+
+	@Test
+	public void constructorWithErrorCodeWhenErrorCodeIsNullThenThrowIllegalArgumentException() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("errorCode must not be empty");
+
+		new BearerTokenError(null);
+	}
+
+	@Test
+	public void constructorWithErrorCodeWhenErrorCodeIsEmptyThenThrowIllegalArgumentException() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("errorCode must not be empty");
+
+		new BearerTokenError("");
+	}
+
+	@Test
+	public void constructorWithAllParametersWhenAllParametersAreValidThenCreated() {
+		BearerTokenError error = new BearerTokenError(TEST_ERROR_CODE, TEST_DESCRIPTION, TEST_URI, TEST_SCOPE);
+
+		assertThat(error.getErrorCode()).isEqualTo(TEST_ERROR_CODE);
+		assertThat(error.getDescription()).isEqualTo(TEST_DESCRIPTION);
+		assertThat(error.getUri()).isEqualTo(TEST_URI);
+		assertThat(error.getScope()).isEqualTo(TEST_SCOPE);
+	}
+
+	@Test
+	public void constructorWithAllParametersWhenErrorCodeIsNullThenThrowIllegalArgumentException() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("errorCode must not be empty");
+
+		new BearerTokenError(null, TEST_DESCRIPTION, TEST_URI, TEST_SCOPE);
+	}
+
+	@Test
+	public void constructorWithAllParametersWhenErrorCodeIsEmptyThenThrowIllegalArgumentException() {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage("errorCode must not be empty");
+
+		new BearerTokenError("", TEST_DESCRIPTION, TEST_URI, TEST_SCOPE);
+	}
+
+}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.resource.web;
+
+import java.util.Base64;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DefaultBearerTokenResolver}.
+ *
+ * @author Vedran Pavic
+ */
+public class DefaultBearerTokenResolverTests {
+
+	private static final String TEST_TOKEN = "test-token";
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private DefaultBearerTokenResolver resolver;
+
+	@Before
+	public void setUp() {
+		this.resolver = new DefaultBearerTokenResolver();
+	}
+
+	@Test
+	public void resolveWhenValidHeaderIsPresentThenTokenIsResolved() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Bearer " + TEST_TOKEN);
+
+		assertThat(this.resolver.resolve(request)).isEqualTo(TEST_TOKEN);
+	}
+
+	@Test
+	public void resolveWhenNoHeaderIsPresentThenTokenIsNotResolved() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+
+		assertThat(this.resolver.resolve(request)).isNull();
+	}
+
+	@Test
+	public void resolveWhenHeaderWithWrongSchemeIsPresentThenTokenIsNotResolved() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString("test:test".getBytes()));
+
+		assertThat(this.resolver.resolve(request)).isNull();
+	}
+
+	@Test
+	public void resolveWhenValidHeaderIsPresentTogetherWithFormParameterThenAuthenticationExceptionIsThrown() {
+		this.thrown.expect(BearerTokenAuthenticationException.class);
+		this.thrown.expectMessage("[invalid_request]");
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Bearer " + TEST_TOKEN);
+		request.setMethod("POST");
+		request.setContentType("application/x-www-form-urlencoded");
+		request.addParameter("access_token", TEST_TOKEN);
+
+		this.resolver.resolve(request);
+	}
+
+	@Test
+	public void resolveWhenValidHeaderIsPresentTogetherWithQueryParameterThenAuthenticationExceptionIsThrown() {
+		this.thrown.expect(BearerTokenAuthenticationException.class);
+		this.thrown.expectMessage("[invalid_request]");
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Bearer " + TEST_TOKEN);
+		request.setMethod("GET");
+		request.addParameter("access_token", TEST_TOKEN);
+
+		this.resolver.resolve(request);
+	}
+
+	@Test
+	public void resolveWhenFormParameterIsPresentAndSupportedThenTokenIsNotResolved() {
+		this.resolver.setUseFormEncodedBodyParameter(true);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("POST");
+		request.setContentType("application/x-www-form-urlencoded");
+		request.addParameter("access_token", TEST_TOKEN);
+
+		assertThat(this.resolver.resolve(request)).isEqualTo(TEST_TOKEN);
+	}
+
+	@Test
+	public void resolveWhenFormParameterIsPresentAndNotSupportedThenTokenIsNotResolved() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("POST");
+		request.setContentType("application/x-www-form-urlencoded");
+		request.addParameter("access_token", TEST_TOKEN);
+
+		assertThat(this.resolver.resolve(request)).isNull();
+	}
+
+	@Test
+	public void resolveWhenQueryParameterIsPresentAndSupportedThenTokenIsNotResolved() {
+		this.resolver.setUseUriQueryParameter(true);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("GET");
+		request.addParameter("access_token", TEST_TOKEN);
+
+		assertThat(this.resolver.resolve(request)).isEqualTo(TEST_TOKEN);
+	}
+
+	@Test
+	public void resolveWhenQueryParameterIsPresentAndNotSupportedThenTokenIsNotResolved() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("GET");
+		request.addParameter("access_token", TEST_TOKEN);
+
+		assertThat(this.resolver.resolve(request)).isNull();
+	}
+
+}


### PR DESCRIPTION
This PR creates `oauth2-resource-server module` and provides a strategy for resolving Bearer Token from HTTP request together with default implementation that aligns with RFC 6750.

The default implementation, `DefaultBearerTokenResolver`, by default uses Authorization Request Header Field for token resolution. It also optionally supports resolution using Form-Encoded Body Parameter and URI Query Parameter. This behavior closely follows [Section 2 of RFC 6750](https://tools.ietf.org/html/rfc6750#section-2) which states:

- Authorization Request Header Field:
> Clients SHOULD make authenticated requests with a bearer token using the "Authorization" request header field with the "Bearer" HTTP authorization scheme.  Resource servers MUST support this method.
- Form-Encoded Body Parameter:
> The "application/x-www-form-urlencoded" method SHOULD NOT be used except in application contexts where participating browsers do not have access to the "Authorization" request header field. Resource servers MAY support this method.
- URI Query Parameter:
> Because of the security weaknesses associated with the URI method (see Section 5), including the high likelihood that the URL containing the access token will be logged, it SHOULD NOT be used unless it is impossible to transport the access token in the "Authorization" request header field or the HTTP request entity-body. Resource servers MAY support this method.

Additionally, in presence of multiple methods of transferring token, an exception will be thrown, as per:

> Clients MUST NOT use more than one method to transmit the token in each request.

> The request is missing a required parameter, includes an unsupported parameter or parameter value, repeats the same parameter, uses more than one method for including an access token, or is otherwise malformed. The resource server SHOULD respond with the HTTP 400 (Bad Request) status code.

The PR also includes `BearerTokenAuthenticationException` and `BearerTokenError` which align with [Section 3 of RFC 6750](https://tools.ietf.org/html/rfc6750#section-3) as well as `BearerTokenErrorCodes` to enumerate standard Bearer Token error codes ([Section 3.1 of RFC 6750](https://tools.ietf.org/html/rfc6750#section-3.1)).

Closes #5121