### PR TITLE
ReactorContextTestExecutionListener should obtain SecurityContext on TestExecutionListenerThread

### DIFF
--- a/test/src/test/java/org/springframework/security/test/web/reactive/server/AbstractMockServerConfigurersTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/reactive/server/AbstractMockServerConfigurersTests.java
@@ -52,7 +52,7 @@ abstract class AbstractMockServerConfigurersTests {
 
 	@RestController
 	protected static class PrincipalController {
-		Principal principal;
+		volatile Principal principal;
 
 		@RequestMapping("/**")
 		public Principal get(Principal principal) {


### PR DESCRIPTION
# The Problem 

During some playing around testing of an application, especially during verification of WebSocket API, I have found that `@WithMockUser` annotation does not work as it expected.

# What I have found

Since we do not have something similar to `TestWebClient` but for verification of the WebSocket API, we need to use `WebSocketClient` (for now). It means that we need to run spring boot app with `@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)` configuration. In turn, it means that execution of the method annotated with, for instance, JUnit's annotation `@Test` will be in a slightly different thread than the execution of `WebSocketHandler`, which will be, for example for Netty, in `reactor-http-nio-blah-blah-blah`.

# It results in

Since `TestSecurityContextHolder` is based on thread local, it means that during execution of `org.springframework.security.test.context.support.ReactorContextTestExecutionListener.DelegateTestExecutionListener.SecuritySubContext#currentContext` mocked `SecurityContext` will not be available in `TestSecurityContextHolder`, since execution of `org.springframework.security.test.context.support.WithSecurityContextTestExecutionListener#beforeTestMethod` (or simply setting `SecurityContext` to `TestSecurityContextHolder`) is on the same thread as execution of test method and in another toward handling of web-socket connection.