### PR TITLE
Improve EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,17 +1,22 @@
 # EditorConfig for Spring Security
 # see https://github.com/spring-projects/spring-security/blob/master/CONTRIBUTING.md#mind-the-whitespace
 
-# top-most EditorConfig file
 root = true
 
-# Unix-style newlines with a newline ending every file
 [*]
 end_of_line = lf
-insert_final_newline = true
-charset = latin1
-
-# 4 tabs indentation
-indent_style = tab
-tab_width = 4
-
 trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 120
+
+[*.java]
+indent_style = tab
+indent_size = 4
+charset = latin1
+continuation_indent_size = 8
+
+[*.xml]
+indent_style = tab
+indent_size = 4
+charset = latin1
+continuation_indent_size = 8


### PR DESCRIPTION
This PR adds several improvements to EditorConfig file:

- separated properties by file types
    - apply common properties (i.e. EOL, trailing whitespace, final newline, line length) to all file types
    - apply others (i.e. indentation, charset) for specific file type
- added `continuation_indent_size` to have continuous indentation work as expected in IntelliJ (see [spring-projects/spring-boot#8497 (comment)](https://github.com/spring-projects/spring-boot/issues/8497#issuecomment-294172853))
- added `max_line_length` with value of 120 to match [contribution guidelines](https://github.com/spring-projects/spring-security/blob/master/CONTRIBUTING.md#mind-the-whitespace)