### PR TITLE
Close quoted expected path in log when matching

### DIFF
--- a/web/src/main/java/org/springframework/security/web/util/matcher/AntPathRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/AntPathRequestMatcher.java
@@ -136,7 +136,7 @@ public final class AntPathRequestMatcher
 			if (logger.isDebugEnabled()) {
 				logger.debug("Request '" + request.getMethod() + " "
 						+ getRequestPath(request) + "'" + " doesn't match '"
-						+ this.httpMethod + " " + this.pattern);
+						+ this.httpMethod + " " + this.pattern + "'");
 			}
 
 			return false;


### PR DESCRIPTION
When a request fails to match `AntPathRequestMatcher.matches` logs the actual and expected requests. The quoted expected request is missing the trailing quote. This PR fixes that.