### PR TITLE
Use Supplier variants of Assert methods

### DIFF
--- a/acl/src/main/java/org/springframework/security/acls/domain/AclFormattingUtils.java
+++ b/acl/src/main/java/org/springframework/security/acls/domain/AclFormattingUtils.java
@@ -92,11 +92,11 @@ public abstract class AclFormattingUtils {
 	 */
 	public static String printBinary(int mask, char code) {
 		Assert.doesNotContain(Character.toString(code),
-				Character.toString(Permission.RESERVED_ON), Permission.RESERVED_ON
-						+ " is a reserved character code");
+				Character.toString(Permission.RESERVED_ON),
+				() -> Permission.RESERVED_ON + " is a reserved character code");
 		Assert.doesNotContain(Character.toString(code),
-				Character.toString(Permission.RESERVED_OFF), Permission.RESERVED_OFF
-						+ " is a reserved character code");
+				Character.toString(Permission.RESERVED_OFF),
+				() -> Permission.RESERVED_OFF + " is a reserved character code");
 
 		return printBinary(mask, Permission.RESERVED_ON, Permission.RESERVED_OFF)
 				.replace(Permission.RESERVED_ON, code);

--- a/acl/src/main/java/org/springframework/security/acls/domain/DefaultPermissionFactory.java
+++ b/acl/src/main/java/org/springframework/security/acls/domain/DefaultPermissionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,9 +104,9 @@ public class DefaultPermissionFactory implements PermissionFactory {
 
 		// Ensure no existing Permission uses this integer or code
 		Assert.isTrue(!registeredPermissionsByInteger.containsKey(mask),
-				"An existing Permission already provides mask " + mask);
+				() -> "An existing Permission already provides mask " + mask);
 		Assert.isTrue(!registeredPermissionsByName.containsKey(permissionName),
-				"An existing Permission already provides name '" + permissionName + "'");
+				() -> "An existing Permission already provides name '" + permissionName + "'");
 
 		// Register the new Permission
 		registeredPermissionsByInteger.put(mask, perm);

--- a/acl/src/main/java/org/springframework/security/acls/jdbc/JdbcAclService.java
+++ b/acl/src/main/java/org/springframework/security/acls/jdbc/JdbcAclService.java
@@ -111,7 +111,7 @@ public class JdbcAclService implements AclService {
 			throws NotFoundException {
 		Map<ObjectIdentity, Acl> map = readAclsById(Arrays.asList(object), sids);
 		Assert.isTrue(map.containsKey(object),
-				"There should have been an Acl entry for ObjectIdentity " + object);
+				() -> "There should have been an Acl entry for ObjectIdentity " + object);
 
 		return (Acl) map.get(object);
 	}

--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/AuthenticationConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/AuthenticationConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,7 +152,7 @@ public class AuthenticationConfiguration {
 			return null;
 		}
 		Assert.isTrue(beanNamesForType.length == 1,
-				"Expecting to only find a single bean for type " + interfaceName
+				() -> "Expecting to only find a single bean for type " + interfaceName
 						+ ", but found " + Arrays.asList(beanNamesForType));
 		lazyTargetSource.setTargetBeanName(beanNamesForType[0]);
 		lazyTargetSource.setBeanFactory(applicationContext);

--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -457,7 +457,7 @@ public class GlobalMethodSecurityConfiguration
 			EnableGlobalMethodSecurity methodSecurityAnnotation = AnnotationUtils
 					.findAnnotation(getClass(), EnableGlobalMethodSecurity.class);
 			Assert.notNull(methodSecurityAnnotation,
-					EnableGlobalMethodSecurity.class.getName() + " is required");
+					() -> EnableGlobalMethodSecurity.class.getName() + " is required");
 			Map<String, Object> methodSecurityAttrs = AnnotationUtils
 					.getAnnotationAttributes(methodSecurityAnnotation);
 			this.enableMethodSecurity = AnnotationAttributes.fromMap(methodSecurityAttrs);

--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecuritySelector.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecuritySelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ final class GlobalMethodSecuritySelector implements ImportSelector {
 				.getAnnotationAttributes(annoType.getName(), false);
 		AnnotationAttributes attributes = AnnotationAttributes
 				.fromMap(annotationAttributes);
-		Assert.notNull(attributes, String.format(
+		Assert.notNull(attributes, () -> String.format(
 				"@%s is not present on importing class '%s' as expected",
 				annoType.getSimpleName(), importingClassMetadata.getClassName()));
 

--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/WebSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/WebSecurity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -278,7 +278,9 @@ public final class WebSecurity extends
 	protected Filter performBuild() throws Exception {
 		Assert.state(
 				!securityFilterChainBuilders.isEmpty(),
-				"At least one SecurityBuilder<? extends SecurityFilterChain> needs to be specified. Typically this done by adding a @Configuration that extends WebSecurityConfigurerAdapter. More advanced users can invoke "
+				() -> "At least one SecurityBuilder<? extends SecurityFilterChain> needs to be specified. "
+						+ "Typically this done by adding a @Configuration that extends WebSecurityConfigurerAdapter. "
+						+ "More advanced users can invoke "
 						+ WebSecurity.class.getSimpleName()
 						+ ".addSecurityFilterChainBuilder directly");
 		int chainSize = ignoredRequests.size() + securityFilterChainBuilders.size();

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/UrlAuthorizationConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/UrlAuthorizationConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -220,7 +220,7 @@ public final class UrlAuthorizationConfigurer<H extends HttpSecurityBuilder<H>> 
 	private static String hasRole(String role) {
 		Assert.isTrue(
 				!role.startsWith("ROLE_"),
-				role
+				() -> role
 						+ " should not start with ROLE_ since ROLE_ is automatically prepended when using hasRole. Consider using hasAuthority or access instead.");
 		return "ROLE_" + role;
 	}

--- a/config/src/main/java/org/springframework/security/config/authentication/AuthenticationManagerBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/authentication/AuthenticationManagerBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,7 +103,7 @@ public class AuthenticationManagerBeanDefinitionParser implements BeanDefinition
 				else {
 					BeanDefinition provider = resolver.resolve(
 							providerElt.getNamespaceURI()).parse(providerElt, pc);
-					Assert.notNull(provider, "Parser for " + providerElt.getNodeName()
+					Assert.notNull(provider, () -> "Parser for " + providerElt.getNodeName()
 							+ " returned a null bean definition");
 					String providerId = pc.getReaderContext().generateBeanName(provider);
 					pc.registerBeanComponent(new BeanComponentDefinition(provider,

--- a/config/src/main/java/org/springframework/security/config/authentication/CachingUserDetailsService.java
+++ b/config/src/main/java/org/springframework/security/config/authentication/CachingUserDetailsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ public class CachingUserDetailsService implements UserDetailsService {
 			user = delegate.loadUserByUsername(username);
 		}
 
-		Assert.notNull(user, "UserDetailsService " + delegate
+		Assert.notNull(user, () -> "UserDetailsService " + delegate
 				+ " returned null for username " + username + ". "
 				+ "This is an interface contract violation");
 

--- a/config/src/main/java/org/springframework/security/config/method/GlobalMethodSecurityBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/method/GlobalMethodSecurityBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -512,7 +512,7 @@ public class GlobalMethodSecurityBeanDefinitionParser implements BeanDefinitionP
 			synchronized (delegateMonitor) {
 				if (delegate == null) {
 					Assert.state(beanFactory != null,
-							"BeanFactory must be set to resolve " + authMgrBean);
+							() -> "BeanFactory must be set to resolve " + authMgrBean);
 					try {
 						delegate = beanFactory.getBean(authMgrBean,
 								AuthenticationManager.class);

--- a/core/src/main/java/org/springframework/security/access/annotation/SecuredAnnotationSecurityMetadataSource.java
+++ b/core/src/main/java/org/springframework/security/access/annotation/SecuredAnnotationSecurityMetadataSource.java
@@ -54,7 +54,7 @@ public class SecuredAnnotationSecurityMetadataSource extends
 		annotationType = (Class<? extends Annotation>) GenericTypeResolver
 				.resolveTypeArgument(annotationExtractor.getClass(),
 						AnnotationMetadataExtractor.class);
-		Assert.notNull(annotationType, annotationExtractor.getClass().getName()
+		Assert.notNull(annotationType, () -> annotationExtractor.getClass().getName()
 				+ " must supply a generic parameter for AnnotationMetadataExtractor");
 	}
 

--- a/core/src/main/java/org/springframework/security/access/intercept/AbstractSecurityInterceptor.java
+++ b/core/src/main/java/org/springframework/security/access/intercept/AbstractSecurityInterceptor.java
@@ -136,18 +136,18 @@ public abstract class AbstractSecurityInterceptor implements InitializingBean,
 				"An SecurityMetadataSource is required");
 		Assert.isTrue(this.obtainSecurityMetadataSource()
 				.supports(getSecureObjectClass()),
-				"SecurityMetadataSource does not support secure object class: "
+				() -> "SecurityMetadataSource does not support secure object class: "
 						+ getSecureObjectClass());
 		Assert.isTrue(this.runAsManager.supports(getSecureObjectClass()),
-				"RunAsManager does not support secure object class: "
+				() -> "RunAsManager does not support secure object class: "
 						+ getSecureObjectClass());
 		Assert.isTrue(this.accessDecisionManager.supports(getSecureObjectClass()),
-				"AccessDecisionManager does not support secure object class: "
+				() -> "AccessDecisionManager does not support secure object class: "
 						+ getSecureObjectClass());
 
 		if (this.afterInvocationManager != null) {
 			Assert.isTrue(this.afterInvocationManager.supports(getSecureObjectClass()),
-					"AfterInvocationManager does not support secure object class: "
+					() -> "AfterInvocationManager does not support secure object class: "
 							+ getSecureObjectClass());
 		}
 

--- a/core/src/main/java/org/springframework/security/access/intercept/AfterInvocationProviderManager.java
+++ b/core/src/main/java/org/springframework/security/access/intercept/AfterInvocationProviderManager.java
@@ -95,7 +95,7 @@ public class AfterInvocationProviderManager implements AfterInvocationManager,
 
 		for (Object currentObject : newList) {
 			Assert.isInstanceOf(AfterInvocationProvider.class, currentObject,
-					"AfterInvocationProvider " + currentObject.getClass().getName()
+					() -> "AfterInvocationProvider " + currentObject.getClass().getName()
 							+ " must implement AfterInvocationProvider");
 			providers.add((AfterInvocationProvider) currentObject);
 		}

--- a/core/src/main/java/org/springframework/security/access/method/MapBasedMethodSecurityMetadataSource.java
+++ b/core/src/main/java/org/springframework/security/access/method/MapBasedMethodSecurityMetadataSource.java
@@ -123,7 +123,7 @@ public class MapBasedMethodSecurityMetadataSource extends
 		}
 
 		String methodName = name.substring(lastDotIndex + 1);
-		Assert.hasText(methodName, "Method not found for '" + name + "'");
+		Assert.hasText(methodName, () -> "Method not found for '" + name + "'");
 
 		String typeName = name.substring(0, lastDotIndex);
 		Class<?> type = ClassUtils.resolveClassName(typeName, this.beanClassLoader);

--- a/core/src/main/java/org/springframework/security/authentication/dao/AbstractUserDetailsAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/dao/AbstractUserDetailsAuthenticationProvider.java
@@ -126,7 +126,7 @@ public abstract class AbstractUserDetailsAuthenticationProvider implements
 	public Authentication authenticate(Authentication authentication)
 			throws AuthenticationException {
 		Assert.isInstanceOf(UsernamePasswordAuthenticationToken.class, authentication,
-				messages.getMessage(
+				() -> messages.getMessage(
 						"AbstractUserDetailsAuthenticationProvider.onlySupports",
 						"Only UsernamePasswordAuthenticationToken is supported"));
 

--- a/core/src/main/java/org/springframework/security/authentication/jaas/JaasAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/jaas/JaasAuthenticationProvider.java
@@ -158,8 +158,9 @@ public class JaasAuthenticationProvider extends AbstractJaasAuthenticationProvid
 		// the superclass is not called because it does additional checks that are
 		// non-passive
 		Assert.hasLength(getLoginContextName(),
-				"loginContextName must be set on " + getClass());
-		Assert.notNull(this.loginConfig, "loginConfig must be set on " + getClass());
+				() -> "loginContextName must be set on " + getClass());
+		Assert.notNull(this.loginConfig,
+				() -> "loginConfig must be set on " + getClass());
 		configureJaas(this.loginConfig);
 
 		Assert.notNull(Configuration.getConfiguration(),

--- a/core/src/main/java/org/springframework/security/core/token/KeyBasedPersistenceTokenService.java
+++ b/core/src/main/java/org/springframework/security/core/token/KeyBasedPersistenceTokenService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ public class KeyBasedPersistenceTokenService implements TokenService, Initializi
 		}
 		String[] tokens = StringUtils.delimitedListToStringArray(
 				Utf8.decode(Base64.getDecoder().decode(Utf8.encode(key))), ":");
-		Assert.isTrue(tokens.length >= 4, "Expected 4 or more tokens but found "
+		Assert.isTrue(tokens.length >= 4, () -> "Expected 4 or more tokens but found "
 				+ tokens.length);
 
 		long creationTime;

--- a/core/src/main/java/org/springframework/security/core/userdetails/User.java
+++ b/core/src/main/java/org/springframework/security/core/userdetails/User.java
@@ -432,7 +432,7 @@ public class User implements UserDetails, CredentialsContainer {
 			List<GrantedAuthority> authorities = new ArrayList<>(
 					roles.length);
 			for (String role : roles) {
-				Assert.isTrue(!role.startsWith("ROLE_"), role
+				Assert.isTrue(!role.startsWith("ROLE_"), () -> role
 						+ " cannot start with ROLE_ (it is automatically added)");
 				authorities.add(new SimpleGrantedAuthority("ROLE_" + role));
 			}

--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/AbstractLdapAuthenticationProvider.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/AbstractLdapAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ public abstract class AbstractLdapAuthenticationProvider
 	public Authentication authenticate(Authentication authentication)
 			throws AuthenticationException {
 		Assert.isInstanceOf(UsernamePasswordAuthenticationToken.class, authentication,
-				this.messages.getMessage("LdapAuthenticationProvider.onlySupports",
+				() -> this.messages.getMessage("LdapAuthenticationProvider.onlySupports",
 						"Only UsernamePasswordAuthenticationToken is supported"));
 
 		final UsernamePasswordAuthenticationToken userToken = (UsernamePasswordAuthenticationToken) authentication;

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -431,7 +431,7 @@ public final class ClientRegistration {
 
 		private void validateAuthorizationCodeGrantType() {
 			Assert.isTrue(AuthorizationGrantType.AUTHORIZATION_CODE.equals(this.authorizationGrantType),
-				"authorizationGrantType must be " + AuthorizationGrantType.AUTHORIZATION_CODE.getValue());
+					() -> "authorizationGrantType must be " + AuthorizationGrantType.AUTHORIZATION_CODE.getValue());
 			Assert.hasText(this.registrationId, "registrationId cannot be empty");
 			Assert.hasText(this.clientId, "clientId cannot be empty");
 			Assert.hasText(this.clientSecret, "clientSecret cannot be empty");
@@ -449,7 +449,7 @@ public final class ClientRegistration {
 
 		private void validateImplicitGrantType() {
 			Assert.isTrue(AuthorizationGrantType.IMPLICIT.equals(this.authorizationGrantType),
-				"authorizationGrantType must be " + AuthorizationGrantType.IMPLICIT.getValue());
+					() -> "authorizationGrantType must be " + AuthorizationGrantType.IMPLICIT.getValue());
 			Assert.hasText(this.registrationId, "registrationId cannot be empty");
 			Assert.hasText(this.clientId, "clientId cannot be empty");
 			Assert.hasText(this.redirectUriTemplate, "redirectUriTemplate cannot be empty");

--- a/web/src/main/java/org/springframework/security/web/access/channel/ChannelDecisionManagerImpl.java
+++ b/web/src/main/java/org/springframework/security/web/access/channel/ChannelDecisionManagerImpl.java
@@ -92,7 +92,7 @@ public class ChannelDecisionManagerImpl implements ChannelDecisionManager,
 
 		for (Object currentObject : newList) {
 			Assert.isInstanceOf(ChannelProcessor.class, currentObject,
-					"ChannelProcessor " + currentObject.getClass().getName()
+					() -> "ChannelProcessor " + currentObject.getClass().getName()
 							+ " must implement ChannelProcessor");
 			channelProcessors.add((ChannelProcessor) currentObject);
 		}

--- a/web/src/main/java/org/springframework/security/web/access/expression/ExpressionBasedFilterInvocationSecurityMetadataSource.java
+++ b/web/src/main/java/org/springframework/security/web/access/expression/ExpressionBasedFilterInvocationSecurityMetadataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ public final class ExpressionBasedFilterInvocationSecurityMetadataSource
 				.entrySet()) {
 			RequestMatcher request = entry.getKey();
 			Assert.isTrue(entry.getValue().size() == 1,
-					"Expected a single expression attribute for " + request);
+					() -> "Expected a single expression attribute for " + request);
 			ArrayList<ConfigAttribute> attributes = new ArrayList<>(1);
 			String expression = entry.getValue().toArray(new ConfigAttribute[1])[0]
 					.getAttribute();

--- a/web/src/main/java/org/springframework/security/web/authentication/ExceptionMappingAuthenticationFailureHandler.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/ExceptionMappingAuthenticationFailureHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ public class ExceptionMappingAuthenticationFailureHandler extends
 					"Exception key must be a String (the exception classname).");
 			Assert.isInstanceOf(String.class, url, "URL must be a String");
 			Assert.isTrue(UrlUtils.isValidRedirectUrl((String) url),
-					"Not a valid redirect URL: " + url);
+					() -> "Not a valid redirect URL: " + url);
 			this.failureUrlMap.put((String) exception, (String) url);
 		}
 	}

--- a/web/src/main/java/org/springframework/security/web/authentication/ForwardAuthenticationFailureHandler.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/ForwardAuthenticationFailureHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,8 +41,8 @@ public class ForwardAuthenticationFailureHandler implements AuthenticationFailur
 	 * @param forwardUrl
 	 */
 	public ForwardAuthenticationFailureHandler(String forwardUrl) {
-		Assert.isTrue(UrlUtils.isValidRedirectUrl(forwardUrl), "'"
-				+ forwardUrl + "' is not a valid forward URL");
+		Assert.isTrue(UrlUtils.isValidRedirectUrl(forwardUrl),
+				() -> "'" + forwardUrl + "' is not a valid forward URL");
 		this.forwardUrl = forwardUrl;
 	}
 

--- a/web/src/main/java/org/springframework/security/web/authentication/ForwardAuthenticationSuccessHandler.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/ForwardAuthenticationSuccessHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,8 +41,8 @@ public class ForwardAuthenticationSuccessHandler implements AuthenticationSucces
 	 * @param forwardUrl
 	 */
 	public ForwardAuthenticationSuccessHandler(String forwardUrl) {
-		Assert.isTrue(UrlUtils.isValidRedirectUrl(forwardUrl), "'"
-				+ forwardUrl + "' is not a valid forward URL");
+		Assert.isTrue(UrlUtils.isValidRedirectUrl(forwardUrl),
+				() -> "'" + forwardUrl + "' is not a valid forward URL");
 		this.forwardUrl = forwardUrl;
 	}
 

--- a/web/src/main/java/org/springframework/security/web/authentication/SimpleUrlAuthenticationFailureHandler.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/SimpleUrlAuthenticationFailureHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -123,8 +123,8 @@ public class SimpleUrlAuthenticationFailureHandler implements
 	 * @param defaultFailureUrl the failure URL, for example "/loginFailed.jsp".
 	 */
 	public void setDefaultFailureUrl(String defaultFailureUrl) {
-		Assert.isTrue(UrlUtils.isValidRedirectUrl(defaultFailureUrl), "'"
-				+ defaultFailureUrl + "' is not a valid redirect URL");
+		Assert.isTrue(UrlUtils.isValidRedirectUrl(defaultFailureUrl),
+				() -> "'" + defaultFailureUrl + "' is not a valid redirect URL");
 		this.defaultFailureUrl = defaultFailureUrl;
 	}
 

--- a/web/src/main/java/org/springframework/security/web/authentication/logout/ForwardLogoutSuccessHandler.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/logout/ForwardLogoutSuccessHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,8 +42,8 @@ public class ForwardLogoutSuccessHandler implements LogoutSuccessHandler {
 	 * @param targetUrl the target URL
 	 */
 	public ForwardLogoutSuccessHandler(String targetUrl) {
-		Assert.isTrue(UrlUtils.isValidRedirectUrl(targetUrl), "'" + targetUrl
-				+ "' is not a valid target URL");
+		Assert.isTrue(UrlUtils.isValidRedirectUrl(targetUrl),
+				() -> "'" + targetUrl + "' is not a valid target URL");
 		this.targetUrl = targetUrl;
 	}
 

--- a/web/src/main/java/org/springframework/security/web/authentication/logout/LogoutFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/logout/LogoutFilter.java
@@ -81,7 +81,7 @@ public class LogoutFilter extends GenericFilterBean {
 		Assert.isTrue(
 				!StringUtils.hasLength(logoutSuccessUrl)
 						|| UrlUtils.isValidRedirectUrl(logoutSuccessUrl),
-				logoutSuccessUrl + " isn't a valid redirect URL");
+				() -> logoutSuccessUrl + " isn't a valid redirect URL");
 		SimpleUrlLogoutSuccessHandler urlLogoutSuccessHandler = new SimpleUrlLogoutSuccessHandler();
 		if (StringUtils.hasText(logoutSuccessUrl)) {
 			urlLogoutSuccessHandler.setDefaultTargetUrl(logoutSuccessUrl);

--- a/web/src/main/java/org/springframework/security/web/server/MatcherSecurityWebFilterChain.java
+++ b/web/src/main/java/org/springframework/security/web/server/MatcherSecurityWebFilterChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ public class MatcherSecurityWebFilterChain implements SecurityWebFilterChain {
 
 	public MatcherSecurityWebFilterChain(ServerWebExchangeMatcher matcher, List<WebFilter> filters) {
 		Assert.notNull(matcher, "matcher cannot be null");
-		Assert.notEmpty(filters, "filters cannot be null or empty. Got " + filters);
+		Assert.notEmpty(filters, () -> "filters cannot be null or empty. Got " + filters);
 		this.matcher = matcher;
 		this.filters = filters;
 	}

--- a/web/src/main/java/org/springframework/security/web/session/ConcurrentSessionFilter.java
+++ b/web/src/main/java/org/springframework/security/web/session/ConcurrentSessionFilter.java
@@ -93,7 +93,7 @@ public class ConcurrentSessionFilter extends GenericFilterBean {
 	public ConcurrentSessionFilter(SessionRegistry sessionRegistry, String expiredUrl) {
 		Assert.notNull(sessionRegistry, "SessionRegistry required");
 		Assert.isTrue(expiredUrl == null || UrlUtils.isValidRedirectUrl(expiredUrl),
-				expiredUrl + " isn't a valid redirect URL");
+				() -> expiredUrl + " isn't a valid redirect URL");
 		this.expiredUrl = expiredUrl;
 		this.sessionRegistry = sessionRegistry;
 		this.sessionInformationExpiredStrategy = new SessionInformationExpiredStrategy() {

--- a/web/src/test/java/org/springframework/security/web/method/ResolvableMethod.java
+++ b/web/src/test/java/org/springframework/security/web/method/ResolvableMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -371,8 +371,8 @@ public class ResolvableMethod {
 		 */
 		public ResolvableMethod build() {
 			Set<Method> methods = MethodIntrospector.selectMethods(this.objectClass, this::isMatch);
-			Assert.state(!methods.isEmpty(), "No matching method: " + this);
-			Assert.state(methods.size() == 1, "Multiple matching methods: " + this + formatMethods(methods));
+			Assert.state(!methods.isEmpty(), () -> "No matching method: " + this);
+			Assert.state(methods.size() == 1, () -> "Multiple matching methods: " + this + formatMethods(methods));
 			return new ResolvableMethod(methods.iterator().next());
 		}
 


### PR DESCRIPTION
Hi,

this PR applies the Supplier variants of Assert.isTrue and alike where possible and saves some unnecesarry string allocations.

Let me know what you think.

Cheers,
Christoph
