### PR TITLE
Fix @since for StrictHttpFirewall

### DIFF
--- a/web/src/main/java/org/springframework/security/web/firewall/StrictHttpFirewall.java
+++ b/web/src/main/java/org/springframework/security/web/firewall/StrictHttpFirewall.java
@@ -63,7 +63,7 @@ import java.util.Set;
  *
  * @see DefaultHttpFirewall
  * @author Rob Winch
- * @since 5.0.1
+ * @since 4.2.4
  */
 public class StrictHttpFirewall implements HttpFirewall {
 	private static final String ENCODED_PERCENT = "%25";


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
4.2.x branch has been fixed in 1159c9f302080f7e91c8a806c957a1c63f5882e4 but master hasn’t.

See #5006 