### PR TITLE
Add FirstOfMultifactorAuthenticationToken

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/AuthenticationTrustResolver.java
+++ b/core/src/main/java/org/springframework/security/authentication/AuthenticationTrustResolver.java
@@ -39,9 +39,26 @@ public interface AuthenticationTrustResolver {
 	 * will always return <code>false</code>)
 	 *
 	 * @return <code>true</code> the passed authentication token represented an anonymous
-	 * principal, <code>false</code> otherwise
+	 * principal or in the middle of multi factor authentication process,
+	 * <code>false</code> otherwise
 	 */
 	boolean isAnonymous(Authentication authentication);
+
+
+	/**
+	 * Indicates whether the passed <code>Authentication</code> token represents a
+	 * fully anonymous user (not authenticated and also not in the middle of multi factor
+	 * authentication process.
+	 * The method is provided to distinguish fully anonymous principal from the principal
+	 * which has passed the first step of multi step (factor) authentication.
+	 *
+	 * @param authentication to test (may be <code>null</code> in which case the method
+	 * will always return <code>false</code>)
+	 *
+	 * @return <code>true</code> the passed authentication token represented an anonymous
+	 * principal, <code>false</code> otherwise
+	 */
+	boolean isFullyAnonymous(Authentication authentication);
 
 	/**
 	 * Indicates whether the passed <code>Authentication</code> token represents user that

--- a/core/src/main/java/org/springframework/security/authentication/AuthenticationTrustResolverImpl.java
+++ b/core/src/main/java/org/springframework/security/authentication/AuthenticationTrustResolverImpl.java
@@ -34,6 +34,7 @@ public class AuthenticationTrustResolverImpl implements AuthenticationTrustResol
 	// ================================================================================================
 
 	private Class<? extends Authentication> anonymousClass = AnonymousAuthenticationToken.class;
+	private Class<? extends Authentication> firstOfMultiFactorClass = FirstOfMultiFactorAuthenticationToken.class;
 	private Class<? extends Authentication> rememberMeClass = RememberMeAuthenticationToken.class;
 
 	// ~ Methods
@@ -43,11 +44,25 @@ public class AuthenticationTrustResolverImpl implements AuthenticationTrustResol
 		return anonymousClass;
 	}
 
+	Class<? extends Authentication> getFirstOfMultiFactorClass() { return firstOfMultiFactorClass; }
+
 	Class<? extends Authentication> getRememberMeClass() {
 		return rememberMeClass;
 	}
 
 	public boolean isAnonymous(Authentication authentication) {
+		if(isFullyAnonymous(authentication)){
+			return true;
+		}
+		if ((firstOfMultiFactorClass == null) || (authentication == null)) {
+			return false;
+		}
+
+		return firstOfMultiFactorClass.isAssignableFrom(authentication.getClass());
+	}
+
+	@Override
+	public boolean isFullyAnonymous(Authentication authentication) {
 		if ((anonymousClass == null) || (authentication == null)) {
 			return false;
 		}
@@ -66,6 +81,8 @@ public class AuthenticationTrustResolverImpl implements AuthenticationTrustResol
 	public void setAnonymousClass(Class<? extends Authentication> anonymousClass) {
 		this.anonymousClass = anonymousClass;
 	}
+
+	public void setFirstOfMultiFactorClass(Class<? extends Authentication> firstOfMultiFactorClass) {this.firstOfMultiFactorClass = firstOfMultiFactorClass; }
 
 	public void setRememberMeClass(Class<? extends Authentication> rememberMeClass) {
 		this.rememberMeClass = rememberMeClass;

--- a/core/src/main/java/org/springframework/security/authentication/FirstOfMultiFactorAuthenticationToken.java
+++ b/core/src/main/java/org/springframework/security/authentication/FirstOfMultiFactorAuthenticationToken.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.security.authentication;
 
 import org.springframework.security.core.GrantedAuthority;

--- a/core/src/main/java/org/springframework/security/authentication/FirstOfMultiFactorAuthenticationToken.java
+++ b/core/src/main/java/org/springframework/security/authentication/FirstOfMultiFactorAuthenticationToken.java
@@ -1,0 +1,43 @@
+package org.springframework.security.authentication;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.SpringSecurityCoreVersion;
+
+import java.util.Collection;
+
+public class FirstOfMultiFactorAuthenticationToken extends AbstractAuthenticationToken {
+
+	private static final long serialVersionUID = SpringSecurityCoreVersion.SERIAL_VERSION_UID;
+
+	private Object principal;
+	private Object credentials;
+
+	// ~ Constructors
+	// ===================================================================================================
+	public FirstOfMultiFactorAuthenticationToken(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+		super(authorities);
+		this.principal = principal;
+		this.credentials = credentials;
+		setAuthenticated(true);
+	}
+
+	// ~ Methods
+	// ========================================================================================================
+
+	@Override
+	public Object getPrincipal() {
+		return principal;
+	}
+
+	@Override
+	public Object getCredentials() {
+		return credentials;
+	}
+
+	@Override
+	public void eraseCredentials() {
+		super.eraseCredentials();
+		credentials = null;
+	}
+
+}

--- a/core/src/test/java/org/springframework/security/authentication/AuthenticationTrustResolverImplTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/AuthenticationTrustResolverImplTests.java
@@ -36,8 +36,21 @@ public class AuthenticationTrustResolverImplTests {
 		AuthenticationTrustResolverImpl trustResolver = new AuthenticationTrustResolverImpl();
 		assertThat(trustResolver.isAnonymous(new AnonymousAuthenticationToken("ignored",
 				"ignored", AuthorityUtils.createAuthorityList("ignored")))).isTrue();
+		assertThat(trustResolver.isAnonymous(new FirstOfMultiFactorAuthenticationToken("ignored",
+			"ignored", AuthorityUtils.createAuthorityList("ignored")))).isTrue();
 		assertThat(trustResolver.isAnonymous(new TestingAuthenticationToken("ignored",
 				"ignored", AuthorityUtils.createAuthorityList("ignored")))).isFalse();
+	}
+
+	@Test
+	public void testCorrectOperationIsFullyAnonymous() {
+		AuthenticationTrustResolverImpl trustResolver = new AuthenticationTrustResolverImpl();
+		assertThat(trustResolver.isFullyAnonymous(new AnonymousAuthenticationToken("ignored",
+			"ignored", AuthorityUtils.createAuthorityList("ignored")))).isTrue();
+		assertThat(trustResolver.isFullyAnonymous(new FirstOfMultiFactorAuthenticationToken("ignored",
+			"ignored", AuthorityUtils.createAuthorityList("ignored")))).isFalse();
+		assertThat(trustResolver.isFullyAnonymous(new TestingAuthenticationToken("ignored",
+			"ignored", AuthorityUtils.createAuthorityList("ignored")))).isFalse();
 	}
 
 	@Test

--- a/core/src/test/java/org/springframework/security/authentication/FirstOfMultiFactorAuthenticationTokenTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/FirstOfMultiFactorAuthenticationTokenTests.java
@@ -1,0 +1,45 @@
+package org.springframework.security.authentication;
+
+import org.junit.Test;
+import org.springframework.security.core.authority.AuthorityUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FirstOfMultiFactorAuthenticationTokenTests {
+	// ~ Methods
+	// ========================================================================================================
+
+	@Test
+	public void authenticatedPropertyContractIsSatisfied() {
+		FirstOfMultiFactorAuthenticationToken token = new FirstOfMultiFactorAuthenticationToken(
+			"Test", "Password", AuthorityUtils.NO_AUTHORITIES);
+
+		// check default given we passed some GrantedAuthority[]s (well, we passed empty
+		// list)
+		assertThat(token.isAuthenticated()).isTrue();
+
+		// check explicit set to untrusted (we can safely go from trusted to untrusted,
+		// but not the reverse)
+		token.setAuthenticated(false);
+		assertThat(token.isAuthenticated()).isFalse();
+
+	}
+
+	@Test
+	public void gettersReturnCorrectData() {
+		FirstOfMultiFactorAuthenticationToken token = new FirstOfMultiFactorAuthenticationToken(
+			"Test", "Password",
+			AuthorityUtils.createAuthorityList("ROLE_ONE", "ROLE_TWO"));
+		assertThat(token.getPrincipal()).isEqualTo("Test");
+		assertThat(token.getCredentials()).isEqualTo("Password");
+		assertThat(AuthorityUtils.authorityListToSet(token.getAuthorities())).contains("ROLE_ONE");
+		assertThat(AuthorityUtils.authorityListToSet(token.getAuthorities())).contains("ROLE_TWO");
+	}
+
+	@Test(expected = NoSuchMethodException.class)
+	public void testNoArgConstructorDoesntExist() throws Exception {
+		Class<?> clazz = UsernamePasswordAuthenticationToken.class;
+		clazz.getDeclaredConstructor((Class[]) null);
+	}
+
+}

--- a/core/src/test/java/org/springframework/security/authentication/FirstOfMultiFactorAuthenticationTokenTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/FirstOfMultiFactorAuthenticationTokenTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.security.authentication;
 
 import org.junit.Test;

--- a/web/src/main/java/org/springframework/security/web/context/HttpSessionSecurityContextRepository.java
+++ b/web/src/main/java/org/springframework/security/web/context/HttpSessionSecurityContextRepository.java
@@ -332,7 +332,7 @@ public class HttpSessionSecurityContextRepository implements SecurityContextRepo
 		/**
 		 * Stores the supplied security context in the session (if available) and if it
 		 * has changed since it was set at the start of the request. If the
-		 * AuthenticationTrustResolver identifies the current user as anonymous, then the
+		 * AuthenticationTrustResolver identifies the current user as fully anonymous, then the
 		 * context will not be stored.
 		 *
 		 * @param context the context object obtained from the SecurityContextHolder after
@@ -347,7 +347,7 @@ public class HttpSessionSecurityContextRepository implements SecurityContextRepo
 			HttpSession httpSession = request.getSession(false);
 
 			// See SEC-776
-			if (authentication == null || trustResolver.isAnonymous(authentication)) {
+			if (authentication == null || trustResolver.isFullyAnonymous(authentication)) {
 				if (logger.isDebugEnabled()) {
 					logger.debug("SecurityContext is empty or contents are anonymous - context will not be stored in HttpSession.");
 				}

--- a/web/src/test/java/org/springframework/security/web/access/ExceptionTranslationFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/access/ExceptionTranslationFilterTests.java
@@ -26,6 +26,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.FirstOfMultiFactorAuthenticationToken;
 import org.springframework.security.authentication.RememberMeAuthenticationToken;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.authority.AuthorityUtils;
@@ -108,6 +109,40 @@ public class ExceptionTranslationFilterTests {
 		assertThat(response.getRedirectedUrl()).isEqualTo("/mycontext/login.jsp");
 		assertThat(getSavedRequestUrl(request)).isEqualTo("http://www.example.com/mycontext/secure/page.html");
 	}
+
+	@Test
+	public void testAccessDeniedWhenFirstOfMultiFactorAuthentication() throws Exception {
+		// Setup our HTTP request
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setServletPath("/secure/page.html");
+		request.setServerPort(80);
+		request.setScheme("http");
+		request.setServerName("www.example.com");
+		request.setContextPath("/mycontext");
+		request.setRequestURI("/mycontext/secure/page.html");
+
+		// Setup the FilterChain to thrown an access denied exception
+		FilterChain fc = mock(FilterChain.class);
+		doThrow(new AccessDeniedException("")).when(fc).doFilter(
+			any(HttpServletRequest.class), any(HttpServletResponse.class));
+
+		// Setup SecurityContextHolder, as filter needs to check if user is
+		// anonymous
+		SecurityContextHolder.getContext().setAuthentication(
+			new FirstOfMultiFactorAuthenticationToken("ignored", "ignored", AuthorityUtils
+				.createAuthorityList("IGNORED")));
+
+		// Test
+		ExceptionTranslationFilter filter = new ExceptionTranslationFilter(mockEntryPoint);
+		filter.setAuthenticationTrustResolver(new AuthenticationTrustResolverImpl());
+		assertThat(filter.getAuthenticationTrustResolver()).isNotNull();
+
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		filter.doFilter(request, response, fc);
+		assertThat(response.getRedirectedUrl()).isEqualTo("/mycontext/login.jsp");
+		assertThat(getSavedRequestUrl(request)).isEqualTo("http://www.example.com/mycontext/secure/page.html");
+	}
+
 
 	@Test
 	public void testAccessDeniedWithRememberMe() throws Exception {

--- a/web/src/test/java/org/springframework/security/web/context/HttpSessionSecurityContextRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/context/HttpSessionSecurityContextRepositoryTests.java
@@ -592,7 +592,7 @@ public class HttpSessionSecurityContextRepositoryTests {
 
 		repo.saveContext(contextToSave, holder.getRequest(), holder.getResponse());
 
-		verify(trustResolver).isAnonymous(contextToSave.getAuthentication());
+		verify(trustResolver).isFullyAnonymous(contextToSave.getAuthentication());
 	}
 
 	@Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
(Please read the issue first : https://github.com/spring-projects/spring-security/issues/2603#issuecomment-377922919)

To support FIDO-U2F or Web Authentication with FIDO-U2F device, an authentication token for indicating the user passed the first step of multi step(factor) authentication is required.
`FirstOfMultiFactorAuthenticationToken` is meant to support the scenario. Also, by making `AuthenticationTrustResolverImpl` return false for the token, existing spring security application can introduce Multi  Factor AuthenticationProvider like https://github.com/ynojima/spring-security-webauthn with minimum modification.


(maybe `FirstOfMultiFactorAuthenticationToken` is not proper naming, but I couldn't find another name.)