### PR TITLE
Fix @since for MockEventListener

### DIFF
--- a/config/src/test/java/org/springframework/security/config/MockEventListener.java
+++ b/config/src/test/java/org/springframework/security/config/MockEventListener.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 /**
  * @author Rob Winch
- * @since 5.0
+ * @since 5.0.2
  */
 public class MockEventListener<T extends ApplicationEvent>
 	implements ApplicationListener<T> {


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

`MockEventListener` looks added since 5.0.2.RELEASE although it can be removed as it's a class for internal tests.

See 49e5b15ce28440fc8b9135217ba0c435a25ff543