### PR TITLE
Documentation typo fixes

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/appendix/database-schema.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/appendix/database-schema.adoc
@@ -84,7 +84,7 @@ There are four tables used by the Spring Security <<domain-acls,ACL>> implementa
 These can be unique principals or authorities which may apply to multiple principals.
 . `acl_class` defines the domain object types to which ACLs apply.
 The `class` column stores the Java class name of the object.
-. `acl_object_identity` stores the object identity definitions of specific domai objects.
+. `acl_object_identity` stores the object identity definitions of specific domain objects.
 . `acl_entry` stores the ACL permissions which apply to a specific object identity and security identity.
 
 It is assumed that the database will auto-generate the primary keys for each of the identities.

--- a/docs/manual/src/docs/asciidoc/_includes/web/csrf.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/web/csrf.adoc
@@ -271,7 +271,7 @@ name: $("meta[name='_csrf_header']").attr("content")
 
 
 The configured client can be shared with any component of the application that needs to make a request to the CSRF protected resource.
-One significant different between rest.js and jQuery is that only requests made with the configured client will contain the CSRF token, vs jQuery where __all__ requests will include the token.
+One significant difference between rest.js and jQuery is that only requests made with the configured client will contain the CSRF token, vs jQuery where __all__ requests will include the token.
 The ability to scope which requests receive the token helps guard against leaking the CSRF token to a third party.
 Please refer to the https://github.com/cujojs/rest/tree/master/docs[rest.js reference documentation] for more information on rest.js.
 


### PR DESCRIPTION
This pull request fixes two minor documentation typos, fixing #5204 and #4792.