### PR TITLE
Fixes bug in SQL queries created by spring-security-acl when using pr…

### DIFF
--- a/acl/src/main/java/org/springframework/security/acls/jdbc/JdbcAclService.java
+++ b/acl/src/main/java/org/springframework/security/acls/jdbc/JdbcAclService.java
@@ -87,7 +87,7 @@ public class JdbcAclService implements AclService {
 	// ========================================================================================================
 
 	public List<ObjectIdentity> findChildren(ObjectIdentity parentIdentity) {
-		Object[] args = { parentIdentity.getIdentifier(), parentIdentity.getType() };
+		Object[] args = { parentIdentity.getIdentifier().toString(), parentIdentity.getType() };
 		List<ObjectIdentity> objects = jdbcTemplate.query(findChildrenSql, args,
 				new RowMapper<ObjectIdentity>() {
 					public ObjectIdentity mapRow(ResultSet rs, int rowNum)

--- a/acl/src/main/java/org/springframework/security/acls/jdbc/JdbcMutableAclService.java
+++ b/acl/src/main/java/org/springframework/security/acls/jdbc/JdbcMutableAclService.java
@@ -170,7 +170,7 @@ public class JdbcMutableAclService extends JdbcAclService implements MutableAclS
 	protected void createObjectIdentity(ObjectIdentity object, Sid owner) {
 		Long sidId = createOrRetrieveSidPrimaryKey(owner, true);
 		Long classId = createOrRetrieveClassPrimaryKey(object.getType(), true, object.getIdentifier().getClass());
-		jdbcTemplate.update(insertObjectIdentity, classId, object.getIdentifier(), sidId,
+		jdbcTemplate.update(insertObjectIdentity, classId, object.getIdentifier().toString(), sidId,
 				Boolean.TRUE);
 	}
 
@@ -340,7 +340,7 @@ public class JdbcMutableAclService extends JdbcAclService implements MutableAclS
 	protected Long retrieveObjectIdentityPrimaryKey(ObjectIdentity oid) {
 		try {
 			return jdbcTemplate.queryForObject(selectObjectIdentityPrimaryKey, Long.class,
-					oid.getType(), oid.getIdentifier());
+					oid.getType(), oid.getIdentifier().toString());
 		}
 		catch (DataAccessException notFound) {
 			return null;


### PR DESCRIPTION
…imary keys for ACL identity objects with types other than String

I´m using spring-security-acl in objects which have UUID as their primary key in a project that uses Microsoft SQL as database. I was getting the following stack trace:

```
org.springframework.dao.DataIntegrityViolationException: PreparedStatementCallback; SQL [select obj.object_id_identity as obj_id, class.class as class, class.class_id_type as class_id_type from acl_object_identity obj, acl_object_identity parent, acl_class class where obj.parent_object = parent.id and obj.object_id_class = class.id and parent.object_id_identity = ? and parent.object_id_class = (select id FROM acl_class where acl_class.class = ?)]; Unable to convert between java.util.UUID and JAVA_OBJECT.; nested exception is java.sql.SQLException: Unable to convert between java.util.UUID and JAVA_OBJECT.
	at org.springframework.jdbc.support.SQLStateSQLExceptionTranslator.doTranslate(SQLStateSQLExceptionTranslator.java:102)
	at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:73)
	at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:81)
	at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:81)
	at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:660)
	at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:695)
	at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:727)
	at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:737)
	at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:787)
	at org.springframework.security.acls.jdbc.JdbcAclService.findChildren(JdbcAclService.java:91)
	at org.springframework.security.acls.jdbc.JdbcMutableAclService.clearCacheIncludingChildren(JdbcMutableAclService.java:378)
	at org.springframework.security.acls.jdbc.JdbcMutableAclService.updateAcl(JdbcMutableAclService.java:369)
[....]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.sql.SQLException: Unable to convert between java.util.UUID and JAVA_OBJECT.
	at net.sourceforge.jtds.jdbc.Support.convert(Support.java:632)
	at net.sourceforge.jtds.jdbc.JtdsPreparedStatement.setObjectBase(JtdsPreparedStatement.java:590)
	at net.sourceforge.jtds.jdbc.JtdsPreparedStatement.setObject(JtdsPreparedStatement.java:907)
	at org.springframework.jdbc.core.StatementCreatorUtils.setValue(StatementCreatorUtils.java:427)
	at org.springframework.jdbc.core.StatementCreatorUtils.setParameterValueInternal(StatementCreatorUtils.java:235)
	at org.springframework.jdbc.core.StatementCreatorUtils.setParameterValue(StatementCreatorUtils.java:166)
	at org.springframework.jdbc.core.ArgumentPreparedStatementSetter.doSetValue(ArgumentPreparedStatementSetter.java:66)
	at org.springframework.jdbc.core.ArgumentPreparedStatementSetter.setValues(ArgumentPreparedStatementSetter.java:47)
	at org.springframework.jdbc.core.JdbcTemplate$1.doInPreparedStatement(JdbcTemplate.java:701)
	at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:644)
        ... 104 common frames omitted
```

After trying to find out the cause of the error, including being suspicious of the database driver I was using, I tracked the bug down to the fact that the identifier of the ObjectIdentity is not converted to String when such identifier gets passed to a SQL query inside the classes JdbcAclService and JdbcMutableAclService.

It´s easy to see the problem looking at the class BasicLookupStrategy, where the following code gets it right(line 394) by correctly calling toString() in the object identity identifier: 

https://github.com/spring-projects/spring-security/blob/d8f91e4261c051e21bf1705188b59c7dbbc31eb6/acl/src/main/java/org/springframework/security/acls/jdbc/BasicLookupStrategy.java#L384-L402

In order to be able to use spring-security-acl with UUIDs I also had to change the source code and add public to the class AclClassIdUtils just like in the issue #4814, what makes me believe that, as of now, not many other people are using spring-security-acl with objects with UUID as primary key elsewhere.