### PR TITLE
DefaultLoginPageGeneratingFilter should calculate ContentLength using UTF-8

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/ui/DefaultLoginPageGeneratingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/ui/DefaultLoginPageGeneratingFilter.java
@@ -31,6 +31,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
@@ -195,7 +196,7 @@ public class DefaultLoginPageGeneratingFilter extends GenericFilterBean {
 			String loginPageHtml = generateLoginPageHtml(request, loginError,
 					logoutSuccess);
 			response.setContentType("text/html;charset=UTF-8");
-			response.setContentLength(loginPageHtml.length());
+			response.setContentLength(loginPageHtml.getBytes(StandardCharsets.UTF_8).length);
 			response.getWriter().write(loginPageHtml);
 
 			return;
@@ -299,8 +300,7 @@ public class DefaultLoginPageGeneratingFilter extends GenericFilterBean {
 
 	private void renderHiddenInputs(StringBuilder sb, HttpServletRequest request) {
 		for(Map.Entry<String, String> input : this.resolveHiddenInputs.apply(request).entrySet()) {
-			sb.append("	<input name=\"" + input.getKey()
-					+ "\" type=\"hidden\" value=\"" + input.getValue() + "\" />\n");
+			sb.append("	<input name=\"").append(input.getKey()).append("\" type=\"hidden\" value=\"").append(input.getValue()).append("\" />\n");
 		}
 	}
 

--- a/web/src/test/java/org/springframework/security/web/authentication/DefaultLoginPageGeneratingFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/DefaultLoginPageGeneratingFilterTests.java
@@ -15,15 +15,6 @@
  */
 package org.springframework.security.web.authentication;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-
-import java.util.Locale;
-
-import javax.servlet.FilterChain;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.junit.Test;
 import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -35,13 +26,22 @@ import org.springframework.security.core.SpringSecurityMessageSource;
 import org.springframework.security.web.WebAttributes;
 import org.springframework.security.web.authentication.ui.DefaultLoginPageGeneratingFilter;
 
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Collections;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
 /**
  *
  * @author Luke Taylor
  * @since 3.0
  */
 public class DefaultLoginPageGeneratingFilterTests {
-	FilterChain chain = mock(FilterChain.class);
+	private FilterChain chain = mock(FilterChain.class);
 
 	@Test
 	public void generatingPageWithAuthenticationProcessingFilterOnlyIsSuccessFul()
@@ -117,6 +117,17 @@ public class DefaultLoginPageGeneratingFilterTests {
 	}
 
 	@Test
+	public void generatesForWithContentLength() throws Exception {
+		DefaultLoginPageGeneratingFilter filter = new DefaultLoginPageGeneratingFilter(new UsernamePasswordAuthenticationFilter());
+		filter.setOauth2LoginEnabled(true);
+		filter.setOauth2AuthenticationUrlToClientName(Collections.singletonMap("XYUU","\u8109\u640F\u7F51\u5E10\u6237\u767B\u5F55"));
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/login");
+		filter.doFilter(request, response, chain);
+		assertThat(response.getContentLength()==response.getContentAsString().getBytes(response.getCharacterEncoding()).length).isTrue();
+	}
+
+	@Test
 	public void generatesForWithQueryNoMatch() throws Exception {
 		DefaultLoginPageGeneratingFilter filter = new DefaultLoginPageGeneratingFilter(
 				new UsernamePasswordAuthenticationFilter());
@@ -142,7 +153,7 @@ public class DefaultLoginPageGeneratingFilterTests {
 	@SuppressWarnings("unused")
 	private static class MockProcessingFilter extends
 			AbstractAuthenticationProcessingFilter {
-		protected MockProcessingFilter() {
+		MockProcessingFilter() {
 			super("/someurl");
 		}
 

--- a/web/src/test/java/org/springframework/security/web/authentication/DefaultLoginPageGeneratingFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/DefaultLoginPageGeneratingFilterTests.java
@@ -118,13 +118,16 @@ public class DefaultLoginPageGeneratingFilterTests {
 
 	@Test
 	public void generatesForWithContentLength() throws Exception {
-		DefaultLoginPageGeneratingFilter filter = new DefaultLoginPageGeneratingFilter(new UsernamePasswordAuthenticationFilter());
+		DefaultLoginPageGeneratingFilter filter = new DefaultLoginPageGeneratingFilter(
+				new UsernamePasswordAuthenticationFilter());
 		filter.setOauth2LoginEnabled(true);
-		filter.setOauth2AuthenticationUrlToClientName(Collections.singletonMap("XYUU","\u8109\u640F\u7F51\u5E10\u6237\u767B\u5F55"));
+		filter.setOauth2AuthenticationUrlToClientName(Collections.singletonMap("XYUU",
+				"\u8109\u640F\u7F51\u5E10\u6237\u767B\u5F55"));
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/login");
 		filter.doFilter(request, response, chain);
-		assertThat(response.getContentLength()==response.getContentAsString().getBytes(response.getCharacterEncoding()).length).isTrue();
+		assertThat(response.getContentLength() == response.getContentAsString().getBytes(
+				response.getCharacterEncoding()).length).isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
Such as
![image](https://user-images.githubusercontent.com/9715021/39284063-1fe67cce-4944-11e8-8d13-886e96a1f429.png)
view source:
![image](https://user-images.githubusercontent.com/9715021/39284074-2896ed5e-4944-11e8-9b70-ba04c1e1c300.png)

Resubmit and including the content of the unit test.