### PR TITLE
Fix 'attributes' deprecation warning in spring-security-docs-guides

### DIFF
--- a/docs/guides/spring-security-docs-guides.gradle
+++ b/docs/guides/spring-security-docs-guides.gradle
@@ -2,24 +2,21 @@ apply plugin: 'org.asciidoctor.gradle.asciidoctor'
 
 asciidoctor {
 	baseDir = file('src/docs/asciidoc')
-	options = [
-	  eruby: 'erubis',
-	  attributes: [
-		  copycss : '',
-		  icons : 'font',
-		  'source-highlighter': 'prettify',
-		  sectanchors : '',
-		  toc: '',
-		  'toc-placement' : 'preamble',
-		  idprefix: '',
-		  idseparator: '-',
-		  doctype: 'book',
-		  'spring-security-version' : project.version,
-		  'download-url' : getDownloadUrl(),
-		  'include-maven-repository' : getMavenRepositoryInclude(),
-		  revnumber : project.version
-	  ]
-	]
+	options eruby: 'erubis'
+
+	attributes copycss : '',
+			icons : 'font',
+			'source-highlighter': 'prettify',
+			sectanchors : '',
+			toc: '',
+			'toc-placement' : 'preamble',
+			idprefix: '',
+			idseparator: '-',
+			doctype: 'book',
+			'spring-security-version' : project.version,
+			'download-url' : getDownloadUrl(),
+			'include-maven-repository' : getMavenRepositoryInclude(),
+			revnumber : project.version
 }
 
 ext.spec = copySpec {


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Build this project shows the following warning:

```
Configure project :spring-security-docs-guides 
Attributes found in options. Existing attributes will be replaced due to assignment. Please use 'attributes' method instead as current behaviour will be removed in future
```

This PR fixes the warning by applying the suggested way in the warning message.

See https://github.com/asciidoctor/asciidoctor-gradle-plugin#options-attributes