### PR TITLE
Use spring-projects for organization in GitHub URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ By participating, you  are expected to uphold this code. Please report unaccepta
 
 # Similar but different
 
-Each Spring module is slightly different than another in terms of team size, number of issues, etc. Therefore each project is managed slightly different. You will notice that this document is very similar to the [Spring Framework Contributor guidelines](https://github.com/SpringSource/spring-framework/wiki/Contributor-guidelines). However, there are some subtle differences between the two documents, so please be sure to read this document thoroughly.
+Each Spring module is slightly different than another in terms of team size, number of issues, etc. Therefore each project is managed slightly different. You will notice that this document is very similar to the [Spring Framework Contributor guidelines](https://github.com/spring-projects/spring-framework/wiki/Contributor-guidelines). However, there are some subtle differences between the two documents, so please be sure to read this document thoroughly.
 
 # Importing into IDE
 

--- a/config/src/test/java/org/springframework/security/config/annotation/authentication/AuthenticationManagerBuilderTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/authentication/AuthenticationManagerBuilderTests.java
@@ -78,7 +78,7 @@ public class AuthenticationManagerBuilderTests {
 		verify(opp, never()).postProcess(provider);
 	}
 
-	// https://github.com/SpringSource/spring-security-javaconfig/issues/132
+	// https://github.com/spring-projects/spring-security-javaconfig/issues/132
 	@Test
 	public void customAuthenticationEventPublisherWithWeb() throws Exception {
 		ObjectPostProcessor<Object> opp = mock(ObjectPostProcessor.class);

--- a/config/src/test/java/org/springframework/security/config/annotation/issue50/Issue50Tests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/issue50/Issue50Tests.java
@@ -62,7 +62,7 @@ public class Issue50Tests {
 	}
 
 	@Test
-	// https://github.com/SpringSource/spring-security-javaconfig/issues/50
+	// https://github.com/spring-projects/spring-security-javaconfig/issues/50
 	public void loadWhenGlobalMethodSecurityConfigurationThenAuthenticationManagerLazy() {
 		// no exception
 	}

--- a/config/src/test/java/org/springframework/security/config/annotation/web/builders/HttpConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/builders/HttpConfigurationTests.java
@@ -88,7 +88,7 @@ public class HttpConfigurationTests {
 		}
 	}
 
-	// https://github.com/SpringSource/spring-security-javaconfig/issues/104
+	// https://github.com/spring-projects/spring-security-javaconfig/issues/104
 	@Test
 	public void configureWhenAddFilterCasAuthenticationFilterThenFilterAdded() throws Exception {
 		CasAuthenticationFilterConfig.CAS_AUTHENTICATION_FILTER = spy(new CasAuthenticationFilter());

--- a/docs/guides/spring-security-docs-guides.gradle
+++ b/docs/guides/spring-security-docs-guides.gradle
@@ -27,7 +27,7 @@ ext.spec = copySpec {
 }
 
 def getDownloadUrl() {
-	snapshotBuild ? "https://github.com/SpringSource/spring-security/archive/master.zip" : "https://github.com/spring-projects/spring-security/archive/${project.version}.zip"
+	snapshotBuild ? "https://github.com/spring-projects/spring-security/archive/master.zip" : "https://github.com/spring-projects/spring-security/archive/${project.version}.zip"
 }
 
 

--- a/docs/guides/src/docs/asciidoc/Guardfile
+++ b/docs/guides/src/docs/asciidoc/Guardfile
@@ -5,7 +5,7 @@ guard 'shell' do
   watch(/^.*\.asc$/) {|m|
     Asciidoctor.render_file(m[0], :to_dir => "build/", :safe => Asciidoctor::SafeMode::UNSAFE, :attributes=> {'toc' => '', 'idprefix' => '', 'idseparator' => '-', 'copycss' => '', 'icons' => 'font', 'source-highlighter' => 'prettify', 'sectanchors' => '', 'toc-placement' => 'preamble', 'revnumber' => '3.2.0.CI-SNAPSHOT',
      'spring-security-version' => '3.2.0.CI-SNAPSHOT',
-     'download-url' => 'https://github.com/SpringSource/spring-security/archive/master.zip',
+     'download-url' => 'https://github.com/spring-projects/spring-security/archive/master.zip',
      'include-maven-repository' => '_includes/maven-repository-snapshot.asc' })
   }
 end


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR changes "SpringSource" to "spring-projects" as it looks a previous one.