### PR TITLE
Suppress deprecation warnings in spring-security-crypto

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/encrypt/BouncyCastleAesCbcBytesEncryptor.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/encrypt/BouncyCastleAesCbcBytesEncryptor.java
@@ -20,7 +20,6 @@ import static org.springframework.security.crypto.util.EncodingUtils.subArray;
 
 import org.bouncycastle.crypto.BufferedBlockCipher;
 import org.bouncycastle.crypto.InvalidCipherTextException;
-import org.bouncycastle.crypto.engines.AESFastEngine;
 import org.bouncycastle.crypto.modes.CBCBlockCipher;
 import org.bouncycastle.crypto.paddings.PKCS7Padding;
 import org.bouncycastle.crypto.paddings.PaddedBufferedBlockCipher;
@@ -51,8 +50,9 @@ public class BouncyCastleAesCbcBytesEncryptor extends BouncyCastleAesBytesEncryp
 	public byte[] encrypt(byte[] bytes) {
 		byte[] iv = this.ivGenerator.generateKey();
 
+		@SuppressWarnings("deprecation")
 		PaddedBufferedBlockCipher blockCipher = new PaddedBufferedBlockCipher(
-				new CBCBlockCipher(new AESFastEngine()), new PKCS7Padding());
+				new CBCBlockCipher(new org.bouncycastle.crypto.engines.AESFastEngine()), new PKCS7Padding());
 		blockCipher.init(true, new ParametersWithIV(secretKey, iv));
 		byte[] encrypted = process(blockCipher, bytes);
 		return iv != null ? concatenate(iv, encrypted) : encrypted;
@@ -64,8 +64,9 @@ public class BouncyCastleAesCbcBytesEncryptor extends BouncyCastleAesBytesEncryp
 		encryptedBytes = subArray(encryptedBytes, this.ivGenerator.getKeyLength(),
 				encryptedBytes.length);
 
+		@SuppressWarnings("deprecation")
 		PaddedBufferedBlockCipher blockCipher = new PaddedBufferedBlockCipher(
-				new CBCBlockCipher(new AESFastEngine()), new PKCS7Padding());
+				new CBCBlockCipher(new org.bouncycastle.crypto.engines.AESFastEngine()), new PKCS7Padding());
 		blockCipher.init(false, new ParametersWithIV(secretKey, iv));
 		return process(blockCipher, encryptedBytes);
 	}

--- a/crypto/src/main/java/org/springframework/security/crypto/encrypt/BouncyCastleAesGcmBytesEncryptor.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/encrypt/BouncyCastleAesGcmBytesEncryptor.java
@@ -19,7 +19,6 @@ import static org.springframework.security.crypto.util.EncodingUtils.concatenate
 import static org.springframework.security.crypto.util.EncodingUtils.subArray;
 
 import org.bouncycastle.crypto.InvalidCipherTextException;
-import org.bouncycastle.crypto.engines.AESFastEngine;
 import org.bouncycastle.crypto.modes.AEADBlockCipher;
 import org.bouncycastle.crypto.modes.GCMBlockCipher;
 import org.bouncycastle.crypto.params.AEADParameters;
@@ -49,7 +48,8 @@ public class BouncyCastleAesGcmBytesEncryptor extends BouncyCastleAesBytesEncryp
 	public byte[] encrypt(byte[] bytes) {
 		byte[] iv = this.ivGenerator.generateKey();
 
-		GCMBlockCipher blockCipher = new GCMBlockCipher(new AESFastEngine());
+		@SuppressWarnings("deprecation")
+		GCMBlockCipher blockCipher = new GCMBlockCipher(new org.bouncycastle.crypto.engines.AESFastEngine());
 		blockCipher.init(true, new AEADParameters(secretKey, 128, iv, null));
 
 		byte[] encrypted = process(blockCipher, bytes);
@@ -62,7 +62,8 @@ public class BouncyCastleAesGcmBytesEncryptor extends BouncyCastleAesBytesEncryp
 		encryptedBytes = subArray(encryptedBytes, this.ivGenerator.getKeyLength(),
 				encryptedBytes.length);
 
-		GCMBlockCipher blockCipher = new GCMBlockCipher(new AESFastEngine());
+		@SuppressWarnings("deprecation")
+		GCMBlockCipher blockCipher = new GCMBlockCipher(new org.bouncycastle.crypto.engines.AESFastEngine());
 		blockCipher.init(false, new AEADParameters(secretKey, 128, iv, null));
 		return process(blockCipher, encryptedBytes);
 	}

--- a/crypto/src/main/java/org/springframework/security/crypto/factory/PasswordEncoderFactories.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/factory/PasswordEncoderFactories.java
@@ -18,13 +18,8 @@ package org.springframework.security.crypto.factory;
 
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
-import org.springframework.security.crypto.password.LdapShaPasswordEncoder;
-import org.springframework.security.crypto.password.Md4PasswordEncoder;
-import org.springframework.security.crypto.password.MessageDigestPasswordEncoder;
-import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
-import org.springframework.security.crypto.password.StandardPasswordEncoder;
 import org.springframework.security.crypto.scrypt.SCryptPasswordEncoder;
 
 import java.util.HashMap;
@@ -45,32 +40,33 @@ public class PasswordEncoderFactories {
 	 *
 	 * <ul>
 	 * <li>bcrypt - {@link BCryptPasswordEncoder} (Also used for encoding)</li>
-	 * <li>ldap - {@link LdapShaPasswordEncoder}</li>
-	 * <li>MD4 - {@link Md4PasswordEncoder}</li>
+	 * <li>ldap - {@link org.springframework.security.crypto.password.LdapShaPasswordEncoder}</li>
+	 * <li>MD4 - {@link org.springframework.security.crypto.password.Md4PasswordEncoder}</li>
 	 * <li>MD5 - {@code new MessageDigestPasswordEncoder("MD5")}</li>
-	 * <li>noop - {@link NoOpPasswordEncoder}</li>
+	 * <li>noop - {@link org.springframework.security.crypto.password.NoOpPasswordEncoder}</li>
 	 * <li>pbkdf2 - {@link Pbkdf2PasswordEncoder}</li>
 	 * <li>scrypt - {@link SCryptPasswordEncoder}</li>
 	 * <li>SHA-1 - {@code new MessageDigestPasswordEncoder("SHA-1")}</li>
 	 * <li>SHA-256 - {@code new MessageDigestPasswordEncoder("SHA-256")}</li>
-	 * <li>sha256 - {@link StandardPasswordEncoder}</li>
+	 * <li>sha256 - {@link org.springframework.security.crypto.password.StandardPasswordEncoder}</li>
 	 * </ul>
 	 *
 	 * @return the {@link PasswordEncoder} to use
 	 */
+	@SuppressWarnings("deprecation")
 	public static PasswordEncoder createDelegatingPasswordEncoder() {
 		String encodingId = "bcrypt";
 		Map<String, PasswordEncoder> encoders = new HashMap<>();
 		encoders.put(encodingId, new BCryptPasswordEncoder());
-		encoders.put("ldap", new LdapShaPasswordEncoder());
-		encoders.put("MD4", new Md4PasswordEncoder());
-		encoders.put("MD5", new MessageDigestPasswordEncoder("MD5"));
-		encoders.put("noop", NoOpPasswordEncoder.getInstance());
+		encoders.put("ldap", new org.springframework.security.crypto.password.LdapShaPasswordEncoder());
+		encoders.put("MD4", new org.springframework.security.crypto.password.Md4PasswordEncoder());
+		encoders.put("MD5", new org.springframework.security.crypto.password.MessageDigestPasswordEncoder("MD5"));
+		encoders.put("noop", org.springframework.security.crypto.password.NoOpPasswordEncoder.getInstance());
 		encoders.put("pbkdf2", new Pbkdf2PasswordEncoder());
 		encoders.put("scrypt", new SCryptPasswordEncoder());
-		encoders.put("SHA-1", new MessageDigestPasswordEncoder("SHA-1"));
-		encoders.put("SHA-256", new MessageDigestPasswordEncoder("SHA-256"));
-		encoders.put("sha256", new StandardPasswordEncoder());
+		encoders.put("SHA-1", new org.springframework.security.crypto.password.MessageDigestPasswordEncoder("SHA-1"));
+		encoders.put("SHA-256", new org.springframework.security.crypto.password.MessageDigestPasswordEncoder("SHA-256"));
+		encoders.put("sha256", new org.springframework.security.crypto.password.StandardPasswordEncoder());
 
 		return new DelegatingPasswordEncoder(encodingId, encoders);
 	}

--- a/crypto/src/test/java/org/springframework/security/crypto/codec/Base64Tests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/codec/Base64Tests.java
@@ -22,6 +22,7 @@ import org.junit.*;
 /**
  * @author Luke Taylor
  */
+@SuppressWarnings("deprecation")
 public class Base64Tests {
 
 	@Test
@@ -33,7 +34,7 @@ public class Base64Tests {
 	}
 
 	@Test
-	public void isBase64ReturnsFalseForInvalidBase64() throws Exception {
+	public void isBase64ReturnsFalseForInvalidBase64() {
 		// Include invalid '`' character
 		assertThat(Base64.isBase64(new byte[] { (byte) 'A', (byte) 'B', (byte) 'C',
 				(byte) '`' })).isFalse();

--- a/crypto/src/test/java/org/springframework/security/crypto/password/LdapShaPasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/password/LdapShaPasswordEncoderTests.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Luke Taylor
  */
+@SuppressWarnings("deprecation")
 public class LdapShaPasswordEncoderTests {
 	// ~ Instance fields
 	// ================================================================================================

--- a/crypto/src/test/java/org/springframework/security/crypto/password/Md4PasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/password/Md4PasswordEncoderTests.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
-
+@SuppressWarnings("deprecation")
 public class Md4PasswordEncoderTests {
 
 	@Test

--- a/crypto/src/test/java/org/springframework/security/crypto/password/MessageDigestPasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/password/MessageDigestPasswordEncoderTests.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Ray Krueger
  * @author Luke Taylor
  */
+@SuppressWarnings("deprecation")
 public class MessageDigestPasswordEncoderTests {
 	// ~ Methods
 	// ========================================================================================================

--- a/crypto/src/test/java/org/springframework/security/crypto/password/StandardPasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/password/StandardPasswordEncoderTests.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
+@SuppressWarnings("deprecation")
 public class StandardPasswordEncoderTests {
 
 	private StandardPasswordEncoder encoder = new StandardPasswordEncoder("secret");


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR suppresses deprecation warnings in `spring-security-crypto`.