### PR TITLE
SEC-5343: Add configuration property to allow consecutive slashes.

### DIFF
--- a/web/src/main/java/org/springframework/security/web/firewall/StrictHttpFirewall.java
+++ b/web/src/main/java/org/springframework/security/web/firewall/StrictHttpFirewall.java
@@ -166,11 +166,11 @@ public class StrictHttpFirewall implements HttpFirewall {
 	 * </p>
 	 * <p>
 	 * For example, some matchers may treat consecutive slashes differently. That could lead to
-	 * mismatch between security controls and application logic. This in turn could lead to 
+	 * mismatch between security controls and application logic. This in turn could lead to
 	 * authorization bypass.
 	 * </p>
 	 *
-	 * @param allowConsecutiveSlashes two or more slashes "/" should be allowed next to each 
+	 * @param allowConsecutiveSlashes two or more slashes "/" should be allowed next to each
 	 * other in the path or not. Default is false.
 	 */
 	public void setAllowConsecutiveSlashes(boolean allowConsecutiveSlashes) {
@@ -349,10 +349,9 @@ public class StrictHttpFirewall implements HttpFirewall {
 
 	/**
 	 * Checks whether a path is normalized (doesn't contain path traversal
-	 * sequences like "./", "/../" or "/.").
-	 * If {@link #allowConsecutiveSlashes} is false (the default) consecutive
-	 * slashes ("//", "///", ...) are also considered as path traversal 
-	 * sequences.
+	 * sequences like "./", "/../" or "/."). If {@link #allowConsecutiveSlashes}
+	 * is false (the default) consecutive slashes ("//", "///", ...) are also
+	 * considered as path traversal sequences.
 	 *
 	 * @param path
 	 *            the path to test

--- a/web/src/test/java/org/springframework/security/web/firewall/StrictHttpFirewallTests.java
+++ b/web/src/test/java/org/springframework/security/web/firewall/StrictHttpFirewallTests.java
@@ -35,10 +35,12 @@ public class StrictHttpFirewallTests {
 
 	public String[] doubleSlashPaths = { "//path", "//path/path", "//path//path", "/path//path" };
 
-	public String[] unnormalizedPaths = Stream.concat(
-			Arrays.stream(dotPaths), 
-			Arrays.stream(doubleSlashPaths)
-			).collect(Collectors.toList()).toArray(new String[0]);
+	public String[] unnormalizedPaths =
+			Stream.concat(
+					Arrays.stream(dotPaths),
+					Arrays.stream(doubleSlashPaths)
+			)
+			.collect(Collectors.toList()).toArray(new String[0]);
 
 
 	private StrictHttpFirewall firewall = new StrictHttpFirewall();


### PR DESCRIPTION
See #5343. I tried to:
* add configuration property `allowConsecutiveSlashes`
* add java docs
* adjust corresponding behavior in `isNormalized(String)`
* make the `isNormalized` methods non-static
* add corresponding unit tests
* slightly refactored test data (`unnormalizedPaths`) for that purpose
It's my first time. Your mileage may vary.