### PR TITLE
SEC-5343: Add configuration property to allow consecutive slashes

### DIFF
--- a/web/src/main/java/org/springframework/security/web/firewall/StrictHttpFirewall.java
+++ b/web/src/main/java/org/springframework/security/web/firewall/StrictHttpFirewall.java
@@ -82,6 +82,8 @@ public class StrictHttpFirewall implements HttpFirewall {
 
 	private Set<String> decodedUrlBlacklist = new HashSet<String>();
 
+	private boolean allowConsecutiveSlashes;
+
 	public StrictHttpFirewall() {
 		urlBlacklistsAddAll(FORBIDDEN_SEMICOLON);
 		urlBlacklistsAddAll(FORBIDDEN_FORWARDSLASH);
@@ -154,6 +156,25 @@ public class StrictHttpFirewall implements HttpFirewall {
 		} else {
 			urlBlacklistsAddAll(FORBIDDEN_FORWARDSLASH);
 		}
+	}
+
+	/**
+	 * <p>
+	 * Determines if two or more slashes "/" should be allowed next to each other in the path
+	 * or not. The default is to not allow this behavior because it is a common way to
+	 * bypass URL based security.
+	 * </p>
+	 * <p>
+	 * For example, some matchers may treat consecutive slashes differently. That could lead to
+	 * mismatch between security controls and application logic. This in turn could lead to
+	 * authorization bypass.
+	 * </p>
+	 *
+	 * @param allowConsecutiveSlashes two or more slashes "/" should be allowed next to each
+	 * other in the path or not. Default is false.
+	 */
+	public void setAllowConsecutiveSlashes(boolean allowConsecutiveSlashes) {
+		this.allowConsecutiveSlashes = allowConsecutiveSlashes;
 	}
 
 	/**
@@ -277,7 +298,7 @@ public class StrictHttpFirewall implements HttpFirewall {
 		return new FirewalledResponse(response);
 	}
 
-	private static boolean isNormalized(HttpServletRequest request) {
+	private boolean isNormalized(HttpServletRequest request) {
 		if (!isNormalized(request.getRequestURI())) {
 			return false;
 		}
@@ -328,19 +349,21 @@ public class StrictHttpFirewall implements HttpFirewall {
 
 	/**
 	 * Checks whether a path is normalized (doesn't contain path traversal
-	 * sequences like "./", "/../" or "/.")
+	 * sequences like "./", "/../" or "/."). If {@link #allowConsecutiveSlashes}
+	 * is false (the default) consecutive slashes ("//", "///", ...) are also
+	 * considered as path traversal sequences.
 	 *
 	 * @param path
 	 *            the path to test
 	 * @return true if the path doesn't contain any path-traversal character
 	 *         sequences.
 	 */
-	private static boolean isNormalized(String path) {
+	private boolean isNormalized(String path) {
 		if (path == null) {
 			return true;
 		}
 
-		if (path.indexOf("//") > -1) {
+		if (!allowConsecutiveSlashes && path.indexOf("//") > -1) {
 			return false;
 		}
 

--- a/web/src/test/java/org/springframework/security/web/firewall/StrictHttpFirewallTests.java
+++ b/web/src/test/java/org/springframework/security/web/firewall/StrictHttpFirewallTests.java
@@ -21,17 +21,33 @@ import org.springframework.mock.web.MockHttpServletRequest;
 
 import static org.assertj.core.api.Assertions.fail;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 /**
  * @author Rob Winch
  */
 public class StrictHttpFirewallTests {
-	public String[] unnormalizedPaths = { "/..", "/./path/", "/path/path/.", "/path/path//.", "./path/../path//.",
-		"./path", ".//path", ".", "//path", "//path/path", "//path//path", "/path//path" };
+
+	public String[] dotPaths = { "/..", "/./path/", "/path/path/.", "/path/path//.", "./path/../path//.",
+			"./path", ".//path", "." };
+
+	public String[] doubleSlashPaths = { "//path", "//path/path", "//path//path", "/path//path" };
+
+	public String[] unnormalizedPaths =
+			Stream.concat(
+					Arrays.stream(dotPaths),
+					Arrays.stream(doubleSlashPaths)
+			)
+			.collect(Collectors.toList()).toArray(new String[0]);
 
 
 	private StrictHttpFirewall firewall = new StrictHttpFirewall();
 
 	private MockHttpServletRequest request = new MockHttpServletRequest();
+
+	// --- normalized ---
 
 	@Test
 	public void getFirewalledRequestWhenRequestURINotNormalizedThenThrowsRequestRejectedException() throws Exception {
@@ -82,6 +98,34 @@ public class StrictHttpFirewallTests {
 				fail(path + " is un-normalized");
 			} catch (RequestRejectedException expected) {
 			}
+		}
+	}
+
+	// --- consecutive slashes ---
+
+	@Test
+	public void getFirewalledRequestWhenRequestURIContainsDotsAndAllowConsecutiveSlashesThenThrowsRequestRejectedException() throws Exception {
+		for (String path : this.dotPaths) {
+			this.request = new MockHttpServletRequest();
+			this.request.setRequestURI(path);
+
+			this.firewall.setAllowConsecutiveSlashes(true);
+			try {
+				this.firewall.getFirewalledRequest(this.request);
+				fail(path + " contains dots");
+			} catch (RequestRejectedException expected) {
+			}
+		}
+	}
+
+	@Test
+	public void getFirewalledRequestWhenRequestURIContainsConsecutiveSlashesAndAllowConsecutiveSlashesThenNoException() throws Exception {
+		for (String path : this.doubleSlashPaths) {
+			this.request = new MockHttpServletRequest();
+			this.request.setRequestURI(path);
+
+			this.firewall.setAllowConsecutiveSlashes(true);
+			this.firewall.getFirewalledRequest(this.request);
 		}
 	}
 


### PR DESCRIPTION
See #5343. I tried to:
* add configuration property `allowConsecutiveSlashes`
* add java docs
* adjust corresponding behavior in `isNormalized(String)`
* make the `isNormalized` methods non-static
* add corresponding unit tests
* slightly refactored test data (`unnormalizedPaths`) for that purpose
Take 2. Fixed whitespace. Your mileage may still vary.