### PR TITLE
Optimize AntPathRequestMatcher.getRequestPath()

### DIFF
--- a/web/src/main/java/org/springframework/security/web/util/matcher/AntPathRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/AntPathRequestMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -173,8 +173,9 @@ public final class AntPathRequestMatcher
 	private String getRequestPath(HttpServletRequest request) {
 		String url = request.getServletPath();
 
-		if (request.getPathInfo() != null) {
-			url += request.getPathInfo();
+		String pathInfo = request.getPathInfo();
+		if (pathInfo != null) {
+			url = url.isEmpty() ? pathInfo : url + pathInfo;
 		}
 
 		return url;

--- a/web/src/main/java/org/springframework/security/web/util/matcher/AntPathRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/AntPathRequestMatcher.java
@@ -175,7 +175,7 @@ public final class AntPathRequestMatcher
 
 		String pathInfo = request.getPathInfo();
 		if (pathInfo != null) {
-			url = url.isEmpty() ? pathInfo : url + pathInfo;
+			url = StringUtils.hasLength(url) ? pathInfo : url + pathInfo;
 		}
 
 		return url;


### PR DESCRIPTION
Hi,

this PR optimizes `AntPathRequestMatcher.getRequestPath()` in situations where the servlet path is empty (quite common in vanilla Spring-Boot apps imho) and therefore saves the allocation overhead when matching (more than 10 calls per request in my case).

As this affects 4.2.x as well I'd appreciate a backport if the PR is accepted.

Let me know what you think.
Cheers,
Christoph