### PR TITLE
HstsSpec maxAge and includeSubdomains now return HstsSpec instead of …

### DIFF
--- a/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
@@ -1439,16 +1439,18 @@ public class ServerHttpSecurity {
 			 * Configures the max age. Default is one year.
 			 * @param maxAge the max age
 			 */
-			public void maxAge(Duration maxAge) {
+			public HstsSpec maxAge(Duration maxAge) {
 				HeaderSpec.this.hsts.setMaxAge(maxAge);
+				return this;
 			}
 
 			/**
 			 * Configures if subdomains should be included. Default is true
 			 * @param includeSubDomains if subdomains should be included
 			 */
-			public void includeSubdomains(boolean includeSubDomains) {
+			public HstsSpec includeSubdomains(boolean includeSubDomains) {
 				HeaderSpec.this.hsts.setIncludeSubDomains(includeSubDomains);
+				return this;
 			}
 
 			/**

--- a/config/src/test/java/org/springframework/security/config/web/server/HeaderSpecTests.java
+++ b/config/src/test/java/org/springframework/security/config/web/server/HeaderSpecTests.java
@@ -110,8 +110,9 @@ public class HeaderSpecTests {
 	public void headersWhenHstsCustomThenCustomHstsWritten() {
 		this.expectedHeaders.remove(StrictTransportSecurityServerHttpHeadersWriter.STRICT_TRANSPORT_SECURITY);
 		this.expectedHeaders.add(StrictTransportSecurityServerHttpHeadersWriter.STRICT_TRANSPORT_SECURITY, "max-age=60");
-		this.headers.hsts().maxAge(Duration.ofSeconds(60));
-		this.headers.hsts().includeSubdomains(false);
+		this.headers.hsts()
+					.maxAge(Duration.ofSeconds(60))
+					.includeSubdomains(false);
 
 		assertHeaders();
 	}


### PR DESCRIPTION
This relates to issue **#5483**.

It's a basic change where **ServerHttpSecurity.HeaderSpec.HstsSpec** methods **maxAge** and **includeSubdomains** return **HstsSpec** instead of void.

The associated test (**HeaderSpecTests** > **headersWhenHstsCustomThenCustomHstsWritten**) has also been updated to use the fluid API.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
