### PR TITLE
Fix oauth2login loginProcessingUrl NPE for java config.

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2LoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2LoginConfigurer.java
@@ -124,6 +124,7 @@ public final class OAuth2LoginConfigurer<B extends HttpSecurityBuilder<B>> exten
 	private final RedirectionEndpointConfig redirectionEndpointConfig = new RedirectionEndpointConfig();
 	private final UserInfoEndpointConfig userInfoEndpointConfig = new UserInfoEndpointConfig();
 	private String loginPage;
+	private String loginProcessingUrl = OAuth2LoginAuthenticationFilter.DEFAULT_FILTER_PROCESSES_URI;
 
 	/**
 	 * Sets the repository of client registrations.
@@ -153,6 +154,13 @@ public final class OAuth2LoginConfigurer<B extends HttpSecurityBuilder<B>> exten
 	public OAuth2LoginConfigurer<B> loginPage(String loginPage) {
 		Assert.hasText(loginPage, "loginPage cannot be empty");
 		this.loginPage = loginPage;
+		return this;
+	}
+
+	@Override
+	public OAuth2LoginConfigurer<B> loginProcessingUrl(String loginProcessingUrl) {
+		Assert.hasText(loginProcessingUrl, "loginProcessingUrl cannot be empty");
+		this.loginProcessingUrl = loginProcessingUrl;
 		return this;
 	}
 
@@ -378,9 +386,9 @@ public final class OAuth2LoginConfigurer<B extends HttpSecurityBuilder<B>> exten
 			new OAuth2LoginAuthenticationFilter(
 				OAuth2ClientConfigurerUtils.getClientRegistrationRepository(this.getBuilder()),
 				OAuth2ClientConfigurerUtils.getAuthorizedClientService(this.getBuilder()),
-				OAuth2LoginAuthenticationFilter.DEFAULT_FILTER_PROCESSES_URI);
+				this.loginProcessingUrl);
 		this.setAuthenticationFilter(authenticationFilter);
-		this.loginProcessingUrl(OAuth2LoginAuthenticationFilter.DEFAULT_FILTER_PROCESSES_URI);
+		super.loginProcessingUrl(this.loginProcessingUrl);
 		if (this.loginPage != null) {
 			super.loginPage(this.loginPage);
 		}


### PR DESCRIPTION
Java Config http.oauth2Login().loginProcessingUrl("url"); throws NPE.
Override loginProcessingUrl method and cached config url.
Then when the config is initialized,
it calls the super method to complete the configuration.

Fixes #5488 

Similar Issue/PR for loginPage config : #4752 2650cad87ee883d37eccfe8e8c252734944476ab