### PR TITLE
Enhance OAuth2AccessToken to be serializable.

### DIFF
--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/OAuth2AccessToken.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/OAuth2AccessToken.java
@@ -15,8 +15,10 @@
  */
 package org.springframework.security.oauth2.core;
 
+import org.springframework.security.core.SpringSecurityCoreVersion;
 import org.springframework.util.Assert;
 
+import java.io.Serializable;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Set;
@@ -90,7 +92,8 @@ public class OAuth2AccessToken extends AbstractOAuth2Token {
 	 *
 	 * @see <a target="_blank" href="https://tools.ietf.org/html/rfc6749#section-7.1">Section 7.1 Access Token Types</a>
 	 */
-	public static final class TokenType {
+	public static final class TokenType implements Serializable {
+		private static final long serialVersionUID = SpringSecurityCoreVersion.SERIAL_VERSION_UID;
 		public static final TokenType BEARER = new TokenType("Bearer");
 		private final String value;
 

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/OAuth2AccessTokenTests.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/OAuth2AccessTokenTests.java
@@ -16,6 +16,7 @@
 package org.springframework.security.oauth2.core;
 
 import org.junit.Test;
+import org.springframework.util.SerializationUtils;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -66,6 +67,22 @@ public class OAuth2AccessTokenTests {
 		OAuth2AccessToken accessToken = new OAuth2AccessToken(
 			TOKEN_TYPE, TOKEN_VALUE, ISSUED_AT, EXPIRES_AT, SCOPES);
 
+		assertThat(accessToken.getTokenType()).isEqualTo(TOKEN_TYPE);
+		assertThat(accessToken.getTokenValue()).isEqualTo(TOKEN_VALUE);
+		assertThat(accessToken.getIssuedAt()).isEqualTo(ISSUED_AT);
+		assertThat(accessToken.getExpiresAt()).isEqualTo(EXPIRES_AT);
+		assertThat(accessToken.getScopes()).isEqualTo(SCOPES);
+	}
+
+	// gh-5492
+	@Test
+	public void constructorWhenCreatedThenIsSerializableAndDeserializable() {
+		OAuth2AccessToken accessToken = new OAuth2AccessToken(
+				TOKEN_TYPE, TOKEN_VALUE, ISSUED_AT, EXPIRES_AT, SCOPES);
+		byte[] serialized = SerializationUtils.serialize(accessToken);
+		accessToken = (OAuth2AccessToken) SerializationUtils.deserialize(serialized);
+
+		assertThat(serialized).isNotNull();
 		assertThat(accessToken.getTokenType()).isEqualTo(TOKEN_TYPE);
 		assertThat(accessToken.getTokenValue()).isEqualTo(TOKEN_VALUE);
 		assertThat(accessToken.getIssuedAt()).isEqualTo(ISSUED_AT);


### PR DESCRIPTION
Change the TokenType to Serializable
so that the OAuth2AccessToken can be serialized.
(org.springframework.security.oauth2.core.OAuth2AccessToken.TokenType)

Fixes gh-5492
