### PR TITLE
Fix DefaultOAuth2AuthorizationRequestResolver baseUrl to exclude queryString

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/DefaultOAuth2AuthorizationRequestResolver.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/DefaultOAuth2AuthorizationRequestResolver.java
@@ -155,6 +155,7 @@ public final class DefaultOAuth2AuthorizationRequestResolver implements OAuth2Au
 		Map<String, String> uriVariables = new HashMap<>();
 		uriVariables.put("registrationId", clientRegistration.getRegistrationId());
 		String baseUrl = UriComponentsBuilder.fromHttpUrl(UrlUtils.buildFullRequestUrl(request))
+				.replaceQuery(null)
 				.replacePath(request.getContextPath())
 				.build()
 				.toUriString();

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/DefaultOAuth2AuthorizationRequestResolverTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/DefaultOAuth2AuthorizationRequestResolverTests.java
@@ -163,6 +163,22 @@ public class DefaultOAuth2AuthorizationRequestResolverTests {
 				"http://localhost/login/oauth2/code/" + clientRegistration.getRegistrationId());
 	}
 
+	// gh-5520
+	@Test
+	public void resolveWhenAuthorizationRequestRedirectUriTemplatedThenRedirectUriExpandedExcludesQueryString() {
+		ClientRegistration clientRegistration = this.registration2;
+		String requestUri = this.authorizationRequestBaseUri + "/" + clientRegistration.getRegistrationId();
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", requestUri);
+		request.setServletPath(requestUri);
+		request.setQueryString("foo=bar");
+
+		OAuth2AuthorizationRequest authorizationRequest = this.resolver.resolve(request);
+		assertThat(authorizationRequest.getRedirectUri()).isNotEqualTo(
+				clientRegistration.getRedirectUriTemplate());
+		assertThat(authorizationRequest.getRedirectUri()).isEqualTo(
+				"http://localhost/login/oauth2/code/" + clientRegistration.getRegistrationId());
+	}
+
 	@Test
 	public void resolveWhenAuthorizationRequestIncludesPort80ThenExpandedRedirectUriExcludesPort() {
 		ClientRegistration clientRegistration = this.registration1;


### PR DESCRIPTION
To create redirect_uri in DefaultOAuth2AuthorizationRequestResolver,
queryParam is included in the current request-based baseUrl.
So when binding to the redirectUriTemplate,
the wrong type of redirect_uri may be created.

redirectUriTempate: "{baseUrl}/{action}/oauth2/code/{registrationId}"
request: http://localhost/oauth2/authorization/registration-1?foo=bar

redirect_uri: http://localhost?foo=bar/login/oauth2/code/registration-1
-> http://localhost/login/oauth2/code/registration-1

Fixed: gh-5520
