### PR TITLE
Support oauth2 redirecturi apply forwarded header

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/DefaultOAuth2AuthorizationRequestResolver.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/DefaultOAuth2AuthorizationRequestResolver.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.security.oauth2.client.web;
 
+import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.security.crypto.keygen.Base64StringKeyGenerator;
 import org.springframework.security.crypto.keygen.StringKeyGenerator;
 import org.springframework.security.oauth2.client.ClientAuthorizationRequiredException;
@@ -23,7 +24,6 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
-import org.springframework.security.web.util.UrlUtils;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.util.Assert;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -154,7 +154,7 @@ public final class DefaultOAuth2AuthorizationRequestResolver implements OAuth2Au
 		// Used in -> CommonOAuth2Provider.DEFAULT_REDIRECT_URL = "{baseUrl}/{action}/oauth2/code/{registrationId}"
 		Map<String, String> uriVariables = new HashMap<>();
 		uriVariables.put("registrationId", clientRegistration.getRegistrationId());
-		String baseUrl = UriComponentsBuilder.fromHttpUrl(UrlUtils.buildFullRequestUrl(request))
+		String baseUrl = UriComponentsBuilder.fromHttpRequest(new ServletServerHttpRequest(request))
 				.replaceQuery(null)
 				.replacePath(request.getContextPath())
 				.build()

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/OAuth2AuthorizationCodeGrantFilter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/OAuth2AuthorizationCodeGrantFilter.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.security.oauth2.client.web;
 
+import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
@@ -36,7 +37,6 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
 import org.springframework.security.web.savedrequest.RequestCache;
 import org.springframework.security.web.savedrequest.SavedRequest;
-import org.springframework.security.web.util.UrlUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
@@ -145,8 +145,10 @@ public class OAuth2AuthorizationCodeGrantFilter extends OncePerRequestFilter {
 		if (authorizationRequest == null) {
 			return false;
 		}
-		String requestUrl = UrlUtils.buildFullRequestUrl(request.getScheme(), request.getServerName(),
-				request.getServerPort(), request.getRequestURI(), null);
+		String requestUrl = UriComponentsBuilder.fromHttpRequest(new ServletServerHttpRequest(request))
+				.replaceQuery(null)
+				.build()
+				.toUriString();
 		MultiValueMap<String, String> params = OAuth2AuthorizationResponseUtils.toMultiMap(request.getParameterMap());
 		if (requestUrl.equals(authorizationRequest.getRedirectUri()) &&
 				OAuth2AuthorizationResponseUtils.isAuthorizationResponse(params)) {


### PR DESCRIPTION
When generating the redirect_uri from the DefaultOAuth2AuthorizationRequestResolver, apply the Forwarded Header to {baseUrl}.

Also, shouldProcessAuthorizationResponse of OAuth2AuthorizationCodeGrantFilter should be compared to redirect_uri based on Forwarded Header application.

#5535 