### PR TITLE
Fix a missing "throws Exception" for @EnableWebSecurity

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configuration/EnableWebSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configuration/EnableWebSecurity.java
@@ -52,7 +52,7 @@ import org.springframework.security.config.annotation.web.WebSecurityConfigurer;
  * 	}
  *
  * 	&#064;Override
- * 	protected void configure(AuthenticationManagerBuilder auth) {
+ * 	protected void configure(AuthenticationManagerBuilder auth) throws Exception {
  * 		auth
  * 		// enable in memory based authentication with a user named &quot;user&quot; and &quot;admin&quot;
  * 		.inMemoryAuthentication().withUser(&quot;user&quot;).password(&quot;password&quot;).roles(&quot;USER&quot;)


### PR DESCRIPTION
The actual method signature look this this:
```java
protected void configure(AuthenticationManagerBuilder auth) throws Exception
```
 This PR aims at aligning the javadoc for this annotation with the actual method signature.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
