### PR TITLE
Validate @EnableGlobalMethodSecurity usage

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfiguration.java
@@ -357,13 +357,23 @@ public class GlobalMethodSecurityConfiguration
 		if (customMethodSecurityMetadataSource != null) {
 			sources.add(customMethodSecurityMetadataSource);
 		}
-		if (prePostEnabled()) {
+
+		boolean isPrePostEnabled = prePostEnabled();
+		boolean isSecureEnabled = securedEnabled();
+		boolean isJsr250Enabled = jsr250Enabled();
+
+		if (!isPrePostEnabled && !isSecureEnabled && !isJsr250Enabled) {
+			logger.warn("In the composition of all global method configuration, " +
+					"no annotation support was actually activated");
+		}
+
+		if (isPrePostEnabled) {
 			sources.add(new PrePostAnnotationSecurityMetadataSource(attributeFactory));
 		}
-		if (securedEnabled()) {
+		if (isSecureEnabled) {
 			sources.add(new SecuredAnnotationSecurityMetadataSource());
 		}
-		if (jsr250Enabled()) {
+		if (isJsr250Enabled) {
 			GrantedAuthorityDefaults grantedAuthorityDefaults =
 					getSingleBeanOrNull(GrantedAuthorityDefaults.class);
 			if (grantedAuthorityDefaults != null) {

--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfiguration.java
@@ -363,7 +363,7 @@ public class GlobalMethodSecurityConfiguration
 		boolean isJsr250Enabled = jsr250Enabled();
 
 		if (!isPrePostEnabled && !isSecureEnabled && !isJsr250Enabled) {
-			logger.warn("In the composition of all global method configuration, " +
+			throw new IllegalStateException("In the composition of all global method configuration, " +
 					"no annotation support was actually activated");
 		}
 

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfigurationTests.java
@@ -17,8 +17,10 @@ package org.springframework.security.config.annotation.method.configuration;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.UnsatisfiedDependencyException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.annotation.AdviceMode;
@@ -64,12 +66,16 @@ import static org.mockito.Mockito.when;
 /**
  *
  * @author Rob Winch
+ * @author Artsiom Yudovin
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SecurityTestExecutionListeners
 public class GlobalMethodSecurityConfigurationTests {
 	@Rule
 	public final SpringTestRule spring = new SpringTestRule();
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
 
 	@Autowired(required = false)
 	private MethodSecurityService service;
@@ -83,6 +89,17 @@ public class GlobalMethodSecurityConfigurationTests {
 
 	@Autowired(required = false)
 	MockEventListener<AbstractAuthenticationEvent> events;
+
+	@Test
+	public void illegalStateGlobalMethodSecurity() {
+		this.thrown.expect(UnsatisfiedDependencyException.class);
+		this.spring.register(IllegalStateGlobalMethodSecurityConfig.class).autowire();
+	}
+
+	@EnableGlobalMethodSecurity
+	public static class IllegalStateGlobalMethodSecurityConfig extends GlobalMethodSecurityConfiguration {
+
+	}
 
 	@Test
 	public void methodSecurityAuthenticationManagerPublishesEvent() {


### PR DESCRIPTION
adding warn that in the composition of all global method configuration, no annotation support was actually activated.
this [improvement](https://github.com/spring-projects/spring-security/issues/5341) 