### PR TITLE
Fix typo

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
@@ -269,7 +269,7 @@ public final class ClientRegistration {
 		}
 
 		/**
-		 * Sets the client identifier.
+		 * Sets the registration id.
 		 *
 		 * @param registrationId the registration id
 		 * @return the {@link Builder}


### PR DESCRIPTION
This PR fixes typos in Javadoc as it looks a copy and paste error from the below.