### PR TITLE
Mention spring-security-data dependency for Spring Data in doc

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/data/index.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/data/index.adoc
@@ -8,7 +8,7 @@ It is not only useful but necessary to include the user in the queries to suppor
 [[data-configuration]]
 == Spring Data & Spring Security Configuration
 
-To use this support, provide a bean of type `SecurityEvaluationContextExtension`.
+To use this support, add `org.springframework.security:spring-security-data` dependency and provide a bean of type `SecurityEvaluationContextExtension`.
 In Java Configuration, this would look like:
 
 [source,java]


### PR DESCRIPTION
This PR adds a mention on `org.springframework.security:spring-security-data` dependency for Spring Data in the reference doc.

Closes #5556 