### PR TITLE
Add @Deprecation on removeAuthorizationRequest()

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/AuthorizationRequestRepository.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/AuthorizationRequestRepository.java
@@ -67,11 +67,12 @@ public interface AuthorizationRequestRepository<T extends OAuth2AuthorizationReq
 	 * @param request the {@code HttpServletRequest}
 	 * @return the removed {@link OAuth2AuthorizationRequest} or {@code null} if not available
 	 */
+	@Deprecated
 	T removeAuthorizationRequest(HttpServletRequest request);
 
 	/**
 	 * Removes and returns the {@link OAuth2AuthorizationRequest} associated to the
-	 * provided {@code HttpServletRequest} or if not available returns {@code null}.
+	 * provided {@code HttpServletRequest} and {@code HttpServletResponse} or if not available returns {@code null}.
 	 *
 	 * @since 5.1
 	 * @param request the {@code HttpServletRequest}


### PR DESCRIPTION
This PR adds `@Deprecation` on `AuthorizationRequestRepository.removeAuthorizationRequest() ` as `@deprecated` tag was added in its Javadoc but `@Deprecation` annotation looks missed in 2c1c2c78c363978fce4297b5de8e929bb8344e52.