### PR TITLE
Made JwtConfigurer fluent

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
@@ -199,13 +199,17 @@ public final class OAuth2ResourceServerConfigurer<H extends HttpSecurityBuilder<
 			this.context = context;
 		}
 
-		public OAuth2ResourceServerConfigurer<H> decoder(JwtDecoder decoder) {
+		public JwtConfigurer decoder(JwtDecoder decoder) {
 			this.decoder = decoder;
-			return OAuth2ResourceServerConfigurer.this;
+			return this;
 		}
 
-		public OAuth2ResourceServerConfigurer<H> jwkSetUri(String uri) {
+		public JwtConfigurer jwkSetUri(String uri) {
 			this.decoder = new NimbusJwtDecoderJwkSupport(uri);
+			return this;
+		}
+
+		public OAuth2ResourceServerConfigurer<H> and() {
 			return OAuth2ResourceServerConfigurer.this;
 		}
 


### PR DESCRIPTION
Adjusted return type of #decoder(JwtDecoder) and #jwkSetUri(String) to return the JwtDecoder itself. Added new method #and() that returns the enclosing OAuth2ResourceServerConfigurer.

Implements the improvements suggested in gh-5595.