### PR TITLE
ScopeClaimAccessor

### DIFF
--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClaimAccessor.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClaimAccessor.java
@@ -15,16 +15,21 @@
  */
 package org.springframework.security.oauth2.core;
 
-import org.springframework.util.Assert;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * An &quot;accessor&quot; for a set of claims that may be used for assertions.
@@ -149,5 +154,36 @@ public interface ClaimAccessor {
 		List<String> claimValues = new ArrayList<>();
 		((List<?>) this.getClaims().get(claim)).forEach(e -> claimValues.add(e.toString()));
 		return claimValues;
+	}
+
+
+	/**
+	 * Coerce a claim into a collection of strings, splitting the string claim by a
+	 * {@code delimiter}, if the claim is not already a {@link Collection}.
+	 *
+	 * @param claim
+	 * @param delimiter
+	 * @return the claim in the form of a collection
+	 *
+	 * @since 5.1
+	 */
+	default Collection<String> getClaimAsStringCollection(String claim, String delimiter) {
+		Assert.notNull(delimiter, "delimiter cannot be null");
+
+		Collection<String> asList = this.getClaimAsStringList(claim);
+		if (asList != null) {
+			return asList;
+		}
+
+		String asString = this.getClaimAsString(claim);
+		if (asString == null) {
+			return null;
+		}
+
+		if (StringUtils.hasText(asString)) {
+			return Stream.of(asString.split(delimiter)).collect(Collectors.toList());
+		} else {
+			return Collections.emptyList();
+		}
 	}
 }

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ScopeClaimAccessor.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ScopeClaimAccessor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.core;
+
+import java.util.Collection;
+
+/**
+ * @author Josh Cummings
+ * @since 5.1
+ */
+public interface ScopeClaimAccessor extends ClaimAccessor {
+	/**
+	 * Retrieve the scope attribute by {@code scopeClaimName} as a collection of individual scopes
+	 *
+	 * @param scopeClaimName
+	 * @return the scope attribute as a collection of individual scopes
+	 */
+	default Collection<String> getScope(String scopeClaimName) {
+		return this.getClaimAsStringCollection(scopeClaimName, " ");
+	}
+}

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/ClaimAccessorTests.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/ClaimAccessorTests.java
@@ -15,15 +15,17 @@
  */
 package org.springframework.security.oauth2.core;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Before;
+import org.junit.Test;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * Tests for {@link ClaimAccessor}.
@@ -100,5 +102,23 @@ public class ClaimAccessorTests {
 		this.claims.put(claimName, null);
 
 		assertThat(this.claimAccessor.getClaimAsString(claimName)).isEqualTo(null);
+	}
+
+	@Test
+	public void getClaimAsStringCollectionWhenNullDelimiterPassedThenThrowsIllegalArgumentException() {
+		String claimName = "list-claim";
+		this.claims.put(claimName, Arrays.asList("some", "values"));
+
+		assertThatCode(() -> this.claimAccessor.getClaimAsStringCollection(claimName, null))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void getClaimAsStringCollectionWhenCustomDelimiterPassedThenIsUsedToGenerateCollection() {
+		String claimName = "delimited-string";
+		this.claims.put(claimName, "a,string,delimited,by,commas");
+
+		assertThat(this.claimAccessor.getClaimAsStringCollection(claimName, ","))
+				.containsExactly("a", "string", "delimited", "by", "commas");
 	}
 }

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/ScopeClaimAccessorTests.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/ScopeClaimAccessorTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.core;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link ScopeClaimAccessor}
+ *
+ * @author Josh Cummings
+ */
+public class ScopeClaimAccessorTests {
+	private static final String MESSAGE_READ = "message:read";
+	private static final String MESSAGE_WRITE = "message:write";
+
+	private static final Map<String, Object> SCOPE =
+			Collections.singletonMap("scope", MESSAGE_READ + " " + MESSAGE_WRITE);
+
+	private static final Map<String, Object> SCP =
+			Collections.singletonMap("scp", Arrays.asList(MESSAGE_READ, MESSAGE_WRITE));
+
+	@Test
+	public void getScopeWhenClaimIsMissingThenReturnsNull() {
+		ScopeClaimAccessor claimAccessor = () -> Collections.emptyMap();
+		assertThat(claimAccessor.getScope("scope")).isNull();
+	}
+
+	@Test
+	public void getScopeWhenClaimIsSpaceDelimitedStringThenReturnsCollection() {
+		ScopeClaimAccessor claimAccessor = () -> SCOPE;
+		assertThat(claimAccessor.getScope("scope"))
+				.containsExactly(MESSAGE_READ, MESSAGE_WRITE);
+	}
+
+	@Test
+	public void getScopeWhenClaimIsCollectionThenReturnsCollection() {
+		ScopeClaimAccessor claimAccessor = () -> SCP;
+		assertThat(claimAccessor.getScope("scp"))
+				.containsExactly(MESSAGE_READ, MESSAGE_WRITE);
+	}
+
+	@Test
+	public void getScopeWhenClaimIsCustomObjectThenRespectsToString() {
+		Object scope = mock(Object.class);
+		when(scope.toString()).thenReturn(MESSAGE_READ + " " + MESSAGE_WRITE);
+
+		ScopeClaimAccessor claimAccessor = () -> Collections.singletonMap("scp", scope);
+		assertThat(claimAccessor.getScope("scp"))
+				.containsExactly(MESSAGE_READ, MESSAGE_WRITE);
+	}
+
+	@Test
+	public void getScopeWhenClaimIsEmptyScopeAttributeThenReturnsEmptyCollection() {
+		ScopeClaimAccessor claimAccessor = () -> Collections.singletonMap("scope", "");
+		assertThat(claimAccessor.getScope("scope")).containsExactly();
+	}
+}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtConverter.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtConverter.java
@@ -16,15 +16,15 @@
 
 package org.springframework.security.oauth2.server.resource.authentication;
 
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.util.StringUtils;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Collectors;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.ScopeClaimAccessor;
+import org.springframework.security.oauth2.jwt.Jwt;
 
 /**
  * @author Rob Winch
@@ -49,16 +49,11 @@ class JwtConverter {
 	}
 
 	private Collection<String> getScopes(Jwt jwt) {
+		ScopeClaimAccessor claimAccessor = () -> jwt.getClaims();
 		for ( String attributeName : WELL_KNOWN_SCOPE_ATTRIBUTE_NAMES ) {
-			Object scopes = jwt.getClaims().get(attributeName);
-			if (scopes instanceof String) {
-				if (StringUtils.hasText((String) scopes)) {
-					return Arrays.asList(((String) scopes).split(" "));
-				} else {
-					return Collections.emptyList();
-				}
-			} else if (scopes instanceof Collection) {
-				return (Collection<String>) scopes;
+			Collection<String> scopes = claimAccessor.getScope(attributeName);
+			if (scopes != null) {
+				return scopes;
 			}
 		}
 


### PR DESCRIPTION
Adds a mechanism for retrieving the scope attribute as a collection of
individual strings.

Fixes: gh-5241
