### PR TITLE
Fix the broken link in the WebSocket documentation

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/web/websocket.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/web/websocket.adoc
@@ -4,7 +4,7 @@
 Spring Security 4 added support for securing http://docs.spring.io/spring/docs/current/spring-framework-reference/html/websocket.html[Spring's WebSocket support].
 This section describes how to use Spring Security's WebSocket support.
 
-NOTE: You can find a complete working sample of WebSocket security in samples/javaconfig/chat.
+NOTE: You can find a complete working sample of WebSocket security at https://github.com/spring-projects/spring-session/tree/master/samples/boot/websocket.
 
 .Direct JSR-356 Support
 ****


### PR DESCRIPTION
Changeset 46bb855 (#4094) removed websocket chat
sample in favor of spring-session one. This commit
updates spring-security documentation link to
point to the up-to-date sample location