### PR TITLE
Add ServerAuthenticationConverter interface

### DIFF
--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/ServerOAuth2LoginAuthenticationTokenConverterTest.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/ServerOAuth2LoginAuthenticationTokenConverterTest.java
@@ -141,6 +141,6 @@ public class ServerOAuth2LoginAuthenticationTokenConverterTest {
 
 	private OAuth2LoginAuthenticationToken applyConverter() {
 		MockServerWebExchange exchange = MockServerWebExchange.from(this.request);
-		return (OAuth2LoginAuthenticationToken) this.converter.apply(exchange).block();
+		return (OAuth2LoginAuthenticationToken) this.converter.convert(exchange).block();
 	}
 }

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/server/ServerBearerTokenAuthenticationConverter.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/server/ServerBearerTokenAuthenticationConverter.java
@@ -25,11 +25,11 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken;
 import org.springframework.security.oauth2.server.resource.BearerTokenError;
 import org.springframework.security.oauth2.server.resource.BearerTokenErrorCodes;
+import org.springframework.security.web.server.authentication.ServerAuthenticationConverter;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -41,13 +41,12 @@ import java.util.regex.Pattern;
  * @since 5.1
  * @see <a href="https://tools.ietf.org/html/rfc6750#section-2" target="_blank">RFC 6750 Section 2: Authenticated Requests</a>
  */
-public class ServerBearerTokenAuthenticationConverter implements
-		Function<ServerWebExchange, Mono<Authentication>> {
+public class ServerBearerTokenAuthenticationConverter implements ServerAuthenticationConverter {
 	private static final Pattern authorizationPattern = Pattern.compile("^Bearer (?<token>[a-zA-Z0-9-._~+/]+)=*$");
 
 	private boolean allowUriQueryParameter = false;
 
-	public Mono<Authentication> apply(ServerWebExchange exchange) {
+	public Mono<Authentication> convert(ServerWebExchange exchange) {
 		return Mono.justOrEmpty(this.token(exchange.getRequest()))
 			.map(BearerTokenAuthenticationToken::new);
 	}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/ServerBearerTokenAuthenticationConverterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/ServerBearerTokenAuthenticationConverterTests.java
@@ -129,6 +129,6 @@ public class ServerBearerTokenAuthenticationConverterTests {
 
 	private BearerTokenAuthenticationToken convertToToken(MockServerHttpRequest request) {
 		MockServerWebExchange exchange = MockServerWebExchange.from(request);
-		return this.converter.apply(exchange).cast(BearerTokenAuthenticationToken.class).block();
+		return this.converter.convert(exchange).cast(BearerTokenAuthenticationToken.class).block();
 	}
 }

--- a/web/src/main/java/org/springframework/security/web/server/ServerFormLoginAuthenticationConverter.java
+++ b/web/src/main/java/org/springframework/security/web/server/ServerFormLoginAuthenticationConverter.java
@@ -15,8 +15,7 @@
  */
 package org.springframework.security.web.server;
 
-import java.util.function.Function;
-
+import org.springframework.security.web.server.authentication.ServerAuthenticationConverter;
 import org.springframework.util.Assert;
 import reactor.core.publisher.Mono;
 
@@ -32,14 +31,14 @@ import org.springframework.web.server.ServerWebExchange;
  * @author Rob Winch
  * @since 5.0
  */
-public class ServerFormLoginAuthenticationConverter implements Function<ServerWebExchange, Mono<Authentication>> {
+public class ServerFormLoginAuthenticationConverter implements ServerAuthenticationConverter {
 
 	private String usernameParameter = "username";
 
 	private String passwordParameter = "password";
 
 	@Override
-	public Mono<Authentication> apply(ServerWebExchange exchange) {
+	public Mono<Authentication> convert(ServerWebExchange exchange) {
 		return exchange.getFormData()
 			.map( data -> createAuthentication(data));
 	}

--- a/web/src/main/java/org/springframework/security/web/server/ServerHttpBasicAuthenticationConverter.java
+++ b/web/src/main/java/org/springframework/security/web/server/ServerHttpBasicAuthenticationConverter.java
@@ -16,12 +16,12 @@
 package org.springframework.security.web.server;
 
 import java.util.Base64;
-import java.util.function.Function;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.web.server.authentication.ServerAuthenticationConverter;
 import org.springframework.web.server.ServerWebExchange;
 
 import reactor.core.publisher.Mono;
@@ -32,12 +32,12 @@ import reactor.core.publisher.Mono;
  * @author Rob Winch
  * @since 5.0
  */
-public class ServerHttpBasicAuthenticationConverter implements Function<ServerWebExchange, Mono<Authentication>> {
+public class ServerHttpBasicAuthenticationConverter implements ServerAuthenticationConverter {
 
 	public static final String BASIC = "Basic ";
 
 	@Override
-	public Mono<Authentication> apply(ServerWebExchange exchange) {
+	public Mono<Authentication> convert(ServerWebExchange exchange) {
 		ServerHttpRequest request = exchange.getRequest();
 
 		String authorization = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);

--- a/web/src/main/java/org/springframework/security/web/server/authentication/ServerAuthenticationConverter.java
+++ b/web/src/main/java/org/springframework/security/web/server/authentication/ServerAuthenticationConverter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.server.authentication;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.web.server.ServerWebExchange;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * A strategy used for converting from a {@link ServerWebExchange} to an {@link Authentication} used for
+ * authenticating with a provided {@link org.springframework.security.authentication.ReactiveAuthenticationManager}.
+ * If the result is {@link Mono#empty()}, then it signals that no authentication attempt should be made.
+ *
+ * @author Eric Deandrea
+ * @since 5.1
+ */
+@FunctionalInterface
+public interface ServerAuthenticationConverter {
+	/**
+	 * Converts a {@link ServerWebExchange} to an {@link Authentication}
+	 * @param exchange The {@link ServerWebExchange}
+	 * @return A {@link Mono} representing an {@link Authentication}
+	 */
+	Mono<Authentication> convert(ServerWebExchange exchange);
+}

--- a/web/src/test/java/org/springframework/security/web/server/ServerFormLoginAuthenticationConverterTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/ServerFormLoginAuthenticationConverterTests.java
@@ -55,7 +55,7 @@ public class ServerFormLoginAuthenticationConverterTests {
 		this.data.add("username", username);
 		this.data.add("password", password);
 
-		Authentication authentication = this.converter.apply(this.exchange).block();
+		Authentication authentication = this.converter.convert(this.exchange).block();
 
 		assertThat(authentication.getName()).isEqualTo(username);
 		assertThat(authentication.getCredentials()).isEqualTo(password);
@@ -73,7 +73,7 @@ public class ServerFormLoginAuthenticationConverterTests {
 		this.data.add(usernameParameter, username);
 		this.data.add(passwordParameter, password);
 
-		Authentication authentication = this.converter.apply(this.exchange).block();
+		Authentication authentication = this.converter.convert(this.exchange).block();
 
 		assertThat(authentication.getName()).isEqualTo(username);
 		assertThat(authentication.getCredentials()).isEqualTo(password);
@@ -82,7 +82,7 @@ public class ServerFormLoginAuthenticationConverterTests {
 
 	@Test
 	public void applyWhenNoDataThenCreatesTokenSuccess() {
-		Authentication authentication = this.converter.apply(this.exchange).block();
+		Authentication authentication = this.converter.convert(this.exchange).block();
 
 		assertThat(authentication.getName()).isNullOrEmpty();
 		assertThat(authentication.getCredentials()).isNull();

--- a/web/src/test/java/org/springframework/security/web/server/ServerHttpBasicAuthenticationConverterTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/ServerHttpBasicAuthenticationConverterTests.java
@@ -96,6 +96,6 @@ public class ServerHttpBasicAuthenticationConverterTests {
 	}
 
 	private Mono<Authentication> apply(MockServerHttpRequest.BaseBuilder<?> request) {
-		return this.converter.apply(MockServerWebExchange.from(this.request.build()));
+		return this.converter.convert(MockServerWebExchange.from(this.request.build()));
 	}
 }


### PR DESCRIPTION
Redo of gh-5340

- Adding a `ServerAuthenticationConverter` interface
- Retro-fitting `ServerOAuth2LoginAuthenticationTokenConverter`,
 `ServerBearerTokenAuthentivationConverter`, `ServerFormLoginAuthenticationConverter`,
 and `ServerHttpBasicAuthenticationConverter` to implement `ServerAuthenticationConverter`
- Deprecate existing `AuthenticationWebFilter.setAuthenticationConverter`
and add overloaded one which takes `ServerAuthenticationConverter`

Fixes gh-5338