### PR TITLE
Polish ActiveDirectoryLdapAuthenticationProviderTests

### DIFF
--- a/ldap/src/test/java/org/springframework/security/ldap/authentication/ad/ActiveDirectoryLdapAuthenticationProviderTests.java
+++ b/ldap/src/test/java/org/springframework/security/ldap/authentication/ad/ActiveDirectoryLdapAuthenticationProviderTests.java
@@ -412,9 +412,10 @@ public class ActiveDirectoryLdapAuthenticationProviderTests {
 
 		try {
 			provider.authenticate(joe);
+			fail("CommunicationException was expected with a root cause of ClassNotFoundException");
 		}
 		catch (org.springframework.ldap.CommunicationException expected) {
-			assertThat(expected.getCause()).isNotInstanceOf(ClassNotFoundException.class);
+			assertThat(expected.getRootCause()).isInstanceOf(ClassNotFoundException.class);
 		}
 	}
 


### PR DESCRIPTION
This PR polishes `ActiveDirectoryLdapAuthenticationProviderTests.contextEnvironmentPropertiesUsed()` by:

- Adding `fail()` to prevent from going through an unexpected path.
- Asserting that the root cause is an instance of `ClassNotFoundException` as the current code doesn't seem to right unless I'm missing something.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
