### PR TITLE
 Upgrade spring-build-conventions to 0.0.18.RELEASE

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ try {
 					currentBuild.result = 'FAILED: check'
 					throw e
 				} finally {
-					junit '**/build/*-results/*.xml'
+					junit '**/build/test-results/*/*.xml'
 				}
 			}
 		}

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	dependencies {
-		classpath 'io.spring.gradle:spring-build-conventions:0.0.16.RELEASE'
+		classpath 'io.spring.gradle:spring-build-conventions:0.0.18.RELEASE'
 		classpath "org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion"
 	}
 	repositories {

--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/ldap/LdapAuthenticationProviderConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/ldap/LdapAuthenticationProviderConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,7 +158,7 @@ public class LdapAuthenticationProviderConfigurer<B extends ProviderManagerBuild
 	 * @throws Exception if errors in {@link SimpleAuthorityMapper#afterPropertiesSet()}
 	 */
 	protected GrantedAuthoritiesMapper getAuthoritiesMapper() throws Exception {
-		if(authoritiesMapper != null) {
+		if (authoritiesMapper != null) {
 			return authoritiesMapper;
 		}
 

--- a/config/src/main/java/org/springframework/security/config/annotation/configuration/AutowireBeanFactoryObjectPostProcessor.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/configuration/AutowireBeanFactoryObjectPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ final class AutowireBeanFactoryObjectPostProcessor
 	 */
 	@Override
 	public void afterSingletonsInstantiated() {
-		for(SmartInitializingSingleton singleton : smartSingletons) {
+		for (SmartInitializingSingleton singleton : smartSingletons) {
 			singleton.afterSingletonsInstantiated();
 		}
 	}

--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfiguration.java
@@ -189,7 +189,7 @@ public class GlobalMethodSecurityConfiguration
 	}
 
 	private void initializeMethodSecurityInterceptor() throws Exception {
-		if(this.methodSecurityInterceptor == null) {
+		if (this.methodSecurityInterceptor == null) {
 			return;
 		}
 		this.methodSecurityInterceptor.setAuthenticationManager(authenticationManager());

--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecuritySelector.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecuritySelector.java
@@ -62,7 +62,7 @@ final class GlobalMethodSecuritySelector implements ImportSelector {
 		boolean jsr250Enabled = attributes.getBoolean("jsr250Enabled");
 
 		List<String> classNames = new ArrayList<>(4);
-		if(isProxy) {
+		if (isProxy) {
 			classNames.add(MethodSecurityMetadataSourceAdvisorRegistrar.class.getName());
 		}
 

--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/MethodSecurityMetadataSourceAdvisorRegistrar.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/MethodSecurityMetadataSourceAdvisorRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ class MethodSecurityMetadataSourceAdvisorRegistrar implements
 
 		MultiValueMap<String, Object> attributes = importingClassMetadata.getAllAnnotationAttributes(EnableGlobalMethodSecurity.class.getName());
 		Integer order = (Integer) attributes.getFirst("order");
-		if(order != null) {
+		if (order != null) {
 			advisor.addPropertyValue("order", order);
 		}
 

--- a/config/src/main/java/org/springframework/security/config/annotation/web/AbstractRequestMatcherRegistry.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/AbstractRequestMatcherRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -163,7 +163,7 @@ public abstract class AbstractRequestMatcherRegistry<C> {
 			String... mvcPatterns) {
 		boolean isServlet30 = ClassUtils.isPresent("javax.servlet.ServletRegistration", getClass().getClassLoader());
 		ObjectPostProcessor<Object> opp = this.context.getBean(ObjectPostProcessor.class);
-		if(!this.context.containsBean(HANDLER_MAPPING_INTROSPECTOR_BEAN_NAME)) {
+		if (!this.context.containsBean(HANDLER_MAPPING_INTROSPECTOR_BEAN_NAME)) {
 			throw new NoSuchBeanDefinitionException("A Bean named " + HANDLER_MAPPING_INTROSPECTOR_BEAN_NAME +" of type " + HandlerMappingIntrospector.class.getName()
 				+ " is required to use MvcRequestMatcher. Please ensure Spring Security & Spring MVC are configured in a shared ApplicationContext.");
 		}

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurerAdapter.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -223,7 +223,7 @@ public abstract class WebSecurityConfigurerAdapter implements
 			List<AbstractHttpConfigurer> defaultHttpConfigurers =
 					SpringFactoriesLoader.loadFactories(AbstractHttpConfigurer.class, classLoader);
 
-			for(AbstractHttpConfigurer configurer : defaultHttpConfigurers) {
+			for (AbstractHttpConfigurer configurer : defaultHttpConfigurers) {
 				http.apply(configurer);
 			}
 		}

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/CorsConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/CorsConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,7 +109,7 @@ public class CorsConfigurer<H extends HttpSecurityBuilder<H>>
 		 * @return
 		 */
 		private static CorsFilter getMvcCorsFilter(ApplicationContext context) {
-			if(!context.containsBean(HANDLER_MAPPING_INTROSPECTOR_BEAN_NAME)) {
+			if (!context.containsBean(HANDLER_MAPPING_INTROSPECTOR_BEAN_NAME)) {
 				throw new NoSuchBeanDefinitionException(HANDLER_MAPPING_INTROSPECTOR_BEAN_NAME, "A Bean named " + HANDLER_MAPPING_INTROSPECTOR_BEAN_NAME +" of type " + HandlerMappingIntrospector.class.getName()
 						+ " is required to use MvcRequestMatcher. Please ensure Spring Security & Spring MVC are configured in a shared ApplicationContext.");
 			}

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ExpressionUrlAuthorizationConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ExpressionUrlAuthorizationConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -213,18 +213,18 @@ public final class ExpressionUrlAuthorizationConfigurer<H extends HttpSecurityBu
 				defaultHandler.setTrustResolver(trustResolver);
 			}
 			ApplicationContext context = http.getSharedObject(ApplicationContext.class);
-			if(context != null) {
+			if (context != null) {
 				String[] roleHiearchyBeanNames = context.getBeanNamesForType(RoleHierarchy.class);
-				if(roleHiearchyBeanNames.length == 1) {
+				if (roleHiearchyBeanNames.length == 1) {
 					defaultHandler.setRoleHierarchy(context.getBean(roleHiearchyBeanNames[0], RoleHierarchy.class));
 				}
 				String[] grantedAuthorityDefaultsBeanNames = context.getBeanNamesForType(GrantedAuthorityDefaults.class);
-				if(grantedAuthorityDefaultsBeanNames.length == 1) {
+				if (grantedAuthorityDefaultsBeanNames.length == 1) {
 					GrantedAuthorityDefaults grantedAuthorityDefaults = context.getBean(grantedAuthorityDefaultsBeanNames[0], GrantedAuthorityDefaults.class);
 					defaultHandler.setDefaultRolePrefix(grantedAuthorityDefaults.getRolePrefix());
 				}
 				String[] permissionEvaluatorBeanNames = context.getBeanNamesForType(PermissionEvaluator.class);
-				if(permissionEvaluatorBeanNames.length == 1) {
+				if (permissionEvaluatorBeanNames.length == 1) {
 					PermissionEvaluator permissionEvaluator = context.getBean(permissionEvaluatorBeanNames[0], PermissionEvaluator.class);
 					defaultHandler.setPermissionEvaluator(permissionEvaluator);
 				}

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HttpBasicConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HttpBasicConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -215,7 +215,7 @@ public final class HttpBasicConfigurer<B extends HttpSecurityBuilder<B>> extends
 					.setAuthenticationDetailsSource(this.authenticationDetailsSource);
 		}
 		RememberMeServices rememberMeServices = http.getSharedObject(RememberMeServices.class);
-		if(rememberMeServices != null) {
+		if (rememberMeServices != null) {
 			basicAuthenticationFilter.setRememberMeServices(rememberMeServices);
 		}
 		basicAuthenticationFilter = postProcess(basicAuthenticationFilter);

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/LogoutConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/LogoutConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -261,7 +261,7 @@ public final class LogoutConfigurer<H extends HttpSecurityBuilder<H>> extends
 	private LogoutSuccessHandler createDefaultSuccessHandler() {
 		SimpleUrlLogoutSuccessHandler urlLogoutHandler = new SimpleUrlLogoutSuccessHandler();
 		urlLogoutHandler.setDefaultTargetUrl(logoutSuccessUrl);
-		if(defaultLogoutSuccessHandlerMappings.isEmpty()) {
+		if (defaultLogoutSuccessHandlerMappings.isEmpty()) {
 			return urlLogoutHandler;
 		}
 		DelegatingLogoutSuccessHandler successHandler = new DelegatingLogoutSuccessHandler(defaultLogoutSuccessHandlerMappings);

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SecurityContextConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SecurityContextConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@ public final class SecurityContextConfigurer<H extends HttpSecurityBuilder<H>> e
 
 		SecurityContextRepository securityContextRepository = http
 				.getSharedObject(SecurityContextRepository.class);
-		if(securityContextRepository == null) {
+		if (securityContextRepository == null) {
 			securityContextRepository = new HttpSessionSecurityContextRepository();
 		}
 		SecurityContextPersistenceFilter securityContextFilter = new SecurityContextPersistenceFilter(

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ServletApiConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ServletApiConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,9 +94,9 @@ public final class ServletApiConfigurer<H extends HttpSecurityBuilder<H>> extend
 			securityContextRequestFilter.setTrustResolver(trustResolver);
 		}
 		ApplicationContext context = http.getSharedObject(ApplicationContext.class);
-		if(context != null) {
+		if (context != null) {
 			String[] grantedAuthorityDefaultsBeanNames = context.getBeanNamesForType(GrantedAuthorityDefaults.class);
-			if(grantedAuthorityDefaultsBeanNames.length == 1) {
+			if (grantedAuthorityDefaultsBeanNames.length == 1) {
 				GrantedAuthorityDefaults grantedAuthorityDefaults = context.getBean(grantedAuthorityDefaultsBeanNames[0], GrantedAuthorityDefaults.class);
 				securityContextRequestFilter.setRolePrefix(grantedAuthorityDefaults.getRolePrefix());
 			}

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
@@ -479,7 +479,7 @@ public final class SessionManagementConfigurer<H extends HttpSecurityBuilder<H>>
 	private ConcurrentSessionFilter createConccurencyFilter(H http) {
 		SessionInformationExpiredStrategy expireStrategy = getExpiredSessionStrategy();
 		SessionRegistry sessionRegistry = getSessionRegistry(http);
-		if(expireStrategy == null) {
+		if (expireStrategy == null) {
 			return new ConcurrentSessionFilter(sessionRegistry);
 		}
 

--- a/config/src/main/java/org/springframework/security/config/annotation/web/reactive/ServerHttpSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/reactive/ServerHttpSecurityConfiguration.java
@@ -72,7 +72,7 @@ class ServerHttpSecurityConfiguration implements WebFluxConfigurer {
 	public AuthenticationPrincipalArgumentResolver authenticationPrincipalArgumentResolver() {
 		AuthenticationPrincipalArgumentResolver resolver = new AuthenticationPrincipalArgumentResolver(
 			this.adapterRegistry);
-		if(this.beanFactory != null) {
+		if (this.beanFactory != null) {
 			resolver.setBeanResolver(new BeanFactoryResolver(this.beanFactory));
 		}
 		return resolver;
@@ -89,13 +89,13 @@ class ServerHttpSecurityConfiguration implements WebFluxConfigurer {
 	}
 
 	private ReactiveAuthenticationManager authenticationManager() {
-		if(this.authenticationManager != null) {
+		if (this.authenticationManager != null) {
 			return this.authenticationManager;
 		}
-		if(this.reactiveUserDetailsService != null) {
+		if (this.reactiveUserDetailsService != null) {
 			UserDetailsRepositoryReactiveAuthenticationManager manager =
 				new UserDetailsRepositoryReactiveAuthenticationManager(this.reactiveUserDetailsService);
-			if(this.passwordEncoder != null) {
+			if (this.passwordEncoder != null) {
 				manager.setPasswordEncoder(this.passwordEncoder);
 			}
 			manager.setUserDetailsPasswordService(this.userDetailsPasswordService);

--- a/config/src/main/java/org/springframework/security/config/annotation/web/reactive/WebFluxSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/reactive/WebFluxSecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ class WebFluxSecurityConfiguration {
 
 	private List<SecurityWebFilterChain> getSecurityWebFilterChains() {
 		List<SecurityWebFilterChain> result = this.securityWebFilterChains;
-		if(ObjectUtils.isEmpty(result)) {
+		if (ObjectUtils.isEmpty(result)) {
 			return Arrays.asList(springSecurityFilterChain());
 		}
 		return result;

--- a/config/src/main/java/org/springframework/security/config/annotation/web/socket/AbstractSecurityWebSocketMessageBrokerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/socket/AbstractSecurityWebSocketMessageBrokerConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -216,7 +216,7 @@ public abstract class AbstractSecurityWebSocketMessageBrokerConfigurer extends
 
 	@Autowired(required = false)
 	public void setMessageExpressionHandler(List<SecurityExpressionHandler<Message<Object>>> expressionHandlers) {
-		if(expressionHandlers.size() == 1) {
+		if (expressionHandlers.size() == 1) {
 			this.expressionHandler = expressionHandlers.get(0);
 		}
 	}
@@ -227,7 +227,7 @@ public abstract class AbstractSecurityWebSocketMessageBrokerConfigurer extends
 	}
 
 	private  SecurityExpressionHandler<Message<Object>> getMessageExpressionHandler() {
-		if(expressionHandler == null) {
+		if (expressionHandler == null) {
 			return defaultExpressionHandler;
 		}
 		return expressionHandler;

--- a/config/src/main/java/org/springframework/security/config/authentication/AuthenticationManagerFactoryBean.java
+++ b/config/src/main/java/org/springframework/security/config/authentication/AuthenticationManagerFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ public class AuthenticationManagerFactoryBean implements
 			}
 
 			UserDetailsService uds = getBeanOrNull(UserDetailsService.class);
-			if(uds == null) {
+			if (uds == null) {
 				throw new NoSuchBeanDefinitionException(BeanIds.AUTHENTICATION_MANAGER,
 					MISSING_BEAN_ERROR_MESSAGE);
 			}

--- a/config/src/main/java/org/springframework/security/config/core/userdetails/UserDetailsResourceFactoryBean.java
+++ b/config/src/main/java/org/springframework/security/config/core/userdetails/UserDetailsResourceFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ public class UserDetailsResourceFactoryBean implements ResourceLoaderAware, Fact
 
 	private Resource getPropertiesResource() {
 		Resource result = resource;
-		if(result == null && resourceLocation != null) {
+		if (result == null && resourceLocation != null) {
 			result = resourceLoader.getResource(resourceLocation);
 		}
 		Assert.notNull(result, "resource cannot be null if resourceLocation is null");

--- a/config/src/main/java/org/springframework/security/config/http/AuthenticationConfigBuilder.java
+++ b/config/src/main/java/org/springframework/security/config/http/AuthenticationConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -849,7 +849,7 @@ final class AuthenticationConfigBuilder {
 		@Override
 		public Map<String, String> apply(HttpServletRequest request) {
 			CsrfToken token = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
-			if(token == null) {
+			if (token == null) {
 				return Collections.emptyMap();
 			}
 			return Collections.singletonMap(token.getParameterName(), token.getToken());

--- a/config/src/main/java/org/springframework/security/config/http/CorsBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/http/CorsBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,17 +39,17 @@ public class CorsBeanDefinitionParser {
 	private static final String ATT_REF = "ref";
 
 	public BeanMetadataElement parse(Element element, ParserContext parserContext) {
-		if(element == null) {
+		if (element == null) {
 			return null;
 		}
 
 		String filterRef = element.getAttribute(ATT_REF);
-		if(StringUtils.hasText(filterRef)) {
+		if (StringUtils.hasText(filterRef)) {
 			return new RuntimeBeanReference(filterRef);
 		}
 
 		BeanMetadataElement configurationSource = getSource(element, parserContext);
-		if(configurationSource == null) {
+		if (configurationSource == null) {
 			throw new BeanCreationException("Could not create CorsFilter");
 		}
 
@@ -66,7 +66,7 @@ public class CorsBeanDefinitionParser {
 
 		boolean mvcPresent = ClassUtils.isPresent(HANDLER_MAPPING_INTROSPECTOR,
 				getClass().getClassLoader());
-		if(!mvcPresent) {
+		if (!mvcPresent) {
 			return null;
 		}
 

--- a/config/src/main/java/org/springframework/security/config/http/FormLoginBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/http/FormLoginBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -183,7 +183,7 @@ public class FormLoginBeanDefinitionParser {
 		if (StringUtils.hasText(successHandlerRef)) {
 			filterBuilder.addPropertyReference("authenticationSuccessHandler",
 					successHandlerRef);
-		} else if(StringUtils.hasText(authenticationSuccessForwardUrl)) {
+		} else if (StringUtils.hasText(authenticationSuccessForwardUrl)) {
 			BeanDefinitionBuilder forwardSuccessHandler = BeanDefinitionBuilder
 					.rootBeanDefinition(ForwardAuthenticationSuccessHandler.class);
 			forwardSuccessHandler.addConstructorArgValue(authenticationSuccessForwardUrl);
@@ -216,7 +216,7 @@ public class FormLoginBeanDefinitionParser {
 		if (StringUtils.hasText(failureHandlerRef)) {
 			filterBuilder.addPropertyReference("authenticationFailureHandler",
 					failureHandlerRef);
-		} else if(StringUtils.hasText(authenticationFailureForwardUrl)) {
+		} else if (StringUtils.hasText(authenticationFailureForwardUrl)) {
 			BeanDefinitionBuilder forwardFailureHandler = BeanDefinitionBuilder
 					.rootBeanDefinition(ForwardAuthenticationFailureHandler.class);
 			forwardFailureHandler.addConstructorArgValue(authenticationFailureForwardUrl);

--- a/config/src/main/java/org/springframework/security/config/http/GrantedAuthorityDefaultsParserUtils.java
+++ b/config/src/main/java/org/springframework/security/config/http/GrantedAuthorityDefaultsParserUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ class GrantedAuthorityDefaultsParserUtils {
 		public final void setApplicationContext(ApplicationContext applicationContext)
 				throws BeansException {
 			String[] grantedAuthorityDefaultsBeanNames = applicationContext.getBeanNamesForType(GrantedAuthorityDefaults.class);
-			if(grantedAuthorityDefaultsBeanNames.length == 1) {
+			if (grantedAuthorityDefaultsBeanNames.length == 1) {
 				GrantedAuthorityDefaults grantedAuthorityDefaults = applicationContext.getBean(grantedAuthorityDefaultsBeanNames[0], GrantedAuthorityDefaults.class);
 				this.rolePrefix = grantedAuthorityDefaults.getRolePrefix();
 			}

--- a/config/src/main/java/org/springframework/security/config/http/HandlerMappingIntrospectorFactoryBean.java
+++ b/config/src/main/java/org/springframework/security/config/http/HandlerMappingIntrospectorFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ class HandlerMappingIntrospectorFactoryBean implements FactoryBean<HandlerMappin
 	private ApplicationContext context;
 
 	public HandlerMappingIntrospector getObject() {
-		if(!this.context.containsBean(HANDLER_MAPPING_INTROSPECTOR_BEAN_NAME)) {
+		if (!this.context.containsBean(HANDLER_MAPPING_INTROSPECTOR_BEAN_NAME)) {
 			throw new NoSuchBeanDefinitionException(HANDLER_MAPPING_INTROSPECTOR_BEAN_NAME, "A Bean named " + HANDLER_MAPPING_INTROSPECTOR_BEAN_NAME +" of type " + HandlerMappingIntrospector.class.getName()
 				+ " is required to use MvcRequestMatcher. Please ensure Spring Security & Spring MVC are configured in a shared ApplicationContext.");
 		}

--- a/config/src/main/java/org/springframework/security/config/http/HttpConfigurationBuilder.java
+++ b/config/src/main/java/org/springframework/security/config/http/HttpConfigurationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -252,7 +252,7 @@ class HttpConfigurationBuilder {
 
 		String repoRef = httpElt.getAttribute(ATT_SECURITY_CONTEXT_REPOSITORY);
 		String disableUrlRewriting = httpElt.getAttribute(ATT_DISABLE_URL_REWRITING);
-		if(!StringUtils.hasText(disableUrlRewriting)) {
+		if (!StringUtils.hasText(disableUrlRewriting)) {
 			disableUrlRewriting = "true";
 		}
 

--- a/config/src/main/java/org/springframework/security/config/method/GlobalMethodSecurityBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/method/GlobalMethodSecurityBeanDefinitionParser.java
@@ -561,7 +561,7 @@ public class GlobalMethodSecurityBeanDefinitionParser implements BeanDefinitionP
 		public final void setApplicationContext(ApplicationContext applicationContext)
 				throws BeansException {
 			String[] grantedAuthorityDefaultsBeanNames = applicationContext.getBeanNamesForType(GrantedAuthorityDefaults.class);
-			if(grantedAuthorityDefaultsBeanNames.length == 1) {
+			if (grantedAuthorityDefaultsBeanNames.length == 1) {
 				GrantedAuthorityDefaults grantedAuthorityDefaults = applicationContext.getBean(grantedAuthorityDefaultsBeanNames[0], GrantedAuthorityDefaults.class);
 				this.rolePrefix = grantedAuthorityDefaults.getRolePrefix();
 			}

--- a/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
@@ -316,7 +316,7 @@ public class ServerHttpSecurity {
 	 * @return the {@link CsrfSpec} to customize
 	 */
 	public CsrfSpec csrf() {
-		if(this.csrf == null) {
+		if (this.csrf == null) {
 			this.csrf = new CsrfSpec();
 		}
 		return this.csrf;
@@ -416,7 +416,7 @@ public class ServerHttpSecurity {
 	 * @return the {@link HttpBasicSpec} to customize
 	 */
 	public HttpBasicSpec httpBasic() {
-		if(this.httpBasic == null) {
+		if (this.httpBasic == null) {
 			this.httpBasic = new HttpBasicSpec();
 		}
 		return this.httpBasic;
@@ -446,7 +446,7 @@ public class ServerHttpSecurity {
 	 * @return the {@link FormLoginSpec} to customize
 	 */
 	public FormLoginSpec formLogin() {
-		if(this.formLogin == null) {
+		if (this.formLogin == null) {
 			this.formLogin = new FormLoginSpec();
 		}
 		return this.formLogin;
@@ -850,7 +850,7 @@ public class ServerHttpSecurity {
 	 * @return the {@link HeaderSpec} to customize
 	 */
 	public HeaderSpec headers() {
-		if(this.headers == null) {
+		if (this.headers == null) {
 			this.headers = new HeaderSpec();
 		}
 		return this.headers;
@@ -875,7 +875,7 @@ public class ServerHttpSecurity {
 	 * @return the {@link ExceptionHandlingSpec} to customize
 	 */
 	public ExceptionHandlingSpec exceptionHandling() {
-		if(this.exceptionHandling == null) {
+		if (this.exceptionHandling == null) {
 			this.exceptionHandling = new ExceptionHandlingSpec();
 		}
 		return this.exceptionHandling;
@@ -913,7 +913,7 @@ public class ServerHttpSecurity {
 	 * @return the {@link AuthorizeExchangeSpec} to customize
 	 */
 	public AuthorizeExchangeSpec authorizeExchange() {
-		if(this.authorizeExchange == null) {
+		if (this.authorizeExchange == null) {
 			this.authorizeExchange = new AuthorizeExchangeSpec();
 		}
 		return this.authorizeExchange;
@@ -983,30 +983,30 @@ public class ServerHttpSecurity {
 	 * @return the {@link SecurityWebFilterChain
 	 */
 	public SecurityWebFilterChain build() {
-		if(this.built != null) {
+		if (this.built != null) {
 			throw new IllegalStateException("This has already been built with the following stacktrace. " + buildToString());
 		}
 		this.built = new RuntimeException("First Build Invocation").fillInStackTrace();
-		if(this.headers != null) {
+		if (this.headers != null) {
 			this.headers.configure(this);
 		}
 		WebFilter securityContextRepositoryWebFilter = securityContextRepositoryWebFilter();
-		if(securityContextRepositoryWebFilter != null) {
+		if (securityContextRepositoryWebFilter != null) {
 			this.webFilters.add(securityContextRepositoryWebFilter);
 		}
-		if(this.csrf != null) {
+		if (this.csrf != null) {
 			this.csrf.configure(this);
 		}
 		if (this.cors != null) {
 			this.cors.configure(this);
 		}
-		if(this.httpBasic != null) {
+		if (this.httpBasic != null) {
 			this.httpBasic.authenticationManager(this.authenticationManager);
 			this.httpBasic.configure(this);
 		}
-		if(this.formLogin != null) {
+		if (this.formLogin != null) {
 			this.formLogin.authenticationManager(this.authenticationManager);
-			if(this.securityContextRepository != null) {
+			if (this.securityContextRepository != null) {
 				this.formLogin.securityContextRepository(this.securityContextRepository);
 			}
 			this.formLogin.configure(this);
@@ -1021,19 +1021,19 @@ public class ServerHttpSecurity {
 			this.client.configure(this);
 		}
 		this.loginPage.configure(this);
-		if(this.logout != null) {
+		if (this.logout != null) {
 			this.logout.configure(this);
 		}
 		this.requestCache.configure(this);
 		this.addFilterAt(new SecurityContextServerWebExchangeWebFilter(), SecurityWebFiltersOrder.SECURITY_CONTEXT_SERVER_WEB_EXCHANGE);
-		if(this.authorizeExchange != null) {
+		if (this.authorizeExchange != null) {
 			ServerAuthenticationEntryPoint authenticationEntryPoint = getAuthenticationEntryPoint();
 			ExceptionTranslationWebFilter exceptionTranslationWebFilter = new ExceptionTranslationWebFilter();
-			if(authenticationEntryPoint != null) {
+			if (authenticationEntryPoint != null) {
 				exceptionTranslationWebFilter.setAuthenticationEntryPoint(
 					authenticationEntryPoint);
 			}
-			if(this.accessDeniedHandler != null) {
+			if (this.accessDeniedHandler != null) {
 				exceptionTranslationWebFilter.setAccessDeniedHandler(this.accessDeniedHandler);
 			}
 			this.addFilterAt(exceptionTranslationWebFilter, SecurityWebFiltersOrder.EXCEPTION_TRANSLATION);
@@ -1042,7 +1042,7 @@ public class ServerHttpSecurity {
 		AnnotationAwareOrderComparator.sort(this.webFilters);
 		List<WebFilter> sortedWebFilters = new ArrayList<>();
 		this.webFilters.forEach( f -> {
-			if(f instanceof OrderedWebFilter) {
+			if (f instanceof OrderedWebFilter) {
 				f = ((OrderedWebFilter) f).webFilter;
 			}
 			sortedWebFilters.add(f);
@@ -1066,10 +1066,10 @@ public class ServerHttpSecurity {
 	}
 
 	private ServerAuthenticationEntryPoint getAuthenticationEntryPoint() {
-		if(this.authenticationEntryPoint != null || this.defaultEntryPoints.isEmpty()) {
+		if (this.authenticationEntryPoint != null || this.defaultEntryPoints.isEmpty()) {
 			return this.authenticationEntryPoint;
 		}
-		if(this.defaultEntryPoints.size() == 1) {
+		if (this.defaultEntryPoints.size() == 1) {
 			return this.defaultEntryPoints.get(0).getEntryPoint();
 		}
 		DelegatingServerAuthenticationEntryPoint result = new DelegatingServerAuthenticationEntryPoint(this.defaultEntryPoints);
@@ -1087,7 +1087,7 @@ public class ServerHttpSecurity {
 
 	private WebFilter securityContextRepositoryWebFilter() {
 		ServerSecurityContextRepository repository = this.securityContextRepository;
-		if(repository == null) {
+		if (repository == null) {
 			return null;
 		}
 		WebFilter result = new ReactorContextWebFilter(repository);
@@ -1130,10 +1130,10 @@ public class ServerHttpSecurity {
 
 		@Override
 		protected Access registerMatcher(ServerWebExchangeMatcher matcher) {
-			if(this.anyExchangeRegistered) {
+			if (this.anyExchangeRegistered) {
 				throw new IllegalStateException("Cannot register " + matcher + " which would be unreachable because anyExchange() has already been registered.");
 			}
-			if(this.matcher != null) {
+			if (this.matcher != null) {
 				throw new IllegalStateException("The matcher " + matcher + " does not have an access rule defined");
 			}
 			this.matcher = matcher;
@@ -1141,7 +1141,7 @@ public class ServerHttpSecurity {
 		}
 
 		protected void configure(ServerHttpSecurity http) {
-			if(this.matcher != null) {
+			if (this.matcher != null) {
 				throw new IllegalStateException("The matcher " + this.matcher + " does not have an access rule defined");
 			}
 			AuthorizationWebFilter result = new AuthorizationWebFilter(this.managerBldr.build());
@@ -1446,7 +1446,7 @@ public class ServerHttpSecurity {
 				this.authenticationManager);
 			authenticationFilter.setAuthenticationFailureHandler(new ServerAuthenticationEntryPointFailureHandler(this.entryPoint));
 			authenticationFilter.setAuthenticationConverter(new ServerHttpBasicAuthenticationConverter());
-			if(this.securityContextRepository != null) {
+			if (this.securityContextRepository != null) {
 				authenticationFilter.setSecurityContextRepository(this.securityContextRepository);
 			}
 			http.addFilterAt(authenticationFilter, SecurityWebFiltersOrder.HTTP_BASIC);
@@ -1596,16 +1596,16 @@ public class ServerHttpSecurity {
 		}
 
 		protected void configure(ServerHttpSecurity http) {
-			if(this.authenticationEntryPoint == null) {
+			if (this.authenticationEntryPoint == null) {
 				this.isEntryPointExplicit = false;
 				loginPage("/login");
 			} else {
 				this.isEntryPointExplicit = true;
 			}
-			if(http.requestCache != null) {
+			if (http.requestCache != null) {
 				ServerRequestCache requestCache = http.requestCache.requestCache;
 				this.defaultSuccessHandler.setRequestCache(requestCache);
-				if(this.defaultEntryPoint != null) {
+				if (this.defaultEntryPoint != null) {
 					this.defaultEntryPoint.setRequestCache(requestCache);
 				}
 			}

--- a/config/src/main/java/org/springframework/security/config/websocket/WebSocketMessageBrokerSecurityBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/websocket/WebSocketMessageBrokerSecurityBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,7 +143,7 @@ public final class WebSocketMessageBrokerSecurityBeanDefinitionParser implements
 				.rootBeanDefinition(ExpressionBasedMessageSecurityMetadataSourceFactory.class);
 		mds.setFactoryMethod("createExpressionMessageMetadataSource");
 		mds.addConstructorArgValue(matcherToExpression);
-		if(expressionHandlerDefined) {
+		if (expressionHandlerDefined) {
 			mds.addConstructorArgReference(expressionHandlerRef);
 		}
 
@@ -151,7 +151,7 @@ public final class WebSocketMessageBrokerSecurityBeanDefinitionParser implements
 
 		ManagedList<BeanDefinition> voters = new ManagedList<>();
 		BeanDefinitionBuilder messageExpressionVoterBldr = BeanDefinitionBuilder.rootBeanDefinition(MessageExpressionVoter.class);
-		if(expressionHandlerDefined) {
+		if (expressionHandlerDefined) {
 			messageExpressionVoterBldr.addPropertyReference("expressionHandler", expressionHandlerRef);
 		}
 		voters.add(messageExpressionVoterBldr.getBeanDefinition());
@@ -172,7 +172,7 @@ public final class WebSocketMessageBrokerSecurityBeanDefinitionParser implements
 		if (StringUtils.hasText(id)) {
 			registry.registerAlias(inSecurityInterceptorName, id);
 
-			if(!registry.containsBeanDefinition(PATH_MATCHER_BEAN_NAME)) {
+			if (!registry.containsBeanDefinition(PATH_MATCHER_BEAN_NAME)) {
 				registry.registerBeanDefinition(PATH_MATCHER_BEAN_NAME, new RootBeanDefinition(AntPathMatcher.class));
 			}
 		}
@@ -267,10 +267,10 @@ public final class WebSocketMessageBrokerSecurityBeanDefinitionParser implements
 							AuthenticationPrincipalArgumentResolver.class));
 					bd.getPropertyValues().add(CUSTOM_ARG_RESOLVERS_PROP, argResolvers);
 
-					if(!registry.containsBeanDefinition(PATH_MATCHER_BEAN_NAME)) {
+					if (!registry.containsBeanDefinition(PATH_MATCHER_BEAN_NAME)) {
 						PropertyValue pathMatcherProp = bd.getPropertyValues().getPropertyValue("pathMatcher");
 						Object pathMatcher = pathMatcherProp == null ? null : pathMatcherProp.getValue();
-						if(pathMatcher instanceof BeanReference) {
+						if (pathMatcher instanceof BeanReference) {
 							registry.registerAlias(((BeanReference) pathMatcher).getBeanName(), PATH_MATCHER_BEAN_NAME);
 						}
 					}
@@ -312,7 +312,7 @@ public final class WebSocketMessageBrokerSecurityBeanDefinitionParser implements
 
 			inboundChannel.getPropertyValues().add(INTERCEPTORS_PROP, interceptors);
 
-			if(!registry.containsBeanDefinition(PATH_MATCHER_BEAN_NAME)) {
+			if (!registry.containsBeanDefinition(PATH_MATCHER_BEAN_NAME)) {
 				registry.registerBeanDefinition(PATH_MATCHER_BEAN_NAME, new RootBeanDefinition(AntPathMatcher.class));
 			}
 		}

--- a/config/src/test/java/org/springframework/security/config/annotation/sec2758/Sec2758Tests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/sec2758/Sec2758Tests.java
@@ -125,13 +125,13 @@ public class Sec2758Tests {
 
 		@Override
 		public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-			if(bean instanceof Jsr250MethodSecurityMetadataSource) {
+			if (bean instanceof Jsr250MethodSecurityMetadataSource) {
 				((Jsr250MethodSecurityMetadataSource) bean).setDefaultRolePrefix(null);
 			}
-			if(bean instanceof DefaultMethodSecurityExpressionHandler) {
+			if (bean instanceof DefaultMethodSecurityExpressionHandler) {
 				((DefaultMethodSecurityExpressionHandler) bean).setDefaultRolePrefix(null);
 			}
-			if(bean instanceof DefaultWebSecurityExpressionHandler) {
+			if (bean instanceof DefaultWebSecurityExpressionHandler) {
 				((DefaultWebSecurityExpressionHandler) bean).setDefaultRolePrefix(null);
 			}
 			return bean;

--- a/config/src/test/java/org/springframework/security/config/annotation/web/WebSecurityConfigurerAdapterPowermockTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/WebSecurityConfigurerAdapterPowermockTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ public class WebSecurityConfigurerAdapterPowermockTests {
 
 	@After
 	public void close() {
-		if(context != null) {
+		if (context != null) {
 			context.close();
 		}
 	}

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/HttpSecurityAntMatchersTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/HttpSecurityAntMatchersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public class HttpSecurityAntMatchersTests {
 
 	@After
 	public void cleanup() {
-		if(context != null) {
+		if (context != null) {
 			context.close();
 		}
 	}

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/HttpSecurityLogoutTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/HttpSecurityLogoutTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ public class HttpSecurityLogoutTests {
 
 	@After
 	public void cleanup() {
-		if(context != null) {
+		if (context != null) {
 			context.close();
 		}
 	}

--- a/config/src/test/java/org/springframework/security/config/doc/XsdDocumentedTests.java
+++ b/config/src/test/java/org/springframework/security/config/doc/XsdDocumentedTests.java
@@ -193,24 +193,24 @@ public class XsdDocumentedTests {
 
 		List<String> lines = Files.readAllLines(Paths.get(this.referenceLocation));
 		for ( String line : lines ) {
-			if(line.matches("^\\[\\[.*\\]\\]$")) {
+			if (line.matches("^\\[\\[.*\\]\\]$")) {
 				String id = line.substring(2, line.length() - 2);
 
-				if(id.endsWith("-children")) {
+				if (id.endsWith("-children")) {
 					docAttrName = id.substring(0, id.length() - 9);
 					currentDocAttrNameToElmt = docAttrNameToChildren;
-				} else if(id.endsWith("-parents")) {
+				} else if (id.endsWith("-parents")) {
 					docAttrName = id.substring(0, id.length() - 8);
 					currentDocAttrNameToElmt = docAttrNameToParents;
-				} else if(docAttrName != null && !id.startsWith(docAttrName)) {
+				} else if (docAttrName != null && !id.startsWith(docAttrName)) {
 					currentDocAttrNameToElmt = null;
 					docAttrName = null;
 				}
 			}
 
-			if(docAttrName != null && currentDocAttrNameToElmt != null) {
+			if (docAttrName != null && currentDocAttrNameToElmt != null) {
 				String expression = "^\\* <<(nsa-.*),.*>>$";
-				if(line.matches(expression)) {
+				if (line.matches(expression)) {
 					String elmtId = line.replaceAll(expression, "$1");
 					currentDocAttrNameToElmt
 							.computeIfAbsent(docAttrName, key -> new ArrayList<>())

--- a/config/src/test/java/org/springframework/security/config/http/HttpInterceptUrlTests.java
+++ b/config/src/test/java/org/springframework/security/config/http/HttpInterceptUrlTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ public class HttpInterceptUrlTests {
 
 	@After
 	public void close() {
-		if(context != null) {
+		if (context != null) {
 			context.close();
 		}
 	}
@@ -57,7 +57,7 @@ public class HttpInterceptUrlTests {
 	}
 
 	private void loadConfig(String... configLocations) {
-		for(int i=0; i<configLocations.length; i++) {
+		for (int i=0; i<configLocations.length; i++) {
 			configLocations[i] = getClass().getName().replaceAll("\\.", "/") + "-" + configLocations[i];
 		}
 		XmlWebApplicationContext context = new XmlWebApplicationContext();

--- a/config/src/test/java/org/springframework/security/config/http/customconfigurer/CustomConfigurer.java
+++ b/config/src/test/java/org/springframework/security/config/http/customconfigurer/CustomConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ public class CustomConfigurer extends SecurityConfigurerAdapter<DefaultSecurityF
 				.antMatchers(permitAllPattern).permitAll()
 				.anyRequest().authenticated();
 
-		if(http.getConfigurer(FormLoginConfigurer.class) == null) {
+		if (http.getConfigurer(FormLoginConfigurer.class) == null) {
 			// only apply if formLogin() was not invoked by the user
 			http
 				.formLogin()

--- a/config/src/test/java/org/springframework/security/config/http/customconfigurer/CustomHttpSecurityConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/http/customconfigurer/CustomHttpSecurityConfigurerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ public class CustomHttpSecurityConfigurerTests {
 
 	@After
 	public void cleanup() {
-		if(context != null) {
+		if (context != null) {
 			context.close();
 		}
 	}

--- a/config/src/test/java/org/springframework/security/config/web/server/HeaderSpecTests.java
+++ b/config/src/test/java/org/springframework/security/config/web/server/HeaderSpecTests.java
@@ -183,7 +183,7 @@ public class HeaderSpecTests {
 	}
 
 	private void expectHeaderNamesNotPresent(String... headerNames) {
-		for(String headerName : headerNames) {
+		for (String headerName : headerNames) {
 			this.expectedHeaders.remove(headerName);
 			this.headerNamesNotPresent.add(headerName);
 		}

--- a/config/src/test/java/org/springframework/security/htmlunit/server/HtmlUnitWebTestClient.java
+++ b/config/src/test/java/org/springframework/security/htmlunit/server/HtmlUnitWebTestClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ final class HtmlUnitWebTestClient {
 		String requestBody = webRequest.getRequestBody();
 		if (requestBody == null) {
 			List<NameValuePair> params = webRequest.getRequestParameters();
-			if(params != null && !params.isEmpty()) {
+			if (params != null && !params.isEmpty()) {
 				return request.body(BodyInserters.fromFormData(formData(params)));
 			}
 			return request;
@@ -153,7 +153,7 @@ final class HtmlUnitWebTestClient {
 			URI location = response.headers().asHttpHeaders().getLocation();
 			String host = request.url().getHost();
 			String scheme = request.url().getScheme();
-			if(location != null) {
+			if (location != null) {
 				String redirectUrl = location.toASCIIString();
 				if (location.getHost() == null) {
 					redirectUrl = scheme+ "://" + host + location.toASCIIString();
@@ -180,7 +180,7 @@ final class HtmlUnitWebTestClient {
 				.doOnSuccess( response -> {
 					response.cookies().values().forEach( cookies -> {
 						cookies.forEach( cookie -> {
-							if(cookie.getMaxAge().isZero()) {
+							if (cookie.getMaxAge().isZero()) {
 								this.cookies.remove(cookie.getName());
 							} else {
 								this.cookies.put(cookie.getName(), cookie);

--- a/core/src/main/java/org/springframework/security/access/prepost/PrePostAdviceReactiveMethodInterceptor.java
+++ b/core/src/main/java/org/springframework/security/access/prepost/PrePostAdviceReactiveMethodInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,14 +90,14 @@ public class PrePostAdviceReactiveMethodInterceptor implements MethodInterceptor
 
 		PostInvocationAttribute attr = findPostInvocationAttribute(attributes);
 
-		if(Mono.class.isAssignableFrom(returnType)) {
+		if (Mono.class.isAssignableFrom(returnType)) {
 			return toInvoke
 				.flatMap( auth -> this.<Mono<?>>proceed(invocation)
 					.map( r -> attr == null ? r : this.postAdvice.after(auth, invocation, attr, r))
 				);
 		}
 
-		if(Flux.class.isAssignableFrom(returnType)) {
+		if (Flux.class.isAssignableFrom(returnType)) {
 			return toInvoke
 				.flatMapMany( auth -> this.<Flux<?>>proceed(invocation)
 					.map( r -> attr == null ? r : this.postAdvice.after(auth, invocation, attr, r))

--- a/core/src/main/java/org/springframework/security/access/vote/RoleVoter.java
+++ b/core/src/main/java/org/springframework/security/access/vote/RoleVoter.java
@@ -96,7 +96,7 @@ public class RoleVoter implements AccessDecisionVoter<Object> {
 
 	public int vote(Authentication authentication, Object object,
 			Collection<ConfigAttribute> attributes) {
-		if(authentication == null) {
+		if (authentication == null) {
 			return ACCESS_DENIED;
 		}
 		int result = ACCESS_ABSTAIN;

--- a/core/src/main/java/org/springframework/security/concurrent/DelegatingSecurityContextCallable.java
+++ b/core/src/main/java/org/springframework/security/concurrent/DelegatingSecurityContextCallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ public final class DelegatingSecurityContextCallable<V> implements Callable<V> {
 		}
 		finally {
 			SecurityContext emptyContext = SecurityContextHolder.createEmptyContext();
-			if(emptyContext.equals(originalSecurityContext)) {
+			if (emptyContext.equals(originalSecurityContext)) {
 				SecurityContextHolder.clearContext();
 			} else {
 				SecurityContextHolder.setContext(originalSecurityContext);

--- a/core/src/main/java/org/springframework/security/concurrent/DelegatingSecurityContextRunnable.java
+++ b/core/src/main/java/org/springframework/security/concurrent/DelegatingSecurityContextRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ public final class DelegatingSecurityContextRunnable implements Runnable {
 		}
 		finally {
 			SecurityContext emptyContext = SecurityContextHolder.createEmptyContext();
-			if(emptyContext.equals(originalSecurityContext)) {
+			if (emptyContext.equals(originalSecurityContext)) {
 				SecurityContextHolder.clearContext();
 			} else {
 				SecurityContextHolder.setContext(originalSecurityContext);

--- a/core/src/main/java/org/springframework/security/jackson2/SecurityJackson2Modules.java
+++ b/core/src/main/java/org/springframework/security/jackson2/SecurityJackson2Modules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ public final class SecurityJackson2Modules {
 	}
 
 	public static void enableDefaultTyping(ObjectMapper mapper) {
-		if(mapper != null) {
+		if (mapper != null) {
 			TypeResolverBuilder<?> typeBuilder = mapper.getDeserializationConfig().getDefaultTyper(null);
 			if (typeBuilder == null) {
 				mapper.setDefaultTyping(createWhitelistedDefaultTyping());
@@ -89,13 +89,13 @@ public final class SecurityJackson2Modules {
 		try {
 			Class<? extends Module> securityModule = (Class<? extends Module>) ClassUtils.forName(className, loader);
 			if (securityModule != null) {
-				if(logger.isDebugEnabled()) {
+				if (logger.isDebugEnabled()) {
 					logger.debug("Loaded module " + className + ", now registering");
 				}
 				instance = securityModule.newInstance();
 			}
 		} catch (Exception e) {
-			if(logger.isDebugEnabled()) {
+			if (logger.isDebugEnabled()) {
 				logger.debug("Cannot load module " + className, e);
 			}
 		}
@@ -195,15 +195,15 @@ public final class SecurityJackson2Modules {
 			DeserializationConfig config = (DeserializationConfig) context.getConfig();
 			JavaType result = delegate.typeFromId(context, id);
 			String className = result.getRawClass().getName();
-			if(isWhitelisted(className)) {
+			if (isWhitelisted(className)) {
 				return delegate.typeFromId(context, id);
 			}
 			boolean isExplicitMixin = config.findMixInClassFor(result.getRawClass()) != null;
-			if(isExplicitMixin) {
+			if (isExplicitMixin) {
 				return result;
 			}
 			JacksonAnnotation jacksonAnnotation = AnnotationUtils.findAnnotation(result.getRawClass(), JacksonAnnotation.class);
-			if(jacksonAnnotation != null) {
+			if (jacksonAnnotation != null) {
 				return result;
 			}
 			throw new IllegalArgumentException("The class with " + id + " and name of " + className + " is not whitelisted. " +

--- a/core/src/main/java/org/springframework/security/jackson2/UserDeserializer.java
+++ b/core/src/main/java/org/springframework/security/jackson2/UserDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ class UserDeserializer extends JsonDeserializer<User> {
 				readJsonNode(jsonNode, "accountNonLocked").asBoolean(), authorities
 		);
 
-		if(password.asText(null) == null) {
+		if (password.asText(null) == null) {
 			result.eraseCredentials();
 		}
 		return result;

--- a/core/src/main/java/org/springframework/security/jackson2/UsernamePasswordAuthenticationTokenDeserializer.java
+++ b/core/src/main/java/org/springframework/security/jackson2/UsernamePasswordAuthenticationTokenDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ class UsernamePasswordAuthenticationTokenDeserializer extends JsonDeserializer<U
 		Boolean authenticated = readJsonNode(jsonNode, "authenticated").asBoolean();
 		JsonNode principalNode = readJsonNode(jsonNode, "principal");
 		Object principal = null;
-		if(principalNode.isObject()) {
+		if (principalNode.isObject()) {
 			principal = mapper.readValue(principalNode.traverse(mapper), Object.class);
 		} else {
 			principal = principalNode.asText();

--- a/crypto/src/main/java/org/springframework/security/crypto/keygen/Base64StringKeyGenerator.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/keygen/Base64StringKeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,10 +60,10 @@ public class Base64StringKeyGenerator implements StringKeyGenerator {
 	 * @param keyLength the key length to use
 	 */
 	public Base64StringKeyGenerator(Base64.Encoder encoder, int keyLength) {
-		if(encoder == null) {
+		if (encoder == null) {
 			throw new IllegalArgumentException("encode cannot be null");
 		}
-		if(keyLength < DEFAULT_KEY_LENGTH) {
+		if (keyLength < DEFAULT_KEY_LENGTH) {
 			throw new IllegalArgumentException("keyLength must be greater than or equal to" + DEFAULT_KEY_LENGTH);
 		}
 		this.encoder = encoder;

--- a/crypto/src/main/java/org/springframework/security/crypto/password/DelegatingPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password/DelegatingPasswordEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,20 +137,20 @@ public class DelegatingPasswordEncoder implements PasswordEncoder {
 	 */
 	public DelegatingPasswordEncoder(String idForEncode,
 		Map<String, PasswordEncoder> idToPasswordEncoder) {
-		if(idForEncode == null) {
+		if (idForEncode == null) {
 			throw new IllegalArgumentException("idForEncode cannot be null");
 		}
-		if(!idToPasswordEncoder.containsKey(idForEncode)) {
+		if (!idToPasswordEncoder.containsKey(idForEncode)) {
 			throw new IllegalArgumentException("idForEncode " + idForEncode + "is not found in idToPasswordEncoder " + idToPasswordEncoder);
 		}
-		for(String id : idToPasswordEncoder.keySet()) {
-			if(id == null) {
+		for (String id : idToPasswordEncoder.keySet()) {
+			if (id == null) {
 				continue;
 			}
-			if(id.contains(PREFIX)) {
+			if (id.contains(PREFIX)) {
 				throw new IllegalArgumentException("id " + id + " cannot contain " + PREFIX);
 			}
-			if(id.contains(SUFFIX)) {
+			if (id.contains(SUFFIX)) {
 				throw new IllegalArgumentException("id " + id + " cannot contain " + SUFFIX);
 			}
 		}
@@ -175,7 +175,7 @@ public class DelegatingPasswordEncoder implements PasswordEncoder {
 	 */
 	public void setDefaultPasswordEncoderForMatches(
 		PasswordEncoder defaultPasswordEncoderForMatches) {
-		if(defaultPasswordEncoderForMatches == null) {
+		if (defaultPasswordEncoderForMatches == null) {
 			throw new IllegalArgumentException("defaultPasswordEncoderForMatches cannot be null");
 		}
 		this.defaultPasswordEncoderForMatches = defaultPasswordEncoderForMatches;
@@ -188,12 +188,12 @@ public class DelegatingPasswordEncoder implements PasswordEncoder {
 
 	@Override
 	public boolean matches(CharSequence rawPassword, String prefixEncodedPassword) {
-		if(rawPassword == null && prefixEncodedPassword == null) {
+		if (rawPassword == null && prefixEncodedPassword == null) {
 			return true;
 		}
 		String id = extractId(prefixEncodedPassword);
 		PasswordEncoder delegate = this.idToPasswordEncoder.get(id);
-		if(delegate == null) {
+		if (delegate == null) {
 			return this.defaultPasswordEncoderForMatches
 				.matches(rawPassword, prefixEncodedPassword);
 		}
@@ -206,11 +206,11 @@ public class DelegatingPasswordEncoder implements PasswordEncoder {
 			return null;
 		}
 		int start = prefixEncodedPassword.indexOf(PREFIX);
-		if(start != 0) {
+		if (start != 0) {
 			return null;
 		}
 		int end = prefixEncodedPassword.indexOf(SUFFIX, start);
-		if(end < 0) {
+		if (end < 0) {
 			return null;
 		}
 		return prefixEncodedPassword.substring(start + 1, end);

--- a/crypto/src/main/java/org/springframework/security/crypto/password/Digester.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password/Digester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2016 the original author or authors.
+ * Copyright 2011-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ final class Digester {
 	}
 
 	final void setIterations(int iterations) {
-		if(iterations <= 0) {
+		if (iterations <= 0) {
 			throw new IllegalArgumentException("Iterations value must be greater than zero");
 		}
 		this.iterations = iterations;

--- a/crypto/src/main/java/org/springframework/security/crypto/password/LdapShaPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password/LdapShaPasswordEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ public class LdapShaPasswordEncoder implements PasswordEncoder {
 	}
 
 	public LdapShaPasswordEncoder(BytesKeyGenerator saltGenerator) {
-		if(saltGenerator == null) {
+		if (saltGenerator == null) {
 			throw new IllegalArgumentException("saltGenerator cannot be null");
 		}
 		this.saltGenerator = saltGenerator;

--- a/crypto/src/main/java/org/springframework/security/crypto/password/Md4PasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password/Md4PasswordEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ public class Md4PasswordEncoder implements PasswordEncoder {
 	}
 
 	private String digest(String salt, CharSequence rawPassword) {
-		if(rawPassword == null) {
+		if (rawPassword == null) {
 			rawPassword = "";
 		}
 		String saltedPassword = rawPassword + salt;
@@ -143,11 +143,11 @@ public class Md4PasswordEncoder implements PasswordEncoder {
 
 	private String extractSalt(String prefixEncodedPassword) {
 		int start = prefixEncodedPassword.indexOf(PREFIX);
-		if(start != 0) {
+		if (start != 0) {
 			return "";
 		}
 		int end = prefixEncodedPassword.indexOf(SUFFIX, start);
-		if(end < 0) {
+		if (end < 0) {
 			return "";
 		}
 		return prefixEncodedPassword.substring(start, end + 1);

--- a/crypto/src/main/java/org/springframework/security/crypto/password/MessageDigestPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password/MessageDigestPasswordEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -162,11 +162,11 @@ public class MessageDigestPasswordEncoder implements PasswordEncoder {
 
 	private String extractSalt(String prefixEncodedPassword) {
 		int start = prefixEncodedPassword.indexOf(PREFIX);
-		if(start != 0) {
+		if (start != 0) {
 			return "";
 		}
 		int end = prefixEncodedPassword.indexOf(SUFFIX, start);
-		if(end < 0) {
+		if (end < 0) {
 			return "";
 		}
 		return prefixEncodedPassword.substring(start, end + 1);

--- a/crypto/src/main/java/org/springframework/security/crypto/password/Pbkdf2PasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password/Pbkdf2PasswordEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ public class Pbkdf2PasswordEncoder implements PasswordEncoder {
 	 * @since 5.0
 	 */
 	public void setAlgorithm(SecretKeyFactoryAlgorithm secretKeyFactoryAlgorithm) {
-		if(secretKeyFactoryAlgorithm == null) {
+		if (secretKeyFactoryAlgorithm == null) {
 			throw new IllegalArgumentException("secretKeyFactoryAlgorithm cannot be null");
 		}
 		String algorithmName = secretKeyFactoryAlgorithm.name();
@@ -131,7 +131,7 @@ public class Pbkdf2PasswordEncoder implements PasswordEncoder {
 	}
 
 	private String encode(byte[] bytes) {
-		if(this.encodeHashAsBase64) {
+		if (this.encodeHashAsBase64) {
 			return Base64.getEncoder().encodeToString(bytes);
 		}
 		return String.valueOf(Hex.encode(bytes));
@@ -160,7 +160,7 @@ public class Pbkdf2PasswordEncoder implements PasswordEncoder {
 	}
 
 	private byte[] decode(String encodedBytes) {
-		if(this.encodeHashAsBase64) {
+		if (this.encodeHashAsBase64) {
 			return Base64.getDecoder().decode(encodedBytes);
 		}
 		return Hex.decode(encodedBytes);

--- a/etc/checkstyle/checkstyle.xml
+++ b/etc/checkstyle/checkstyle.xml
@@ -4,12 +4,12 @@
 <module name="Checker">
 	<!-- Suppressions -->
 	<module name="SuppressionFilter">
-		<property name="file" value="${configDir}/suppressions.xml"/>
+		<property name="file" value="${config_loc}/suppressions.xml"/>
 	</module>
 
 	<!-- Root Checks -->
 	<module name="RegexpHeader">
-		<property name="headerFile" value="${configDir}/header.txt"/>
+		<property name="headerFile" value="${config_loc}/header.txt"/>
 		<property name="fileExtensions" value="java"/>
 	</module>
 

--- a/itest/web/src/integration-test/java/org/springframework/security/integration/AbstractWebServerIntegrationTests.java
+++ b/itest/web/src/integration-test/java/org/springframework/security/integration/AbstractWebServerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,13 +37,13 @@ public abstract class AbstractWebServerIntegrationTests {
 
 	@After
 	public void close() {
-		if(context != null) {
+		if (context != null) {
 			context.close();
 		}
 	}
 
 	protected final MockMvc createMockMvc(String... configLocations) throws Exception {
-		if(this.context != null) {
+		if (this.context != null) {
 			throw new IllegalStateException("context is already loaded");
 		}
 

--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/PasswordComparisonAuthenticator.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/PasswordComparisonAuthenticator.java
@@ -123,10 +123,10 @@ public final class PasswordComparisonAuthenticator extends AbstractLdapAuthentic
 
 	private String getPassword(DirContextOperations user) {
 		Object passwordAttrValue = user.getObjectAttribute(this.passwordAttributeName);
-		if(passwordAttrValue == null) {
+		if (passwordAttrValue == null) {
 			return null;
 		}
-		if(passwordAttrValue instanceof byte[]) {
+		if (passwordAttrValue instanceof byte[]) {
 			return new String((byte[]) passwordAttrValue);
 		}
 		return String.valueOf(passwordAttrValue);

--- a/test/src/main/java/org/springframework/security/test/context/support/ReactorContextTestExecutionListener.java
+++ b/test/src/main/java/org/springframework/security/test/context/support/ReactorContextTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ public class ReactorContextTestExecutionListener
 			@Override
 			public Context currentContext() {
 				Context context = delegate.currentContext();
-				if(context.hasKey(CONTEXT_DEFAULTED_ATTR_NAME)) {
+				if (context.hasKey(CONTEXT_DEFAULTED_ATTR_NAME)) {
 					return context;
 				}
 				context = context.put(CONTEXT_DEFAULTED_ATTR_NAME, Boolean.TRUE);

--- a/test/src/main/java/org/springframework/security/test/context/support/WithMockUserSecurityContextFactory.java
+++ b/test/src/main/java/org/springframework/security/test/context/support/WithMockUserSecurityContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ final class WithMockUserSecurityContextFactory implements
 			grantedAuthorities.add(new SimpleGrantedAuthority(authority));
 		}
 
-		if(grantedAuthorities.isEmpty()) {
+		if (grantedAuthorities.isEmpty()) {
 			for (String role : withUser.roles()) {
 				if (role.startsWith("ROLE_")) {
 					throw new IllegalArgumentException("roles cannot start with ROLE_ Got "
@@ -59,7 +59,7 @@ final class WithMockUserSecurityContextFactory implements
 				}
 				grantedAuthorities.add(new SimpleGrantedAuthority("ROLE_" + role));
 			}
-		} else if(!(withUser.roles().length == 1 && "USER".equals(withUser.roles()[0]))) {
+		} else if (!(withUser.roles().length == 1 && "USER".equals(withUser.roles()[0]))) {
 			throw new IllegalStateException("You cannot define roles attribute "+ Arrays.asList(withUser.roles())+" with authorities attribute "+ Arrays.asList(withUser.authorities()));
 		}
 

--- a/test/src/main/java/org/springframework/security/test/context/support/WithSecurityContextTestExecutionListener.java
+++ b/test/src/main/java/org/springframework/security/test/context/support/WithSecurityContextTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ public class WithSecurityContextTestExecutionListener
 	@Override
 	public void beforeTestExecution(TestContext testContext) {
 		SecurityContext securityContext = (SecurityContext) testContext.removeAttribute(SECURITY_CONTEXT_ATTR_NAME);
-		if(securityContext != null) {
+		if (securityContext != null) {
 			TestSecurityContextHolder.setContext(securityContext);
 		}
 	}

--- a/test/src/main/java/org/springframework/security/test/context/support/WithUserDetailsSecurityContextFactory.java
+++ b/test/src/main/java/org/springframework/security/test/context/support/WithUserDetailsSecurityContextFactory.java
@@ -67,7 +67,7 @@ final class WithUserDetailsSecurityContextFactory implements
 	}
 
 	private UserDetailsService findUserDetailsService(String beanName) {
-		if(reactorPresent) {
+		if (reactorPresent) {
 			UserDetailsService reactive = findAndAdaptReactiveUserDetailsService(beanName);
 			if (reactive != null) {
 				return reactive;

--- a/test/src/main/java/org/springframework/security/test/web/reactive/server/SecurityMockServerConfigurers.java
+++ b/test/src/main/java/org/springframework/security/test/web/reactive/server/SecurityMockServerConfigurers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -286,7 +286,7 @@ public class SecurityMockServerConfigurers {
 		@Override
 		public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain webFilterChain) {
 			Supplier<Mono<SecurityContext>> context = exchange.getAttribute(ATTRIBUTE_NAME);
-			if(context != null) {
+			if (context != null) {
 				exchange.getAttributes().remove(ATTRIBUTE_NAME);
 				return webFilterChain.filter(exchange)
 					.subscriberContext(ReactiveSecurityContextHolder.withSecurityContext(context.get()));

--- a/web/src/main/java/org/springframework/security/web/authentication/preauth/AbstractPreAuthenticatedProcessingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/preauth/AbstractPreAuthenticatedProcessingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -149,7 +149,7 @@ public abstract class AbstractPreAuthenticatedProcessingFilter extends GenericFi
 			return false;
 		}
 
-		if(logger.isDebugEnabled()) {
+		if (logger.isDebugEnabled()) {
 			logger.debug("Pre-authenticated principal has changed to " + principal + " and will be reauthenticated");
 		}
 		return true;
@@ -205,7 +205,7 @@ public abstract class AbstractPreAuthenticatedProcessingFilter extends GenericFi
 			return false;
 		}
 
-		if(!principalChanged(request, currentUser)) {
+		if (!principalChanged(request, currentUser)) {
 			return false;
 		}
 
@@ -242,7 +242,7 @@ public abstract class AbstractPreAuthenticatedProcessingFilter extends GenericFi
 					authResult, this.getClass()));
 		}
 
-		if(authenticationSuccessHandler != null) {
+		if (authenticationSuccessHandler != null) {
 			authenticationSuccessHandler.onAuthenticationSuccess(request, response, authResult);
 		}
 	}
@@ -262,7 +262,7 @@ public abstract class AbstractPreAuthenticatedProcessingFilter extends GenericFi
 		}
 		request.setAttribute(WebAttributes.AUTHENTICATION_EXCEPTION, failed);
 
-		if(authenticationFailureHandler != null) {
+		if (authenticationFailureHandler != null) {
 			authenticationFailureHandler.onAuthenticationFailure(request, response, failed);
 		}
 	}

--- a/web/src/main/java/org/springframework/security/web/authentication/ui/DefaultLoginPageGeneratingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/ui/DefaultLoginPageGeneratingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -295,7 +295,7 @@ public class DefaultLoginPageGeneratingFilter extends GenericFilterBean {
 
 	private String renderHiddenInputs(HttpServletRequest request) {
 		StringBuilder sb = new StringBuilder();
-		for(Map.Entry<String, String> input : this.resolveHiddenInputs.apply(request).entrySet()) {
+		for (Map.Entry<String, String> input : this.resolveHiddenInputs.apply(request).entrySet()) {
 			sb.append("<input name=\"").append(input.getKey()).append("\" type=\"hidden\" value=\"").append(input.getValue()).append("\" />\n");
 		}
 		return sb.toString();

--- a/web/src/main/java/org/springframework/security/web/authentication/ui/DefaultLogoutPageGeneratingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/ui/DefaultLogoutPageGeneratingFilter.java
@@ -95,7 +95,7 @@ public class DefaultLogoutPageGeneratingFilter extends OncePerRequestFilter {
 
 	private String renderHiddenInputs(HttpServletRequest request) {
 		StringBuilder sb = new StringBuilder();
-		for(Map.Entry<String, String> input : this.resolveHiddenInputs.apply(request).entrySet()) {
+		for (Map.Entry<String, String> input : this.resolveHiddenInputs.apply(request).entrySet()) {
 			sb.append("<input name=\"").append(input.getKey()).append("\" type=\"hidden\" value=\"").append(input.getValue()).append("\" />\n");
 		}
 		return sb.toString();

--- a/web/src/main/java/org/springframework/security/web/firewall/FirewalledResponse.java
+++ b/web/src/main/java/org/springframework/security/web/firewall/FirewalledResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ class FirewalledResponse extends HttpServletResponseWrapper {
 
 	@Override
 	public void addCookie(Cookie cookie) {
-		if(cookie != null) {
+		if (cookie != null) {
 			validateCrlf(SET_COOKIE_HEADER, cookie.getName());
 			validateCrlf(SET_COOKIE_HEADER, cookie.getValue());
 			validateCrlf(SET_COOKIE_HEADER, cookie.getPath());

--- a/web/src/main/java/org/springframework/security/web/header/writers/frameoptions/XFrameOptionsHeaderWriter.java
+++ b/web/src/main/java/org/springframework/security/web/header/writers/frameoptions/XFrameOptionsHeaderWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ public final class XFrameOptionsHeaderWriter implements HeaderWriter {
 	public void writeHeaders(HttpServletRequest request, HttpServletResponse response) {
 		if (XFrameOptionsMode.ALLOW_FROM.equals(frameOptionsMode)) {
 			String allowFromValue = this.allowFromStrategy.getAllowFromValue(request);
-			if(XFrameOptionsMode.DENY.getMode().equals(allowFromValue)) {
+			if (XFrameOptionsMode.DENY.getMode().equals(allowFromValue)) {
 				response.setHeader(XFRAME_OPTIONS_HEADER, XFrameOptionsMode.DENY.getMode());
 			} else if (allowFromValue != null) {
 				response.setHeader(XFRAME_OPTIONS_HEADER,

--- a/web/src/main/java/org/springframework/security/web/jackson2/PreAuthenticatedAuthenticationTokenDeserializer.java
+++ b/web/src/main/java/org/springframework/security/web/jackson2/PreAuthenticatedAuthenticationTokenDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ class PreAuthenticatedAuthenticationTokenDeserializer extends JsonDeserializer<P
 		Boolean authenticated = readJsonNode(jsonNode, "authenticated").asBoolean();
 		JsonNode principalNode = readJsonNode(jsonNode, "principal");
 		Object principal = null;
-		if(principalNode.isObject()) {
+		if (principalNode.isObject()) {
 			principal = mapper.readValue(principalNode.traverse(mapper), Object.class);
 		} else {
 			principal = principalNode.asText();

--- a/web/src/main/java/org/springframework/security/web/reactive/result/view/CsrfRequestDataValueProcessor.java
+++ b/web/src/main/java/org/springframework/security/web/reactive/result/view/CsrfRequestDataValueProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ public class CsrfRequestDataValueProcessor implements RequestDataValueProcessor 
 			return Collections.emptyMap();
 		}
 		CsrfToken token = exchange.getAttribute(DEFAULT_CSRF_ATTR_NAME);
-		if(token == null) {
+		if (token == null) {
 			return Collections.emptyMap();
 		}
 		return Collections.singletonMap(token.getParameterName(), token.getToken());

--- a/web/src/main/java/org/springframework/security/web/savedrequest/DefaultSavedRequest.java
+++ b/web/src/main/java/org/springframework/security/web/savedrequest/DefaultSavedRequest.java
@@ -492,7 +492,7 @@ public class DefaultSavedRequest implements SavedRequest {
 
 		public DefaultSavedRequest build() {
 			DefaultSavedRequest savedRequest = new DefaultSavedRequest(this);
-			if(!ObjectUtils.isEmpty(this.cookies)) {
+			if (!ObjectUtils.isEmpty(this.cookies)) {
 				for (SavedCookie cookie : this.cookies) {
 					savedRequest.addCookie(cookie.getCookie());
 				}

--- a/web/src/main/java/org/springframework/security/web/server/DefaultServerRedirectStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/server/DefaultServerRedirectStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,11 +46,11 @@ public class DefaultServerRedirectStrategy implements ServerRedirectStrategy {
 	}
 
 	private URI createLocation(ServerWebExchange exchange, URI location) {
-		if(!this.contextRelative) {
+		if (!this.contextRelative) {
 			return location;
 		}
 		String url = location.toASCIIString();
-		if(url.startsWith("/")) {
+		if (url.startsWith("/")) {
 			String context = exchange.getRequest().getPath().contextPath().value();
 			return URI.create(context + url);
 		}

--- a/web/src/main/java/org/springframework/security/web/server/ServerHttpBasicAuthenticationConverter.java
+++ b/web/src/main/java/org/springframework/security/web/server/ServerHttpBasicAuthenticationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ public class ServerHttpBasicAuthenticationConverter implements
 		ServerHttpRequest request = exchange.getRequest();
 
 		String authorization = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
-		if(authorization == null || !authorization.toLowerCase().startsWith("basic ")) {
+		if (authorization == null || !authorization.toLowerCase().startsWith("basic ")) {
 			return Mono.empty();
 		}
 
@@ -56,7 +56,7 @@ public class ServerHttpBasicAuthenticationConverter implements
 		String decodedAuthz = new String(decodedCredentials);
 		String[] userParts = decodedAuthz.split(":");
 
-		if(userParts.length != 2) {
+		if (userParts.length != 2) {
 			return Mono.empty();
 		}
 

--- a/web/src/main/java/org/springframework/security/web/server/context/WebSessionServerSecurityContextRepository.java
+++ b/web/src/main/java/org/springframework/security/web/server/context/WebSessionServerSecurityContextRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class WebSessionServerSecurityContextRepository
 	public Mono<Void> save(ServerWebExchange exchange, SecurityContext context) {
 		return exchange.getSession()
 			.doOnNext(session -> {
-				if(context == null) {
+				if (context == null) {
 					session.getAttributes().remove(this.springSecurityContextAttrName);
 				} else {
 					session.getAttributes().put(this.springSecurityContextAttrName, context);

--- a/web/src/main/java/org/springframework/security/web/server/header/StaticServerHttpHeadersWriter.java
+++ b/web/src/main/java/org/springframework/security/web/server/header/StaticServerHttpHeadersWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ public class StaticServerHttpHeadersWriter implements ServerHttpHeadersWriter {
 	public Mono<Void> writeHttpHeaders(ServerWebExchange exchange) {
 		HttpHeaders headers = exchange.getResponse().getHeaders();
 		boolean containsOneHeaderToAdd = Collections.disjoint(headers.keySet(), this.headersToAdd.keySet());
-		if(containsOneHeaderToAdd) {
+		if (containsOneHeaderToAdd) {
 			this.headersToAdd.forEach((name, values) -> {
 				headers.put(name, values);
 			});

--- a/web/src/main/java/org/springframework/security/web/server/header/XXssProtectionServerHttpHeadersWriter.java
+++ b/web/src/main/java/org/springframework/security/web/server/header/XXssProtectionServerHttpHeadersWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,7 +108,7 @@ public class XXssProtectionServerHttpHeadersWriter implements ServerHttpHeadersW
 		if (!enabled) {
 			return  "0";
 		}
-		if(!block) {
+		if (!block) {
 			return "1";
 		}
 		return "1 ; mode=block";

--- a/web/src/main/java/org/springframework/security/web/server/util/matcher/PathPatternParserServerWebExchangeMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/server/util/matcher/PathPatternParserServerWebExchangeMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,12 +61,12 @@ public final class PathPatternParserServerWebExchangeMatcher implements ServerWe
 	@Override
 	public Mono<MatchResult> matches(ServerWebExchange exchange) {
 		ServerHttpRequest request = exchange.getRequest();
-		if(this.method != null && !this.method.equals(request.getMethod())) {
+		if (this.method != null && !this.method.equals(request.getMethod())) {
 			return MatchResult.notMatch();
 		}
 		PathContainer path = request.getPath().pathWithinApplication();
 		boolean match = this.pattern.matches(path);
-		if(!match) {
+		if (!match) {
 			return MatchResult.notMatch();
 		}
 		Map<String, String> pathVariables = this.pattern.matchAndExtract(path).getUriVariables();

--- a/web/src/main/java/org/springframework/security/web/util/UrlUtils.java
+++ b/web/src/main/java/org/springframework/security/web/util/UrlUtils.java
@@ -137,7 +137,7 @@ public final class UrlUtils {
 	 * defined in RFC 1738.
 	 */
 	public static boolean isAbsoluteUrl(String url) {
-		if(url == null) {
+		if (url == null) {
 			return false;
 		}
 		final Pattern ABSOLUTE_URL = Pattern.compile("\\A[a-z0-9.+-]+://.*",


### PR DESCRIPTION
This PR upgrades `spring-build-conventions` to `0.0.18.RELEASE`.

Note that there are 2 commits in this PR:

- the first commit addresses `WhitespaceAfterCheck` Checkstyle check failures, since the check in subject has changed since the `6.16.1` release of Checkstyle, that was used in `0.0.17.RELEASE` and earlier
- the second commit upgrades the `spring-build-conventions` and updates the necessary build configuration