### PR TITLE
Force snapshot repo in snapshot stage build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ try {
 			node {
 				checkout scm
 				try {
-					sh "./gradlew clean test -PspringVersion='5.1.0.BUILD-SNAPSHOT' -PreactorVersion=Californium-BUILD-SNAPSHOT -PspringDataVersion=Lovelace-BUILD-SNAPSHOT --refresh-dependencies --no-daemon --stacktrace"
+					sh "./gradlew clean test -PforceMavenRepositories=snapshot -PspringVersion='5.1.0.BUILD-SNAPSHOT' -PreactorVersion=Californium-BUILD-SNAPSHOT -PspringDataVersion=Lovelace-BUILD-SNAPSHOT --refresh-dependencies --no-daemon --stacktrace"
 				} catch(Exception e) {
 					currentBuild.result = 'FAILED: snapshots'
 					throw e


### PR DESCRIPTION
This PR leverages newly introduced (see spring-gradle-plugins/spring-build-conventions#35) feature of `spring-build-conventions` that allows forcing of dependency resolution repository. By default, the repository was deduced was deduced from current project version.

Related #5738.