### PR TITLE
Reactive insufficient_scope support

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/access/server/BearerTokenServerAccessDeniedHandler.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/access/server/BearerTokenServerAccessDeniedHandler.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.resource.web.access.server;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.BearerTokenErrorCodes;
+import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
+import org.springframework.security.web.server.authorization.ServerAccessDeniedHandler;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * Translates any {@link AccessDeniedException} into an HTTP response in accordance with
+ * <a href="https://tools.ietf.org/html/rfc6750#section-3" target="_blank">RFC 6750 Section 3: The WWW-Authenticate</a>.
+ *
+ * So long as the class can prove that the request has a valid OAuth 2.0 {@link Authentication}, then will return an
+ * <a href="https://tools.ietf.org/html/rfc6750#section-3.1" target="_blank">insufficient scope error</a>; otherwise,
+ * it will simply indicate the scheme (Bearer) and any configured realm.
+ *
+ * @author Josh Cummings
+ * @since 5.1
+ *
+ */
+public class BearerTokenServerAccessDeniedHandler implements ServerAccessDeniedHandler {
+	private static final Collection<String> WELL_KNOWN_SCOPE_ATTRIBUTE_NAMES =
+			Arrays.asList("scope", "scp");
+
+	private String realmName;
+
+	@Override
+	public Mono<Void> handle(ServerWebExchange exchange, AccessDeniedException denied) {
+
+		Map<String, String> parameters = new LinkedHashMap<>();
+
+		if (this.realmName != null) {
+			parameters.put("realm", this.realmName);
+		}
+
+		return exchange.getPrincipal()
+				.filter(AbstractOAuth2TokenAuthenticationToken.class::isInstance)
+				.cast(AbstractOAuth2TokenAuthenticationToken.class)
+				.map(token -> errorMessageParameters(token, parameters))
+				.switchIfEmpty(Mono.just(parameters))
+				.flatMap(params -> respond(exchange, params));
+	}
+
+	/**
+	 * Set the default realm name to use in the bearer token error response
+	 *
+	 * @param realmName
+	 */
+	public final void setRealmName(String realmName) {
+		this.realmName = realmName;
+	}
+
+	private static Map<String, String> errorMessageParameters(
+			AbstractOAuth2TokenAuthenticationToken token,
+			Map<String, String> parameters) {
+
+		String scope = getScope(token);
+
+		parameters.put("error", BearerTokenErrorCodes.INSUFFICIENT_SCOPE);
+		parameters.put("error_description",
+				String.format("The token provided has insufficient scope [%s] for this request", scope));
+		parameters.put("error_uri", "https://tools.ietf.org/html/rfc6750#section-3.1");
+
+		if (StringUtils.hasText(scope)) {
+			parameters.put("scope", scope);
+		}
+
+		return parameters;
+	}
+
+	private static Mono<Void> respond(ServerWebExchange exchange, Map<String, String> parameters) {
+		String wwwAuthenticate = computeWWWAuthenticateHeaderValue(parameters);
+		exchange.getResponse().setStatusCode(HttpStatus.FORBIDDEN);
+		exchange.getResponse().getHeaders().set(HttpHeaders.WWW_AUTHENTICATE, wwwAuthenticate);
+		return exchange.getResponse().setComplete();
+	}
+
+	private static String getScope(AbstractOAuth2TokenAuthenticationToken token) {
+
+		Map<String, Object> attributes = token.getTokenAttributes();
+
+		for (String attributeName : WELL_KNOWN_SCOPE_ATTRIBUTE_NAMES) {
+			Object scopes = attributes.get(attributeName);
+			if (scopes instanceof String) {
+				return (String) scopes;
+			} else if (scopes instanceof Collection) {
+				Collection coll = (Collection) scopes;
+				return (String) coll.stream()
+						.map(String::valueOf)
+						.collect(Collectors.joining(" "));
+			}
+		}
+
+		return "";
+	}
+
+	private static String computeWWWAuthenticateHeaderValue(Map<String, String> parameters) {
+		String wwwAuthenticate = "Bearer";
+		if (!parameters.isEmpty()) {
+			wwwAuthenticate += parameters.entrySet().stream()
+					.map(attribute -> attribute.getKey() + "=\"" + attribute.getValue() + "\"")
+					.collect(Collectors.joining(", ", " ", ""));
+		}
+
+		return wwwAuthenticate;
+	}
+}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/access/server/BearerTokenServerAccessDeniedHandlerTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/access/server/BearerTokenServerAccessDeniedHandlerTests.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.resource.web.access.server;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import org.assertj.core.util.Maps;
+import org.junit.Before;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpResponse;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.AbstractOAuth2Token;
+import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
+import org.springframework.web.server.ServerWebExchange;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BearerTokenServerAccessDeniedHandlerTests {
+	private BearerTokenServerAccessDeniedHandler accessDeniedHandler;
+
+	@Before
+	public void setUp() {
+		this.accessDeniedHandler = new BearerTokenServerAccessDeniedHandler();
+	}
+
+	@Test
+	public void handleWhenNotOAuth2AuthenticatedThenStatus403() {
+
+		Authentication token = new TestingAuthenticationToken("user", "pass");
+		ServerWebExchange exchange = mock(ServerWebExchange.class);
+		when(exchange.getPrincipal()).thenReturn(Mono.just(token));
+		when(exchange.getResponse()).thenReturn(new MockServerHttpResponse());
+
+		this.accessDeniedHandler.handle(exchange, null).block();
+
+		assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+		assertThat(exchange.getResponse().getHeaders().get("WWW-Authenticate")).isEqualTo(
+				Arrays.asList("Bearer"));
+	}
+
+	@Test
+	public void handleWhenNotOAuth2AuthenticatedAndRealmSetThenStatus403AndAuthHeaderWithRealm() {
+
+		Authentication token = new TestingAuthenticationToken("user", "pass");
+		ServerWebExchange exchange = mock(ServerWebExchange.class);
+		when(exchange.getPrincipal()).thenReturn(Mono.just(token));
+		when(exchange.getResponse()).thenReturn(new MockServerHttpResponse());
+
+		this.accessDeniedHandler.setRealmName("test");
+		this.accessDeniedHandler.handle(exchange, null).block();
+
+		assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+		assertThat(exchange.getResponse().getHeaders().get("WWW-Authenticate")).isEqualTo(
+				Arrays.asList("Bearer realm=\"test\""));
+	}
+
+	@Test
+	public void handleWhenTokenHasNoScopesThenInsufficientScopeError() {
+
+		Authentication token = new TestingOAuth2TokenAuthenticationToken(Collections.emptyMap());
+		ServerWebExchange exchange = mock(ServerWebExchange.class);
+		when(exchange.getPrincipal()).thenReturn(Mono.just(token));
+		when(exchange.getResponse()).thenReturn(new MockServerHttpResponse());
+
+		this.accessDeniedHandler.handle(exchange, null).block();
+
+		assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+		assertThat(exchange.getResponse().getHeaders().get("WWW-Authenticate")).isEqualTo(
+				Arrays.asList("Bearer error=\"insufficient_scope\", " +
+				"error_description=\"The token provided has insufficient scope [] for this request\", " +
+				"error_uri=\"https://tools.ietf.org/html/rfc6750#section-3.1\""));
+	}
+
+
+	@Test
+	public void handleWhenTokenHasScopeAttributeThenInsufficientScopeErrorWithScopes() {
+		Map<String, Object> attributes = Maps.newHashMap("scope", "message:read message:write");
+		Authentication token = new TestingOAuth2TokenAuthenticationToken(attributes);
+		ServerWebExchange exchange = mock(ServerWebExchange.class);
+		when(exchange.getPrincipal()).thenReturn(Mono.just(token));
+		when(exchange.getResponse()).thenReturn(new MockServerHttpResponse());
+
+		this.accessDeniedHandler.handle(exchange, null).block();
+
+		assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+		assertThat(exchange.getResponse().getHeaders().get("WWW-Authenticate")).isEqualTo(
+				Arrays.asList("Bearer error=\"insufficient_scope\", " +
+				"error_description=\"The token provided has insufficient scope [message:read message:write] for this request\", " +
+				"error_uri=\"https://tools.ietf.org/html/rfc6750#section-3.1\", " +
+				"scope=\"message:read message:write\""));
+	}
+
+	@Test
+	public void handleWhenTokenHasEmptyScopeAttributeThenInsufficientScopeError() {
+		Map<String, Object> attributes = Maps.newHashMap("scope", "");
+		Authentication token = new TestingOAuth2TokenAuthenticationToken(attributes);
+		ServerWebExchange exchange = mock(ServerWebExchange.class);
+		when(exchange.getPrincipal()).thenReturn(Mono.just(token));
+		when(exchange.getResponse()).thenReturn(new MockServerHttpResponse());
+
+		this.accessDeniedHandler.handle(exchange, null).block();
+
+		assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+		assertThat(exchange.getResponse().getHeaders().get("WWW-Authenticate")).isEqualTo(
+				Arrays.asList("Bearer error=\"insufficient_scope\", " +
+				"error_description=\"The token provided has insufficient scope [] for this request\", " +
+				"error_uri=\"https://tools.ietf.org/html/rfc6750#section-3.1\""));
+	}
+
+	@Test
+	public void handleWhenTokenHasScpAttributeThenInsufficientScopeErrorWithScopes() {
+		Map<String, Object> attributes = Maps.newHashMap("scp", Arrays.asList("message:read", "message:write"));
+		Authentication token = new TestingOAuth2TokenAuthenticationToken(attributes);
+		ServerWebExchange exchange = mock(ServerWebExchange.class);
+		when(exchange.getPrincipal()).thenReturn(Mono.just(token));
+		when(exchange.getResponse()).thenReturn(new MockServerHttpResponse());
+
+		this.accessDeniedHandler.handle(exchange, null).block();
+
+		assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+		assertThat(exchange.getResponse().getHeaders().get("WWW-Authenticate")).isEqualTo(
+				Arrays.asList("Bearer error=\"insufficient_scope\", " +
+				"error_description=\"The token provided has insufficient scope [message:read message:write] for this request\", " +
+				"error_uri=\"https://tools.ietf.org/html/rfc6750#section-3.1\", " +
+				"scope=\"message:read message:write\""));
+	}
+
+	@Test
+	public void handleWhenTokenHasEmptyScpAttributeThenInsufficientScopeError() {
+
+		Map<String, Object> attributes = Maps.newHashMap("scp", Collections.emptyList());
+		Authentication token = new TestingOAuth2TokenAuthenticationToken(attributes);
+		ServerWebExchange exchange = mock(ServerWebExchange.class);
+		when(exchange.getPrincipal()).thenReturn(Mono.just(token));
+		when(exchange.getResponse()).thenReturn(new MockServerHttpResponse());
+
+		this.accessDeniedHandler.handle(exchange, null).block();
+
+		assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+		assertThat(exchange.getResponse().getHeaders().get("WWW-Authenticate")).isEqualTo(
+				Arrays.asList("Bearer error=\"insufficient_scope\", " +
+				"error_description=\"The token provided has insufficient scope [] for this request\", " +
+				"error_uri=\"https://tools.ietf.org/html/rfc6750#section-3.1\""));
+	}
+
+	@Test
+	public void handleWhenTokenHasBothScopeAndScpAttributesTheInsufficientErrorBasedOnScopeAttribute() {
+		Map<String, Object> attributes = Maps.newHashMap("scp", Arrays.asList("message:read", "message:write"));
+		attributes.put("scope", "missive:read missive:write");
+		Authentication token = new TestingOAuth2TokenAuthenticationToken(attributes);
+		ServerWebExchange exchange = mock(ServerWebExchange.class);
+		when(exchange.getPrincipal()).thenReturn(Mono.just(token));
+		when(exchange.getResponse()).thenReturn(new MockServerHttpResponse());
+
+		this.accessDeniedHandler.handle(exchange, null).block();
+
+		assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+		assertThat(exchange.getResponse().getHeaders().get("WWW-Authenticate")).isEqualTo(
+				Arrays.asList("Bearer error=\"insufficient_scope\", " +
+				"error_description=\"The token provided has insufficient scope [missive:read missive:write] for this request\", " +
+				"error_uri=\"https://tools.ietf.org/html/rfc6750#section-3.1\", " +
+				"scope=\"missive:read missive:write\""));
+	}
+
+	@Test
+	public void handleWhenTokenHasScopeAttributeAndRealmIsSetThenInsufficientScopeErrorWithScopesAndRealm() {
+		Map<String, Object> attributes = Maps.newHashMap("scope", "message:read message:write");
+		Authentication token = new TestingOAuth2TokenAuthenticationToken(attributes);
+		ServerWebExchange exchange = mock(ServerWebExchange.class);
+		when(exchange.getPrincipal()).thenReturn(Mono.just(token));
+		when(exchange.getResponse()).thenReturn(new MockServerHttpResponse());
+
+		this.accessDeniedHandler.setRealmName("test");
+		this.accessDeniedHandler.handle(exchange, null).block();
+
+		assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+		assertThat(exchange.getResponse().getHeaders().get("WWW-Authenticate"))
+				.isEqualTo(Arrays.asList("Bearer realm=\"test\", " +
+				"error=\"insufficient_scope\", " +
+				"error_description=\"The token provided has insufficient scope [message:read message:write] for this request\", " +
+				"error_uri=\"https://tools.ietf.org/html/rfc6750#section-3.1\", " +
+				"scope=\"message:read message:write\""));
+	}
+
+	@Test
+	public void setRealmNameWhenNullRealmNameThenNoExceptionThrown() {
+		assertThatCode(() -> this.accessDeniedHandler.setRealmName(null))
+				.doesNotThrowAnyException();
+	}
+
+	static class TestingOAuth2TokenAuthenticationToken
+			extends AbstractOAuth2TokenAuthenticationToken<TestingOAuth2TokenAuthenticationToken.TestingOAuth2Token> {
+
+		private Map<String, Object> attributes;
+
+		protected TestingOAuth2TokenAuthenticationToken(Map<String, Object> attributes) {
+			super(new TestingOAuth2TokenAuthenticationToken.TestingOAuth2Token("token"));
+			this.attributes = attributes;
+		}
+
+		@Override
+		public Map<String, Object> getTokenAttributes() {
+			return this.attributes;
+		}
+
+		static class TestingOAuth2Token extends AbstractOAuth2Token {
+			public TestingOAuth2Token(String tokenValue) {
+				super(tokenValue);
+			}
+		}
+	}
+}

--- a/web/src/main/java/org/springframework/security/web/server/authorization/ServerWebExchangeDelegatingServerAccessDeniedHandler.java
+++ b/web/src/main/java/org/springframework/security/web/server/authorization/ServerWebExchangeDelegatingServerAccessDeniedHandler.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.server.authorization;
+
+import java.util.Arrays;
+import java.util.List;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
+import org.springframework.util.Assert;
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * A {@link ServerAccessDeniedHandler} which delegates to multiple {@link ServerAccessDeniedHandler}s based
+ * on a {@link ServerWebExchangeMatcher}
+ *
+ * @author Josh Cummings
+ * @since 5.1
+ */
+public class ServerWebExchangeDelegatingServerAccessDeniedHandler
+	implements ServerAccessDeniedHandler {
+
+	private final List<DelegateEntry> handlers;
+
+	private ServerAccessDeniedHandler defaultHandler = (exchange, e) -> {
+		exchange.getResponse().setStatusCode(HttpStatus.FORBIDDEN);
+		return exchange.getResponse().setComplete();
+	};
+
+	/**
+	 * Creates a new instance
+	 *
+	 * @param handlers a list of {@link ServerWebExchangeMatcher}/
+	 * {@link ServerAccessDeniedHandler} pairs that should be used. Each is considered
+	 * in the order they are specified and only the first {@link ServerAccessDeniedHandler}
+	 * is used. If none match, then the default {@link ServerAccessDeniedHandler}
+	 * is used.
+	 */
+	public ServerWebExchangeDelegatingServerAccessDeniedHandler(
+			DelegateEntry... handlers) {
+		this(Arrays.asList(handlers));
+	}
+
+	/**
+	 * Creates a new instance
+	 *
+	 * @param handlers a list of {@link ServerWebExchangeMatcher}/
+	 * {@link ServerAccessDeniedHandler} pairs that should be used. Each is considered
+	 * in the order they are specified and only the first {@link ServerAccessDeniedHandler}
+	 * is used. If none match, then the default {@link ServerAccessDeniedHandler}
+	 * is used.
+	 */
+	public ServerWebExchangeDelegatingServerAccessDeniedHandler(
+			List<DelegateEntry> handlers) {
+		Assert.notEmpty(handlers, "handlers cannot be null");
+		this.handlers = handlers;
+	}
+
+	@Override
+	public Mono<Void> handle(ServerWebExchange exchange,
+		AccessDeniedException denied) {
+		return Flux.fromIterable(this.handlers)
+				.filterWhen(entry -> isMatch(exchange, entry))
+				.next()
+				.map(DelegateEntry::getAccessDeniedHandler)
+				.defaultIfEmpty(this.defaultHandler)
+				.flatMap(handler -> handler.handle(exchange, denied));
+	}
+
+	/**
+	 * Use this {@link ServerAccessDeniedHandler} when no {@link ServerWebExchangeMatcher}
+	 * matches.
+	 *
+	 * @param accessDeniedHandler - the default {@link ServerAccessDeniedHandler} to use
+	 */
+	public void setDefaultAccessDeniedHandler(ServerAccessDeniedHandler accessDeniedHandler) {
+		Assert.notNull(accessDeniedHandler, "accessDeniedHandler cannot be null");
+		this.defaultHandler = accessDeniedHandler;
+	}
+
+	public static class DelegateEntry {
+		private final ServerWebExchangeMatcher matcher;
+		private final ServerAccessDeniedHandler accessDeniedHandler;
+
+		public DelegateEntry(ServerWebExchangeMatcher matcher,
+				ServerAccessDeniedHandler accessDeniedHandler) {
+			this.matcher = matcher;
+			this.accessDeniedHandler = accessDeniedHandler;
+		}
+
+		public ServerWebExchangeMatcher getMatcher() {
+			return this.matcher;
+		}
+
+		public ServerAccessDeniedHandler getAccessDeniedHandler() {
+			return this.accessDeniedHandler;
+		}
+	}
+
+	private Mono<Boolean> isMatch(ServerWebExchange exchange, DelegateEntry entry) {
+		ServerWebExchangeMatcher matcher = entry.getMatcher();
+		return matcher.matches(exchange)
+				.map(ServerWebExchangeMatcher.MatchResult::isMatch);
+	}
+}

--- a/web/src/test/java/org/springframework/security/web/server/authorization/ServerWebExchangeDelegatingServerAccessDeniedHandlerTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/authorization/ServerWebExchangeDelegatingServerAccessDeniedHandlerTests.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.server.authorization;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import reactor.core.publisher.Mono;
+
+import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
+import org.springframework.web.server.ServerWebExchange;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.web.server.authorization.ServerWebExchangeDelegatingServerAccessDeniedHandler.DelegateEntry;
+import static org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher.MatchResult.match;
+import static org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher.MatchResult.notMatch;
+
+public class ServerWebExchangeDelegatingServerAccessDeniedHandlerTests {
+	private ServerWebExchangeDelegatingServerAccessDeniedHandler delegator;
+	private List<ServerWebExchangeDelegatingServerAccessDeniedHandler.DelegateEntry> entries;
+	private ServerAccessDeniedHandler accessDeniedHandler;
+	private ServerWebExchange exchange;
+
+	@Before
+	public void setup() {
+		this.accessDeniedHandler = mock(ServerAccessDeniedHandler.class);
+		this.entries = new ArrayList<>();
+		this.exchange = mock(ServerWebExchange.class);
+	}
+
+	@Test
+	public void handleWhenNothingMatchesThenOnlyDefaultHandlerInvoked() {
+		ServerAccessDeniedHandler handler = mock(ServerAccessDeniedHandler.class);
+		ServerWebExchangeMatcher matcher = mock(ServerWebExchangeMatcher.class);
+		when(matcher.matches(this.exchange)).thenReturn(notMatch());
+		when(handler.handle(this.exchange, null)).thenReturn(Mono.empty());
+		when(this.accessDeniedHandler.handle(this.exchange, null)).thenReturn(Mono.empty());
+
+		this.entries.add(new DelegateEntry(matcher, handler));
+		this.delegator = new ServerWebExchangeDelegatingServerAccessDeniedHandler(this.entries);
+		this.delegator.setDefaultAccessDeniedHandler(this.accessDeniedHandler);
+
+		this.delegator.handle(this.exchange, null).block();
+
+		verify(this.accessDeniedHandler).handle(this.exchange, null);
+		verify(handler, never()).handle(this.exchange, null);
+	}
+
+	@Test
+	public void handleWhenFirstMatchesThenOnlyFirstInvoked() {
+		ServerAccessDeniedHandler firstHandler = mock(ServerAccessDeniedHandler.class);
+		ServerWebExchangeMatcher firstMatcher = mock(ServerWebExchangeMatcher.class);
+		ServerAccessDeniedHandler secondHandler = mock(ServerAccessDeniedHandler.class);
+		ServerWebExchangeMatcher secondMatcher = mock(ServerWebExchangeMatcher.class);
+		when(firstMatcher.matches(this.exchange)).thenReturn(match());
+		when(firstHandler.handle(this.exchange, null)).thenReturn(Mono.empty());
+		when(secondHandler.handle(this.exchange, null)).thenReturn(Mono.empty());
+
+		this.entries.add(new DelegateEntry(firstMatcher, firstHandler));
+		this.entries.add(new DelegateEntry(secondMatcher, secondHandler));
+		this.delegator = new ServerWebExchangeDelegatingServerAccessDeniedHandler(this.entries);
+		this.delegator.setDefaultAccessDeniedHandler(this.accessDeniedHandler);
+
+		this.delegator.handle(this.exchange, null).block();
+
+		verify(firstHandler).handle(this.exchange, null);
+		verify(secondHandler, never()).handle(this.exchange, null);
+		verify(this.accessDeniedHandler, never()).handle(this.exchange, null);
+		verify(secondMatcher, never()).matches(this.exchange);
+	}
+
+	@Test
+	public void handleWhenSecondMatchesThenOnlySecondInvoked() {
+		ServerAccessDeniedHandler firstHandler = mock(ServerAccessDeniedHandler.class);
+		ServerWebExchangeMatcher firstMatcher = mock(ServerWebExchangeMatcher.class);
+		ServerAccessDeniedHandler secondHandler = mock(ServerAccessDeniedHandler.class);
+		ServerWebExchangeMatcher secondMatcher = mock(ServerWebExchangeMatcher.class);
+		when(firstMatcher.matches(this.exchange)).thenReturn(notMatch());
+		when(secondMatcher.matches(this.exchange)).thenReturn(match());
+		when(firstHandler.handle(this.exchange, null)).thenReturn(Mono.empty());
+		when(secondHandler.handle(this.exchange, null)).thenReturn(Mono.empty());
+
+		this.entries.add(new DelegateEntry(firstMatcher, firstHandler));
+		this.entries.add(new DelegateEntry(secondMatcher, secondHandler));
+		this.delegator = new ServerWebExchangeDelegatingServerAccessDeniedHandler(this.entries);
+
+		this.delegator.handle(this.exchange, null).block();
+
+		verify(secondHandler).handle(this.exchange, null);
+		verify(firstHandler, never()).handle(this.exchange, null);
+		verify(this.accessDeniedHandler, never()).handle(this.exchange, null);
+	}
+}


### PR DESCRIPTION
This introduces an implementation of ServerAccessDeniedHandler that is
compliant with the OAuth 2.0 spec for insufficent_scope errors.

Fixes: gh-5705
