### PR TITLE
Polish OAuth2ResourceServerConfigurerTests

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
@@ -1300,11 +1300,7 @@ public class OAuth2ResourceServerConfigurerTests {
 					.and()
 				.oauth2ResourceServer()
 					.jwt();
-		}
-
-		@Bean
-		JwtDecoder jwtDecoder() {
-			return mock(JwtDecoder.class);
+			// @formatter:on
 		}
 	}
 


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR polishes `OAuth2ResourceServerConfigurerTests` by:

- adding a missing `@formatter:on`.
- removing a `JwtDecoder` bean declaration as it will be registered with `JwtDecoderConfig`.