### PR TITLE
Fix method name in the Contact sample code

### DIFF
--- a/samples/xml/contacts/src/main/java/sample/contact/AddDeleteContactController.java
+++ b/samples/xml/contacts/src/main/java/sample/contact/AddDeleteContactController.java
@@ -69,7 +69,7 @@ public class AddDeleteContactController {
 	}
 
 	@RequestMapping(value = "/secure/del.htm", method = RequestMethod.GET)
-	public ModelAndView handleRequest(@RequestParam("contactId") int contactId) {
+	public ModelAndView delContact(@RequestParam("contactId") int contactId) {
 		Contact contact = contactManager.getById(Long.valueOf(contactId));
 		contactManager.delete(contact);
 


### PR DESCRIPTION
The method name for handling `/secure/del.htm` was `handleRequest()`, but it should be `delContact()` (similar to `addContact()`).