### PR TITLE
Add a missing space in Secured.value() signature

### DIFF
--- a/core/src/main/java/org/springframework/security/access/annotation/Secured.java
+++ b/core/src/main/java/org/springframework/security/access/annotation/Secured.java
@@ -55,5 +55,5 @@ public @interface Secured {
 	 *
 	 * @return String[] The secure method attributes
 	 */
-	public String[]value();
+	public String[] value();
 }


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
This PR adds a missing space in the `Secured.value()` signature.