### PR TITLE
extract permission mask comparison for subclasses to override

### DIFF
--- a/acl/src/main/java/org/springframework/security/acls/domain/DefaultPermissionGrantingStrategy.java
+++ b/acl/src/main/java/org/springframework/security/acls/domain/DefaultPermissionGrantingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ public class DefaultPermissionGrantingStrategy implements PermissionGrantingStra
 
 				for (AccessControlEntry ace : aces) {
 
-					if ((ace.getPermission().getMask() == p.getMask())
+					if (comparePermissionMasks(ace, p)
 							&& ace.getSid().equals(sid)) {
 						// Found a matching ACE, so its authorization decision will
 						// prevail
@@ -140,6 +140,27 @@ public class DefaultPermissionGrantingStrategy implements PermissionGrantingStra
 			throw new NotFoundException(
 					"Unable to locate a matching ACE for passed permissions and SIDs");
 		}
+	}
+
+	/**
+	 * Compares an ACE Permission to the given Permission.
+	 * By default, we compare the Permission masks for exact match.
+	 * Subclasses of this strategy can override this behavior and implement
+	 * more sophisticated comparisons, e.g. a bitwise comparison for ACEs that grant access.
+	 * <pre>{@code
+	 * if (ace.isGranting() && p.getMask() != 0) {
+	 *    return (ace.getPermission().getMask() & p.getMask()) != 0;
+	 * } else {
+	 *    return ace.getPermission().getMask() == p.getMask();
+	 * }
+	 * }</pre>
+	 * 
+	 * @param ace the ACE from the Acl holding the mask.
+	 * @param p the Permission we are checking against.
+	 * @return true, if the respective masks are considered to be equal.
+	 */
+	protected boolean comparePermissionMasks(AccessControlEntry ace, Permission p) {
+		return ace.getPermission().getMask() == p.getMask();
 	}
 
 }

--- a/acl/src/main/java/org/springframework/security/acls/domain/DefaultPermissionGrantingStrategy.java
+++ b/acl/src/main/java/org/springframework/security/acls/domain/DefaultPermissionGrantingStrategy.java
@@ -87,7 +87,7 @@ public class DefaultPermissionGrantingStrategy implements PermissionGrantingStra
 
 				for (AccessControlEntry ace : aces) {
 
-					if (comparePermissionMasks(ace, p)
+					if (isGranted(ace, p)
 							&& ace.getSid().equals(sid)) {
 						// Found a matching ACE, so its authorization decision will
 						// prevail
@@ -159,7 +159,7 @@ public class DefaultPermissionGrantingStrategy implements PermissionGrantingStra
 	 * @param p the Permission we are checking against.
 	 * @return true, if the respective masks are considered to be equal.
 	 */
-	protected boolean comparePermissionMasks(AccessControlEntry ace, Permission p) {
+	protected boolean isGranted(AccessControlEntry ace, Permission p) {
 		return ace.getPermission().getMask() == p.getMask();
 	}
 

--- a/acl/src/main/java/org/springframework/security/acls/domain/DefaultPermissionGrantingStrategy.java
+++ b/acl/src/main/java/org/springframework/security/acls/domain/DefaultPermissionGrantingStrategy.java
@@ -154,7 +154,7 @@ public class DefaultPermissionGrantingStrategy implements PermissionGrantingStra
 	 *    return ace.getPermission().getMask() == p.getMask();
 	 * }
 	 * }</pre>
-	 * 
+	 *
 	 * @param ace the ACE from the Acl holding the mask.
 	 * @param p the Permission we are checking against.
 	 * @return true, if the respective masks are considered to be equal.

--- a/acl/src/test/java/org/springframework/security/acls/domain/AclImplTests.java
+++ b/acl/src/test/java/org/springframework/security/acls/domain/AclImplTests.java
@@ -49,6 +49,7 @@ public class AclImplTests {
 	PermissionGrantingStrategy pgs;
 	AuditLogger mockAuditLogger;
 	ObjectIdentity objectIdentity = new ObjectIdentityImpl(TARGET_CLASS, 100);
+	private DefaultPermissionFactory permissionFactory;
 
 	// ~ Methods
 	// ========================================================================================================
@@ -60,6 +61,7 @@ public class AclImplTests {
 		mockAuditLogger = mock(AuditLogger.class);
 		pgs = new DefaultPermissionGrantingStrategy(mockAuditLogger);
 		auth.setAuthenticated(true);
+		permissionFactory = new DefaultPermissionFactory();
 	}
 
 	@After
@@ -560,8 +562,38 @@ public class AclImplTests {
 		childAcl.setParent(changeParentAcl);
 	}
 
+	// SEC-2342
+	@Test
+	public void maskPermissionGrantingStrategy() {
+		DefaultPermissionGrantingStrategy maskPgs = new MaskPermissionGrantingStrategy(mockAuditLogger);
+		MockAclService service = new MockAclService();
+		AclImpl acl = new AclImpl(objectIdentity, 1, authzStrategy, maskPgs, null, null,
+				true, new PrincipalSid("joe"));
+		Permission permission = permissionFactory.buildFromMask(BasePermission.READ.getMask() | BasePermission.WRITE.getMask());
+		Sid sid = new PrincipalSid("ben");
+		acl.insertAce(0, permission, sid, true);
+		service.updateAcl(acl);
+		List<Permission> permissions = Arrays.asList(BasePermission.READ);
+		List<Sid> sids = Arrays.asList(sid);
+		assertThat(acl.isGranted(permissions, sids, false)).isTrue();
+	}
+
 	// ~ Inner Classes
 	// ==================================================================================================
+
+	private static class MaskPermissionGrantingStrategy extends DefaultPermissionGrantingStrategy {
+		public MaskPermissionGrantingStrategy(AuditLogger auditLogger) {
+			super(auditLogger);
+		}
+
+		@Override
+		protected boolean isGranted(AccessControlEntry ace, Permission p) {
+			if (p.getMask() != 0) {
+				return (p.getMask() & ace.getPermission().getMask()) != 0;
+			}
+			return super.isGranted(ace, p);
+		}
+	}
 
 	private class MockAclService implements MutableAclService {
 		public MutableAcl createAcl(ObjectIdentity objectIdentity)


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
**SEC-2342**
Extracts the mask comparison in DefaultPermissionGrantingStrategy into a protected method.
This allows overriding the default behavior in a subclass without having to copy the whole isGranted() method.
As discussed in the above issue (and others like [SEC-1140](https://github.com/spring-projects/spring-security/issues/1388)), users can choose to implement a different strategy, e.g. do a bitwise mask comparison instead of the integer comparison.