### PR TITLE
Allow in-memory client registration repos to be constructed with a map

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/InMemoryClientRegistrationRepository.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/InMemoryClientRegistrationRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import static java.util.stream.Collectors.toConcurrentMap;
  *
  * @author Joe Grandja
  * @author Rob Winch
+ * @author Vedran Pavic
  * @since 5.0
  * @see ClientRegistrationRepository
  * @see ClientRegistration
@@ -56,11 +57,25 @@ public final class InMemoryClientRegistrationRepository implements ClientRegistr
 	 * @param registrations the client registration(s)
 	 */
 	public InMemoryClientRegistrationRepository(List<ClientRegistration> registrations) {
+		this(createRegistrationsMap(registrations));
+	}
+
+	private static Map<String, ClientRegistration> createRegistrationsMap(List<ClientRegistration> registrations) {
 		Assert.notEmpty(registrations, "registrations cannot be empty");
 		Collector<ClientRegistration, ?, ConcurrentMap<String, ClientRegistration>> collector =
-			toConcurrentMap(ClientRegistration::getRegistrationId, Function.identity());
-		this.registrations = registrations.stream()
-			.collect(collectingAndThen(collector, Collections::unmodifiableMap));
+				toConcurrentMap(ClientRegistration::getRegistrationId, Function.identity());
+		return registrations.stream().collect(collectingAndThen(collector, Collections::unmodifiableMap));
+	}
+
+	/**
+	 * Constructs an {@code InMemoryReactiveClientRegistrationRepository} backed by a {@link Map} of client ids to
+	 * {@link ClientRegistration}s.
+	 *
+	 * @param registrations the map of client registration(s)
+	 */
+	public InMemoryClientRegistrationRepository(Map<String, ClientRegistration> registrations) {
+		Assert.notNull(registrations, "registrations cannot be null");
+		this.registrations = registrations;
 	}
 
 	@Override

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/InMemoryReactiveClientRegistrationRepository.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/InMemoryReactiveClientRegistrationRepository.java
@@ -30,6 +30,7 @@ import reactor.core.publisher.Mono;
  * A Reactive {@link ClientRegistrationRepository} that stores {@link ClientRegistration}(s) in-memory.
  *
  * @author Rob Winch
+ * @author Vedran Pavic
  * @since 5.1
  * @see ClientRegistrationRepository
  * @see ClientRegistration
@@ -64,6 +65,16 @@ public final class InMemoryReactiveClientRegistrationRepository
 				.collect(Collectors.toConcurrentMap(ClientRegistration::getRegistrationId, Function.identity()));
 	}
 
+	/**
+	 * Constructs an {@code InMemoryReactiveClientRegistrationRepository} backed by a {@link Map} of client ids to
+	 * {@link ClientRegistration}s. Note that the supplied map must be a non-blocking map.
+	 *
+	 * @param registrations the map of client registration(s)
+	 */
+	public InMemoryReactiveClientRegistrationRepository(Map<String, ClientRegistration> registrations) {
+		Assert.notNull(registrations, "registrations cannot be null");
+		this.clientIdToClientRegistration = registrations;
+	}
 
 	@Override
 	public Mono<ClientRegistration> findByRegistrationId(String registrationId) {

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/InMemoryClientRegistrationRepositoryTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/InMemoryClientRegistrationRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,9 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link InMemoryClientRegistrationRepository}.
  *
  * @author Rob Winch
+ * @author Vedran Pavic
  * @since 5.0
  */
 public class InMemoryClientRegistrationRepositoryTests {
@@ -51,6 +54,17 @@ public class InMemoryClientRegistrationRepositoryTests {
 	public void constructorListClientRegistrationWhenDuplicateIdThenIllegalArgumentException() {
 		List<ClientRegistration> registrations = Arrays.asList(this.registration, this.registration);
 		new InMemoryClientRegistrationRepository(registrations);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void constructorMapClientRegistrationWhenNullThenIllegalArgumentException() {
+		new InMemoryClientRegistrationRepository((Map<String, ClientRegistration>) null);
+	}
+
+	@Test
+	public void constructorMapClientRegistrationWhenEmptyMapThenRepositoryIsEmpty() {
+		InMemoryClientRegistrationRepository clients = new InMemoryClientRegistrationRepository(new HashMap<>());
+		assertThat(clients).isEmpty();
 	}
 
 	@Test

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/InMemoryReactiveClientRegistrationRepositoryTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/InMemoryReactiveClientRegistrationRepositoryTests.java
@@ -19,7 +19,9 @@ package org.springframework.security.oauth2.client.registration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -28,6 +30,7 @@ import reactor.test.StepVerifier;
 
 /**
  * @author Rob Winch
+ * @author Vedran Pavic
  * @since 5.1
  */
 public class InMemoryReactiveClientRegistrationRepositoryTests {
@@ -66,6 +69,20 @@ public class InMemoryReactiveClientRegistrationRepositoryTests {
 		ClientRegistration registration = null;
 		assertThatThrownBy(() -> new InMemoryReactiveClientRegistrationRepository(registration))
 				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void constructorWhenClientRegistrationMapIsNullThenIllegalArgumentException() {
+		Map<String, ClientRegistration> registrations = null;
+		assertThatThrownBy(() -> new InMemoryReactiveClientRegistrationRepository(registrations))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void constructorWhenClientRegistrationMapIsEmptyThenRepositoryIsEmpty() {
+		InMemoryReactiveClientRegistrationRepository repository = new InMemoryReactiveClientRegistrationRepository(
+				new HashMap<>());
+		assertThat(repository).isEmpty();
 	}
 
 	@Test


### PR DESCRIPTION
This would allow to back `InMemoryClientRegistrationRepository` with a distributed `Map`, such as Hazelcast's `IMap` for instance.

Ideally, the implementations should be renamed as well in order to reflect their nature (e.g. to `MapClientRegistrationRepository`). In that case, to ensure backwards compatibility the `InMemoryClientRegistrationRepository` that would be provided as an implementation that simply delegates to `MapClientRegistrationRepository` and is marked as deprecated. Let me know what's your opinion on this, and if accepted should I do it via this PR or another one later on.