### PR TITLE
Add postProcess call to HttpSecurity.oauth2Login()

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
@@ -989,7 +989,9 @@ public final class HttpSecurity extends
 	 * @throws Exception
 	 */
 	public OAuth2LoginConfigurer<HttpSecurity> oauth2Login() throws Exception {
-		return getOrApply(new OAuth2LoginConfigurer<>());
+		OAuth2LoginConfigurer configurer = getOrApply(new OAuth2LoginConfigurer<>());
+		this.postProcess(configurer);
+		return configurer;
 	}
 
 	/**


### PR DESCRIPTION
This matches the pattern oauth2Client() and oauth2ResourceServer() use

NOTE: I'm not sure this is approprate or not for this method.  I went looking for a way to customize the `OAuth2LoginConfigurer` from an auto configuration and realized this didn't follow the pattern of the other two.

A PR seemed like the easiest way to discuss it, feel free to close otherwise.