### PR TITLE
Support reactive method security with reactive types

### DIFF
--- a/config/src/integration-test/java/org/springframework/security/config/annotation/method/configuration/ReactiveMethodSecurityConfigurationTests.java
+++ b/config/src/integration-test/java/org/springframework/security/config/annotation/method/configuration/ReactiveMethodSecurityConfigurationTests.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.config.annotation.method.configuration;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.prepost.PostAuthorize;
+import org.springframework.security.access.prepost.PostFilter;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.access.prepost.PreFilter;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.core.userdetails.MapReactiveUserDetailsService;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * @author Eric Deandrea
+ * @since 5.1.2
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = ReactiveMethodSecurityConfigurationTests.ReactiveMethodSecurityConfigurationTestsConfig.class)
+@ActiveProfiles("ReactiveMethodSecurityConfigurationTests")
+public class ReactiveMethodSecurityConfigurationTests {
+	@Autowired
+	private Methods methods;
+
+	@Test
+	public void preAuthorizeMonoTrue() {
+		StepVerifier.create(this.methods.preAuthorizeMonoTrue())
+				.expectNext(Methods.getSomething())
+				.verifyComplete();
+	}
+
+	@Test
+	public void preAuthorizeMonoFalse() {
+		StepVerifier.create(this.methods.preAuthorizeMonoFalse())
+				.verifyError(AccessDeniedException.class);
+	}
+
+	@Test
+	public void postAuthorizeMonoTrue() {
+		StepVerifier.create(this.methods.postAuthorizeMonoTrue())
+				.expectNext(Methods.getSomething())
+				.verifyComplete();
+	}
+
+	@Test
+	public void postAuthorizeMonoFalse() {
+		StepVerifier.create(this.methods.postAuthorizeMonoFalse())
+				.verifyError(AccessDeniedException.class);
+	}
+
+	@Test
+	public void preAuthorizeFluxTrue() {
+		StepVerifier.create(this.methods.preAuthorizeFluxTrue())
+				.expectNext(Methods.getSomething())
+				.expectNext(Methods.getSomethingElse())
+				.verifyComplete();
+	}
+
+	@Test
+	public void preAuthorizeFluxFalse() {
+		StepVerifier.create(this.methods.preAuthorizeFluxFalse())
+				.verifyError(AccessDeniedException.class);
+	}
+
+	@Test
+	public void postAuthorizeFluxTrue() {
+		StepVerifier.create(this.methods.postAuthorizeFluxTrue())
+				.expectNext(Methods.getSomething())
+				.expectNext(Methods.getSomethingElse())
+				.verifyComplete();
+	}
+
+	@Test
+	public void postAuthorizeFluxFalse() {
+		StepVerifier.create(this.methods.postAuthorizeFluxFalse())
+				.verifyError(AccessDeniedException.class);
+	}
+
+	@Test
+	public void preFilterMonoPasses() {
+		StepVerifier.create(this.methods.preFilterMonoPasses(Mono.just(Methods.getSomething())))
+				.expectNext(Methods.getSomething())
+				.verifyComplete();
+	}
+
+	@Test
+	public void preFilterMultipleArgsMonoPasses() {
+		StepVerifier.create(this.methods.preFilterMultipleArgsMonoPasses(Mono.just(Methods.getSomethingElse()), Mono.just(Methods.getSomething())))
+				.expectNext(Methods.getSomething())
+				.verifyComplete();
+	}
+
+	@Test
+	public void preFilterMonoDoesntPass() {
+		StepVerifier.create(this.methods.preFilterMonoDoesntPass(Mono.just(Methods.getSomethingElse())))
+				.expectNext(Methods.getEmpty())
+				.verifyComplete();
+	}
+
+	@Test
+	public void preFilterMultipleArgsMonoDoesntPass() {
+		StepVerifier.create(this.methods.preFilterMultipleArgsMonoDoesntPass(Mono.just(Methods.getSomething()), Mono.just(Methods.getSomethingElse())))
+				.expectNext(Methods.getEmpty())
+				.verifyComplete();
+	}
+
+	@Test
+	public void postFilterMonoPasses() {
+		StepVerifier.create(this.methods.postFilterMonoPasses(Mono.just(Methods.getSomething())))
+				.expectNext(Methods.getSomething())
+				.verifyComplete();
+	}
+
+	@Test
+	public void postFilterMonoDoesntPass() {
+		StepVerifier.create(this.methods.postFilterMonoDoesntPass(Mono.just(Methods.getSomethingElse())))
+				.verifyComplete();
+	}
+
+	@Test
+	public void preFilterFluxAllPass() {
+		StepVerifier.create(this.methods.preFilterFluxAllPass(Flux.just(Methods.getSomething(), Methods.getSomethingElse())))
+				.expectNext(Methods.getSomething())
+				.expectNext(Methods.getSomethingElse())
+				.verifyComplete();
+	}
+
+	@Test
+	public void preFilterFluxOnePasses() {
+		StepVerifier.create(this.methods.preFilterFluxOnePasses(Flux.just(Methods.getSomething(), Methods.getSomethingElse())))
+				.expectNext(Methods.getSomething())
+				.verifyComplete();
+	}
+
+	@Test
+	public void preFilterMultipleArgsFluxAllPass() {
+		StepVerifier.create(this.methods.preFilterMultipleArgsFluxAllPass(Mono.just(Methods.getEmpty()), Flux.just(Methods.getSomething(), Methods.getSomethingElse())))
+				.expectNext(Methods.getSomething())
+				.expectNext(Methods.getSomethingElse())
+				.verifyComplete();
+	}
+
+	@Test
+	public void preFilterMultipleArgsFluxOnePasses() {
+		StepVerifier.create(this.methods.preFilterMultipleArgsFluxOnePasses(Mono.just(Methods.getEmpty()), Flux.just(Methods.getSomething(), Methods.getSomethingElse())))
+				.expectNext(Methods.getSomething())
+				.verifyComplete();
+	}
+
+	@Test
+	public void postFilterFluxAllPass() {
+		StepVerifier.create(this.methods.postFilterFluxAllPass())
+				.expectNext(Methods.getSomething())
+				.expectNext(Methods.getSomethingElse())
+				.verifyComplete();
+	}
+
+	@Test
+	public void postFilterFluxOnePasses() {
+		StepVerifier.create(this.methods.postFilterFluxOnePasses())
+				.expectNext(Methods.getSomething())
+				.verifyComplete();
+	}
+
+	static class Permissions {
+		public Mono<Boolean> trueMono() {
+			return Mono.just(true);
+		}
+
+		public Mono<Boolean> falseMono() {
+			return Mono.just(false);
+		}
+
+		public Mono<Boolean> allPassFilter(String string) {
+			return Mono.just(true);
+		}
+
+		public Mono<Boolean> onePassFilter(String string) {
+			return Mono.just(Methods.getSomething().equals(string));
+		}
+	}
+
+	static class Methods {
+		public static String getSomething() {
+			return "something";
+		}
+
+		public static String getSomethingElse() {
+			return "something else";
+		}
+
+		public static String getEmpty() {
+			return "empty";
+		}
+
+		@PreAuthorize("@permissions.trueMono()")
+		public Mono<String> preAuthorizeMonoTrue() {
+			return Mono.just(getSomething());
+		}
+
+		@PreAuthorize("@permissions.falseMono()")
+		public Mono<String> preAuthorizeMonoFalse() {
+			return Mono.just(getSomething());
+		}
+
+		@PostAuthorize("@permissions.trueMono()")
+		public Mono<String> postAuthorizeMonoTrue() {
+			return Mono.just(getSomething());
+		}
+
+		@PostAuthorize("@permissions.falseMono()")
+		public Mono<String> postAuthorizeMonoFalse() {
+			return Mono.just(getSomething());
+		}
+
+		@PreAuthorize("@permissions.trueMono()")
+		public Flux<String> preAuthorizeFluxTrue() {
+			return Flux.just(getSomething(), getSomethingElse());
+		}
+
+		@PreAuthorize("@permissions.falseMono()")
+		public Flux<String> preAuthorizeFluxFalse() {
+			return Flux.just(getSomething(), getSomethingElse());
+		}
+
+		@PostAuthorize("@permissions.trueMono()")
+		public Flux<String> postAuthorizeFluxTrue() {
+			return Flux.just(getSomething(), getSomethingElse());
+		}
+
+		@PostAuthorize("@permissions.falseMono()")
+		public Flux<String> postAuthorizeFluxFalse() {
+			return Flux.just(getSomething(), getSomethingElse());
+		}
+
+		@PreFilter("@permissions.allPassFilter(filterObject)")
+		public Mono<String> preFilterMonoPasses(Mono<String> mono) {
+			return mono.switchIfEmpty(Mono.just(getEmpty()));
+		}
+
+		@PreFilter(value = "@permissions.allPassFilter(filterObject)", filterTarget = "mono2")
+		public Mono<String> preFilterMultipleArgsMonoPasses(Mono<String> mono1, Mono<String> mono2) {
+			return mono2.switchIfEmpty(Mono.just(getEmpty()));
+		}
+
+		@PreFilter("@permissions.onePassFilter(filterObject)")
+		public Mono<String> preFilterMonoDoesntPass(Mono<String> mono) {
+			return mono.switchIfEmpty(Mono.just(getEmpty()));
+		}
+
+		@PreFilter(value = "@permissions.onePassFilter(filterObject)", filterTarget = "mono2")
+		public Mono<String> preFilterMultipleArgsMonoDoesntPass(Mono<String> mono1, Mono<String> mono2) {
+			return mono2.switchIfEmpty(Mono.just(getEmpty()));
+		}
+
+		@PostFilter("@permissions.allPassFilter(filterObject)")
+		public Mono<String> postFilterMonoPasses(Mono<String> mono) {
+			return mono.switchIfEmpty(Mono.just(getEmpty()));
+		}
+
+		@PostFilter("@permissions.onePassFilter(filterObject)")
+		public Mono<String> postFilterMonoDoesntPass(Mono<String> mono) {
+			return mono.switchIfEmpty(Mono.just(getEmpty()));
+		}
+
+		@PreFilter("@permissions.allPassFilter(filterObject)")
+		public Flux<String> preFilterFluxAllPass(Flux<String> flux) {
+			return flux;
+		}
+
+		@PreFilter("@permissions.onePassFilter(filterObject)")
+		public Flux<String> preFilterFluxOnePasses(Flux<String> flux) {
+			return flux;
+		}
+
+		@PreFilter(filterTarget = "flux", value = "@permissions.allPassFilter(filterObject)")
+		public Flux<String> preFilterMultipleArgsFluxAllPass(Mono<String> mono,  Flux<String> flux) {
+			return flux;
+		}
+
+		@PreFilter(filterTarget = "flux", value = "@permissions.onePassFilter(filterObject)")
+		public Flux<String> preFilterMultipleArgsFluxOnePasses(Mono<String> mono,  Flux<String> flux) {
+			return flux;
+		}
+
+		@PostFilter("@permissions.allPassFilter(filterObject)")
+		public Flux<String> postFilterFluxAllPass() {
+			return Flux.just(getSomething(), getSomethingElse());
+		}
+
+		@PostFilter("@permissions.onePassFilter(filterObject)")
+		public Flux<String> postFilterFluxOnePasses() {
+			return Flux.just(getSomething(), getSomethingElse());
+		}
+	}
+
+	@Configuration
+	@Profile("ReactiveMethodSecurityConfigurationTests")
+	@EnableWebFluxSecurity
+	@EnableReactiveMethodSecurity
+	static class ReactiveMethodSecurityConfigurationTestsConfig {
+		@Bean
+		public Permissions permissions() {
+			return new Permissions();
+		}
+
+		@Bean
+		public Methods methods() {
+			return new Methods();
+		}
+
+		@Bean
+		public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity httpSecurity) {
+			return httpSecurity
+					.csrf().disable()
+					.cors().disable()
+					.authorizeExchange()
+						.anyExchange().permitAll()
+					.and().build();
+		}
+
+		@Bean
+		public MapReactiveUserDetailsService userDetailsService() {
+			UserDetails user = User.withDefaultPasswordEncoder()
+					.username("user")
+					.password("password")
+					.roles("USER")
+					.build();
+
+			return new MapReactiveUserDetailsService(user);
+		}
+	}
+}

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/DelegatingReactiveMessageService.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/DelegatingReactiveMessageService.java
@@ -16,10 +16,12 @@
 package org.springframework.security.config.annotation.method.configuration;
 
 import org.reactivestreams.Publisher;
-import org.springframework.security.access.prepost.PostAuthorize;
-import org.springframework.security.access.prepost.PreAuthorize;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import org.springframework.security.access.prepost.PostAuthorize;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 public class DelegatingReactiveMessageService implements ReactiveMessageService {
 	private final ReactiveMessageService delegate;
@@ -47,7 +49,7 @@ public class DelegatingReactiveMessageService implements ReactiveMessageService 
 	}
 
 	@Override
-	@PostAuthorize("returnObject?.contains(authentication?.name)")
+	@PostAuthorize("@authz.containsAuthenticationName(returnObject, authentication?.name)")
 	public Mono<String> monoPostAuthorizeFindById(
 			long id) {
 		return delegate.monoPostAuthorizeFindById(id);
@@ -80,7 +82,7 @@ public class DelegatingReactiveMessageService implements ReactiveMessageService 
 	}
 
 	@Override
-	@PostAuthorize("returnObject?.contains(authentication?.name)")
+	@PostAuthorize("@authz.containsAuthenticationName(returnObject, authentication?.name)")
 	public Flux<String> fluxPostAuthorizeFindById(
 			long id) {
 		return delegate.fluxPostAuthorizeFindById(id);
@@ -113,7 +115,7 @@ public class DelegatingReactiveMessageService implements ReactiveMessageService 
 	}
 
 	@Override
-	@PostAuthorize("returnObject?.contains(authentication?.name)")
+	@PostAuthorize("@authz.containsAuthenticationName(returnObject, authentication?.name)")
 	public Publisher<String> publisherPostAuthorizeFindById(
 			long id) {
 		return delegate.publisherPostAuthorizeFindById(id);

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/EnableReactiveMethodSecurityTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/EnableReactiveMethodSecurityTests.java
@@ -16,11 +16,21 @@
 
 package org.springframework.security.config.annotation.method.configuration;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.reactivestreams.Publisher;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import reactor.test.publisher.TestPublisher;
+import reactor.util.context.Context;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.access.AccessDeniedException;
@@ -28,14 +38,6 @@ import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
-import reactor.test.publisher.TestPublisher;
-import reactor.util.context.Context;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
 
 /**
  * @author Rob Winch
@@ -66,7 +68,7 @@ public class EnableReactiveMethodSecurityTests {
 		assertThatThrownBy(() -> this.messageService.notPublisherPreAuthorizeFindById(1L))
 			.isInstanceOf(IllegalStateException.class)
 			.extracting(Throwable::getMessage)
-			.isEqualTo("The returnType class java.lang.String on public abstract java.lang.String org.springframework.security.config.annotation.method.configuration.ReactiveMessageService.notPublisherPreAuthorizeFindById(long) must return an instance of org.reactivestreams.Publisher (i.e. Mono / Flux) in order to support Reactor Context");
+			.isEqualTo("The return type java.lang.String on method public abstract java.lang.String org.springframework.security.config.annotation.method.configuration.ReactiveMessageService.notPublisherPreAuthorizeFindById(long) must return an instance of org.reactivestreams.Publisher (i.e. Mono / Flux) in order to support Reactor Context");
 	}
 
 	@Test
@@ -589,8 +591,8 @@ public class EnableReactiveMethodSecurityTests {
 		}
 
 		@Bean
-		public Authz authz() {
-			return new Authz();
+		public ReactiveAuthz authz() {
+			return new ReactiveAuthz();
 		}
 	}
 }

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/ReactiveAuthz.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/ReactiveAuthz.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.config.annotation.method.configuration;
+
+import org.reactivestreams.Publisher;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.security.core.Authentication;
+
+/**
+ * @author Eric Deandrea
+ * @since 5.1.2
+ */
+public class ReactiveAuthz {
+	public Mono<Boolean> check(boolean result) {
+		return Mono.defer(() -> Mono.just(result));
+	}
+
+	public Mono<Boolean> check(long id) {
+		return Mono.defer(() -> Mono.just(id % 2 == 0));
+	}
+
+	public Mono<Boolean> check(Authentication authentication, Flux<String> message) {
+		return check(authentication, Mono.from(message));
+	}
+
+	public Mono<Boolean> check(Authentication authentication, Mono<String> message) {
+		return message
+				.filter(m -> m.contains(authentication.getName()))
+				.map(m -> true)
+				.defaultIfEmpty(false);
+	}
+
+	public Mono<Boolean> containsAuthenticationName(Mono<String> mono, String authenticationName) {
+		return mono
+				.map(string -> (string != null) && string.contains(authenticationName))
+				.defaultIfEmpty(false);
+	}
+
+	public Mono<Boolean> containsAuthenticationName(Flux<String> flux, String authenticationName) {
+		return flux
+				.filter(string -> (string != null) && string.contains(authenticationName))
+				.flatMap(string -> Mono.just(true))
+				.defaultIfEmpty(false)
+				.next();
+	}
+
+	public Mono<Boolean> containsAuthenticationName(Publisher<String> publisher, String authenticationName) {
+		return containsAuthenticationName(Flux.first(publisher), authenticationName);
+	}
+}

--- a/core/src/main/java/org/springframework/security/access/expression/ReactiveExpressionUtils.java
+++ b/core/src/main/java/org/springframework/security/access/expression/ReactiveExpressionUtils.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.access.expression;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.EvaluationException;
+import org.springframework.expression.Expression;
+
+/**
+ * Reactive version of {@link ExpressionUtils} for evaluating expressions that return reactive types.
+ *
+ * @author Eric Deandrea
+ * @since 5.1.2
+ */
+public final class ReactiveExpressionUtils {
+	/**
+	 * Evaluates an {@link Expression} that can either return a {@code boolean} or a {@code Mono<Boolean>}.
+	 * @param expr The {@link Expression}
+	 * @param ctx The {@link EvaluationContext}
+	 * @return A {@link Mono} that can be subscribed to containing the result of the expression
+	 */
+	public static Mono<Boolean> evaluateAsBoolean(Expression expr, EvaluationContext ctx) {
+		return Mono.defer(() -> {
+			try {
+				Object value = expr.getValue(ctx);
+
+				if (value instanceof Boolean) {
+					return Mono.just((Boolean) value);
+				}
+				else if (value instanceof Mono) {
+					return ((Mono<?>) value)
+							.filter(Boolean.class::isInstance)
+							.cast(Boolean.class)
+							.switchIfEmpty(createInvalidTypeMono(expr));
+				}
+				else {
+					return createInvalidTypeMono(expr);
+				}
+			}
+			catch (EvaluationException ex) {
+				return Mono.error(new IllegalArgumentException(String.format("Failed to evaluate expression '%s': %s", expr.getExpressionString(), ex.getMessage()), ex));
+			}
+		});
+	}
+
+	private static Mono<Boolean> createInvalidTypeMono(Expression expr) {
+		return Mono.error(new IllegalArgumentException(String.format("Expression '%s' needs to either return boolean or Mono<Boolean> but it does not", expr.getExpressionString())));
+	}
+}

--- a/core/src/main/java/org/springframework/security/access/expression/method/AbstractMethodSecurityExpressionHandler.java
+++ b/core/src/main/java/org/springframework/security/access/expression/method/AbstractMethodSecurityExpressionHandler.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.access.expression.method;
+
+import org.aopalliance.intercept.MethodInvocation;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.core.ParameterNameDiscoverer;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.security.access.PermissionCacheOptimizer;
+import org.springframework.security.access.expression.AbstractSecurityExpressionHandler;
+import org.springframework.security.authentication.AuthenticationTrustResolver;
+import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.parameters.DefaultSecurityParameterNameDiscoverer;
+import org.springframework.util.Assert;
+
+/**
+ * Base class for method security expression handlers
+ *
+ * @author Eric Deandrea
+ * @since 5.1.2
+ */
+public abstract class AbstractMethodSecurityExpressionHandler extends AbstractSecurityExpressionHandler<MethodInvocation> {
+	protected final Log logger = LogFactory.getLog(getClass());
+
+	private AuthenticationTrustResolver trustResolver = new AuthenticationTrustResolverImpl();
+	private ParameterNameDiscoverer parameterNameDiscoverer = new DefaultSecurityParameterNameDiscoverer();
+	private PermissionCacheOptimizer permissionCacheOptimizer = null;
+	private String defaultRolePrefix = "ROLE_";
+
+	/**
+	 * Uses a {@link MethodSecurityEvaluationContext} as the <tt>EvaluationContext</tt>
+	 * implementation.
+	 */
+	@Override
+	public StandardEvaluationContext createEvaluationContextInternal(Authentication auth,
+			MethodInvocation mi) {
+		return new MethodSecurityEvaluationContext(auth, mi, getParameterNameDiscoverer());
+	}
+
+	/**
+	 * Creates the root object for expression evaluation.
+	 */
+	@Override
+	protected MethodSecurityExpressionOperations createSecurityExpressionRoot(
+			Authentication authentication, MethodInvocation invocation) {
+		MethodSecurityExpressionRoot root = new MethodSecurityExpressionRoot(
+				authentication);
+		root.setThis(invocation.getThis());
+		root.setPermissionEvaluator(getPermissionEvaluator());
+		root.setTrustResolver(getTrustResolver());
+		root.setRoleHierarchy(getRoleHierarchy());
+		root.setDefaultRolePrefix(getDefaultRolePrefix());
+
+		return root;
+	}
+
+	/**
+	 * Sets the {@link AuthenticationTrustResolver} to be used. The default is
+	 * {@link AuthenticationTrustResolverImpl}.
+	 *
+	 * @param trustResolver the {@link AuthenticationTrustResolver} to use. Cannot be
+	 * null.
+	 */
+	public void setTrustResolver(AuthenticationTrustResolver trustResolver) {
+		Assert.notNull(trustResolver, "trustResolver cannot be null");
+		this.trustResolver = trustResolver;
+	}
+
+	/**
+	 * @return The current {@link AuthenticationTrustResolver}
+	 */
+	protected AuthenticationTrustResolver getTrustResolver() {
+		return trustResolver;
+	}
+
+	/**
+	 * Sets the {@link ParameterNameDiscoverer} to use. The default is
+	 * {@link DefaultSecurityParameterNameDiscoverer}.
+	 * @param parameterNameDiscoverer
+	 */
+	public void setParameterNameDiscoverer(ParameterNameDiscoverer parameterNameDiscoverer) {
+		this.parameterNameDiscoverer = parameterNameDiscoverer;
+	}
+
+	/**
+	 * @return The current {@link ParameterNameDiscoverer}
+	 */
+	protected ParameterNameDiscoverer getParameterNameDiscoverer() {
+		return parameterNameDiscoverer;
+	}
+
+	public void setPermissionCacheOptimizer(PermissionCacheOptimizer permissionCacheOptimizer) {
+		this.permissionCacheOptimizer = permissionCacheOptimizer;
+	}
+
+	protected PermissionCacheOptimizer getPermissionCacheOptimizer() {
+		return this.permissionCacheOptimizer;
+	}
+
+	public void setReturnObject(Object returnObject, EvaluationContext ctx) {
+		((MethodSecurityExpressionOperations) ctx.getRootObject().getValue())
+				.setReturnObject(returnObject);
+	}
+
+	/**
+	 * <p>
+	 * Sets the default prefix to be added to {@link org.springframework.security.access.expression.SecurityExpressionRoot#hasAnyRole(String...)} or
+	 * {@link org.springframework.security.access.expression.SecurityExpressionRoot#hasRole(String)}. For example, if hasRole("ADMIN") or hasRole("ROLE_ADMIN")
+	 * is passed in, then the role ROLE_ADMIN will be used when the defaultRolePrefix is
+	 * "ROLE_" (default).
+	 * </p>
+	 *
+	 * <p>
+	 * If null or empty, then no default role prefix is used.
+	 * </p>
+	 *
+	 * @param defaultRolePrefix the default prefix to add to roles. Default "ROLE_".
+	 */
+	public void setDefaultRolePrefix(String defaultRolePrefix) {
+		this.defaultRolePrefix = defaultRolePrefix;
+	}
+
+	/**
+	 * @return The default role prefix
+	 */
+	protected String getDefaultRolePrefix() {
+		return defaultRolePrefix;
+	}
+}

--- a/core/src/main/java/org/springframework/security/access/expression/method/DefaultMethodSecurityExpressionHandler.java
+++ b/core/src/main/java/org/springframework/security/access/expression/method/DefaultMethodSecurityExpressionHandler.java
@@ -20,22 +20,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
-import org.aopalliance.intercept.MethodInvocation;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.core.ParameterNameDiscoverer;
+
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
-import org.springframework.expression.spel.support.StandardEvaluationContext;
-import org.springframework.security.access.PermissionCacheOptimizer;
-import org.springframework.security.access.expression.AbstractSecurityExpressionHandler;
 import org.springframework.security.access.expression.ExpressionUtils;
-import org.springframework.security.authentication.AuthenticationTrustResolver;
-import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.parameters.DefaultSecurityParameterNameDiscoverer;
-import org.springframework.util.Assert;
 
 /**
  * The standard implementation of {@code MethodSecurityExpressionHandler}.
@@ -46,44 +38,10 @@ import org.springframework.util.Assert;
  * @author Luke Taylor
  * @since 3.0
  */
-public class DefaultMethodSecurityExpressionHandler extends
-		AbstractSecurityExpressionHandler<MethodInvocation> implements
-		MethodSecurityExpressionHandler {
+public class DefaultMethodSecurityExpressionHandler extends AbstractMethodSecurityExpressionHandler
+		implements MethodSecurityExpressionHandler {
 
 	protected final Log logger = LogFactory.getLog(getClass());
-
-	private AuthenticationTrustResolver trustResolver = new AuthenticationTrustResolverImpl();
-	private ParameterNameDiscoverer parameterNameDiscoverer = new DefaultSecurityParameterNameDiscoverer();
-	private PermissionCacheOptimizer permissionCacheOptimizer = null;
-	private String defaultRolePrefix = "ROLE_";
-
-	public DefaultMethodSecurityExpressionHandler() {
-	}
-
-	/**
-	 * Uses a {@link MethodSecurityEvaluationContext} as the <tt>EvaluationContext</tt>
-	 * implementation.
-	 */
-	public StandardEvaluationContext createEvaluationContextInternal(Authentication auth,
-			MethodInvocation mi) {
-		return new MethodSecurityEvaluationContext(auth, mi, getParameterNameDiscoverer());
-	}
-
-	/**
-	 * Creates the root object for expression evaluation.
-	 */
-	protected MethodSecurityExpressionOperations createSecurityExpressionRoot(
-			Authentication authentication, MethodInvocation invocation) {
-		MethodSecurityExpressionRoot root = new MethodSecurityExpressionRoot(
-				authentication);
-		root.setThis(invocation.getThis());
-		root.setPermissionEvaluator(getPermissionEvaluator());
-		root.setTrustResolver(getTrustResolver());
-		root.setRoleHierarchy(getRoleHierarchy());
-		root.setDefaultRolePrefix(getDefaultRolePrefix());
-
-		return root;
-	}
 
 	/**
 	 * Filters the {@code filterTarget} object (which must be either a collection or an
@@ -93,6 +51,7 @@ public class DefaultMethodSecurityExpressionHandler extends
 	 * the elements for which the permission expression evaluates to {@code true}. For an
 	 * array, a new array instance will be returned.
 	 */
+	@Override
 	@SuppressWarnings("unchecked")
 	public Object filter(Object filterTarget, Expression filterExpression,
 			EvaluationContext ctx) {
@@ -115,10 +74,11 @@ public class DefaultMethodSecurityExpressionHandler extends
 						+ " elements");
 			}
 
-			if (permissionCacheOptimizer != null) {
-				permissionCacheOptimizer.cachePermissionsFor(
-						rootObject.getAuthentication(), collection);
-			}
+			Optional.ofNullable(getPermissionCacheOptimizer())
+					.ifPresent(permissionCacheOptimizer ->
+							permissionCacheOptimizer.cachePermissionsFor(rootObject.getAuthentication(),
+									collection)
+					);
 
 			for (Object filterObject : (Collection) filterTarget) {
 				rootObject.setFilterObject(filterObject);
@@ -146,10 +106,11 @@ public class DefaultMethodSecurityExpressionHandler extends
 				logger.debug("Filtering array with " + array.length + " elements");
 			}
 
-			if (permissionCacheOptimizer != null) {
-				permissionCacheOptimizer.cachePermissionsFor(
-						rootObject.getAuthentication(), Arrays.asList(array));
-			}
+			Optional.ofNullable(getPermissionCacheOptimizer())
+					.ifPresent(permissionCacheOptimizer ->
+							permissionCacheOptimizer.cachePermissionsFor(rootObject.getAuthentication(),
+									Arrays.asList(array))
+					);
 
 			for (Object o : array) {
 				rootObject.setFilterObject(o);
@@ -175,75 +136,5 @@ public class DefaultMethodSecurityExpressionHandler extends
 		throw new IllegalArgumentException(
 				"Filter target must be a collection or array type, but was "
 						+ filterTarget);
-	}
-
-	/**
-	 * Sets the {@link AuthenticationTrustResolver} to be used. The default is
-	 * {@link AuthenticationTrustResolverImpl}.
-	 *
-	 * @param trustResolver the {@link AuthenticationTrustResolver} to use. Cannot be
-	 * null.
-	 */
-	public void setTrustResolver(AuthenticationTrustResolver trustResolver) {
-		Assert.notNull(trustResolver, "trustResolver cannot be null");
-		this.trustResolver = trustResolver;
-	}
-
-	/**
-	 * @return The current {@link AuthenticationTrustResolver}
-     */
-	protected AuthenticationTrustResolver getTrustResolver() {
-		return trustResolver;
-	}
-
-	/**
-	 * Sets the {@link ParameterNameDiscoverer} to use. The default is
-	 * {@link DefaultSecurityParameterNameDiscoverer}.
-	 * @param parameterNameDiscoverer
-	 */
-	public void setParameterNameDiscoverer(ParameterNameDiscoverer parameterNameDiscoverer) {
-		this.parameterNameDiscoverer = parameterNameDiscoverer;
-	}
-
-	/**
-	 * @return The current {@link ParameterNameDiscoverer}
-     */
-	protected ParameterNameDiscoverer getParameterNameDiscoverer() {
-		return parameterNameDiscoverer;
-	}
-
-	public void setPermissionCacheOptimizer(
-			PermissionCacheOptimizer permissionCacheOptimizer) {
-		this.permissionCacheOptimizer = permissionCacheOptimizer;
-	}
-
-	public void setReturnObject(Object returnObject, EvaluationContext ctx) {
-		((MethodSecurityExpressionOperations) ctx.getRootObject().getValue())
-				.setReturnObject(returnObject);
-	}
-
-	/**
-	 * <p>
-	 * Sets the default prefix to be added to {@link org.springframework.security.access.expression.SecurityExpressionRoot#hasAnyRole(String...)} or
-	 * {@link org.springframework.security.access.expression.SecurityExpressionRoot#hasRole(String)}. For example, if hasRole("ADMIN") or hasRole("ROLE_ADMIN")
-	 * is passed in, then the role ROLE_ADMIN will be used when the defaultRolePrefix is
-	 * "ROLE_" (default).
-	 * </p>
-	 *
-	 * <p>
-	 * If null or empty, then no default role prefix is used.
-	 * </p>
-	 *
-	 * @param defaultRolePrefix the default prefix to add to roles. Default "ROLE_".
-	 */
-	public void setDefaultRolePrefix(String defaultRolePrefix) {
-		this.defaultRolePrefix = defaultRolePrefix;
-	}
-
-	/**
-	 * @return The default role prefix
-     */
-	protected String getDefaultRolePrefix() {
-		return defaultRolePrefix;
 	}
 }

--- a/core/src/main/java/org/springframework/security/access/expression/method/DefaultReactiveMethodSecurityExpressionHandler.java
+++ b/core/src/main/java/org/springframework/security/access/expression/method/DefaultReactiveMethodSecurityExpressionHandler.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.access.expression.method;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.reactivestreams.Publisher;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.lang.Nullable;
+import org.springframework.security.access.PermissionCacheOptimizer;
+import org.springframework.security.access.expression.ReactiveExpressionUtils;
+
+/**
+ * The standard implementation of {@link ReactiveMethodSecurityExpressionHandler}.
+ * <p>
+ *   A single instance should usually be shared amongst the beans that require expression
+ *   support.
+ * </p>
+ * <p>
+ *   This is the reactive equivalent of {@link DefaultMethodSecurityExpressionHandler}.
+ * </p>
+ *
+ * @author Eric Deandrea
+ * @since 5.1.2
+ * @see DefaultMethodSecurityExpressionHandler
+ */
+public class DefaultReactiveMethodSecurityExpressionHandler extends AbstractMethodSecurityExpressionHandler
+		implements ReactiveMethodSecurityExpressionHandler {
+
+	@Override
+	public <T extends Publisher<?>> T filter(T filterTarget, @Nullable Expression filterExpression, EvaluationContext ctx) {
+		return Optional.ofNullable(filterExpression)
+				.map(filter -> applyFilter(filterTarget, filter, ctx))
+				.orElse(filterTarget);
+	}
+
+	private <T extends Publisher<?>> T applyFilter(T filterTarget, Expression filterExpression, EvaluationContext ctx) {
+		MethodSecurityExpressionOperations rootObject = (MethodSecurityExpressionOperations) ctx
+				.getRootObject().getValue();
+
+		Class<?> returnType = filterTarget.getClass();
+
+		Function<Object, ? extends Publisher<Boolean>> filter = item -> {
+			rootObject.setFilterObject(item);
+			return ReactiveExpressionUtils.evaluateAsBoolean(filterExpression, ctx);
+		};
+
+		if (Mono.class.isAssignableFrom(returnType)) {
+			return (T) ((Mono<?>) filterTarget)
+					.filterWhen(filter);
+		}
+		else if (Flux.class.isAssignableFrom(returnType)) {
+			return (T) ((Flux<?>) filterTarget)
+					.filterWhen(filter);
+		}
+
+		return (T) Flux.from(filterTarget)
+				.filterWhen(filter);
+	}
+
+	/**
+	 * Sets the {@link PermissionCacheOptimizer}. Currently just throws {@link UnsupportedOperationException}.
+	 * <p>
+	 *   This is currently not yet supported on the reactive stack
+	 * </p>
+	 * @param permissionCacheOptimizer The {@link PermissionCacheOptimizer} to set
+	 */
+	@Override
+	public void setPermissionCacheOptimizer(PermissionCacheOptimizer permissionCacheOptimizer) {
+		throw new UnsupportedOperationException("PermissionCacheOptimizer is not yet supported on the reactive stack!");
+	}
+}

--- a/core/src/main/java/org/springframework/security/access/expression/method/ExpressionBasedAnnotationAttributeFactory.java
+++ b/core/src/main/java/org/springframework/security/access/expression/method/ExpressionBasedAnnotationAttributeFactory.java
@@ -15,9 +15,12 @@
  */
 package org.springframework.security.access.expression.method;
 
+import org.aopalliance.intercept.MethodInvocation;
+
 import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.ParseException;
+import org.springframework.security.access.expression.SecurityExpressionHandler;
 import org.springframework.security.access.prepost.PostInvocationAttribute;
 import org.springframework.security.access.prepost.PreInvocationAttribute;
 import org.springframework.security.access.prepost.PrePostInvocationAttributeFactory;
@@ -34,13 +37,24 @@ public class ExpressionBasedAnnotationAttributeFactory implements
 		PrePostInvocationAttributeFactory {
 	private final Object parserLock = new Object();
 	private ExpressionParser parser;
-	private MethodSecurityExpressionHandler handler;
+	private SecurityExpressionHandler<MethodInvocation> handler;
 
 	public ExpressionBasedAnnotationAttributeFactory(
 			MethodSecurityExpressionHandler handler) {
 		this.handler = handler;
 	}
 
+	/**
+	 * Support for reactive method secutiry
+	 * @param handler The {@link ReactiveMethodSecurityExpressionHandler}
+	 * @since 5.1.2
+	 */
+	public ExpressionBasedAnnotationAttributeFactory(
+			ReactiveMethodSecurityExpressionHandler handler) {
+		this.handler = handler;
+	}
+
+	@Override
 	public PreInvocationAttribute createPreInvocationAttribute(String preFilterAttribute,
 			String filterObject, String preAuthorizeAttribute) {
 		try {
@@ -60,6 +74,7 @@ public class ExpressionBasedAnnotationAttributeFactory implements
 		}
 	}
 
+	@Override
 	public PostInvocationAttribute createPostInvocationAttribute(
 			String postFilterAttribute, String postAuthorizeAttribute) {
 		try {

--- a/core/src/main/java/org/springframework/security/access/expression/method/ExpressionBasedReactivePostInvocationAuthorizationAdvice.java
+++ b/core/src/main/java/org/springframework/security/access/expression/method/ExpressionBasedReactivePostInvocationAuthorizationAdvice.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.access.expression.method;
+
+import java.util.Optional;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.reactivestreams.Publisher;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.expression.EvaluationContext;
+import org.springframework.lang.Nullable;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.expression.ReactiveExpressionUtils;
+import org.springframework.security.access.prepost.PostInvocationAttribute;
+import org.springframework.security.access.prepost.ReactivePostInvocationAuthorizationAdvice;
+import org.springframework.security.core.Authentication;
+
+/**
+ * Reactive argument filtering and authorization logic based on expressions.
+ * <p>
+ *   Reactive equivalent of {@link ExpressionBasedPostInvocationAdvice}
+ * </p>
+ *
+ * @author Eric Deandrea
+ * @since 5.1.2
+ * @see ExpressionBasedPostInvocationAdvice
+ */
+public class ExpressionBasedReactivePostInvocationAuthorizationAdvice implements ReactivePostInvocationAuthorizationAdvice {
+	private final ReactiveMethodSecurityExpressionHandler expressionHandler;
+
+	public ExpressionBasedReactivePostInvocationAuthorizationAdvice() {
+		this(null);
+	}
+
+	public ExpressionBasedReactivePostInvocationAuthorizationAdvice(@Nullable ReactiveMethodSecurityExpressionHandler expressionHandler) {
+		this.expressionHandler = Optional.ofNullable(expressionHandler).orElseGet(DefaultReactiveMethodSecurityExpressionHandler::new);
+	}
+
+	@Override
+	public <T extends Publisher<?>> T after(Authentication authentication, MethodInvocation mi, @Nullable PostInvocationAttribute postInvocationAttribute, T returnedObject) {
+		Optional<PostInvocationExpressionAttribute> postAttr = Optional.ofNullable(postInvocationAttribute)
+				.filter(PostInvocationExpressionAttribute.class::isInstance)
+				.map(PostInvocationExpressionAttribute.class::cast);
+
+		EvaluationContext ctx = this.expressionHandler.createEvaluationContext(authentication, mi);
+
+		T filteredReturnObject = postAttr
+				.map(PostInvocationExpressionAttribute::getFilterExpression)
+				.map(postFilter -> this.expressionHandler.filter(returnedObject, postFilter, ctx))
+				.orElse(returnedObject);
+
+		this.expressionHandler.setReturnObject(filteredReturnObject, ctx);
+
+		Class<?> returnType = filteredReturnObject.getClass();
+		Mono<Boolean> authorized = postAttr
+				.map(PostInvocationExpressionAttribute::getAuthorizeExpression)
+				.map(pa -> ReactiveExpressionUtils.evaluateAsBoolean(pa, ctx))
+				.orElseGet(() -> Mono.just(true));
+
+		if (Mono.class.isAssignableFrom(returnType)) {
+			return (T) authorized
+					.flatMap(isAuthorized -> isAuthorized ? (Mono<?>) filteredReturnObject : Mono.error(this::createAccessDeniedException));
+		}
+		else if (Flux.class.isAssignableFrom(returnType)) {
+			return (T) authorized
+					.flatMapMany(isAuthorized -> isAuthorized ? (Flux<?>) filteredReturnObject : Flux.error(this::createAccessDeniedException));
+		}
+
+		return (T) authorized
+				.flatMapMany(isAuthorized -> isAuthorized ? Flux.from(filteredReturnObject) : Flux.error(this::createAccessDeniedException));
+	}
+
+	private AccessDeniedException createAccessDeniedException() {
+		return new AccessDeniedException("Access is denied");
+	}
+}

--- a/core/src/main/java/org/springframework/security/access/expression/method/ExpressionBasedReactivePreInvocationAuthorizationAdvice.java
+++ b/core/src/main/java/org/springframework/security/access/expression/method/ExpressionBasedReactivePreInvocationAuthorizationAdvice.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.access.expression.method;
+
+import java.util.Optional;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.reactivestreams.Publisher;
+
+import reactor.core.Exceptions;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.aop.ProxyMethodInvocation;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.lang.Nullable;
+import org.springframework.security.access.expression.ReactiveExpressionUtils;
+import org.springframework.security.access.prepost.PreInvocationAttribute;
+import org.springframework.security.access.prepost.ReactivePreInvocationAuthorizationAdvice;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.util.SimpleMethodInvocation;
+import org.springframework.util.StringUtils;
+
+/**
+ * Reactive argument filtering and authorization logic based on expressions.
+ * <p>
+ *   Reactive equivalent of {@link ExpressionBasedPreInvocationAdvice}
+ * </p>
+ *
+ * @author Eric Deandrea
+ * @since 5.1.2
+ * @see ExpressionBasedPreInvocationAdvice
+ */
+public class ExpressionBasedReactivePreInvocationAuthorizationAdvice implements ReactivePreInvocationAuthorizationAdvice {
+	private final ReactiveMethodSecurityExpressionHandler expressionHandler;
+
+	public ExpressionBasedReactivePreInvocationAuthorizationAdvice() {
+		this(null);
+	}
+
+	public ExpressionBasedReactivePreInvocationAuthorizationAdvice(@Nullable ReactiveMethodSecurityExpressionHandler expressionHandler) {
+		this.expressionHandler = Optional.ofNullable(expressionHandler).orElseGet(DefaultReactiveMethodSecurityExpressionHandler::new);
+	}
+
+	@Override
+	public Mono<Boolean> before(Authentication authentication, MethodInvocation mi, @Nullable PreInvocationAttribute preInvocationAttribute) {
+		Optional<PreInvocationExpressionAttribute> preAttr = Optional.ofNullable(preInvocationAttribute)
+				.filter(PreInvocationExpressionAttribute.class::isInstance)
+				.map(PreInvocationExpressionAttribute.class::cast);
+
+		EvaluationContext ctx = this.expressionHandler.createEvaluationContext(authentication, mi);
+
+		preAttr
+				.map(PreInvocationExpressionAttribute::getFilterExpression)
+				.ifPresent(preFilter -> preAttr
+						.map(PreInvocationExpressionAttribute::getFilterTarget)
+						.ifPresent(filterTargetName -> applyFilterTarget(filterTargetName, preFilter, ctx, mi))
+				);
+
+		return preAttr
+				.map(PreInvocationExpressionAttribute::getAuthorizeExpression)
+				.map(preAuthorize -> ReactiveExpressionUtils.evaluateAsBoolean(preAuthorize, ctx))
+				.orElseGet(() -> Mono.defer(() -> Mono.just(true)));
+	}
+
+	private <T extends Publisher<?>> void applyFilterTarget(@Nullable String filterTargetName, Expression preFilter, @Nullable EvaluationContext ctx, MethodInvocation mi) {
+		if (StringUtils.hasText(filterTargetName)) {
+			Optional<EvaluationContext> contextOptional = Optional.ofNullable(ctx);
+			T filterTarget = (T) contextOptional
+					.map(evaluationContext -> evaluationContext.lookupVariable(filterTargetName))
+					.filter(Publisher.class::isInstance)
+					.map(Publisher.class::cast)
+					.orElseThrow(() -> Exceptions.propagate(
+							new IllegalArgumentException(
+									String.format(
+											"Filter target was null, or no argument with name %s found in method",
+											filterTargetName))
+							)
+					);
+
+			contextOptional
+					.filter(MethodSecurityEvaluationContext.class::isInstance)
+					.map(MethodSecurityEvaluationContext.class::cast)
+					.ifPresent(evaluationContext -> {
+						evaluationContext.setVariable(filterTargetName, this.expressionHandler.filter(filterTarget, preFilter, evaluationContext));
+						setArguments(mi, evaluationContext.getMethodInvocationArgs());
+					});
+		}
+		else if (mi.getArguments().length == 1) {
+			Object arg = mi.getArguments()[0];
+			T filterTarget = (T) Optional.ofNullable(arg)
+					.filter(Publisher.class::isInstance)
+					.map(Publisher.class::cast)
+					.orElseThrow(() -> Exceptions.propagate(
+							new IllegalArgumentException(
+									String.format(
+											"A PreFilter expression was set but the method argument type %s is not a %s",
+											getErrorClass(arg.getClass()),
+											Publisher.class.getName()))
+							)
+					);
+
+			setArguments(mi, this.expressionHandler.filter(filterTarget, preFilter, ctx));
+		}
+	}
+
+	private void setArguments(MethodInvocation mi, Object... arguments) {
+		// On the non-reactive side the filter will actually mutate the Collection that is passed in
+		// during the method invocation (see DefaultMethodSecurityExpressionHandler.filter
+		// Here we don't have that luxury - reactive types are immutable, so we need to
+		// apply a filter to the Publisher chain
+		// Therefore we need a hook into the set of arguments that are actually passed in
+		// during the method invocation
+		if (ProxyMethodInvocation.class.isInstance(mi)) {
+			((ProxyMethodInvocation) mi).setArguments(arguments);
+		}
+		else if (SimpleMethodInvocation.class.isInstance(mi)) {
+			((SimpleMethodInvocation) mi).setArguments(arguments);
+		}
+	}
+
+	private Class<?> getErrorClass(Class<?> clazz) {
+		if (Mono.class.isAssignableFrom(clazz)) {
+			return Mono.class;
+		}
+		else if (Flux.class.isAssignableFrom(clazz)) {
+			return Flux.class;
+		}
+		else if (Publisher.class.isAssignableFrom(clazz)) {
+			return Publisher.class;
+		}
+
+		return clazz;
+	}
+}

--- a/core/src/main/java/org/springframework/security/access/expression/method/MethodSecurityEvaluationContext.java
+++ b/core/src/main/java/org/springframework/security/access/expression/method/MethodSecurityEvaluationContext.java
@@ -16,16 +16,24 @@
 package org.springframework.security.access.expression.method;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.IntStream;
 
 import org.aopalliance.intercept.MethodInvocation;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.aop.framework.AopProxyUtils;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.core.ParameterNameDiscoverer;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.parameters.DefaultSecurityParameterNameDiscoverer;
+import org.springframework.util.Assert;
 
 /**
  * Internal security-specific EvaluationContext implementation which lazily adds the
@@ -41,7 +49,7 @@ class MethodSecurityEvaluationContext extends StandardEvaluationContext {
 
 	private ParameterNameDiscoverer parameterNameDiscoverer;
 	private final MethodInvocation mi;
-	private boolean argumentsAdded;
+	private final AtomicBoolean argumentsAdded = new AtomicBoolean(false);
 
 	/**
 	 * Intended for testing. Don't use in practice as it creates a new parameter resolver
@@ -66,54 +74,69 @@ class MethodSecurityEvaluationContext extends StandardEvaluationContext {
 			return variable;
 		}
 
-		if (!argumentsAdded) {
+		if (this.argumentsAdded.compareAndSet(false, true)) {
 			addArgumentsAsVariables();
-			argumentsAdded = true;
 		}
 
-		variable = super.lookupVariable(name);
+		return super.lookupVariable(name);
+	}
 
-		if (variable != null) {
-			return variable;
-		}
-
-		return null;
+	/**
+	 * Gets the arguments from {@link MethodInvocation#getArguments()}, but substituting
+	 * any variable references for actual arguments.
+	 *
+	 * @return The substituted arguments
+	 * @since 5.1.2
+	 */
+	public Object[] getMethodInvocationArgs() {
+		return getArgumentParameterNames().stream()
+				.map(this::lookupVariable)
+				.toArray(Object[]::new);
 	}
 
 	public void setParameterNameDiscoverer(ParameterNameDiscoverer parameterNameDiscoverer) {
 		this.parameterNameDiscoverer = parameterNameDiscoverer;
 	}
 
-	private void addArgumentsAsVariables() {
+	private List<String> getArgumentParameterNames() {
 		Object[] args = mi.getArguments();
+		List<String> parameterNames = new ArrayList<>(args.length);
 
-		if (args.length == 0) {
-			return;
+		if (args.length > 0) {
+			Object targetObject = this.mi.getThis();
+			// SEC-1454
+			Class<?> targetClass = AopProxyUtils.ultimateTargetClass(targetObject);
+
+			if (targetClass == null) {
+				// TODO: Spring should do this, but there's a bug in ultimateTargetClass()
+				// which returns null
+				targetClass = targetObject.getClass();
+			}
+
+			Method method = AopUtils.getMostSpecificMethod(mi.getMethod(), targetClass);
+			String[] paramNames = this.parameterNameDiscoverer.getParameterNames(method);
+
+			if (paramNames == null) {
+				logger.warn("Unable to resolve method parameter names for method: "
+						+ method
+						+ ". Debug symbol information is required if you are using parameter names in expressions.");
+			}
+			else {
+				parameterNames.addAll(Arrays.asList(paramNames));
+			}
 		}
 
-		Object targetObject = mi.getThis();
-		// SEC-1454
-		Class<?> targetClass = AopProxyUtils.ultimateTargetClass(targetObject);
-
-		if (targetClass == null) {
-			// TODO: Spring should do this, but there's a bug in ultimateTargetClass()
-			// which returns null
-			targetClass = targetObject.getClass();
-		}
-
-		Method method = AopUtils.getMostSpecificMethod(mi.getMethod(), targetClass);
-		String[] paramNames = parameterNameDiscoverer.getParameterNames(method);
-
-		if (paramNames == null) {
-			logger.warn("Unable to resolve method parameter names for method: "
-					+ method
-					+ ". Debug symbol information is required if you are using parameter names in expressions.");
-			return;
-		}
-
-		for (int i = 0; i < args.length; i++) {
-			super.setVariable(paramNames[i], args[i]);
-		}
+		return parameterNames;
 	}
 
+	private void addArgumentsAsVariables() {
+		Object[] args = mi.getArguments();
+		List<String> paramNames = getArgumentParameterNames();
+
+		Assert.state(args.length == paramNames.size(),
+				"Parameter names should have the same size as the argument list");
+
+		IntStream.range(0, args.length)
+				.forEach(i -> super.setVariable(paramNames.get(i), args[i]));
+	}
 }

--- a/core/src/main/java/org/springframework/security/access/expression/method/ReactiveMethodSecurityExpressionHandler.java
+++ b/core/src/main/java/org/springframework/security/access/expression/method/ReactiveMethodSecurityExpressionHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.access.expression.method;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.reactivestreams.Publisher;
+
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.lang.Nullable;
+import org.springframework.security.access.expression.SecurityExpressionHandler;
+
+/**
+ * Extended expression-handler facade which adds methods which are specific to securing
+ * method invocations on reactive types.
+ * <p>
+ *   Reactive equivalent of {@link MethodSecurityExpressionHandler}
+ * </p>
+ *
+ * @author Eric Deandrea
+ * @since 5.1.2
+ * @see  MethodSecurityExpressionHandler
+ */
+public interface ReactiveMethodSecurityExpressionHandler extends SecurityExpressionHandler<MethodInvocation> {
+	/**
+	 * Filters a target {@link Publisher}. Only applies to method invocations.
+	 *
+	 * @param filterTarget The {@link Publisher} to be filtered. Really only makes sense for a {@link reactor.core.publisher.Flux Flux}.
+	 * @param filterExpression The expression which should be used as the filter condition.
+	 *                         If it returns false on evaluation, the object will be filtered out from
+	 *                         the returned {@link Publisher}.
+	 * @param ctx The current evaluation context (as created through a call to
+	 *            {@link #createEvaluationContext(org.springframework.security.core.Authentication, Object)}
+	 * @param <T> The type of {@link Publisher}
+	 * @return The filtered {@link Publisher} if the {@link Publisher} is a {@link reactor.core.publisher.Flux}. Otherwise just returns the {@link Publisher}.
+	 */
+	<T extends Publisher<?>> T filter(T filterTarget, @Nullable Expression filterExpression, EvaluationContext ctx);
+
+	/**
+	 * Used to inform the expression system of the return object for the given evaluation
+	 * context. Only applies to method invocations.
+	 *
+	 * @param returnObject The return object value
+	 * @param ctx The context within which the object should be set (as created through a
+	 *            call to {@link #createEvaluationContext(org.springframework.security.core.Authentication, Object)}
+	 */
+	void setReturnObject(Object returnObject, EvaluationContext ctx);
+}

--- a/core/src/main/java/org/springframework/security/access/prepost/PreFilter.java
+++ b/core/src/main/java/org/springframework/security/access/prepost/PreFilter.java
@@ -25,13 +25,16 @@ import java.lang.annotation.Target;
 /**
  * Annotation for specifying a method filtering expression which will be evaluated before
  * a method has been invoked. The name of the argument to be filtered is specified using
- * the <tt>filterTarget</tt> attribute. This must be a Java Collection implementation
+ * the <tt>filterTarget</tt> attribute. For non-reactive types, this must be a Java Collection implementation
  * which supports the {@link java.util.Collection#remove(Object) remove} method.
  * Pre-filtering isn't supported on array types and will fail if the value of named filter
  * target argument is null at runtime.
  * <p>
- * For methods which have a single argument which is a collection type, this argument will
- * be used as the filter target.
+ *   For reactive types, the argument can be either a {@code Flux} or {@code Mono}.
+ * </p>
+ * <p>
+ * For methods which have a single argument which is a collection type or reactive type,
+ * this argument will be used as the filter target.
  * <p>
  * The annotation value contains the expression which will be evaluated for each element
  * in the collection. If the expression evaluates to false, the element will be removed.
@@ -54,8 +57,8 @@ public @interface PreFilter {
 
 	/**
 	 * @return the name of the parameter which should be filtered (must be a non-null
-	 * collection instance) If the method contains a single collection argument, then this
-	 * attribute can be omitted.
+	 * collection instance, or one of the reactive types (i.e. {@code Mono}/{@code Flux}).
+	 * If the method contains a single collection argument/reactive type, then this attribute can be omitted.
 	 */
 	public String filterTarget() default "";
 }

--- a/core/src/main/java/org/springframework/security/access/prepost/ReactivePostInvocationAuthorizationAdvice.java
+++ b/core/src/main/java/org/springframework/security/access/prepost/ReactivePostInvocationAuthorizationAdvice.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.access.prepost;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.reactivestreams.Publisher;
+
+import org.springframework.aop.framework.AopInfrastructureBean;
+import org.springframework.lang.Nullable;
+import org.springframework.security.core.Authentication;
+
+/**
+ * Performs reactive filtering and authorization logic after a reactive method is invoked.
+ * <p>
+ *   This is the reactive equivalent of {@link PostInvocationAuthorizationAdvice}
+ * </p>
+ *
+ * @author Eric Deandrea
+ * @since 5.1.2
+ * @see PostInvocationAuthorizationAdvice
+ */
+@FunctionalInterface
+public interface ReactivePostInvocationAuthorizationAdvice extends AopInfrastructureBean {
+	/**
+	 * The "after" advice which should be executed to perform any filtering necessary after
+	 * method invocation to decide whether the method call was authorized
+	 *
+	 * @param authentication The information on the principal on whose account the
+	 *                       decision should be made
+	 * @param mi The method invocation which was executed
+	 * @param pia The attribute build from the {@code @PostFilter} and {@code @PostAuthorize}
+	 *            annotations
+	 * @param returnedObject The object which was returned from the method invocation
+	 * @param <T> The type of {@link Publisher}
+	 * @return A {@link Publisher} which emits the returnedObject if authorized, or an error
+	 * {@link org.springframework.security.access.AccessDeniedException AccessDeniedException} otherwise
+	 */
+	<T extends Publisher<?>> T after(Authentication authentication, MethodInvocation mi,
+			@Nullable PostInvocationAttribute pia, T returnedObject);
+}

--- a/core/src/main/java/org/springframework/security/access/prepost/ReactivePreInvocationAuthorizationAdvice.java
+++ b/core/src/main/java/org/springframework/security/access/prepost/ReactivePreInvocationAuthorizationAdvice.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.access.prepost;
+
+import org.aopalliance.intercept.MethodInvocation;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.aop.framework.AopInfrastructureBean;
+import org.springframework.lang.Nullable;
+import org.springframework.security.core.Authentication;
+
+/**
+ * Performs reactive argument filtering and authorization logic before a reactive method is invoked.
+ * <p>
+ *   Reactive equivalent of {@link PreInvocationAuthorizationAdvice}
+ * </p>
+ *
+ * @author Eric Deandrea
+ * @since 5.1.2
+ * @see PreInvocationAuthorizationAdvice
+ */
+@FunctionalInterface
+public interface ReactivePreInvocationAuthorizationAdvice extends AopInfrastructureBean {
+	/**
+	 * The "before" advice which should be executed to decide whether the method call is authorized
+	 *
+	 * @param authentication The information on the principal on whose account the
+	 *                       decision should be made
+	 * @param mi The method invocation being attempted
+	 * @param preInvocationAttribute The attribute built from the {@code @PreFilter} and {@code @PreAuthorize}
+	 *                                  annotations
+	 * @return A {@link Mono} which emits {@code true} if authorized, {@code false} otherwise
+ 	 */
+	Mono<Boolean> before(Authentication authentication, MethodInvocation mi,
+			@Nullable PreInvocationAttribute preInvocationAttribute);
+}

--- a/core/src/main/java/org/springframework/security/access/prepost/ReactivePrePostAdviceMethodInterceptor.java
+++ b/core/src/main/java/org/springframework/security/access/prepost/ReactivePrePostAdviceMethodInterceptor.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.access.prepost;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Optional;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.reactivestreams.Publisher;
+
+import reactor.core.Exceptions;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.ConfigAttribute;
+import org.springframework.security.access.method.MethodSecurityMetadataSource;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link MethodInterceptor} that supports {@link PreAuthorize} and {@link PostAuthorize} for methods that return
+ * {@link Mono} or {@link Flux}.
+ * <p>
+ *   This class differs from {@link PrePostAdviceReactiveMethodInterceptor} in that this supports
+ *   pre/post expressions that return reactive types, whereas {@link PrePostAdviceReactiveMethodInterceptor}
+ *   only supports pre/post expressions that are non reactive - just applied to methods that
+ *   return reactive types.
+ * </p>
+ * <p>
+ *   For example, this class supports this scenario:
+ * </p>
+ * <pre>
+ *   {@literal @}PreAuthorize("@someBean.hasPermission()")
+ *   public Flux{@literal <}String{@literal >} someMethodReturningAFlux() {
+ *     ...
+ *     return someFlux;
+ *   }
+ *
+ *   {@literal @}Component
+ *   public class SomeBean {
+ *     public Mono{@literal <}Boolean{@literal >} hasPermission() {
+ *       ...
+ *       return someBooleanMono;
+ *     }
+ *   }
+ * </pre>
+ * <p>
+ *   {@link PrePostAdviceReactiveMethodInterceptor} supports putting expressions on methods
+ *   that return reactive types, but the methods in the expressions themselves can't return
+ *   reactive types.
+ * </p>
+ *
+ * @author Eric Deandrea
+ * @since 5.1.2
+ */
+public class ReactivePrePostAdviceMethodInterceptor implements MethodInterceptor {
+	private Authentication anonymous = new AnonymousAuthenticationToken("key", "anonymous",
+			AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS"));
+
+	private final MethodSecurityMetadataSource attributeSource;
+	private final ReactivePreInvocationAuthorizationAdvice preInvocationAdvice;
+	private final ReactivePostInvocationAuthorizationAdvice postInvocationAdvice;
+
+	/**
+	 * Creates a new instance
+	 * @param attributeSource the {@link MethodSecurityMetadataSource} to use
+	 * @param preInvocationAdvice the {@link ReactivePreInvocationAuthorizationAdvice} to use
+	 * @param postInvocationAdvice the {@link ReactivePostInvocationAuthorizationAdvice} to use
+	 * @since 5.1.2
+	 */
+	public ReactivePrePostAdviceMethodInterceptor(MethodSecurityMetadataSource attributeSource,
+			ReactivePreInvocationAuthorizationAdvice preInvocationAdvice, ReactivePostInvocationAuthorizationAdvice postInvocationAdvice) {
+		Assert.notNull(attributeSource, "attributeSource cannot be null");
+		Assert.notNull(preInvocationAdvice, "preInvocationAdvice cannot be null");
+		Assert.notNull(postInvocationAdvice, "postInvocationAdvice cannot be null");
+
+		this.attributeSource = attributeSource;
+		this.preInvocationAdvice = preInvocationAdvice;
+		this.postInvocationAdvice = postInvocationAdvice;
+	}
+
+	@Override
+	public Object invoke(final MethodInvocation invocation) throws Throwable {
+		Method method = invocation.getMethod();
+		Class<?> returnType = method.getReturnType();
+
+		if (!Publisher.class.isAssignableFrom(returnType)) {
+			throw new IllegalStateException(String.format("The return type %s on method %s must return an instance of %s (i.e. Mono / Flux) in order to support Reactor Context", returnType.getName(), method, Publisher.class.getName()));
+		}
+
+		Class<?> targetClass = invocation.getThis().getClass();
+		Collection<ConfigAttribute> attributes = this.attributeSource.getAttributes(method, targetClass);
+
+		Optional<PreInvocationAttribute> preAttr = findPreInvocationAttribute(attributes);
+		Mono<Authentication> toInvoke = ReactiveSecurityContextHolder.getContext()
+				.map(SecurityContext::getAuthentication)
+				.defaultIfEmpty(this.anonymous)
+				.filterWhen(auth -> preAttr
+						.map(attr -> this.preInvocationAdvice.before(auth, invocation, attr))
+						.orElseGet(() -> Mono.defer(() -> Mono.just(true)))
+				)
+				.switchIfEmpty(Mono.defer(() -> Mono.error(new AccessDeniedException("Denied"))));
+
+		Optional<PostInvocationAttribute> postAttr = findPostInvocationAttribute(attributes);
+
+		if (Mono.class.isAssignableFrom(returnType)) {
+			return toInvoke
+					.flatMap(auth -> after(postAttr, auth, invocation, proceed(invocation)));
+		}
+		else if (Flux.class.isAssignableFrom(returnType)) {
+			return toInvoke
+					.flatMapMany(auth -> after(postAttr, auth, invocation, proceed(invocation)));
+		}
+
+		return toInvoke
+				.flatMapMany(auth -> after(postAttr, auth, invocation, Flux.from(proceed(invocation))));
+	}
+
+	private <P extends Publisher<?>> P after(Optional<PostInvocationAttribute> postAttr, Authentication auth, MethodInvocation mi, P returnPublisher) {
+		return postAttr
+				.map(attr -> this.postInvocationAdvice.after(auth, mi, attr, returnPublisher))
+				.orElseGet(() -> returnPublisher);
+	}
+
+	private static <T extends Publisher<?>> T proceed(final MethodInvocation invocation) {
+		try {
+			return (T) invocation.proceed();
+		}
+		catch (Throwable throwable) {
+			throw Exceptions.propagate(throwable);
+		}
+	}
+
+	private static Optional<PostInvocationAttribute> findPostInvocationAttribute(Collection<ConfigAttribute> config) {
+		return config.stream()
+				.filter(PostInvocationAttribute.class::isInstance)
+				.map(PostInvocationAttribute.class::cast)
+				.findFirst();
+	}
+
+	private static Optional<PreInvocationAttribute> findPreInvocationAttribute(Collection<ConfigAttribute> config) {
+		return config.stream()
+				.filter(PreInvocationAttribute.class::isInstance)
+				.map(PreInvocationAttribute.class::cast)
+				.findFirst();
+	}
+}

--- a/core/src/main/java/org/springframework/security/util/SimpleMethodInvocation.java
+++ b/core/src/main/java/org/springframework/security/util/SimpleMethodInvocation.java
@@ -16,10 +16,12 @@
 
 package org.springframework.security.util;
 
-import org.aopalliance.intercept.MethodInvocation;
-
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Method;
+
+import org.aopalliance.intercept.MethodInvocation;
+
+import org.springframework.lang.Nullable;
 
 /**
  * Represents the AOP Alliance <code>MethodInvocation</code>.
@@ -49,23 +51,37 @@ public class SimpleMethodInvocation implements MethodInvocation {
 	// ~ Methods
 	// ========================================================================================================
 
+	@Override
 	public Object[] getArguments() {
 		return arguments;
 	}
 
+	@Override
 	public Method getMethod() {
 		return method;
 	}
 
+	@Override
 	public AccessibleObject getStaticPart() {
 		throw new UnsupportedOperationException("mock method not implemented");
 	}
 
+	@Override
 	public Object getThis() {
 		return targetObject;
 	}
 
+	@Override
 	public Object proceed() throws Throwable {
 		throw new UnsupportedOperationException("mock method not implemented");
+	}
+
+	/**
+	 * Sets the arguments
+	 * @param arguments The arguments
+	 * @since 5.1.2
+	 */
+	public void setArguments(@Nullable Object... arguments) {
+		this.arguments = (arguments == null) ? new Object[0] : arguments;
 	}
 }

--- a/core/src/test/java/org/springframework/security/access/expression/ReactiveExpressionUtilsTests.java
+++ b/core/src/test/java/org/springframework/security/access/expression/ReactiveExpressionUtilsTests.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.access.expression;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.expression.EvaluationException;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+/**
+ * @author Eric Deandrea
+ * @since 5.1.2
+ */
+public class ReactiveExpressionUtilsTests {
+	private StandardEvaluationContext ctx = new StandardEvaluationContext();
+	private ExpressionParser expressionParser = new SpelExpressionParser();
+
+	@Before
+	public void setup() {
+		this.ctx.setVariable("methods", new Methods());
+	}
+
+	@Test
+	public void returnsBooleanPrimitive() {
+		StepVerifier.create(ReactiveExpressionUtils.evaluateAsBoolean(this.expressionParser.parseExpression("#methods.returnTrue()"), this.ctx))
+				.expectNext(true)
+				.verifyComplete();
+
+		StepVerifier.create(ReactiveExpressionUtils.evaluateAsBoolean(this.expressionParser.parseExpression("#methods.returnFalse()"), this.ctx))
+				.expectNext(false)
+				.verifyComplete();
+	}
+
+	@Test
+	public void returnsBooleanMono() {
+		StepVerifier.create(ReactiveExpressionUtils.evaluateAsBoolean(this.expressionParser.parseExpression("#methods.returnMonoTrue()"), this.ctx))
+				.expectNext(true)
+				.verifyComplete();
+
+		StepVerifier.create(ReactiveExpressionUtils.evaluateAsBoolean(this.expressionParser.parseExpression("#methods.returnMonoFalse()"), this.ctx))
+				.expectNext(false)
+				.verifyComplete();
+	}
+
+	@Test
+	public void errorsOnSomethingOtherThanBoolean() {
+		StepVerifier.create(ReactiveExpressionUtils.evaluateAsBoolean(this.expressionParser.parseExpression("#methods.returnSomethingElse()"), ctx))
+				.verifyErrorSatisfies(ex -> {
+					assertThat(ex)
+						.isNotNull()
+						.isExactlyInstanceOf(IllegalArgumentException.class)
+						.hasMessage("Expression '#methods.returnSomethingElse()' needs to either return boolean or Mono<Boolean> but it does not");
+				});
+
+		StepVerifier.create(ReactiveExpressionUtils.evaluateAsBoolean(this.expressionParser.parseExpression("#methods.returnMonoSomethingElse()"), ctx))
+				.verifyErrorSatisfies(ex -> {
+					assertThat(ex)
+							.isNotNull()
+							.isExactlyInstanceOf(IllegalArgumentException.class)
+							.hasMessage("Expression '#methods.returnMonoSomethingElse()' needs to either return boolean or Mono<Boolean> but it does not");
+				});
+	}
+
+	@Test
+	public void someOtherError() {
+		// Expression that doesn't exist
+		StepVerifier.create(ReactiveExpressionUtils.evaluateAsBoolean(this.expressionParser.parseExpression("#methods.returnAnotherThing()"), ctx))
+				.verifyErrorSatisfies(ex -> {
+					assertThat(ex)
+							.isNotNull()
+							.isExactlyInstanceOf(IllegalArgumentException.class)
+							.hasMessage("Failed to evaluate expression '#methods.returnAnotherThing()': EL1004E: Method call: Method returnAnotherThing() cannot be found on type org.springframework.security.access.expression.ReactiveExpressionUtilsTests$Methods")
+							.hasCauseInstanceOf(EvaluationException.class);
+				});
+	}
+
+	class Methods {
+		public boolean returnTrue() {
+			return true;
+		}
+
+		public boolean returnFalse() {
+			return false;
+		}
+
+		public Mono<Boolean> returnMonoTrue() {
+			return Mono.fromSupplier(this::returnTrue);
+		}
+
+		public Mono<Boolean> returnMonoFalse() {
+			return Mono.fromSupplier(this::returnFalse);
+		}
+
+		public String returnSomethingElse() {
+			return "Something Else";
+		}
+
+		public Mono<String> returnMonoSomethingElse() {
+			return Mono.fromSupplier(this::returnSomethingElse);
+		}
+	}
+}

--- a/core/src/test/java/org/springframework/security/access/expression/method/DefaultReactiveMethodSecurityExpressionHandlerTests.java
+++ b/core/src/test/java/org/springframework/security/access/expression/method/DefaultReactiveMethodSecurityExpressionHandlerTests.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.access.expression.method;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+
+/**
+ * @author Eric Deandrea
+ * @since 5.1.2
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultReactiveMethodSecurityExpressionHandlerTests {
+	private DefaultReactiveMethodSecurityExpressionHandler handler = new DefaultReactiveMethodSecurityExpressionHandler();
+
+	@Mock
+	private Authentication authentication;
+
+	@Mock
+	private MethodInvocation methodInvocation;
+
+	@After
+	public void cleanup() {
+		Mono<SecurityContext> context = Mono.subscriberContext()
+				.flatMap( c -> ReactiveSecurityContextHolder.getContext())
+				.subscriberContext(ReactiveSecurityContextHolder.clearContext());
+
+		StepVerifier.create(context)
+				.verifyComplete();
+	}
+
+	@Test
+	public void setTrustResolverNull() {
+		assertThatThrownBy(() -> this.handler.setTrustResolver(null))
+				.isExactlyInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void setPermissionCacheOptimizerIsInvalid() {
+		assertThatThrownBy(() -> this.handler.setPermissionCacheOptimizer((authentication1, objects) -> {}))
+				.isExactlyInstanceOf(UnsupportedOperationException.class)
+				.hasMessage("PermissionCacheOptimizer is not yet supported on the reactive stack!")
+				.hasNoCause();
+	}
+
+	@Test
+	public void nullFilterExpression() {
+		EvaluationContext ctx = this.handler.createEvaluationContext(this.authentication, this.methodInvocation);
+
+		StepVerifier.create(this.handler.filter(Mono.just(Methods.getSomething()), null, ctx))
+				.expectNext(Methods.getSomething())
+				.verifyComplete();
+
+		assertFilterObject(null, ctx);
+	}
+
+	@Test
+	public void monoPasses() {
+		Expression expression = this.handler.getExpressionParser().parseExpression(String.format("T(%s).trueMono()", Methods.class.getName()));
+		EvaluationContext ctx = this.handler.createEvaluationContext(this.authentication, this.methodInvocation);
+
+		StepVerifier.create(this.handler.filter(Mono.just(Methods.getSomething()), expression, ctx))
+				.expectNext(Methods.getSomething())
+				.verifyComplete();
+
+		assertFilterObject(Methods.getSomething(), ctx);
+	}
+
+	@Test
+	public void monoDoesntPass() {
+		Expression expression = this.handler.getExpressionParser().parseExpression(String.format("T(%s).falseMono()", Methods.class.getName()));
+		EvaluationContext ctx = this.handler.createEvaluationContext(this.authentication, this.methodInvocation);
+
+		StepVerifier.create(this.handler.filter(Mono.just(Methods.getSomething()), expression, ctx))
+				.verifyComplete();
+
+		assertFilterObject(Methods.getSomething(), ctx);
+	}
+
+	@Test
+	public void fluxAllPasses() {
+		Expression expression = this.handler.getExpressionParser().parseExpression(String.format("T(%s).allPassFilter(filterObject)", Methods.class.getName()));
+		EvaluationContext ctx = this.handler.createEvaluationContext(this.authentication, this.methodInvocation);
+
+		StepVerifier.create(this.handler.filter(Flux.just(Methods.getSomething(), Methods.getSomethingElse()), expression, ctx))
+				.expectNext(Methods.getSomething())
+				.expectNext(Methods.getSomethingElse())
+				.verifyComplete();
+
+		assertFilterObject(Methods.getSomethingElse(), ctx);
+	}
+
+	@Test
+	public void fluxSomePass() {
+		Expression expression = this.handler.getExpressionParser().parseExpression(String.format("T(%s).onePassFilter(filterObject)", Methods.class.getName()));
+		EvaluationContext ctx = this.handler.createEvaluationContext(this.authentication, this.methodInvocation);
+
+		StepVerifier.create(this.handler.filter(Flux.just(Methods.getSomething(), Methods.getSomethingElse()), expression, ctx))
+				.expectNext(Methods.getSomething())
+				.verifyComplete();
+
+		assertFilterObject(Methods.getSomethingElse(), ctx);
+	}
+
+	private static <T> void assertFilterObject(T expectedFilterObject, EvaluationContext ctx) {
+		MethodSecurityExpressionOperations rootObject = (MethodSecurityExpressionOperations) ctx.getRootObject().getValue();
+
+		if (expectedFilterObject == null) {
+			assertThat(rootObject.getFilterObject())
+					.isNull();
+		}
+		else {
+			assertThat(rootObject.getFilterObject())
+					.isEqualTo(expectedFilterObject);
+		}
+	}
+
+	private static class Methods {
+		public static String getSomething() {
+			return "something";
+		}
+
+		public static String getSomethingElse() {
+			return "something else";
+		}
+
+		public static Mono<Boolean> trueMono() {
+			return Mono.just(true);
+		}
+
+		public static Mono<Boolean> falseMono() {
+			return Mono.just(false);
+		}
+
+		public static Mono<Boolean> allPassFilter(String string) {
+			return Mono.just(true);
+		}
+
+		public static Mono<Boolean> onePassFilter(String string) {
+			return Mono.just(getSomething().equals(string));
+		}
+	}
+}

--- a/core/src/test/java/org/springframework/security/access/expression/method/ExpressionBasedReactivePostInvocationAuthorizationAdviceTests.java
+++ b/core/src/test/java/org/springframework/security/access/expression/method/ExpressionBasedReactivePostInvocationAuthorizationAdviceTests.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.access.expression.method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.*;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.reactivestreams.Publisher;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.prepost.PostInvocationAttribute;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.util.ReactiveMethodInvocation;
+
+/**
+ * @author Eric Deandrea
+ * @since 5.1.2
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ExpressionBasedReactivePostInvocationAuthorizationAdviceTests {
+	@Spy
+	private ReactiveMethodSecurityExpressionHandler expressionHandler = new DefaultReactiveMethodSecurityExpressionHandler();
+	private ExpressionBasedReactivePostInvocationAuthorizationAdvice postAdvice;
+	private Methods methods = new Methods();
+	private Authentication anonymous = new AnonymousAuthenticationToken("key", "anonymous",
+			AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS"));
+
+	@Before
+	public void setup() {
+		this.postAdvice = new ExpressionBasedReactivePostInvocationAuthorizationAdvice(this.expressionHandler);
+	}
+
+	@Test
+	public void nullPostInvocationAttribute() {
+		Mono<String> mono = this.methods.postAuthorizeMono();
+		StepVerifier.create(this.postAdvice.after(this.anonymous, new ReactiveMethodInvocation(this.methods, "postAuthorizeMono"), null, mono))
+				.expectNext(Methods.getSomething())
+				.verifyComplete();
+
+		verifyReturnObject(mono);
+	}
+
+	@Test
+	public void postAuthorizeMonoTrue() {
+		MethodInvocation invocation = new ReactiveMethodInvocation(this.methods, "postAuthorizeMono");
+		PostInvocationAttribute attr = new PostInvocationExpressionAttribute(null, String.format("T(%s).trueMono()", Methods.class.getName()));
+
+		Mono<String> mono = this.methods.postAuthorizeMono();
+
+		StepVerifier.create(this.postAdvice.after(this.anonymous, invocation, attr, mono))
+				.expectNext(Methods.getSomething())
+				.verifyComplete();
+
+		verifyReturnObject(mono);
+	}
+
+	@Test
+	public void postAuthorizeMonoFalse() {
+		MethodInvocation invocation = new ReactiveMethodInvocation(this.methods, "postAuthorizeMono");
+		PostInvocationAttribute attr = new PostInvocationExpressionAttribute(null, String.format("T(%s).falseMono()", Methods.class.getName()));
+
+		Mono<String> mono = this.methods.postAuthorizeMono();
+
+		StepVerifier.create(this.postAdvice.after(this.anonymous, invocation, attr, mono))
+				.verifyErrorSatisfies(error -> {
+					assertThat(error)
+							.isNotNull()
+							.isExactlyInstanceOf(AccessDeniedException.class)
+							.hasMessage("Access is denied")
+							.hasNoCause();
+				});
+
+		verifyReturnObject(mono);
+	}
+
+	@Test
+	public void postAuthorizeFluxTrue() {
+		MethodInvocation invocation = new ReactiveMethodInvocation(this.methods, "postAuthorizeFlux");
+		PostInvocationAttribute attr = new PostInvocationExpressionAttribute(null, String.format("T(%s).trueMono()", Methods.class.getName()));
+
+		Flux<String> flux = this.methods.postAuthorizeFlux();
+
+		StepVerifier.create(this.postAdvice.after(this.anonymous, invocation, attr, flux))
+				.expectNext(Methods.getSomething())
+				.expectNext(Methods.getSomethingElse())
+				.verifyComplete();
+
+		verifyReturnObject(flux);
+	}
+
+	@Test
+	public void postAuthorizeFluxFalse() {
+		MethodInvocation invocation = new ReactiveMethodInvocation(this.methods, "postAuthorizeFlux");
+		PostInvocationAttribute attr = new PostInvocationExpressionAttribute(null, String.format("T(%s).falseMono()", Methods.class.getName()));
+
+		Flux<String> flux = this.methods.postAuthorizeFlux();
+
+		StepVerifier.create(this.postAdvice.after(this.anonymous, invocation, attr, flux))
+				.verifyErrorSatisfies(error -> {
+					assertThat(error)
+							.isNotNull()
+							.isExactlyInstanceOf(AccessDeniedException.class)
+							.hasMessage("Access is denied")
+							.hasNoCause();
+				});
+
+		verifyReturnObject(flux);
+	}
+
+	@Test
+	public void postFilterMonoPasses() {
+		Mono<String> postFilterInput = Mono.just(Methods.getSomething());
+		Mono<String> mono = this.methods.postFilter(postFilterInput);
+		Expression filterExpression = this.expressionHandler.getExpressionParser().parseExpression(String.format("T(%s).allPassFilter(filterObject)", Methods.class.getName()));
+		MethodInvocation mi = new ReactiveMethodInvocation(this.methods, "postFilter", postFilterInput);
+		PostInvocationAttribute attr = new PostInvocationExpressionAttribute(filterExpression, null);
+		given(this.expressionHandler.filter(any(Publisher.class), eq(filterExpression), any(EvaluationContext.class)))
+				.willAnswer(invocation -> invocation.getArgument(0));
+
+		StepVerifier.create(this.postAdvice.after(this.anonymous, mi, attr, mono))
+				.expectNext(Methods.getSomething())
+				.verifyComplete();
+
+		verifyReturnObject(mono);
+	}
+
+	@Test
+	public void postFilterMonDoesntPass() {
+		Mono<String> postFilterInput = Mono.just(Methods.getSomethingElse());
+		Mono<String> filteredInput = postFilterInput.filterWhen(Methods::onePassFilter);
+		Expression filterExpression = this.expressionHandler.getExpressionParser().parseExpression(String.format("T(%s).onePassFilter(filterObject)", Methods.class.getName()));
+		MethodInvocation mi = new ReactiveMethodInvocation(this.methods, "postFilter", postFilterInput);
+		PostInvocationAttribute attr = new PostInvocationExpressionAttribute(filterExpression, null);
+		given(this.expressionHandler.filter(any(Publisher.class), eq(filterExpression), any(EvaluationContext.class)))
+				.willAnswer(invocation -> filteredInput);
+
+		StepVerifier.create(this.postAdvice.after(this.anonymous, mi, attr, this.methods.postFilter(postFilterInput)))
+				.verifyComplete();
+
+		verifyReturnObject(filteredInput);
+	}
+
+	@Test
+	public void postFilterFluxAllPass() {
+		Flux<String> postFilterInput = Flux.just(Methods.getSomething(), Methods.getSomethingElse());
+		Flux<String> flux = this.methods.postFilter(postFilterInput);
+		Expression filterExpression = this.expressionHandler.getExpressionParser().parseExpression(String.format("T(%s).allPassFilter(filterObject)", Methods.class.getName()));
+		MethodInvocation mi = new ReactiveMethodInvocation(this.methods, "postFilter", postFilterInput);
+		PostInvocationAttribute attr = new PostInvocationExpressionAttribute(filterExpression, null);
+		given(this.expressionHandler.filter(any(Publisher.class), eq(filterExpression), any(EvaluationContext.class)))
+				.willAnswer(invocation -> invocation.getArgument(0));
+
+		StepVerifier.create(this.postAdvice.after(this.anonymous, mi, attr, flux))
+				.expectNext(Methods.getSomething())
+				.expectNext(Methods.getSomethingElse())
+				.verifyComplete();
+
+		verifyReturnObject(flux);
+	}
+
+	@Test
+	public void postFilterFluxSomePass() {
+		Flux<String> postFilterInput = Flux.just(Methods.getSomething(), Methods.getSomethingElse());
+		Flux<String> filteredInput = postFilterInput.filterWhen(Methods::onePassFilter);
+		Expression filterExpression = this.expressionHandler.getExpressionParser().parseExpression(String.format("T(%s).onePassFilter(filterObject)", Methods.class.getName()));
+		MethodInvocation mi = new ReactiveMethodInvocation(this.methods, "postFilter", postFilterInput);
+		PostInvocationAttribute attr = new PostInvocationExpressionAttribute(filterExpression, null);
+		given(this.expressionHandler.filter(any(Publisher.class), eq(filterExpression), any(EvaluationContext.class)))
+				.willAnswer(invocation -> filteredInput);
+
+		StepVerifier.create(this.postAdvice.after(this.anonymous, mi, attr, this.methods.postFilter(postFilterInput)))
+				.expectNext(Methods.getSomething())
+				.verifyComplete();
+
+		verifyReturnObject(filteredInput);
+	}
+
+	private <P extends Publisher<?>> void verifyReturnObject(P publisher) {
+		verify(this.expressionHandler)
+				.setReturnObject(eq(publisher), any(EvaluationContext.class));
+	}
+
+	private static class Methods {
+		public static String getSomething() {
+			return "something";
+		}
+
+		public static String getSomethingElse() {
+			return "something else";
+		}
+
+		public static Mono<Boolean> trueMono() {
+			return Mono.just(true);
+		}
+
+		public static Mono<Boolean> falseMono() {
+			return Mono.just(false);
+		}
+
+		public Mono<String> postAuthorizeMono() {
+			return Mono.just(getSomething());
+		}
+
+		public Flux<String> postAuthorizeFlux() {
+			return Flux.just(getSomething(), getSomethingElse());
+		}
+
+		public Mono<String> postFilter(Mono<String> mono) {
+			return mono;
+		}
+
+		public Flux<String> postFilter(Flux<String> flux) {
+			return flux;
+		}
+
+		public static Mono<Boolean> allPassFilter(String string) {
+			return Mono.just(true);
+		}
+
+		public static Mono<Boolean> onePassFilter(String string) {
+			return Mono.just(getSomething().equals(string));
+		}
+	}
+}

--- a/core/src/test/java/org/springframework/security/access/expression/method/ExpressionBasedReactivePreInvocationAuthorizationAdviceTests.java
+++ b/core/src/test/java/org/springframework/security/access/expression/method/ExpressionBasedReactivePreInvocationAuthorizationAdviceTests.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.access.expression.method;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.reactivestreams.Publisher;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.security.access.prepost.PreInvocationAttribute;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.util.ReactiveMethodInvocation;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Eric Deandrea
+ * @since 5.1.2
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ExpressionBasedReactivePreInvocationAuthorizationAdviceTests {
+	@Spy
+	private ReactiveMethodSecurityExpressionHandler expressionHandler = new DefaultReactiveMethodSecurityExpressionHandler();
+	private ExpressionBasedReactivePreInvocationAuthorizationAdvice preAdvice;
+	private Methods methods = new Methods();
+	private Authentication anonymous = new AnonymousAuthenticationToken("key", "anonymous",
+			AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS"));
+
+	@Before
+	public void setup() {
+		this.preAdvice = new ExpressionBasedReactivePreInvocationAuthorizationAdvice(this.expressionHandler);
+	}
+
+	@Test
+	public void nullPreInvocationAttribute() {
+		StepVerifier.create(this.preAdvice.before(this.anonymous, new ReactiveMethodInvocation(this.methods, "preAuthorizeMono"), null))
+				.expectNext(true)
+				.verifyComplete();
+	}
+
+	@Test
+	public void preAuthorizeMonoTrue() {
+		MethodInvocation invocation = new ReactiveMethodInvocation(this.methods, "preAuthorizeMono");
+		PreInvocationAttribute attr = new PreInvocationExpressionAttribute(null, "", String.format("T(%s).trueMono()", Methods.class.getName()));
+
+		StepVerifier.create(this.preAdvice.before(this.anonymous, invocation, attr))
+				.expectNext(true)
+				.verifyComplete();
+	}
+
+	@Test
+	public void preAuthorizeMonoFalse() {
+		MethodInvocation invocation = new ReactiveMethodInvocation(this.methods, "preAuthorizeMono");
+		PreInvocationAttribute attr = new PreInvocationExpressionAttribute(null, "", String.format("T(%s).falseMono()", Methods.class.getName()));
+
+		StepVerifier.create(this.preAdvice.before(this.anonymous, invocation, attr))
+				.expectNext(false)
+				.verifyComplete();
+	}
+
+	@Test
+	public void preAuthorizeFluxTrue() {
+		MethodInvocation invocation = new ReactiveMethodInvocation(this.methods, "preAuthorizeFlux");
+		PreInvocationAttribute attr = new PreInvocationExpressionAttribute(null, "", String.format("T(%s).trueMono()", Methods.class.getName()));
+
+		StepVerifier.create(this.preAdvice.before(this.anonymous, invocation, attr))
+				.expectNext(true)
+				.verifyComplete();
+	}
+
+	@Test
+	public void preAuthorizeFluxFalse() {
+		MethodInvocation mi = new ReactiveMethodInvocation(this.methods, "preAuthorizeFlux");
+		PreInvocationAttribute attr = new PreInvocationExpressionAttribute(null, "", String.format("T(%s).falseMono()", Methods.class.getName()));
+
+		StepVerifier.create(this.preAdvice.before(this.anonymous, mi, attr))
+				.expectNext(false)
+				.verifyComplete();
+	}
+
+	@Test
+	public void applyFilterTargetFromArgument() {
+		MethodInvocation mi = new ReactiveMethodInvocation(this.methods, "preFilter", Flux.just(Methods.getSomething(), Methods.getSomethingElse()));
+		EvaluationContext ctx = this.expressionHandler.createEvaluationContext(this.anonymous, mi);
+		ReflectionTestUtils.invokeMethod(this.preAdvice, "applyFilterTarget", null, null, ctx, mi);
+
+		assertThat(mi.getArguments())
+				.isNotNull()
+				.isNotEmpty()
+				.hasSize(1);
+
+		StepVerifier.create((Flux<String>) mi.getArguments()[0])
+				.expectNext(Methods.getSomething())
+				.expectNext(Methods.getSomethingElse())
+				.verifyComplete();
+	}
+
+	@Test
+	public void applyFilterTargetNoFilterTargetFound() {
+		MethodInvocation mi = new ReactiveMethodInvocation(this.methods, "preAuthorizeFlux");
+		EvaluationContext ctx = this.expressionHandler.createEvaluationContext(this.anonymous, mi);
+		ReflectionTestUtils.invokeMethod(this.preAdvice, "applyFilterTarget", null, null, ctx, mi);
+
+		assertThat(mi.getArguments())
+				.isNotNull()
+				.isEmpty();
+	}
+
+	@Test
+	public void applyFilterTargetFromMethodWithMono() {
+		MethodInvocation mi = new ReactiveMethodInvocation(this.methods, "preFilterWithNoFluxArg", Mono.just(Methods.getSomething()));
+		EvaluationContext ctx = this.expressionHandler.createEvaluationContext(this.anonymous, mi);
+		ReflectionTestUtils.invokeMethod(this.preAdvice, "applyFilterTarget", null, null, ctx, mi);
+
+		assertThat(mi.getArguments())
+				.isNotNull()
+				.isNotEmpty()
+				.hasSize(1);
+
+		StepVerifier.create((Mono<String>) mi.getArguments()[0])
+				.expectNext(Methods.getSomething())
+				.verifyComplete();
+	}
+
+	@Test
+	public void applyFilterTargetWhenMultipleArgumentsVariableNotSpecified() {
+		MethodInvocation mi = new ReactiveMethodInvocation(this.methods,
+				"preFilterWithMultipleArgs",
+				Mono.just(Methods.getSomething()),
+				Flux.just(Methods.getSomething(), Methods.getSomethingElse()));
+		EvaluationContext ctx = this.expressionHandler.createEvaluationContext(this.anonymous, mi);
+		ReflectionTestUtils.invokeMethod(this.preAdvice, "applyFilterTarget", null, null, ctx, mi);
+
+		assertThat(mi.getArguments())
+				.isNotNull()
+				.isNotEmpty()
+				.hasSize(2);
+
+		verify(this.expressionHandler, never()).filter(any(Publisher.class), any(Expression.class), eq(ctx));
+	}
+
+	@Test
+	public void applyFilterTargetWhenMultipleArgumentsVariableSpecifiedNotFound() {
+		MethodInvocation mi = new ReactiveMethodInvocation(this.methods,
+				"preFilterWithMultipleArgs",
+				Mono.just(Methods.getSomething()),
+				Flux.just(Methods.getSomething(), Methods.getSomethingElse()));
+		EvaluationContext ctx = this.expressionHandler.createEvaluationContext(this.anonymous, mi);
+
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> ReflectionTestUtils.invokeMethod(this.preAdvice, "applyFilterTarget", "someFlux1", null, ctx, mi))
+				.withMessage("Filter target was null, or no argument with name someFlux1 found in method")
+				.withNoCause();
+	}
+
+	@Test
+	public void applyFilterTargetFromNonReactiveArgument() {
+		MethodInvocation mi = new ReactiveMethodInvocation(this.methods,
+				"preFilter",
+				Methods.getSomething()
+		);
+		EvaluationContext ctx = this.expressionHandler.createEvaluationContext(this.anonymous, mi);
+
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> ReflectionTestUtils.invokeMethod(this.preAdvice, "applyFilterTarget", null, null, ctx, mi))
+				.withMessage(String.format("A PreFilter expression was set but the method argument type %s is not a %s", String.class, Publisher.class.getName()))
+				.withNoCause();
+	}
+
+	@Test
+	public void applyFilterTargetWhenMultipleArgumentsVariableSpecified() {
+		MethodInvocation mi = new ReactiveMethodInvocation(this.methods,
+				"preFilterWithMultipleArgs",
+				Mono.just(Methods.getSomething()),
+				Flux.just(Methods.getSomething(), Methods.getSomethingElse()));
+		EvaluationContext ctx = this.expressionHandler.createEvaluationContext(this.anonymous, mi);
+		ReflectionTestUtils.invokeMethod(this.preAdvice, "applyFilterTarget", "someFlux", null, ctx, mi);
+
+		assertThat(mi.getArguments())
+				.isNotNull()
+				.isNotEmpty()
+				.hasSize(2);
+
+		StepVerifier.create((Flux<String>) mi.getArguments()[1])
+				.expectNext(Methods.getSomething())
+				.expectNext(Methods.getSomethingElse())
+				.verifyComplete();
+	}
+
+	@Test
+	public void preFilterAllPass() {
+		Expression filterExpression = this.expressionHandler.getExpressionParser().parseExpression(String.format("T(%s).allPassFilter(filterObject)", Methods.class.getName()));
+		MethodInvocation mi = new ReactiveMethodInvocation(this.methods, "preFilter", Flux.just(Methods.getSomething(), Methods.getSomethingElse()));
+		PreInvocationAttribute attr = new PreInvocationExpressionAttribute(filterExpression, "", null);
+		given(this.expressionHandler.filter(any(Publisher.class), eq(filterExpression), any(EvaluationContext.class)))
+				.willAnswer(invocation -> invocation.getArgument(0));
+
+		StepVerifier.create(this.preAdvice.before(this.anonymous, mi, attr))
+				.expectNext(true)
+				.verifyComplete();
+
+		verify(this.expressionHandler).filter(any(Flux.class), eq(filterExpression), any(EvaluationContext.class));
+	}
+
+	@Test
+	public void preFilterSomePass() {
+		Expression filterExpression = this.expressionHandler.getExpressionParser().parseExpression(String.format("T(%s).onePassFilter(filterObject)", Methods.class.getName()));
+		MethodInvocation mi = new ReactiveMethodInvocation(this.methods, "preFilter", Flux.just(Methods.getSomething(), Methods.getSomethingElse()));
+		PreInvocationAttribute attr = new PreInvocationExpressionAttribute(filterExpression, "", null);
+		given(this.expressionHandler.filter(any(Publisher.class), eq(filterExpression), any(EvaluationContext.class)))
+				.willAnswer(invocation -> invocation.<Flux<String>>getArgument(0).filterWhen(Methods::onePassFilter));
+
+		StepVerifier.create(this.preAdvice.before(this.anonymous, mi, attr))
+				.expectNext(true)
+				.verifyComplete();
+
+		verify(this.expressionHandler).filter(any(Flux.class), eq(filterExpression), any(EvaluationContext.class));
+	}
+
+	private static class Methods {
+		public static String getSomething() {
+			return "something";
+		}
+
+		public static String getSomethingElse() {
+			return "something else";
+		}
+
+		public static Mono<Boolean> trueMono() {
+			return Mono.just(true);
+		}
+
+		public static Mono<Boolean> falseMono() {
+			return Mono.just(false);
+		}
+
+		public Mono<String> preAuthorizeMono() {
+			return Mono.just(getSomething());
+		}
+
+		public Flux<String> preAuthorizeFlux() {
+			return Flux.just(getSomething(), getSomethingElse());
+		}
+
+		public Flux<String> preFilter(Flux<String> flux) {
+			return flux;
+		}
+
+		public Mono<String> preFilter(String string) {
+			return Mono.just(string);
+		}
+
+		public Flux<String> preFilterWithNoFluxArg(Mono<String> someMono) {
+			return someMono.flux();
+		}
+
+		public Flux<String> preFilterWithMultipleArgs(Mono<String> someMono, Flux<String> someFlux) {
+			return someFlux;
+		}
+
+		public static Mono<Boolean> allPassFilter(String string) {
+			return Mono.just(true);
+		}
+
+		public static Mono<Boolean> onePassFilter(String string) {
+			return Mono.just(getSomething().equals(string));
+		}
+	}
+}

--- a/core/src/test/java/org/springframework/security/access/prepost/ReactivePrePostAdviceMethodInterceptorTests.java
+++ b/core/src/test/java/org/springframework/security/access/prepost/ReactivePrePostAdviceMethodInterceptorTests.java
@@ -1,0 +1,418 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.access.prepost;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.eq;
+import static org.mockito.BDDMockito.given;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import reactor.core.Exceptions;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.expression.method.DefaultReactiveMethodSecurityExpressionHandler;
+import org.springframework.security.access.expression.method.ExpressionBasedAnnotationAttributeFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.util.ReactiveMethodInvocation;
+
+/**
+ * @author Eric Deandrea
+ * @since 5.1.2
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ReactivePrePostAdviceMethodInterceptorTests {
+	@Mock
+	private ReactivePreInvocationAuthorizationAdvice preAdvice;
+
+	@Mock
+	private ReactivePostInvocationAuthorizationAdvice postAdvice;
+
+	private Methods methods = new Methods();
+	private ReactivePrePostAdviceMethodInterceptor methodInterceptor;
+
+	@Before
+	public void setup() {
+		this.methodInterceptor = new ReactivePrePostAdviceMethodInterceptor(
+				new PrePostAnnotationSecurityMetadataSource(
+						new ExpressionBasedAnnotationAttributeFactory(
+								new DefaultReactiveMethodSecurityExpressionHandler()
+						)
+				),
+				this.preAdvice,
+				this.postAdvice);
+	}
+
+	@Test
+	public void nonReactiveMethod() {
+		assertThatThrownBy(() -> this.methodInterceptor.invoke(new ReactiveMethodInvocation(this.methods, "getSomething")))
+				.isExactlyInstanceOf(IllegalStateException.class)
+				.hasMessage("The return type java.lang.String on method public java.lang.String org.springframework.security.access.prepost.ReactivePrePostAdviceMethodInterceptorTests$Methods.getSomething() must return an instance of org.reactivestreams.Publisher (i.e. Mono / Flux) in order to support Reactor Context")
+				.hasNoCause();
+	}
+
+	@Test
+	public void preAuthorizeMonoTrue() {
+		MethodInvocation methodInvocation = new ReactiveMethodInvocation(this.methods, "preAuthorizeMonoTrue");
+		given(this.preAdvice.before(any(Authentication.class), eq(methodInvocation), any(PreInvocationAttribute.class)))
+				.willReturn(this.methods.trueMono());
+
+		Mono<String> p;
+
+		try {
+			p = (Mono<String>) this.methodInterceptor.invoke(methodInvocation);
+		}
+		catch (Throwable t) {
+			throw Exceptions.propagate(t);
+		}
+
+		StepVerifier.create(p)
+				.expectNext("something")
+				.verifyComplete();
+	}
+
+	@Test
+	public void preAuthorizeMonoFalse() {
+		MethodInvocation methodInvocation = new ReactiveMethodInvocation(this.methods, "preAuthorizeMonoFalse");
+		given(this.preAdvice.before(any(Authentication.class), eq(methodInvocation), any(PreInvocationAttribute.class)))
+				.willReturn(this.methods.falseMono());
+
+		Mono<String> p;
+
+		try {
+			p = (Mono<String>) this.methodInterceptor.invoke(methodInvocation);
+		}
+		catch (Throwable t) {
+			throw Exceptions.propagate(t);
+		}
+
+		StepVerifier.create(p)
+				.verifyError(AccessDeniedException.class);
+	}
+
+	@Test
+	public void postAuthorizeMonoTrue() {
+		MethodInvocation methodInvocation = new ReactiveMethodInvocation(this.methods, "postAuthorizeMonoTrue");
+		given(this.preAdvice.before(any(Authentication.class), eq(methodInvocation), any(PreInvocationAttribute.class)))
+				.willReturn(this.methods.trueMono());
+		given(this.postAdvice.after(any(Authentication.class), eq(methodInvocation), any(PostInvocationAttribute.class), any()))
+				.willReturn(this.methods.postAuthorizeMonoTrue());
+
+		Mono<String> p;
+
+		try {
+			p = (Mono<String>) this.methodInterceptor.invoke(methodInvocation);
+		}
+		catch (Throwable t) {
+			throw Exceptions.propagate(t);
+		}
+
+		StepVerifier.create(p)
+				.expectNext("something")
+				.verifyComplete();
+	}
+
+	@Test
+	public void postAuthorizeMonoFalse() {
+		MethodInvocation methodInvocation = new ReactiveMethodInvocation(this.methods, "postAuthorizeMonoFalse");
+		given(this.preAdvice.before(any(Authentication.class), eq(methodInvocation), any(PreInvocationAttribute.class)))
+				.willReturn(this.methods.trueMono());
+		given(this.postAdvice.after(any(Authentication.class), eq(methodInvocation), any(PostInvocationAttribute.class), any()))
+				.willReturn(Mono.error(new AccessDeniedException("Denied")));
+
+		Mono<String> p;
+
+		try {
+			p = (Mono<String>) this.methodInterceptor.invoke(methodInvocation);
+		}
+		catch (Throwable t) {
+			throw Exceptions.propagate(t);
+		}
+
+		StepVerifier.create(p)
+				.verifyError(AccessDeniedException.class);
+	}
+
+	@Test
+	public void preAuthorizeFluxTrue() {
+		MethodInvocation methodInvocation = new ReactiveMethodInvocation(this.methods, "preAuthorizeFluxTrue");
+		given(this.preAdvice.before(any(Authentication.class), eq(methodInvocation), any(PreInvocationAttribute.class)))
+				.willReturn(this.methods.trueMono());
+
+		Flux<String> p;
+
+		try {
+			p = (Flux<String>) this.methodInterceptor.invoke(methodInvocation);
+		}
+		catch (Throwable t) {
+			throw Exceptions.propagate(t);
+		}
+
+		StepVerifier.create(p)
+				.expectNext("something")
+				.expectNext("something else")
+				.verifyComplete();
+	}
+
+	@Test
+	public void preAuthorizeFluxFalse() {
+		MethodInvocation methodInvocation = new ReactiveMethodInvocation(this.methods, "preAuthorizeFluxFalse");
+		given(this.preAdvice.before(any(Authentication.class), eq(methodInvocation), any(PreInvocationAttribute.class)))
+				.willReturn(this.methods.falseMono());
+
+		Flux<String> p;
+
+		try {
+			p = (Flux<String>) this.methodInterceptor.invoke(methodInvocation);
+		}
+		catch (Throwable t) {
+			throw Exceptions.propagate(t);
+		}
+
+		StepVerifier.create(p)
+				.verifyError(AccessDeniedException.class);
+	}
+
+	@Test
+	public void postAuthorizeFluxTrue() {
+		MethodInvocation methodInvocation = new ReactiveMethodInvocation(this.methods, "postAuthorizeFluxTrue");
+		given(this.preAdvice.before(any(Authentication.class), eq(methodInvocation), any(PreInvocationAttribute.class)))
+				.willReturn(this.methods.trueMono());
+		given(this.postAdvice.after(any(Authentication.class), eq(methodInvocation), any(PostInvocationAttribute.class), any()))
+				.willAnswer(invocation -> invocation.getArgument(3));
+
+		Flux<String> p;
+
+		try {
+			p = (Flux<String>) this.methodInterceptor.invoke(methodInvocation);
+		}
+		catch (Throwable t) {
+			throw Exceptions.propagate(t);
+		}
+
+		StepVerifier.create(p)
+				.expectNext("something")
+				.expectNext("something else")
+				.verifyComplete();
+	}
+
+	@Test
+	public void postAuthorizeFluxFalse() {
+		MethodInvocation methodInvocation = new ReactiveMethodInvocation(this.methods, "postAuthorizeFluxFalse");
+		given(this.preAdvice.before(any(Authentication.class), eq(methodInvocation), any(PreInvocationAttribute.class)))
+				.willReturn(this.methods.trueMono());
+		given(this.postAdvice.after(any(Authentication.class), eq(methodInvocation), any(PostInvocationAttribute.class), any()))
+				.willReturn(Mono.error(new AccessDeniedException("Denied")));
+
+		Flux<String> p;
+
+		try {
+			p = (Flux<String>) this.methodInterceptor.invoke(methodInvocation);
+		}
+		catch (Throwable t) {
+			throw Exceptions.propagate(t);
+		}
+
+		StepVerifier.create(p)
+				.verifyError(AccessDeniedException.class);
+	}
+
+	@Test
+	public void preFilterAllPass() {
+		MethodInvocation methodInvocation = new ReactiveMethodInvocation(this.methods, "preFilterAllPass", Flux.just(this.methods.getSomething(), this.methods.getSomethingElse()));
+		given(this.preAdvice.before(any(Authentication.class), eq(methodInvocation), any(PreInvocationAttribute.class)))
+				.willReturn(Mono.just(true));
+
+		Flux<String> p;
+
+		try {
+			p = (Flux<String>) this.methodInterceptor.invoke(methodInvocation);
+		}
+		catch (Throwable t) {
+			throw Exceptions.propagate(t);
+		}
+
+		StepVerifier.create(p)
+				.expectNext("something")
+				.expectNext("something else")
+				.verifyComplete();
+	}
+
+	@Test
+	public void preFilterOnePasses() {
+		MethodInvocation methodInvocation = new ReactiveMethodInvocation(this.methods, "preFilterOnePasses", Flux.just(this.methods.getSomething(), this.methods.getSomethingElse()));
+		given(this.preAdvice.before(any(Authentication.class), eq(methodInvocation), any(PreInvocationAttribute.class)))
+				.willAnswer(invocation -> {
+					MethodInvocation mi = invocation.getArgument(1);
+					mi.getArguments()[0] = ((Flux<String>) mi.getArguments()[0]).filterWhen(this.methods::onePassFilter);
+
+					return this.methods.trueMono();
+				});
+
+		Flux<String> p;
+
+		try {
+			p = (Flux<String>) this.methodInterceptor.invoke(methodInvocation);
+		}
+		catch (Throwable t) {
+			throw Exceptions.propagate(t);
+		}
+
+		StepVerifier.create(p)
+				.expectNext("something")
+				.verifyComplete();
+	}
+
+	@Test
+	public void postFilterAllPass() {
+		MethodInvocation methodInvocation = new ReactiveMethodInvocation(this.methods, "postFilterAllPass");
+		given(this.preAdvice.before(any(Authentication.class), eq(methodInvocation), any(PreInvocationAttribute.class)))
+				.willReturn(this.methods.trueMono());
+		given(this.postAdvice.after(any(Authentication.class), eq(methodInvocation), any(PostInvocationAttribute.class), any()))
+				.willAnswer(invocation -> invocation.getArgument(3));
+
+		Flux<String> p;
+
+		try {
+			p = (Flux<String>) this.methodInterceptor.invoke(methodInvocation);
+		}
+		catch (Throwable t) {
+			throw Exceptions.propagate(t);
+		}
+
+		StepVerifier.create(p)
+				.expectNext("something")
+				.expectNext("something else")
+				.verifyComplete();
+	}
+
+	@Test
+	public void postFilterOnePasses() {
+		MethodInvocation methodInvocation = new ReactiveMethodInvocation(this.methods, "postFilterOnePasses");
+		given(this.preAdvice.before(any(Authentication.class), eq(methodInvocation), any(PreInvocationAttribute.class)))
+				.willReturn(Mono.just(true));
+		given(this.postAdvice.after(any(Authentication.class), eq(methodInvocation), any(PostInvocationAttribute.class), any()))
+				.willAnswer(invocation -> ((Flux<String>) invocation.getArgument(3)).filterWhen(this.methods::onePassFilter));
+
+		Flux<String> p;
+
+		try {
+			p = (Flux<String>) this.methodInterceptor.invoke(methodInvocation);
+		}
+		catch (Throwable t) {
+			throw Exceptions.propagate(t);
+		}
+
+		StepVerifier.create(p)
+				.expectNext("something")
+				.verifyComplete();
+	}
+
+	private static class Methods {
+		public String getSomething() {
+			return "something";
+		}
+
+		public String getSomethingElse() {
+			return "something else";
+		}
+
+		@PreAuthorize("trueMono()")
+		public Mono<String> preAuthorizeMonoTrue() {
+			return Mono.just(getSomething());
+		}
+
+		@PreAuthorize("falseMono()")
+		public Mono<String> preAuthorizeMonoFalse() {
+			return Mono.just(getSomething());
+		}
+
+		@PostAuthorize("trueMono()")
+		public Mono<String> postAuthorizeMonoTrue() {
+			return Mono.just(getSomething());
+		}
+
+		@PostAuthorize("falseMono()")
+		public Mono<String> postAuthorizeMonoFalse() {
+			return Mono.just(getSomething());
+		}
+
+		@PreAuthorize("trueMono()")
+		public Flux<String> preAuthorizeFluxTrue() {
+			return Flux.just(getSomething(), getSomethingElse());
+		}
+
+		@PreAuthorize("falseMono()")
+		public Flux<String> preAuthorizeFluxFalse() {
+			return Flux.just(getSomething(), getSomethingElse());
+		}
+
+		@PostAuthorize("trueMono()")
+		public Flux<String> postAuthorizeFluxTrue() {
+			return Flux.just(getSomething(), getSomethingElse());
+		}
+
+		@PostAuthorize("falseMono()")
+		public Flux<String> postAuthorizeFluxFalse() {
+			return Flux.just(getSomething(), getSomethingElse());
+		}
+
+		@PreFilter("allPassFilter(filterObject)")
+		public Flux<String> preFilterAllPass(Flux<String> flux) {
+			return flux;
+		}
+
+		@PreFilter("onePassFilter(filterObject)")
+		public Flux<String> preFilterOnePasses(Flux<String> flux) {
+			return flux;
+		}
+
+		@PostFilter("allPassFilter(filterObject)")
+		public Flux<String> postFilterAllPass() {
+			return Flux.just(getSomething(), getSomethingElse());
+		}
+
+		@PostFilter("onePassFilter(filterObject)")
+		public Flux<String> postFilterOnePasses() {
+			return Flux.just(getSomething(), getSomethingElse());
+		}
+
+		public Mono<Boolean> trueMono() {
+			return Mono.just(true);
+		}
+
+		public Mono<Boolean> falseMono() {
+			return Mono.just(false);
+		}
+
+		public Mono<Boolean> allPassFilter(String string) {
+			return Mono.just(true);
+		}
+
+		public Mono<Boolean> onePassFilter(String string) {
+			return Mono.just(getSomething().equals(string));
+		}
+	}
+}

--- a/core/src/test/java/org/springframework/security/util/ReactiveMethodInvocation.java
+++ b/core/src/test/java/org/springframework/security/util/ReactiveMethodInvocation.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.util;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.reactivestreams.Publisher;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * A {@link SimpleMethodInvocation} that makes it easy to write tests that involve reactive methods.
+ *
+ * @author Eric Deandrea
+ * @since 5.1.2
+ */
+public class ReactiveMethodInvocation extends SimpleMethodInvocation {
+	public ReactiveMethodInvocation(Object targetObject, String methodName, Object... arguments) {
+		this(targetObject, ReflectionUtils.findMethod(targetObject.getClass(), methodName, getParameterClasses(arguments)), arguments);
+	}
+
+	public ReactiveMethodInvocation(Object targetObject, Method method, Object... arguments) {
+		super(targetObject, method, arguments);
+	}
+
+	private static Class<?>[] getParameterClasses(Object... arguments) {
+		return Optional.ofNullable(arguments)
+				.map(Arrays::stream)
+				.orElseGet(Stream::empty)
+				.map(Object::getClass)
+				.map(ReactiveMethodInvocation::getParameterClass)
+				.toArray(Class<?>[]::new);
+	}
+
+	private static Class<?> getParameterClass(Class<?> clazz) {
+		if (Flux.class.isAssignableFrom(clazz)) {
+			return Flux.class;
+		}
+		else if (Mono.class.isAssignableFrom(clazz)) {
+			return Mono.class;
+		}
+		else if (Publisher.class.isAssignableFrom(clazz)) {
+			return Publisher.class;
+		}
+
+		return clazz;
+	}
+
+	@Override
+	public Object proceed() throws Throwable {
+		Method method = getMethod();
+		ReflectionUtils.makeAccessible(method);
+
+		return ReflectionUtils.invokeMethod(method, getThis(), getArguments());
+	}
+}


### PR DESCRIPTION
From #4841 - copying in last comment from that issue into this PR, while adding some comments. What is in this PR is probably not the final version - there will probably be some re-work, but I want to settle on a few design decisions before re-working a bit:

   > We don't want to remove tests that already exist (i.e. EnableReactiveMethodSecurityTests) This runs the risk of breaking backwards compatibility.

   > Focus on as few changes as possible. For example, ReactiveMessageService has methods removed from it.

In my opinion - the tests that were removed don't really make sense for reactive types. Things like

```java
@PostAuthorize("returnObject?.contains(authentication?.name)")
```

when the return type is a `Mono` / `Flux` / `Publisher` don't make a whole lot of sense. Spring-el doesn't yet support lambda functions within expressions so calling methods on those types within an expression doesn't make much sense to me.

I also added a ton of new functional/integration (see [ReactiveMethodSecurityConfigurationTests](https://github.com/spring-projects/spring-security/pull/5980/files#diff-1b6bcc9a28eb0c2969367060081ef646R51)) tests to cover lots of the scenarios.

   > We cannot [remove a constructor](https://github.com/edeandrea/spring-security/commit/00d8b1a7a48e467da8b77434f9755c7a9f07668c#diff-f31832b1006ea62f7afe660bbeb60f72L61) because it is a breaking change. The old constructor should be adapted to work with the new reactive APIs and a new constructor should be added.

I'm unsure of how to "adapt" the old constructor and its arguments (`PreInvocationAuthorizationAdvice` and `PostInvocationAuthorizationAdvice`) to work with the new reactive api (`ReactivePreInvocationAuthorizationAdvice` and `ReactivePostInvocationAuthorizationAdvice`).
- Their method signatures are completely different (blocking types vs reactive types)
- Functionally their implementations are very different (blocking (using `ExpressionUtils`) vs non-blocking (using `ReactiveExpressionUtils`))
- It isn't enough to change these arguments - the body of the `invoke` method needs to change as well in order to work with the reactive streams

What I ended up doing was leaving `PrePostAdviceReactiveMethodInterceptor` alone & marking the class itself as deprecated and introducing a new `ReactivePrePostAdviceMethodInterceptor` class which uses the new reactive pre/post advice implementations.

If you have a clearer picture of how to adapt the existing pre/post advice interfaces into the new reactive ones then I'm all ears - I just don't see what they have in common to be able to programmatically adapt the old ones to the new ones.

   > We do not want to make SimpleMethodInvocation mutable. This adds concerns around concurrency

I made that change because of the way the `MethodInvocation` itself works. In the pre-advice scenario we need to be able to alter the arguments that are "fed" into `MethodInvocation.proceed()`. In the blocking scenario, `DefaultMethodSecurityExpressionHandler.filter` actually mutates the arguments _in place_, assuming the argument is a `Collection`. In the reactive world we don't have that luxury - the reactive types are all immutable and can't be modified _in place_. So in order to get around that we need to be able to supply a different set of arguments completely (i.e. a `Mono` / `Flux` with a `filterWhen` attached to it).

The only solution I was able to come up with was in [`ExpressionBasedReactivePreInvocationAuthorizationAdvice.setArguments`](https://github.com/spring-projects/spring-security/commit/2d75b19b0d972a443fc209cc2bac5ac8efa1b433#diff-14e767a0e12b05e6d98b272bb0eb2bf9R121). I thought it best to be able to support all the various implementations of `MethodInvocation` as possible (not just `ProxyMethodInvocation`). That's why I added the `setArguments` method to `SimpleMethodInvocation`.

Not to mention all the tests I wrote for testing all this functionality use a sub-class of `SimpleMethodInvocation`, so without it none of my tests will work either.

I can refactor a bit and take `SimpleMethodInvocation` out of the picture but then the whole pre-advice will only work correctly if the `MethodInvocation` is a `ProxyMethodInvocation`. I don't know enough about the rest of the codebase to know whether that is acceptable or not.

The only other solution I thought about but I feel would be a somewhat larger undertaking would be to change the implementation of the `ReactivePrePostAdviceMethodInterceptor` altogether and use the AspectJ classes (`ProceedingJoinPoint`) instead of the Spring AOP `MethodInvocation`. From there instead of only having a single `MethodInvocation.proceed()` method, there would be a `ProceedingJoinPoint.proceed(Object[])` method that we could use to supply different arguments. This would also involve some re-structuring of the way the pre-advice class works as well, since right now it only has a single `before` method that returns `Mono<Boolean>`. I think we would instead need 2 methods - 1 for `beforeAuthorize` and one for `beforeFilter`.

I didn't go that route originally though because I didn't see AspectJ being used anywhere and I wanted to keep the implementation on the reactive side as close as possible to the non-reactive side.

I'm open to ideas though - just wanted to put some context into why I made some of the decisions that I did.