### PR TITLE
Fixing IllegalStateException message in OAuth2ResourceServerConfigurer

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
@@ -183,9 +183,9 @@ public final class OAuth2ResourceServerConfigurer<H extends HttpSecurityBuilder<
 		if ( this.jwtConfigurer == null ) {
 			throw new IllegalStateException("Jwt is the only supported format for bearer tokens " +
 					"in Spring Security and no Jwt configuration was found. Make sure to specify " +
-					"a jwk set uri by doing http.oauth2().resourceServer().jwt().jwkSetUri(uri), or wire a " +
-					"JwtDecoder instance by doing http.oauth2().resourceServer().jwt().decoder(decoder), or " +
-					"expose a JwtDecoder instance as a bean and do http.oauth2().resourceServer().jwt().");
+					"a jwk set uri by doing http.oauth2ResourceServer().jwt().jwkSetUri(uri), or wire a " +
+					"JwtDecoder instance by doing http.oauth2ResourceServer().jwt().decoder(decoder), or " +
+					"expose a JwtDecoder instance as a bean and do http.oauth2ResourceServer().jwt().");
 		}
 
 		JwtDecoder decoder = this.jwtConfigurer.getJwtDecoder();


### PR DESCRIPTION
Updated message to include `http.oauth2ResourceServer()`