### PR TITLE
Allow in-memory authorized client services to be constructed with a map

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/InMemoryOAuth2AuthorizedClientService.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/InMemoryOAuth2AuthorizedClientService.java
@@ -36,8 +36,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * @see Authentication
  */
 public final class InMemoryOAuth2AuthorizedClientService implements OAuth2AuthorizedClientService {
-	private final Map<OAuth2AuthorizedClientId, OAuth2AuthorizedClient> authorizedClients = new ConcurrentHashMap<>();
 	private final ClientRegistrationRepository clientRegistrationRepository;
+	private Map<OAuth2AuthorizedClientId, OAuth2AuthorizedClient> authorizedClients = new ConcurrentHashMap<>();
 
 	/**
 	 * Constructs an {@code InMemoryOAuth2AuthorizedClientService} using the provided parameters.
@@ -47,6 +47,15 @@ public final class InMemoryOAuth2AuthorizedClientService implements OAuth2Author
 	public InMemoryOAuth2AuthorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
 		Assert.notNull(clientRegistrationRepository, "clientRegistrationRepository cannot be null");
 		this.clientRegistrationRepository = clientRegistrationRepository;
+	}
+
+	/**
+	 * Sets the map of authorized clients to use.
+	 * @param authorizedClients the map of authorized clients
+	 */
+	public void setAuthorizedClients(Map<OAuth2AuthorizedClientId, OAuth2AuthorizedClient> authorizedClients) {
+		Assert.notNull(authorizedClients, "authorizedClients cannot be null");
+		this.authorizedClients = authorizedClients;
 	}
 
 	@Override

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/OAuth2AuthorizedClientId.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/OAuth2AuthorizedClientId.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.util.Assert;
+
+/**
+ * The identifier for {@link OAuth2AuthorizedClient}.
+ *
+ * @author Vedran Pavic
+ * @since 5.2
+ * @see OAuth2AuthorizedClient
+ * @see OAuth2AuthorizedClientService
+ */
+public final class OAuth2AuthorizedClientId implements Serializable {
+
+	private final String clientRegistrationId;
+
+	private final String principalName;
+
+	private OAuth2AuthorizedClientId(String clientRegistrationId, String principalName) {
+		Assert.notNull(clientRegistrationId, "clientRegistrationId cannot be null");
+		Assert.notNull(principalName, "principalName cannot be null");
+		this.clientRegistrationId = clientRegistrationId;
+		this.principalName = principalName;
+	}
+
+	/**
+	 * Factory method for creating new {@link OAuth2AuthorizedClientId} using
+	 * {@link ClientRegistration} and principal name.
+	 * @param clientRegistration the client registration
+	 * @param principalName the principal name
+	 * @return the new authorized client id
+	 */
+	public static OAuth2AuthorizedClientId create(ClientRegistration clientRegistration,
+			String principalName) {
+		return new OAuth2AuthorizedClientId(clientRegistration.getRegistrationId(),
+				principalName);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null || getClass() != obj.getClass()) {
+			return false;
+		}
+		OAuth2AuthorizedClientId that = (OAuth2AuthorizedClientId) obj;
+		return Objects.equals(this.clientRegistrationId, that.clientRegistrationId)
+				&& Objects.equals(this.principalName, that.principalName);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.clientRegistrationId, this.principalName);
+	}
+
+}

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/OAuth2AuthorizedClientIdTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/OAuth2AuthorizedClientIdTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client;
+
+import org.junit.Test;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link OAuth2AuthorizedClientId}.
+ *
+ * @author Vedran Pavic
+ */
+public class OAuth2AuthorizedClientIdTests {
+
+	@Test
+	public void equalsWhenSameRegistrationIdAndPrincipalThenShouldReturnTrue() {
+		OAuth2AuthorizedClientId id1 = OAuth2AuthorizedClientId.create(testClientRegistration("test-client"),
+				"test-principal");
+		OAuth2AuthorizedClientId id2 = OAuth2AuthorizedClientId.create(testClientRegistration("test-client"),
+				"test-principal");
+		assertThat(id1.equals(id2)).isTrue();
+	}
+
+	@Test
+	public void equalsWhenDifferentRegistrationIdAndSamePrincipalThenShouldReturnFalse() {
+		OAuth2AuthorizedClientId id1 = OAuth2AuthorizedClientId.create(testClientRegistration("test-client1"),
+				"test-principal");
+		OAuth2AuthorizedClientId id2 = OAuth2AuthorizedClientId.create(testClientRegistration("test-client2"),
+				"test-principal");
+		assertThat(id1.equals(id2)).isFalse();
+	}
+
+	@Test
+	public void equalsWhenSameRegistrationIdAndDifferentPrincipalThenShouldReturnFalse() {
+		OAuth2AuthorizedClientId id1 = OAuth2AuthorizedClientId.create(testClientRegistration("test-client"),
+				"test-principal1");
+		OAuth2AuthorizedClientId id2 = OAuth2AuthorizedClientId.create(testClientRegistration("test-client"),
+				"test-principal2");
+		assertThat(id1.equals(id2)).isFalse();
+	}
+
+	@Test
+	public void hashCodeWhenSameRegistrationIdAndPrincipalThenShouldReturnSame() {
+		OAuth2AuthorizedClientId id1 = OAuth2AuthorizedClientId.create(testClientRegistration("test-client"),
+				"test-principal");
+		OAuth2AuthorizedClientId id2 = OAuth2AuthorizedClientId.create(testClientRegistration("test-client"),
+				"test-principal");
+		assertThat(id1.hashCode()).isEqualTo(id2.hashCode());
+	}
+
+	@Test
+	public void hashCodeWhenDifferentRegistrationIdAndSamePrincipalThenShouldNotReturnSame() {
+		OAuth2AuthorizedClientId id1 = OAuth2AuthorizedClientId.create(testClientRegistration("test-client1"),
+				"test-principal");
+		OAuth2AuthorizedClientId id2 = OAuth2AuthorizedClientId.create(testClientRegistration("test-client2"),
+				"test-principal");
+		assertThat(id1.hashCode()).isNotEqualTo(id2.hashCode());
+	}
+
+	@Test
+	public void hashCodeWhenSameRegistrationIdAndDifferentPrincipalThenShouldNotReturnSame() {
+		OAuth2AuthorizedClientId id1 = OAuth2AuthorizedClientId.create(testClientRegistration("test-client"),
+				"test-principal1");
+		OAuth2AuthorizedClientId id2 = OAuth2AuthorizedClientId.create(testClientRegistration("test-client"),
+				"test-principal2");
+		assertThat(id1.hashCode()).isNotEqualTo(id2.hashCode());
+	}
+
+	private static ClientRegistration testClientRegistration(String registrationId) {
+		return ClientRegistration.withRegistrationId(registrationId).clientId("id").clientSecret("secret")
+				.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+				.redirectUriTemplate("{baseUrl}/{action}/oauth2/code/{registrationId}")
+				.authorizationUri("http://example.com/authorize").tokenUri("http://example.com/token").build();
+	}
+
+}


### PR DESCRIPTION
This is the equivalent of #5918 only this time for `InMemoryOAuth2AuthorizedClientService` ~and its reactive counterpart~.