### PR TITLE
#3743 adds PostFilter support for streams

### DIFF
--- a/core/src/main/java/org/springframework/security/access/expression/method/DefaultMethodSecurityExpressionHandler.java
+++ b/core/src/main/java/org/springframework/security/access/expression/method/DefaultMethodSecurityExpressionHandler.java
@@ -175,21 +175,12 @@ public class DefaultMethodSecurityExpressionHandler extends
 
 		if (filterTarget instanceof Stream) {
 			final Stream<?> original = (Stream<?>) filterTarget;
-			if (debug) {
-				logger.debug("Filtering stream with " + original.count() + " elements");
-			}
 
-			Stream<?> filtered = original.filter(filterObject -> {
+			return original.filter(filterObject -> {
 				rootObject.setFilterObject(filterObject);
 				return ExpressionUtils.evaluateAsBoolean(filterExpression, ctx);
 			})
 					.onClose(original::close);
-
-			if (debug) {
-				logger.debug("Retaining elements: " + filtered.collect(Collectors.toList()));
-			}
-
-			return filtered;
 		}
 
 		throw new IllegalArgumentException(

--- a/core/src/main/java/org/springframework/security/access/expression/method/DefaultMethodSecurityExpressionHandler.java
+++ b/core/src/main/java/org/springframework/security/access/expression/method/DefaultMethodSecurityExpressionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.*;
 
 import org.aopalliance.intercept.MethodInvocation;
 import org.apache.commons.logging.Log;
@@ -86,8 +87,8 @@ public class DefaultMethodSecurityExpressionHandler extends
 	}
 
 	/**
-	 * Filters the {@code filterTarget} object (which must be either a collection or an
-	 * array), by evaluating the supplied expression.
+	 * Filters the {@code filterTarget} object (which must be either a collection, array,
+	 * or stream), by evaluating the supplied expression.
 	 * <p>
 	 * If a {@code Collection} is used, the original instance will be modified to contain
 	 * the elements for which the permission expression evaluates to {@code true}. For an
@@ -172,8 +173,27 @@ public class DefaultMethodSecurityExpressionHandler extends
 			return filtered;
 		}
 
+		if (filterTarget instanceof Stream) {
+			final Stream<?> original = (Stream<?>) filterTarget;
+			if (debug) {
+				logger.debug("Filtering stream with " + original.count() + " elements");
+			}
+
+			Stream<?> filtered = original.filter(filterObject -> {
+				rootObject.setFilterObject(filterObject);
+				return ExpressionUtils.evaluateAsBoolean(filterExpression, ctx);
+			})
+					.onClose(original::close);
+
+			if (debug) {
+				logger.debug("Retaining elements: " + filtered.collect(Collectors.toList()));
+			}
+
+			return filtered;
+		}
+
 		throw new IllegalArgumentException(
-				"Filter target must be a collection or array type, but was "
+				"Filter target must be a collection, array, or stream type, but was "
 						+ filterTarget);
 	}
 


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Resolves #3743 - adding support for `Stream`s in `@PostFilter` expressions by adding to `DefaultMethodSecurityExpressionHandler::filter`.