### PR TITLE
Fix csrf:token-repository-ref XSD documentation

### DIFF
--- a/config/src/main/resources/org/springframework/security/config/spring-security-4.2.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-4.2.rnc
@@ -748,7 +748,7 @@ csrf-options.attlist &=
 	## The RequestMatcher instance to be used to determine if CSRF should be applied. Default is any HTTP method except "GET", "TRACE", "HEAD", "OPTIONS"
 	attribute request-matcher-ref { xsd:token }?
 csrf-options.attlist &=
-	## The CsrfTokenRepository to use. The default is HttpSessionCsrfTokenRepository
+	## The CsrfTokenRepository to use. The default is HttpSessionCsrfTokenRepository wrapped by LazyCsrfTokenRepository.
 	attribute token-repository-ref { xsd:token }?
 
 headers =

--- a/config/src/main/resources/org/springframework/security/config/spring-security-4.2.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-4.2.xsd
@@ -2337,7 +2337,8 @@
       </xs:attribute>
       <xs:attribute name="token-repository-ref" type="xs:token">
          <xs:annotation>
-            <xs:documentation>The CsrfTokenRepository to use. The default is HttpSessionCsrfTokenRepository
+            <xs:documentation>The CsrfTokenRepository to use. The default is HttpSessionCsrfTokenRepository wrapped by
+                LazyCsrfTokenRepository.
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>

--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.0.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.0.rnc
@@ -738,7 +738,7 @@ csrf-options.attlist &=
 	## The RequestMatcher instance to be used to determine if CSRF should be applied. Default is any HTTP method except "GET", "TRACE", "HEAD", "OPTIONS"
 	attribute request-matcher-ref { xsd:token }?
 csrf-options.attlist &=
-	## The CsrfTokenRepository to use. The default is HttpSessionCsrfTokenRepository
+	## The CsrfTokenRepository to use. The default is HttpSessionCsrfTokenRepository wrapped by LazyCsrfTokenRepository.
 	attribute token-repository-ref { xsd:token }?
 
 headers =

--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.0.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.0.xsd
@@ -2232,7 +2232,8 @@
       </xs:attribute>
       <xs:attribute name="token-repository-ref" type="xs:token">
          <xs:annotation>
-            <xs:documentation>The CsrfTokenRepository to use. The default is HttpSessionCsrfTokenRepository
+            <xs:documentation>The CsrfTokenRepository to use. The default is HttpSessionCsrfTokenRepository wrapped by
+                LazyCsrfTokenRepository.
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>

--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.1.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.1.rnc
@@ -738,7 +738,7 @@ csrf-options.attlist &=
 	## The RequestMatcher instance to be used to determine if CSRF should be applied. Default is any HTTP method except "GET", "TRACE", "HEAD", "OPTIONS"
 	attribute request-matcher-ref { xsd:token }?
 csrf-options.attlist &=
-	## The CsrfTokenRepository to use. The default is HttpSessionCsrfTokenRepository
+	## The CsrfTokenRepository to use. The default is HttpSessionCsrfTokenRepository wrapped by LazyCsrfTokenRepository.
 	attribute token-repository-ref { xsd:token }?
 
 headers =

--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.1.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.1.xsd
@@ -2232,7 +2232,8 @@
       </xs:attribute>
       <xs:attribute name="token-repository-ref" type="xs:token">
          <xs:annotation>
-            <xs:documentation>The CsrfTokenRepository to use. The default is HttpSessionCsrfTokenRepository
+            <xs:documentation>The CsrfTokenRepository to use. The default is HttpSessionCsrfTokenRepository wrapped by
+                LazyCsrfTokenRepository.
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>


### PR DESCRIPTION
The documentation of the `token-repository-ref attribute` of the `csrf``  element in the schema has been updated to make clear the default repository is lazy.

Fixes #6037.

I wasn't sure which versions should be targeted, so I chose 4.2, 5.0 and 5.1. If this is incorrect, I'll update this PR.