### PR TITLE
InMemoryUserDetailsManager.updatePassword case-insenstive

### DIFF
--- a/core/src/main/java/org/springframework/security/provisioning/InMemoryUserDetailsManager.java
+++ b/core/src/main/java/org/springframework/security/provisioning/InMemoryUserDetailsManager.java
@@ -143,7 +143,7 @@ public class InMemoryUserDetailsManager implements UserDetailsManager,
 	@Override
 	public UserDetails updatePassword(UserDetails user, String newPassword) {
 		String username = user.getUsername();
-		MutableUserDetails mutableUser = this.users.get(username);
+		MutableUserDetails mutableUser = this.users.get(username.toLowerCase());
 		mutableUser.setPassword(newPassword);
 		return mutableUser;
 	}

--- a/core/src/test/java/org/springframework/security/provisioning/InMemoryUserDetailsManagerTests.java
+++ b/core/src/test/java/org/springframework/security/provisioning/InMemoryUserDetailsManagerTests.java
@@ -18,6 +18,7 @@ package org.springframework.security.provisioning;
 
 import org.junit.Test;
 import org.springframework.security.core.userdetails.PasswordEncodedUser;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import static org.assertj.core.api.Assertions.*;
@@ -36,5 +37,16 @@ public class InMemoryUserDetailsManagerTests {
 		String newPassword = "newPassword";
 		this.manager.updatePassword(this.user, newPassword);
 		assertThat(this.manager.loadUserByUsername(this.user.getUsername()).getPassword()).isEqualTo(newPassword);
+	}
+
+	@Test
+	public void changePasswordWhenUsernameIsNotInLowercase() {
+		UserDetails userNotLowerCase = User.withUserDetails(PasswordEncodedUser.user())
+				.username("User")
+				.build();
+
+		String newPassword = "newPassword";
+		this.manager.updatePassword(userNotLowerCase, newPassword);
+		assertThat(this.manager.loadUserByUsername(userNotLowerCase.getUsername()).getPassword()).isEqualTo(newPassword);
 	}
 }


### PR DESCRIPTION
When username is not in lowercase It throws a null pointer exception.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
