### PR TITLE
Docs: Fix Maven Property example `spring-security.version`

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/preface/getting-spring-security.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/preface/getting-spring-security.adoc
@@ -49,7 +49,7 @@ If you wish to override the Spring Security version, you may do so by providing 
 ----
 <properties>
 	<!-- ... -->
-	<spring-security.version>{spring-security-version}</spring.security.version>
+	<spring-security.version>{spring-security-version}</spring-security.version>
 </dependencies>
 ----
 


### PR DESCRIPTION
resolves https://github.com/spring-projects/spring-security/issues/6065

Should this possibly be back-ported?