### PR TITLE
Make AesBytesEncryptor public

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/encrypt/AesBytesEncryptor.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/encrypt/AesBytesEncryptor.java
@@ -41,7 +41,7 @@ import org.springframework.security.crypto.keygen.KeyGenerators;
  * @author Keith Donald
  * @author Dave Syer
  */
-final class AesBytesEncryptor implements BytesEncryptor {
+public final class AesBytesEncryptor implements BytesEncryptor {
 
 	private final SecretKey secretKey;
 


### PR DESCRIPTION
Hi

Please see https://github.com/spring-projects/spring-security/issues/5099 for the description of the problem and https://github.com/spring-projects/spring-security/pull/5102 for the proposed solution (implemented in this commit).
