### PR TITLE
Fix Typo in Reference Docs

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/servlet/architecture/jackson.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/architecture/jackson.adoc
@@ -4,7 +4,7 @@
 Spring Security has added Jackson Support for persisting Spring Security related classes.
 This can improve the performance of serializing Spring Security related classes when working with distributed sessions (i.e. session replication, Spring Session, etc).
 
-To use it, register the `JacksonJacksonModules.getModules(ClassLoader)` as http://wiki.fasterxml.com/JacksonFeatureModules[Jackson Modules].
+To use it, register the `SecurityJackson2Modules.getModules(ClassLoader)` as http://wiki.fasterxml.com/JacksonFeatureModules[Jackson Modules].
 
 [source,java]
 ----


### PR DESCRIPTION
fix typo in reference docs ( `JacksonJacksonModules` to `SecurityJackson2Modules` ) 
#6076 



