### PR TITLE
Support Path Variables in Message Expressions

### DIFF
--- a/messaging/src/main/java/org/springframework/security/messaging/access/expression/EvaluationContextPostProcessor.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/access/expression/EvaluationContextPostProcessor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.messaging.access.expression;
+
+import org.springframework.expression.EvaluationContext;
+
+/**
+ *
+/**
+ * Allows post processing the {@link EvaluationContext}
+ *
+ * <p>
+ * This API is intentionally kept package scope as it may evolve over time.
+ * </p>
+ *
+ * @author Daniel Bustamante Ospina
+ * @since 5.1
+ */
+interface EvaluationContextPostProcessor<I> {
+
+	/**
+	 * Allows post processing of the {@link EvaluationContext}. Implementations
+	 * may return a new instance of {@link EvaluationContext} or modify the
+	 * {@link EvaluationContext} that was passed in.
+	 *
+	 * @param context
+	 *            the original {@link EvaluationContext}
+	 * @param invocation
+	 *            the security invocation object (i.e. Message)
+	 * @return the upated context.
+	 */
+	EvaluationContext postProcess(EvaluationContext context, I invocation);
+}

--- a/messaging/src/main/java/org/springframework/security/messaging/access/expression/ExpressionBasedMessageSecurityMetadataSourceFactory.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/access/expression/ExpressionBasedMessageSecurityMetadataSourceFactory.java
@@ -48,6 +48,7 @@ public final class ExpressionBasedMessageSecurityMetadataSourceFactory {
 	 *     LinkedHashMap&lt;MessageMatcher&lt;?&gt;,String&gt; matcherToExpression = new LinkedHashMap&lt;MessageMatcher&lt;Object&gt;,String&gt;();
 	 *     matcherToExpression.put(new SimDestinationMessageMatcher("/public/**"), "permitAll");
 	 *     matcherToExpression.put(new SimDestinationMessageMatcher("/admin/**"), "hasRole('ROLE_ADMIN')");
+	 *     matcherToExpression.put(new SimDestinationMessageMatcher("/topics/{name}/**"), "@someBean.customLogic(authentication, #name)");
 	 *     matcherToExpression.put(new SimDestinationMessageMatcher("/**"), "authenticated");
 	 *
 	 *     MessageSecurityMetadataSource metadataSource = createExpressionMessageMetadataSource(matcherToExpression);
@@ -82,6 +83,7 @@ public final class ExpressionBasedMessageSecurityMetadataSourceFactory {
 	 *     LinkedHashMap&lt;MessageMatcher&lt;?&gt;,String&gt; matcherToExpression = new LinkedHashMap&lt;MessageMatcher&lt;Object&gt;,String&gt;();
 	 *     matcherToExpression.put(new SimDestinationMessageMatcher("/public/**"), "permitAll");
 	 *     matcherToExpression.put(new SimDestinationMessageMatcher("/admin/**"), "hasRole('ROLE_ADMIN')");
+	 *     matcherToExpression.put(new SimDestinationMessageMatcher("/topics/{name}/**"), "@someBean.customLogic(authentication, #name)");
 	 *     matcherToExpression.put(new SimDestinationMessageMatcher("/**"), "authenticated");
 	 *
 	 *     MessageSecurityMetadataSource metadataSource = createExpressionMessageMetadataSource(matcherToExpression);
@@ -113,7 +115,7 @@ public final class ExpressionBasedMessageSecurityMetadataSourceFactory {
 			String rawExpression = entry.getValue();
 			Expression expression = handler.getExpressionParser().parseExpression(
 					rawExpression);
-			ConfigAttribute attribute = new MessageExpressionConfigAttribute(expression);
+			ConfigAttribute attribute = new MessageExpressionConfigAttribute(expression, matcher);
 			matcherToAttrs.put(matcher, Arrays.asList(attribute));
 		}
 		return new DefaultMessageSecurityMetadataSource(matcherToAttrs);

--- a/messaging/src/main/java/org/springframework/security/messaging/access/expression/MessageExpressionVoter.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/access/expression/MessageExpressionVoter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import java.util.Collection;
  *
  * @since 4.0
  * @author Rob Winch
+ * @author Daniel Bustamante Ospina
  */
 public class MessageExpressionVoter<T> implements AccessDecisionVoter<Message<T>> {
 	private SecurityExpressionHandler<Message<T>> expressionHandler = new DefaultMessageSecurityExpressionHandler<>();
@@ -53,6 +54,7 @@ public class MessageExpressionVoter<T> implements AccessDecisionVoter<Message<T>
 
 		EvaluationContext ctx = expressionHandler.createEvaluationContext(authentication,
 				message);
+		ctx = attr.postProcess(ctx, message);
 
 		return ExpressionUtils.evaluateAsBoolean(attr.getAuthorizeExpression(), ctx) ? ACCESS_GRANTED
 				: ACCESS_DENIED;

--- a/messaging/src/main/java/org/springframework/security/messaging/util/matcher/SimpDestinationMessageMatcher.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/util/matcher/SimpDestinationMessageMatcher.java
@@ -22,6 +22,9 @@ import org.springframework.util.AntPathMatcher;
 import org.springframework.util.Assert;
 import org.springframework.util.PathMatcher;
 
+import java.util.Collections;
+import java.util.Map;
+
 /**
  * <p>
  * MessageMatcher which compares a pre-defined pattern against the destination of a
@@ -127,6 +130,14 @@ public final class SimpDestinationMessageMatcher implements MessageMatcher<Objec
 		String destination = SimpMessageHeaderAccessor.getDestination(message
 				.getHeaders());
 		return destination != null && matcher.match(pattern, destination);
+	}
+
+
+	public Map<String, String> extractPathVariables(Message<? extends Object> message){
+		final String destination = SimpMessageHeaderAccessor.getDestination(message
+				.getHeaders());
+		return destination != null ? matcher.extractUriTemplateVariables(pattern, destination)
+				: Collections.emptyMap();
 	}
 
 	public MessageMatcher<Object> getMessageTypeMatcher() {

--- a/messaging/src/test/java/org/springframework/security/messaging/access/expression/MessageExpressionConfigAttributeTests.java
+++ b/messaging/src/test/java/org/springframework/security/messaging/access/expression/MessageExpressionConfigAttributeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,26 +20,40 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.security.messaging.util.matcher.MessageMatcher;
+import org.springframework.security.messaging.util.matcher.SimpDestinationMessageMatcher;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MessageExpressionConfigAttributeTests {
 	@Mock
 	Expression expression;
 
+	@Mock
+	MessageMatcher<?> matcher;
+
 	MessageExpressionConfigAttribute attribute;
 
 	@Before
 	public void setup() {
-		attribute = new MessageExpressionConfigAttribute(expression);
+		attribute = new MessageExpressionConfigAttribute(expression, matcher);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void constructorNullExpression() {
-		new MessageExpressionConfigAttribute(null);
+		new MessageExpressionConfigAttribute(null, matcher);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void constructorNullMatcher() {
+		new MessageExpressionConfigAttribute(expression, null);
 	}
 
 	@Test
@@ -57,5 +71,17 @@ public class MessageExpressionConfigAttributeTests {
 		when(expression.getExpressionString()).thenReturn("toString");
 
 		assertThat(attribute.toString()).isEqualTo(expression.getExpressionString());
+	}
+
+	@Test
+	public void postProcessContext() {
+		SimpDestinationMessageMatcher matcher = new SimpDestinationMessageMatcher("/topics/{topic}/**");
+		Message<?> message = MessageBuilder.withPayload("M").setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "/topics/someTopic/sub1").build();
+		EvaluationContext context = mock(EvaluationContext.class);
+
+		attribute = new MessageExpressionConfigAttribute(expression, matcher);
+		attribute.postProcess(context, message);
+
+		verify(context).setVariable("topic", "someTopic");
 	}
 }

--- a/messaging/src/test/java/org/springframework/security/messaging/util/matcher/SimpDestinationMessageMatcherTests.java
+++ b/messaging/src/test/java/org/springframework/security/messaging/util/matcher/SimpDestinationMessageMatcherTests.java
@@ -128,6 +128,23 @@ public class SimpDestinationMessageMatcherTests {
 	}
 
 	@Test
+	public void extractPathVariablesFromDestination() throws Exception {
+		matcher = new SimpDestinationMessageMatcher("/topics/{topic}/**");
+
+		messageBuilder.setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "/topics/someTopic/sub1");
+		messageBuilder.setHeader(SimpMessageHeaderAccessor.MESSAGE_TYPE_HEADER,
+				SimpMessageType.MESSAGE);
+
+		assertThat(matcher.extractPathVariables(messageBuilder.build()).get("topic")).isEqualTo("someTopic");
+	}
+
+	@Test
+	public void extractedVariablesAreEmptyInNullDestination() throws Exception {
+		matcher = new SimpDestinationMessageMatcher("/topics/{topic}/**");
+		assertThat(matcher.extractPathVariables(messageBuilder.build())).isEmpty();
+	}
+
+	@Test
 	public void typeConstructorParameterIsTransmitted() throws Exception {
 		matcher = SimpDestinationMessageMatcher.createMessageMatcher("/match",
 				pathMatcher);


### PR DESCRIPTION
Extract path variables expressed in SimpDestinationMessageMatcher's pattern.

Fixes: gh-4469

