### PR TITLE
WebClient support should get new access token when expired and client_credentials

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/reactive/function/client/OAuth2AuthorizedClientResolver.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/reactive/function/client/OAuth2AuthorizedClientResolver.java
@@ -133,7 +133,7 @@ class OAuth2AuthorizedClientResolver {
 			});
 }
 
-	private Mono<? extends OAuth2AuthorizedClient> clientCredentials(
+	Mono<OAuth2AuthorizedClient> clientCredentials(
 			ClientRegistration clientRegistration, Authentication authentication, ServerWebExchange exchange) {
 		OAuth2ClientCredentialsGrantRequest grantRequest = new OAuth2ClientCredentialsGrantRequest(clientRegistration);
 		return this.clientCredentialsTokenResponseClient.getTokenResponse(grantRequest)

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServletOAuth2AuthorizedClientExchangeFilterFunction.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServletOAuth2AuthorizedClientExchangeFilterFunction.java
@@ -332,10 +332,14 @@ public final class ServletOAuth2AuthorizedClientExchangeFilterFunction implement
 		if (clientRegistration == null) {
 			throw new IllegalArgumentException("Could not find ClientRegistration with id " + clientRegistrationId);
 		}
-		if (AuthorizationGrantType.CLIENT_CREDENTIALS.equals(clientRegistration.getAuthorizationGrantType())) {
+		if (isClientCredentialsGrantType(clientRegistration)) {
 			return getAuthorizedClient(clientRegistration, attrs);
 		}
 		throw new ClientAuthorizationRequiredException(clientRegistrationId);
+	}
+
+	private boolean isClientCredentialsGrantType(ClientRegistration clientRegistration) {
+		return AuthorizationGrantType.CLIENT_CREDENTIALS.equals(clientRegistration.getAuthorizationGrantType());
 	}
 
 
@@ -366,7 +370,11 @@ public final class ServletOAuth2AuthorizedClientExchangeFilterFunction implement
 	}
 
 	private Mono<OAuth2AuthorizedClient> authorizedClient(ClientRequest request, ExchangeFunction next, OAuth2AuthorizedClient authorizedClient) {
-		if (shouldRefresh(authorizedClient)) {
+		ClientRegistration clientRegistration = authorizedClient.getClientRegistration();
+		if (isClientCredentialsGrantType(clientRegistration) && hasTokenExpired(authorizedClient)) {
+			//Client credentials grant do not have refresh tokens but can expire so we need to get another one
+			return Mono.fromSupplier(() -> getAuthorizedClient(clientRegistration, request.attributes()));
+		} else if (shouldRefresh(authorizedClient)) {
 			return refreshAuthorizedClient(request, next, authorizedClient);
 		}
 		return Mono.just(authorizedClient);
@@ -407,6 +415,10 @@ public final class ServletOAuth2AuthorizedClientExchangeFilterFunction implement
 		if (refreshToken == null) {
 			return false;
 		}
+		return hasTokenExpired(authorizedClient);
+	}
+
+	private boolean hasTokenExpired(OAuth2AuthorizedClient authorizedClient) {
 		Instant now = this.clock.instant();
 		Instant expiresAt = authorizedClient.getAccessToken().getExpiresAt();
 		if (now.isAfter(expiresAt.minus(this.accessTokenExpiresSkew))) {

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServletOAuth2AuthorizedClientExchangeFilterFunctionTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServletOAuth2AuthorizedClientExchangeFilterFunctionTests.java
@@ -78,6 +78,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -418,6 +419,80 @@ public class ServletOAuth2AuthorizedClientExchangeFilterFunctionTests {
 
 		ClientRequest request1 = requests.get(1);
 		assertThat(request1.headers().getFirst(HttpHeaders.AUTHORIZATION)).isEqualTo("Bearer token-1");
+		assertThat(request1.url().toASCIIString()).isEqualTo("https://example.com");
+		assertThat(request1.method()).isEqualTo(HttpMethod.GET);
+		assertThat(getBody(request1)).isEmpty();
+	}
+
+	@Test
+	public void filterWhenClientCredentialsTokenNotExpiredThenUseCurrentToken() {
+		this.registration = TestClientRegistrations.clientCredentials().build();
+
+		this.function = new ServletOAuth2AuthorizedClientExchangeFilterFunction(this.clientRegistrationRepository,
+				this.authorizedClientRepository);
+		this.function.setClientCredentialsTokenResponseClient(this.clientCredentialsTokenResponseClient);
+
+		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.registration,
+				"principalName", this.accessToken, null);
+		ClientRequest request = ClientRequest.create(GET, URI.create("https://example.com"))
+				.attributes(oauth2AuthorizedClient(authorizedClient))
+				.attributes(authentication(this.authentication))
+				.build();
+
+		this.function.filter(request, this.exchange).block();
+
+		verify(this.authorizedClientRepository, never()).saveAuthorizedClient(any(), eq(this.authentication), any(), any());
+
+		verify(clientCredentialsTokenResponseClient, never()).getTokenResponse(any());
+
+		List<ClientRequest> requests = this.exchange.getRequests();
+		assertThat(requests).hasSize(1);
+
+		ClientRequest request1 = requests.get(0);
+		assertThat(request1.headers().getFirst(HttpHeaders.AUTHORIZATION)).isEqualTo("Bearer token-0");
+		assertThat(request1.url().toASCIIString()).isEqualTo("https://example.com");
+		assertThat(request1.method()).isEqualTo(HttpMethod.GET);
+		assertThat(getBody(request1)).isEmpty();
+	}
+
+	@Test
+	public void filterWhenClientCredentialsTokenExpiredThenGetNewToken() {
+		this.registration = TestClientRegistrations.clientCredentials().build();
+
+		OAuth2AccessTokenResponse accessTokenResponse = TestOAuth2AccessTokenResponses
+				.accessTokenResponse().build();
+		when(this.clientCredentialsTokenResponseClient.getTokenResponse(any())).thenReturn(
+				accessTokenResponse);
+
+		Instant issuedAt = Instant.now().minus(Duration.ofDays(1));
+		Instant accessTokenExpiresAt = issuedAt.plus(Duration.ofHours(1));
+
+		this.accessToken = new OAuth2AccessToken(this.accessToken.getTokenType(),
+				this.accessToken.getTokenValue(),
+				issuedAt,
+				accessTokenExpiresAt);
+		this.function = new ServletOAuth2AuthorizedClientExchangeFilterFunction(this.clientRegistrationRepository,
+				this.authorizedClientRepository);
+		this.function.setClientCredentialsTokenResponseClient(this.clientCredentialsTokenResponseClient);
+
+		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.registration,
+				"principalName", this.accessToken, null);
+		ClientRequest request = ClientRequest.create(GET, URI.create("https://example.com"))
+				.attributes(oauth2AuthorizedClient(authorizedClient))
+				.attributes(authentication(this.authentication))
+				.build();
+
+		this.function.filter(request, this.exchange).block();
+
+		verify(this.authorizedClientRepository).saveAuthorizedClient(any(), eq(this.authentication), any(), any());
+
+		verify(clientCredentialsTokenResponseClient).getTokenResponse(any());
+
+		List<ClientRequest> requests = this.exchange.getRequests();
+		assertThat(requests).hasSize(1);
+
+		ClientRequest request1 = requests.get(0);
+		assertThat(request1.headers().getFirst(HttpHeaders.AUTHORIZATION)).isEqualTo("Bearer token");
 		assertThat(request1.url().toASCIIString()).isEqualTo("https://example.com");
 		assertThat(request1.method()).isEqualTo(HttpMethod.GET);
 		assertThat(getBody(request1)).isEmpty();


### PR DESCRIPTION
Updating the Servlet and Server OAuth2 authorized exchange filter functions so that they get a new access token when the current access token has expired and  client_credentials flow is used.

Fixes #5893 
