### PR TITLE
Replace deprecated Gradle Task method in AspectJPlugin.groovy

### DIFF
--- a/buildSrc/src/main/groovy/aspectj/AspectJPlugin.groovy
+++ b/buildSrc/src/main/groovy/aspectj/AspectJPlugin.groovy
@@ -59,7 +59,7 @@ class AspectJPlugin implements Plugin<Project> {
 				aspectPath = project.configurations.aspectpath
 			}
 
-			javaCompileTask.deleteAllActions()
+			javaCompileTask.setActions Arrays.asList()
 			javaCompileTask.dependsOn ajCompileTask
 
 		}


### PR DESCRIPTION
This commit ensures that the method Task.deleteAllActions is not used

Fixes: gh-6128
