### PR TITLE
Remove unused dependency slf4j-api in javaconfig x509 sample application

### DIFF
--- a/samples/javaconfig/x509/spring-security-samples-javaconfig-x509.gradle
+++ b/samples/javaconfig/x509/spring-security-samples-javaconfig-x509.gradle
@@ -8,10 +8,7 @@ dependencies {
 	compile 'javax.servlet.jsp.jstl:javax.servlet.jsp.jstl-api'
 	compile 'javax.validation:validation-api'
 	compile 'org.hibernate:hibernate-validator'
-	compile 'org.slf4j:jcl-over-slf4j'
-	compile 'org.slf4j:jul-to-slf4j'
-	compile 'org.slf4j:log4j-over-slf4j'
-	compile 'org.slf4j:slf4j-api'
+	compile 'ch.qos.logback:logback-classic'
 	compile 'org.springframework:spring-jdbc'
 	compile 'org.springframework:spring-webmvc'
 


### PR DESCRIPTION
This commit ensures that unused dependencies are not imported, that will prevent warning messages being thrown when building the project.

Fixes: gh-6130