### PR TITLE
Enable Code Coverage Reports in Sonar

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ try {
 				checkout scm
 				withCredentials([string(credentialsId: 'spring-sonar.login', variable: 'SONAR_LOGIN')]) {
 					try {
-						sh "./gradlew clean sonarqube -PexcludeProjects='**/samples/**' -Dsonar.host.url=$SPRING_SONAR_HOST_URL -Dsonar.login=$SONAR_LOGIN --refresh-dependencies --no-daemon --stacktrace"
+						sh "./gradlew clean jacocoTestReport sonarqube -Dsonar.jacoco.reportPaths='**/build/jacoco/*.exec' -PexcludeProjects='**/samples/**' -Dsonar.host.url=$SPRING_SONAR_HOST_URL -Dsonar.login=$SONAR_LOGIN --refresh-dependencies --no-daemon --stacktrace"
 					} catch(Exception e) {
 						currentBuild.result = 'FAILED: sonar'
 						throw e


### PR DESCRIPTION
This commit ensures that jacocoTestReport task is called when running the Sonar stage.
Additionally, a variable is passed instructing Sonar where to find the test result data.

Fixes: gh-6092

