### PR TITLE
ReactorContextTestExecutionListener should use named hooks

### DIFF
--- a/test/src/main/java/org/springframework/security/test/context/support/ReactorContextTestExecutionListener.java
+++ b/test/src/main/java/org/springframework/security/test/context/support/ReactorContextTestExecutionListener.java
@@ -44,6 +44,7 @@ public class ReactorContextTestExecutionListener
 	extends DelegatingTestExecutionListener {
 
 	private static final String HOOKS_CLASS_NAME = "reactor.core.publisher.Hooks";
+	private static final String CONTEXT_OPERATOR_KEY = SecurityContext.class.getName();
 
 	public ReactorContextTestExecutionListener() {
 		super(createDelegate());
@@ -59,12 +60,12 @@ public class ReactorContextTestExecutionListener
 		@Override
 		public void beforeTestMethod(TestContext testContext) throws Exception {
 			SecurityContext securityContext = TestSecurityContextHolder.getContext();
-			Hooks.onLastOperator(Operators.lift((s, sub) -> new SecuritySubContext<>(sub, securityContext)));
+			Hooks.onLastOperator(CONTEXT_OPERATOR_KEY, Operators.lift((s, sub) -> new SecuritySubContext<>(sub, securityContext)));
 		}
 
 		@Override
 		public void afterTestMethod(TestContext testContext) throws Exception {
-			Hooks.resetOnLastOperator();
+			Hooks.resetOnLastOperator(CONTEXT_OPERATOR_KEY);
 		}
 
 		private static class SecuritySubContext<T> implements CoreSubscriber<T> {

--- a/test/src/test/java/org/springframework/security/test/context/support/ReactorContextTestExecutionListenerTests.java
+++ b/test/src/test/java/org/springframework/security/test/context/support/ReactorContextTestExecutionListenerTests.java
@@ -175,6 +175,16 @@ public class ReactorContextTestExecutionListenerTests {
 	}
 
 	@Test
+	public void afterTestMethodWhenDifferentHookIsRegistered() throws Exception {
+		Object obj = new Object();
+
+		Hooks.onLastOperator("CUSTOM_HOOK", p -> Mono.just(obj));
+		this.listener.afterTestMethod(this.testContext);
+
+		assertThat(Mono.subscriberContext().block()).isEqualTo(obj);
+	}
+
+	@Test
 	public void orderWhenComparedToWithSecurityContextTestExecutionListenerIsAfter() {
 		OrderComparator comparator = new OrderComparator();
 		WithSecurityContextTestExecutionListener withSecurity = new WithSecurityContextTestExecutionListener();


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
