### PR TITLE
Extract bearer token from arbitrary header

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/HeaderBearerTokenResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/HeaderBearerTokenResolver.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.resource.web;
+
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.util.Assert;
+
+/**
+ * Generic resolver extracting pre-authenticated JWT identity from a custom header.
+ *
+ * @author Elena Felder
+ * @since 5.2
+ */
+public class HeaderBearerTokenResolver implements BearerTokenResolver {
+
+	private String header;
+
+	public HeaderBearerTokenResolver(String header) {
+		Assert.hasText(header, "header cannot be empty");
+		this.header = header;
+	}
+
+	@Override
+	public String resolve(HttpServletRequest request) {
+		return request.getHeader(this.header);
+	}
+}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/HeaderBearerTokenResolverTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/HeaderBearerTokenResolverTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.resource.web;
+
+import org.junit.Test;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Tests for {@link HeaderBearerTokenResolver}
+ *
+ * @author Elena Felder
+ */
+public class HeaderBearerTokenResolverTests {
+
+	private static final String TEST_TOKEN = "test-token";
+
+	private static final String CORRECT_HEADER = "jwt-assertion";
+
+	private HeaderBearerTokenResolver resolver = new HeaderBearerTokenResolver(CORRECT_HEADER);
+
+	@Test
+	public void constructorWhenHeaderNullThenThrowIllegalArgumentException() {
+		assertThatCode(() -> { new HeaderBearerTokenResolver(null); })
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("header cannot be empty");
+	}
+
+	@Test
+	public void constructorWhenHeaderEmptyThenThrowIllegalArgumentException() {
+		assertThatCode(() -> { new HeaderBearerTokenResolver(""); })
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("header cannot be empty");
+	}
+
+	@Test
+	public void resolveWhenTokenPresentThenTokenIsResolved() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader(CORRECT_HEADER, TEST_TOKEN);
+
+		assertThat(this.resolver.resolve(request)).isEqualTo(TEST_TOKEN);
+	}
+
+	@Test
+	public void resolveWhenTokenNotPresentThenTokenIsNotResolved() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+
+		assertThat(this.resolver.resolve(request)).isNull();
+	}
+}


### PR DESCRIPTION
The new `HeaderBearerTokenResolver` extracts the bearer token (most likely JWT) from the application-defined HTTP request header.

This allows Spring Security Resource Server to understand, for example, [Google Cloud IAP proxy authentication](https://cloud.google.com/iap/docs/signed-headers-howto), which places JWT tokens in a `x-goog-iap-jwt-assertion` header.

