### PR TITLE
Make CachingUserDetailsService Public

### DIFF
--- a/config/src/main/java/org/springframework/security/config/authentication/AbstractUserDetailsServiceBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/authentication/AbstractUserDetailsServiceBeanDefinitionParser.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.beans.factory.xml.BeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.security.authentication.CachingUserDetailsService;
 import org.springframework.security.config.BeanIds;
 import org.springframework.util.StringUtils;
 import org.w3c.dom.Element;

--- a/config/src/main/java/org/springframework/security/config/http/UserDetailsServiceFactoryBean.java
+++ b/config/src/main/java/org/springframework/security/config/http/UserDetailsServiceFactoryBean.java
@@ -25,7 +25,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ApplicationContextException;
 import org.springframework.security.config.authentication.AbstractUserDetailsServiceBeanDefinitionParser;
-import org.springframework.security.config.authentication.CachingUserDetailsService;
+import org.springframework.security.authentication.CachingUserDetailsService;
 import org.springframework.security.core.userdetails.AuthenticationUserDetailsService;
 import org.springframework.security.core.userdetails.UserDetailsByNameServiceWrapper;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/config/src/test/java/org/springframework/security/config/authentication/JdbcUserServiceBeanDefinitionParserTests.java
+++ b/config/src/test/java/org/springframework/security/config/authentication/JdbcUserServiceBeanDefinitionParserTests.java
@@ -17,6 +17,7 @@ package org.springframework.security.config.authentication;
 
 import org.junit.After;
 import org.junit.Test;
+import org.springframework.security.authentication.CachingUserDetailsService;
 import org.w3c.dom.Element;
 
 import org.springframework.security.authentication.AuthenticationManager;

--- a/core/src/main/java/org/springframework/security/authentication/CachingUserDetailsService.java
+++ b/core/src/main/java/org/springframework/security/authentication/CachingUserDetailsService.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.security.config.authentication;
+package org.springframework.security.authentication;
 
 import org.springframework.security.core.userdetails.UserCache;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -30,7 +30,7 @@ public class CachingUserDetailsService implements UserDetailsService {
 	private UserCache userCache = new NullUserCache();
 	private final UserDetailsService delegate;
 
-	CachingUserDetailsService(UserDetailsService delegate) {
+	public CachingUserDetailsService(UserDetailsService delegate) {
 		this.delegate = delegate;
 	}
 


### PR DESCRIPTION
- changed default to public constructor in CachingUserDetailsService

Changed based on the comments in this thread https://github.com/spring-projects/spring-security/issues/4139