### PR TITLE
Restored Jacoco default task dependence

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ try {
 				checkout scm
 				withCredentials([string(credentialsId: 'spring-sonar.login', variable: 'SONAR_LOGIN')]) {
 					try {
-						sh "./gradlew clean jacocoTestReport sonarqube -Dsonar.jacoco.reportPaths='**/build/jacoco/*.exec' -PexcludeProjects='**/samples/**' -Dsonar.host.url=$SPRING_SONAR_HOST_URL -Dsonar.login=$SONAR_LOGIN --refresh-dependencies --no-daemon --stacktrace"
+						sh "./gradlew sonarqube -PexcludeProjects='**/samples/**' -Dsonar.host.url=$SPRING_SONAR_HOST_URL -Dsonar.login=$SONAR_LOGIN --refresh-dependencies --no-daemon --stacktrace"
 					} catch(Exception e) {
 						currentBuild.result = 'FAILED: sonar'
 						throw e

--- a/build.gradle
+++ b/build.gradle
@@ -19,23 +19,8 @@ ext.milestoneBuild = !(snapshotBuild || releaseBuild)
 
 dependencyManagementExport.projects = subprojects.findAll { !it.name.contains('-boot') }
 
-// Disable JaCoCo when not explicitly requested to enable caching of test
-// See https://discuss.gradle.org/t/do-not-cache-if-condition-matched-jacoco-agent-configured-with-append-true-satisfied/23504
-gradle.taskGraph.whenReady { graph ->
-	def enabled = graph.allTasks.any { it instanceof JacocoReport }
-	subprojects { project ->
-		project.plugins.withType(JacocoPlugin) {
-		    project.tasks.withType(Test) {
-		        jacoco.enabled = enabled
-		    }
-		}
-	}
-}
-
-
 subprojects {
 	plugins.withType(JavaPlugin) {
 		project.sourceCompatibility='1.8'
 	}
 }
-


### PR DESCRIPTION
This commit ensures that the jacoco plugin is applied when calling
check and test tasks.
Also remoed the clean task that prevented sonarqube using coverage data

Fixes: gh-6199

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
