### PR TITLE
feat(Oauth2) : make RequestRepository configurable

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/ImplicitGrantConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/ImplicitGrantConfigurer.java
@@ -15,14 +15,10 @@
  */
 package org.springframework.security.config.annotation.web.configurers.oauth2.client;
 
-import org.springframework.context.ApplicationContext;
 import org.springframework.security.config.annotation.web.HttpSecurityBuilder;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
-import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
-import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.util.Assert;
 
 /**

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/ImplicitGrantConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/ImplicitGrantConfigurer.java
@@ -15,10 +15,14 @@
  */
 package org.springframework.security.config.annotation.web.configurers.oauth2.client;
 
+import org.springframework.context.ApplicationContext;
 import org.springframework.security.config.annotation.web.HttpSecurityBuilder;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.util.Assert;
 
 /**
@@ -85,7 +89,7 @@ public final class ImplicitGrantConfigurer<B extends HttpSecurityBuilder<B>> ext
 	@Override
 	public void configure(B http) throws Exception {
 		OAuth2AuthorizationRequestRedirectFilter authorizationRequestFilter = new OAuth2AuthorizationRequestRedirectFilter(
-			OAuth2ClientConfigurerUtils.getClientRegistrationRepository(this.getBuilder()), this.getAuthorizationRequestBaseUri());
+			OAuth2ClientConfigurerUtils.getClientRegistrationRepository(this.getBuilder()), this.getAuthorizationRequestBaseUri(), OAuth2ClientConfigurerUtils.getAuthorizationRequestRepository(this.getBuilder()));
 		http.addFilter(this.postProcess(authorizationRequestFilter));
 	}
 
@@ -94,4 +98,5 @@ public final class ImplicitGrantConfigurer<B extends HttpSecurityBuilder<B>> ext
 			this.authorizationRequestBaseUri :
 			OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI;
 	}
+
 }

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2ClientConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2ClientConfigurer.java
@@ -211,7 +211,7 @@ public final class OAuth2ClientConfigurer<B extends HttpSecurityBuilder<B>> exte
 		private OAuth2AuthorizationRequestRedirectFilter createAuthorizationRequestRedirectFilter(B builder) {
 			OAuth2AuthorizationRequestResolver resolver = getAuthorizationRequestResolver();
 			OAuth2AuthorizationRequestRedirectFilter authorizationRequestRedirectFilter =
-					new OAuth2AuthorizationRequestRedirectFilter(resolver,OAuth2ClientConfigurerUtils.getAuthorizationRequestRepository(builder));
+					new OAuth2AuthorizationRequestRedirectFilter(resolver, OAuth2ClientConfigurerUtils.getAuthorizationRequestRepository(builder));
 
 			if (this.authorizationRequestRepository != null) {
 				authorizationRequestRedirectFilter.setAuthorizationRequestRepository(this.authorizationRequestRepository);

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2ClientConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2ClientConfigurer.java
@@ -211,7 +211,7 @@ public final class OAuth2ClientConfigurer<B extends HttpSecurityBuilder<B>> exte
 		private OAuth2AuthorizationRequestRedirectFilter createAuthorizationRequestRedirectFilter(B builder) {
 			OAuth2AuthorizationRequestResolver resolver = getAuthorizationRequestResolver();
 			OAuth2AuthorizationRequestRedirectFilter authorizationRequestRedirectFilter =
-					new OAuth2AuthorizationRequestRedirectFilter(resolver);
+					new OAuth2AuthorizationRequestRedirectFilter(resolver,OAuth2ClientConfigurerUtils.getAuthorizationRequestRepository(builder));
 
 			if (this.authorizationRequestRepository != null) {
 				authorizationRequestRedirectFilter.setAuthorizationRequestRepository(this.authorizationRequestRepository);

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2ClientConfigurerUtils.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2ClientConfigurerUtils.java
@@ -24,7 +24,10 @@ import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClient
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.AuthenticatedPrincipalOAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.util.StringUtils;
 
 import java.util.Map;
@@ -95,5 +98,15 @@ final class OAuth2ClientConfigurerUtils {
 					authorizedClientServiceMap.size() + ": " + StringUtils.collectionToCommaDelimitedString(authorizedClientServiceMap.keySet()));
 		}
 		return (!authorizedClientServiceMap.isEmpty() ? authorizedClientServiceMap.values().iterator().next() : null);
+	}
+
+	static <B extends HttpSecurityBuilder<B>> AuthorizationRequestRepository<OAuth2AuthorizationRequest> getAuthorizationRequestRepository(B builder) {
+		AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository = builder
+				.getSharedObject(ApplicationContext.class).getBean(AuthorizationRequestRepository.class);
+		if (authorizationRequestRepository == null) {
+			authorizationRequestRepository = new HttpSessionOAuth2AuthorizationRequestRepository();
+			builder.setSharedObject(AuthorizationRequestRepository.class, authorizationRequestRepository);
+		}
+		return authorizationRequestRepository;
 	}
 }

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2LoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2LoginConfigurer.java
@@ -45,7 +45,6 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.client.web.AuthenticatedPrincipalOAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
-import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
@@ -507,14 +506,15 @@ public final class OAuth2LoginConfigurer<B extends HttpSecurityBuilder<B>> exten
 
 		if (this.authorizationEndpointConfig.authorizationRequestResolver != null) {
 			authorizationRequestFilter = new OAuth2AuthorizationRequestRedirectFilter(
-					this.authorizationEndpointConfig.authorizationRequestResolver,OAuth2ClientConfigurerUtils.getAuthorizationRequestRepository(this.getBuilder()));
+					this.authorizationEndpointConfig.authorizationRequestResolver,
+					OAuth2ClientConfigurerUtils.getAuthorizationRequestRepository(this.getBuilder()));
 		} else {
 			String authorizationRequestBaseUri = this.authorizationEndpointConfig.authorizationRequestBaseUri;
 			if (authorizationRequestBaseUri == null) {
 				authorizationRequestBaseUri = OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI;
 			}
 			authorizationRequestFilter = new OAuth2AuthorizationRequestRedirectFilter(
-					OAuth2ClientConfigurerUtils.getClientRegistrationRepository(this.getBuilder()), authorizationRequestBaseUri,OAuth2ClientConfigurerUtils.getAuthorizationRequestRepository(this.getBuilder()));
+					OAuth2ClientConfigurerUtils.getClientRegistrationRepository(this.getBuilder()), authorizationRequestBaseUri, OAuth2ClientConfigurerUtils.getAuthorizationRequestRepository(this.getBuilder()));
 		}
 
 		if (this.authorizationEndpointConfig.authorizationRequestRepository != null) {

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2LoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2LoginConfigurer.java
@@ -45,6 +45,7 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.client.web.AuthenticatedPrincipalOAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
@@ -426,7 +427,8 @@ public final class OAuth2LoginConfigurer<B extends HttpSecurityBuilder<B>> exten
 			new OAuth2LoginAuthenticationFilter(
 				OAuth2ClientConfigurerUtils.getClientRegistrationRepository(this.getBuilder()),
 				OAuth2ClientConfigurerUtils.getAuthorizedClientRepository(this.getBuilder()),
-				this.loginProcessingUrl);
+				this.loginProcessingUrl,
+				OAuth2ClientConfigurerUtils.getAuthorizationRequestRepository(this.getBuilder()));
 		this.setAuthenticationFilter(authenticationFilter);
 		super.loginProcessingUrl(this.loginProcessingUrl);
 		RequestMatcher authenticationNullMatcher = request -> SecurityContextHolder.getContext().getAuthentication() == null;
@@ -505,14 +507,14 @@ public final class OAuth2LoginConfigurer<B extends HttpSecurityBuilder<B>> exten
 
 		if (this.authorizationEndpointConfig.authorizationRequestResolver != null) {
 			authorizationRequestFilter = new OAuth2AuthorizationRequestRedirectFilter(
-					this.authorizationEndpointConfig.authorizationRequestResolver);
+					this.authorizationEndpointConfig.authorizationRequestResolver,OAuth2ClientConfigurerUtils.getAuthorizationRequestRepository(this.getBuilder()));
 		} else {
 			String authorizationRequestBaseUri = this.authorizationEndpointConfig.authorizationRequestBaseUri;
 			if (authorizationRequestBaseUri == null) {
 				authorizationRequestBaseUri = OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI;
 			}
 			authorizationRequestFilter = new OAuth2AuthorizationRequestRedirectFilter(
-					OAuth2ClientConfigurerUtils.getClientRegistrationRepository(this.getBuilder()), authorizationRequestBaseUri);
+					OAuth2ClientConfigurerUtils.getClientRegistrationRepository(this.getBuilder()), authorizationRequestBaseUri,OAuth2ClientConfigurerUtils.getAuthorizationRequestRepository(this.getBuilder()));
 		}
 
 		if (this.authorizationEndpointConfig.authorizationRequestRepository != null) {

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/OAuth2AuthorizationRequestRedirectFilter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/OAuth2AuthorizationRequestRedirectFilter.java
@@ -56,9 +56,9 @@ import java.io.IOException;
  *
  * <p>
  * The default base {@code URI} {@code /oauth2/authorization} may be overridden
- * via the constructor {@link #OAuth2AuthorizationRequestRedirectFilter(ClientRegistrationRepository, String)},
+ * via the constructor {@link #OAuth2AuthorizationRequestRedirectFilter(ClientRegistrationRepository, String,AuthorizationRequestRepository)},
  * or alternatively, an {@code OAuth2AuthorizationRequestResolver} may be provided to the constructor
- * {@link #OAuth2AuthorizationRequestRedirectFilter(OAuth2AuthorizationRequestResolver)}
+ * {@link #OAuth2AuthorizationRequestRedirectFilter(OAuth2AuthorizationRequestResolver,AuthorizationRequestRepository)}
  * to override the resolving of authorization requests.
 
  * @author Joe Grandja
@@ -69,6 +69,7 @@ import java.io.IOException;
  * @see AuthorizationRequestRepository
  * @see ClientRegistration
  * @see ClientRegistrationRepository
+ * @see AuthorizationRequestRepository
  * @see <a target="_blank" href="https://tools.ietf.org/html/rfc6749#section-4.1">Section 4.1 Authorization Code Grant</a>
  * @see <a target="_blank" href="https://tools.ietf.org/html/rfc6749#section-4.1.1">Section 4.1.1 Authorization Request (Authorization Code)</a>
  * @see <a target="_blank" href="https://tools.ietf.org/html/rfc6749#section-4.2">Section 4.2 Implicit Grant</a>
@@ -82,8 +83,7 @@ public class OAuth2AuthorizationRequestRedirectFilter extends OncePerRequestFilt
 	private final ThrowableAnalyzer throwableAnalyzer = new DefaultThrowableAnalyzer();
 	private final RedirectStrategy authorizationRedirectStrategy = new DefaultRedirectStrategy();
 	private OAuth2AuthorizationRequestResolver authorizationRequestResolver;
-	private AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository =
-		new HttpSessionOAuth2AuthorizationRequestRepository();
+	private AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository;
 	private RequestCache requestCache = new HttpSessionRequestCache();
 
 	/**
@@ -91,8 +91,9 @@ public class OAuth2AuthorizationRequestRedirectFilter extends OncePerRequestFilt
 	 *
 	 * @param clientRegistrationRepository the repository of client registrations
 	 */
-	public OAuth2AuthorizationRequestRedirectFilter(ClientRegistrationRepository clientRegistrationRepository) {
-		this(clientRegistrationRepository, DEFAULT_AUTHORIZATION_REQUEST_BASE_URI);
+	public OAuth2AuthorizationRequestRedirectFilter(ClientRegistrationRepository clientRegistrationRepository,
+													AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository) {
+		this(clientRegistrationRepository, DEFAULT_AUTHORIZATION_REQUEST_BASE_URI,authorizationRequestRepository);
 	}
 
 	/**
@@ -102,11 +103,14 @@ public class OAuth2AuthorizationRequestRedirectFilter extends OncePerRequestFilt
 	 * @param authorizationRequestBaseUri the base {@code URI} used for authorization requests
 	 */
 	public OAuth2AuthorizationRequestRedirectFilter(ClientRegistrationRepository clientRegistrationRepository,
-													String authorizationRequestBaseUri) {
+													String authorizationRequestBaseUri,
+													AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository) {
 		Assert.notNull(clientRegistrationRepository, "clientRegistrationRepository cannot be null");
 		Assert.hasText(authorizationRequestBaseUri, "authorizationRequestBaseUri cannot be empty");
+		Assert.notNull(authorizationRequestRepository,"authorizationRequestRepository cannot be null");
 		this.authorizationRequestResolver = new DefaultOAuth2AuthorizationRequestResolver(
 				clientRegistrationRepository, authorizationRequestBaseUri);
+		this.authorizationRequestRepository=authorizationRequestRepository;
 	}
 
 	/**
@@ -115,9 +119,12 @@ public class OAuth2AuthorizationRequestRedirectFilter extends OncePerRequestFilt
 	 * @since 5.1
 	 * @param authorizationRequestResolver the resolver used for resolving authorization requests
 	 */
-	public OAuth2AuthorizationRequestRedirectFilter(OAuth2AuthorizationRequestResolver authorizationRequestResolver) {
+	public OAuth2AuthorizationRequestRedirectFilter(OAuth2AuthorizationRequestResolver authorizationRequestResolver,
+													AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository) {
 		Assert.notNull(authorizationRequestResolver, "authorizationRequestResolver cannot be null");
+		Assert.notNull(authorizationRequestRepository,"authorizationRequestRepository cannot be null");
 		this.authorizationRequestResolver = authorizationRequestResolver;
+		this.authorizationRequestRepository=authorizationRequestRepository;
 	}
 
 	/**

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/OAuth2LoginAuthenticationFilter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/OAuth2LoginAuthenticationFilter.java
@@ -102,8 +102,7 @@ public class OAuth2LoginAuthenticationFilter extends AbstractAuthenticationProce
 	private static final String CLIENT_REGISTRATION_NOT_FOUND_ERROR_CODE = "client_registration_not_found";
 	private ClientRegistrationRepository clientRegistrationRepository;
 	private OAuth2AuthorizedClientRepository authorizedClientRepository;
-	private AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository =
-		new HttpSessionOAuth2AuthorizationRequestRepository();
+	private AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository;
 
 	/**
 	 * Constructs an {@code OAuth2LoginAuthenticationFilter} using the provided parameters.
@@ -112,8 +111,9 @@ public class OAuth2LoginAuthenticationFilter extends AbstractAuthenticationProce
 	 * @param authorizedClientService the authorized client service
 	 */
 	public OAuth2LoginAuthenticationFilter(ClientRegistrationRepository clientRegistrationRepository,
-											OAuth2AuthorizedClientService authorizedClientService) {
-		this(clientRegistrationRepository, authorizedClientService, DEFAULT_FILTER_PROCESSES_URI);
+											OAuth2AuthorizedClientService authorizedClientService,
+											AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository) {
+		this(clientRegistrationRepository, authorizedClientService, DEFAULT_FILTER_PROCESSES_URI,authorizationRequestRepository);
 	}
 
 	/**
@@ -125,9 +125,10 @@ public class OAuth2LoginAuthenticationFilter extends AbstractAuthenticationProce
 	 */
 	public OAuth2LoginAuthenticationFilter(ClientRegistrationRepository clientRegistrationRepository,
 											OAuth2AuthorizedClientService authorizedClientService,
-											String filterProcessesUrl) {
+											String filterProcessesUrl,
+											AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository) {
 		this(clientRegistrationRepository,
-				new AuthenticatedPrincipalOAuth2AuthorizedClientRepository(authorizedClientService), filterProcessesUrl);
+				new AuthenticatedPrincipalOAuth2AuthorizedClientRepository(authorizedClientService), filterProcessesUrl,authorizationRequestRepository);
 	}
 
 	/**
@@ -140,12 +141,15 @@ public class OAuth2LoginAuthenticationFilter extends AbstractAuthenticationProce
 	 */
 	public OAuth2LoginAuthenticationFilter(ClientRegistrationRepository clientRegistrationRepository,
 											OAuth2AuthorizedClientRepository authorizedClientRepository,
-											String filterProcessesUrl) {
+											String filterProcessesUrl,
+											AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository) {
 		super(filterProcessesUrl);
 		Assert.notNull(clientRegistrationRepository, "clientRegistrationRepository cannot be null");
 		Assert.notNull(authorizedClientRepository, "authorizedClientRepository cannot be null");
+		Assert.notNull(authorizationRequestRepository,"authorizationRequestRepository cannot be null");
 		this.clientRegistrationRepository = clientRegistrationRepository;
 		this.authorizedClientRepository = authorizedClientRepository;
+		this.authorizationRequestRepository=authorizationRequestRepository;
 	}
 
 	@Override

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/OAuth2LoginAuthenticationFilterTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/OAuth2LoginAuthenticationFilterTests.java
@@ -94,7 +94,7 @@ public class OAuth2LoginAuthenticationFilterTests {
 		this.failureHandler = mock(AuthenticationFailureHandler.class);
 		this.authenticationManager = mock(AuthenticationManager.class);
 		this.filter = spy(new OAuth2LoginAuthenticationFilter(this.clientRegistrationRepository,
-				this.authorizedClientRepository, OAuth2LoginAuthenticationFilter.DEFAULT_FILTER_PROCESSES_URI));
+				this.authorizedClientRepository, OAuth2LoginAuthenticationFilter.DEFAULT_FILTER_PROCESSES_URI,authorizationRequestRepository));
 		this.filter.setAuthorizationRequestRepository(this.authorizationRequestRepository);
 		this.filter.setAuthenticationFailureHandler(this.failureHandler);
 		this.filter.setAuthenticationManager(this.authenticationManager);
@@ -102,26 +102,26 @@ public class OAuth2LoginAuthenticationFilterTests {
 
 	@Test
 	public void constructorWhenClientRegistrationRepositoryIsNullThenThrowIllegalArgumentException() {
-		assertThatThrownBy(() -> new OAuth2LoginAuthenticationFilter(null, this.authorizedClientService))
+		assertThatThrownBy(() -> new OAuth2LoginAuthenticationFilter(null, this.authorizedClientService,authorizationRequestRepository))
 				.isInstanceOf(IllegalArgumentException.class);
 	}
 
 	@Test
 	public void constructorWhenAuthorizedClientServiceIsNullThenThrowIllegalArgumentException() {
-		assertThatThrownBy(() -> new OAuth2LoginAuthenticationFilter(this.clientRegistrationRepository, null))
+		assertThatThrownBy(() -> new OAuth2LoginAuthenticationFilter(this.clientRegistrationRepository, null,authorizationRequestRepository))
 				.isInstanceOf(IllegalArgumentException.class);
 	}
 
 	@Test
 	public void constructorWhenAuthorizedClientRepositoryIsNullThenThrowIllegalArgumentException() {
 		assertThatThrownBy(() -> new OAuth2LoginAuthenticationFilter(this.clientRegistrationRepository,
-				(OAuth2AuthorizedClientRepository) null, OAuth2LoginAuthenticationFilter.DEFAULT_FILTER_PROCESSES_URI))
+				(OAuth2AuthorizedClientRepository) null, OAuth2LoginAuthenticationFilter.DEFAULT_FILTER_PROCESSES_URI,authorizationRequestRepository))
 				.isInstanceOf(IllegalArgumentException.class);
 	}
 
 	@Test
 	public void constructorWhenFilterProcessesUrlIsNullThenThrowIllegalArgumentException() {
-		assertThatThrownBy(() -> new OAuth2LoginAuthenticationFilter(this.clientRegistrationRepository, this.authorizedClientRepository, null))
+		assertThatThrownBy(() -> new OAuth2LoginAuthenticationFilter(this.clientRegistrationRepository, this.authorizedClientRepository, null,authorizationRequestRepository))
 				.isInstanceOf(IllegalArgumentException.class);
 	}
 
@@ -279,7 +279,7 @@ public class OAuth2LoginAuthenticationFilterTests {
 	public void doFilterWhenCustomFilterProcessesUrlThenFilterProcesses() throws Exception {
 		String filterProcessesUrl = "/login/oauth2/custom/*";
 		this.filter = spy(new OAuth2LoginAuthenticationFilter(
-			this.clientRegistrationRepository, this.authorizedClientRepository, filterProcessesUrl));
+			this.clientRegistrationRepository, this.authorizedClientRepository, filterProcessesUrl,authorizationRequestRepository));
 		this.filter.setAuthenticationManager(this.authenticationManager);
 
 		String requestUri = "/login/oauth2/custom/" + this.registration2.getRegistrationId();


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
Hello,

In order to overide the AuthorizationRequestRepository, I need to make it configurable. So I suggest to make developpers able to inject theirs own bean of AuthorizationRequestRepository to replace the HttpSessionOAuth2AuthorizationRequestRepository, especially to run it on a stateless environnement.

Thank you for your feedbacks,

