### PR TITLE
Accept a case-insensitive "Bearer" keyword

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/server/ServerBearerTokenAuthenticationConverter.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/server/ServerBearerTokenAuthenticationConverter.java
@@ -43,7 +43,9 @@ import java.util.regex.Pattern;
  */
 public class ServerBearerTokenAuthenticationConverter
 		implements ServerAuthenticationConverter {
-	private static final Pattern authorizationPattern = Pattern.compile("^Bearer (?<token>[a-zA-Z0-9-._~+/]+)=*$");
+	private static final Pattern authorizationPattern = Pattern.compile(
+		"^Bearer (?<token>[a-zA-Z0-9-._~+/]+)=*$",
+		Pattern.CASE_INSENSITIVE);
 
 	private boolean allowUriQueryParameter = false;
 
@@ -85,7 +87,7 @@ public class ServerBearerTokenAuthenticationConverter
 
 	private static String resolveFromAuthorizationHeader(HttpHeaders headers) {
 		String authorization = headers.getFirst(HttpHeaders.AUTHORIZATION);
-		if (StringUtils.hasText(authorization) && authorization.startsWith("Bearer")) {
+		if (StringUtils.startsWithIgnoreCase(authorization, "bearer")) {
 			Matcher matcher = authorizationPattern.matcher(authorization);
 
 			if ( !matcher.matches() ) {

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/ServerBearerTokenAuthenticationConverterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/ServerBearerTokenAuthenticationConverterTests.java
@@ -53,6 +53,15 @@ public class ServerBearerTokenAuthenticationConverterTests {
 	}
 
 	@Test
+	public void resolveWhenLowercaseHeaderIsPresentThenTokenIsResolved() {
+		MockServerHttpRequest.BaseBuilder<?> request = MockServerHttpRequest
+				.get("/")
+				.header(HttpHeaders.AUTHORIZATION, "bearer " + TEST_TOKEN);
+
+		assertThat(convertToToken(request).getToken()).isEqualTo(TEST_TOKEN);
+	}
+
+	@Test
 	public void resolveWhenNoHeaderIsPresentThenTokenIsNotResolved() {
 		MockServerHttpRequest.BaseBuilder<?> request = MockServerHttpRequest
 				.get("/");


### PR DESCRIPTION
The Authorization header was matched for OAuth2
against the "Bearer" keyword in a case sensitive
fashion.
According to RFC 2617, it should be case insensitive
and some oauth clients (including some earlier
versions of spring-security) expect it so.

This is the reactive counterpart to commit
63f2b6094f59cc9ded6a83ac3def4a1726890a8b .

Fixes gh-6195

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
