### PR TITLE
RoleVoter Configuration Defaults Prefix Using GrantedAuthorityDefauts

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfiguration.java
@@ -255,7 +255,13 @@ public class GlobalMethodSecurityConfiguration
 		if (jsr250Enabled()) {
 			decisionVoters.add(new Jsr250Voter());
 		}
-		decisionVoters.add(new RoleVoter());
+		RoleVoter roleVoter = new RoleVoter();
+		GrantedAuthorityDefaults grantedAuthorityDefaults =
+				getSingleBeanOrNull(GrantedAuthorityDefaults.class);
+		if (grantedAuthorityDefaults != null) {
+			roleVoter.setRolePrefix(grantedAuthorityDefaults.getRolePrefix());
+		}
+		decisionVoters.add(roleVoter);
 		decisionVoters.add(new AuthenticatedVoter());
 		return new AffirmativeBased(decisionVoters);
 	}


### PR DESCRIPTION
RoleVoter Configuration Defaults Prefix Using GrantedAuthorityDefauts

Fixes: gh-4876

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
