### PR TITLE
Allow setting realm for Http Basic

### DIFF
--- a/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
@@ -1879,6 +1879,19 @@ public class ServerHttpSecurity {
 		}
 
 		/**
+		 * Allows easily setting the entry point.
+		 * @param authenticationEntryPoint the {@link ServerAuthenticationEntryPoint} to use
+		 * @return {@link HttpBasicSpec} for additional customization
+		 * @since 5.2.0
+		 * @author Ankur Pathak
+		 */
+		public HttpBasicSpec authenticationEntryPoint(ServerAuthenticationEntryPoint authenticationEntryPoint){
+			Assert.notNull(authenticationEntryPoint, "authenticationEntryPoint cannot be null");
+			this.entryPoint = authenticationEntryPoint;
+			return this;
+		}
+
+		/**
 		 * Allows method chaining to continue configuring the {@link ServerHttpSecurity}
 		 * @return the {@link ServerHttpSecurity} to continue configuring
 		 */


### PR DESCRIPTION
1. Added method realmName in ServerHttpSecurity to allow
specifying realm name.
2. Added test in ServerHttpSecurityTests to check if
specified realm name is returned.

Pull request for issue: https://github.com/spring-projects/spring-security/issues/6270