### PR TITLE
Fix DefaultLoginPageGeneratingFilter Markup

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/ui/DefaultLoginPageGeneratingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/ui/DefaultLoginPageGeneratingFilter.java
@@ -272,7 +272,7 @@ public class DefaultLoginPageGeneratingFilter extends GenericFilterBean {
 		}
 
 		if (oauth2LoginEnabled) {
-			sb.append("<h2 class=\"form-signin-heading\">Login with OAuth 2.0</h3>");
+			sb.append("<h2 class=\"form-signin-heading\">Login with OAuth 2.0</h2>");
 			sb.append(createError(loginError, errorMsg));
 			sb.append(createLogoutSuccess(logoutSuccess));
 			sb.append("<table class=\"table table-striped\">\n");


### PR DESCRIPTION
Fix DefaultLoginPageGeneratingFilter Markup
![image](https://user-images.githubusercontent.com/16068212/49988264-0ac86680-ffb1-11e8-86fa-5bcb65b27be3.png)

the `</h3>` should be `</h2>`.
