### PR TITLE
Better logging support by id in RequestMatcher

### DIFF
--- a/config/src/integration-test/groovy/org/springframework/security/config/ldap/LdapProviderBeanDefinitionParserTests.groovy
+++ b/config/src/integration-test/groovy/org/springframework/security/config/ldap/LdapProviderBeanDefinitionParserTests.groovy
@@ -2,13 +2,11 @@ package org.springframework.security.config.ldap
 
 import org.springframework.security.crypto.password.NoOpPasswordEncoder
 
-import static org.mockito.Mockito.*
 
 import java.text.MessageFormat
 
 import org.springframework.beans.factory.config.PropertyPlaceholderConfigurer
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.config.AbstractXmlConfigTests
 import org.springframework.security.config.BeanIds
 import org.springframework.security.util.FieldUtils

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/PermitAllSupport.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/PermitAllSupport.java
@@ -20,6 +20,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.springframework.security.access.SecurityConfig;
 import org.springframework.security.config.annotation.web.HttpSecurityBuilder;
 import org.springframework.security.config.annotation.web.configurers.AbstractConfigAttributeRequestMatcherRegistry.UrlMapping;
+import org.springframework.security.web.util.matcher.AbstractRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
 /**
@@ -64,7 +65,7 @@ final class PermitAllSupport {
 		}
 	}
 
-	private final static class ExactUrlRequestMatcher implements RequestMatcher {
+	private final static class ExactUrlRequestMatcher extends AbstractRequestMatcher {
 		private String processUrl;
 
 		private ExactUrlRequestMatcher(String processUrl) {
@@ -89,7 +90,7 @@ final class PermitAllSupport {
 		@Override
 		public String toString() {
 			StringBuilder sb = new StringBuilder();
-			sb.append("ExactUrl [processUrl='").append(processUrl).append("']");
+			sb.append("ExactUrl [processUrl='").append(processUrl).append("', id=").append(getId()).append("]");
 			return sb.toString();
 		}
 	}

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
@@ -40,7 +40,7 @@ import org.springframework.security.oauth2.server.resource.web.DefaultBearerToke
 import org.springframework.security.oauth2.server.resource.web.access.BearerTokenAccessDeniedHandler;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.access.AccessDeniedHandler;
-import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.security.web.util.matcher.AbstractRequestMatcher;
 import org.springframework.util.Assert;
 
 import static org.springframework.security.oauth2.jwt.JwtProcessors.withJwkSetUri;
@@ -294,7 +294,7 @@ public final class OAuth2ResourceServerConfigurer<H extends HttpSecurityBuilder<
 		return this.bearerTokenResolver;
 	}
 
-	private static final class BearerTokenRequestMatcher implements RequestMatcher {
+	private static final class BearerTokenRequestMatcher extends AbstractRequestMatcher {
 		private BearerTokenResolver bearerTokenResolver;
 
 		@Override

--- a/config/src/test/java/org/springframework/security/config/annotation/web/builders/NamespaceHttpTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/builders/NamespaceHttpTests.java
@@ -41,9 +41,9 @@ import org.springframework.security.web.authentication.LoginUrlAuthenticationEnt
 import org.springframework.security.web.context.NullSecurityContextRepository;
 import org.springframework.security.web.jaasapi.JaasApiIntegrationFilter;
 import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestWrapper;
+import org.springframework.security.web.util.matcher.AbstractRequestMatcher;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RegexRequestMatcher;
-import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.stereotype.Controller;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -386,7 +386,7 @@ public class NamespaceHttpTests {
 				.requestMatcher(new MyRequestMatcher());
 		}
 
-		static class MyRequestMatcher implements RequestMatcher {
+		static class MyRequestMatcher extends AbstractRequestMatcher {
 			public boolean matches(HttpServletRequest request) {
 				return true;
 			}

--- a/web/src/main/java/org/springframework/security/web/DefaultSecurityFilterChain.java
+++ b/web/src/main/java/org/springframework/security/web/DefaultSecurityFilterChain.java
@@ -15,13 +15,14 @@
  */
 package org.springframework.security.web;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.springframework.security.web.util.matcher.RequestMatcher;
-
 import javax.servlet.Filter;
 import javax.servlet.http.HttpServletRequest;
 import java.util.*;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.security.web.util.matcher.RequestMatcher;
 
 /**
  * Standard implementation of {@code SecurityFilterChain}.
@@ -30,10 +31,11 @@ import java.util.*;
  *
  * @since 3.1
  */
-public final class DefaultSecurityFilterChain implements SecurityFilterChain {
+public final class DefaultSecurityFilterChain implements SecurityFilterChain{
 	private static final Log logger = LogFactory.getLog(DefaultSecurityFilterChain.class);
 	private final RequestMatcher requestMatcher;
 	private final List<Filter> filters;
+	private String beanName;
 
 	public DefaultSecurityFilterChain(RequestMatcher requestMatcher, Filter... filters) {
 		this(requestMatcher, Arrays.asList(filters));
@@ -61,4 +63,5 @@ public final class DefaultSecurityFilterChain implements SecurityFilterChain {
 	public String toString() {
 		return "[ " + requestMatcher + ", " + filters + "]";
 	}
+
 }

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
@@ -31,6 +31,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.access.AccessDeniedHandlerImpl;
 import org.springframework.security.web.util.UrlUtils;
+import org.springframework.security.web.util.matcher.AbstractRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -159,7 +160,7 @@ public final class CsrfFilter extends OncePerRequestFilter {
 		this.accessDeniedHandler = accessDeniedHandler;
 	}
 
-	private static final class DefaultRequiresCsrfMatcher implements RequestMatcher {
+	private static final class DefaultRequiresCsrfMatcher extends AbstractRequestMatcher {
 		private final HashSet<String> allowedMethods = new HashSet<>(
 				Arrays.asList("GET", "HEAD", "TRACE", "OPTIONS"));
 

--- a/web/src/main/java/org/springframework/security/web/header/writers/HpkpHeaderWriter.java
+++ b/web/src/main/java/org/springframework/security/web/header/writers/HpkpHeaderWriter.java
@@ -18,6 +18,7 @@ package org.springframework.security.web.header.writers;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.security.web.header.HeaderWriter;
+import org.springframework.security.web.util.matcher.AbstractRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
 
@@ -430,7 +431,7 @@ public final class HpkpHeaderWriter implements HeaderWriter {
 		this.hpkpHeaderValue = headerValue;
 	}
 
-	private static final class SecureRequestMatcher implements RequestMatcher {
+	private static final class SecureRequestMatcher extends AbstractRequestMatcher {
 		public boolean matches(HttpServletRequest request) {
 			return request.isSecure();
 		}

--- a/web/src/main/java/org/springframework/security/web/header/writers/HstsHeaderWriter.java
+++ b/web/src/main/java/org/springframework/security/web/header/writers/HstsHeaderWriter.java
@@ -22,6 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.security.web.header.HeaderWriter;
+import org.springframework.security.web.util.matcher.AbstractRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
 
@@ -195,7 +196,7 @@ public final class HstsHeaderWriter implements HeaderWriter {
 		this.hstsHeaderValue = headerValue;
 	}
 
-	private static final class SecureRequestMatcher implements RequestMatcher {
+	private static final class SecureRequestMatcher extends AbstractRequestMatcher {
 		public boolean matches(HttpServletRequest request) {
 			return request.isSecure();
 		}

--- a/web/src/main/java/org/springframework/security/web/servlet/util/matcher/MvcRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/servlet/util/matcher/MvcRequestMatcher.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.http.HttpMethod;
+import org.springframework.security.web.util.matcher.AbstractRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.security.web.util.matcher.RequestVariablesExtractor;
 import org.springframework.util.AntPathMatcher;
@@ -45,7 +46,7 @@ import org.springframework.web.util.UrlPathHelper;
  * @author Rob Winch
  * @since 4.1.1
  */
-public class MvcRequestMatcher implements RequestMatcher, RequestVariablesExtractor {
+public class MvcRequestMatcher extends AbstractRequestMatcher implements RequestVariablesExtractor {
 
 	private final DefaultMatcher defaultMatcher = new DefaultMatcher();
 
@@ -141,7 +142,7 @@ public class MvcRequestMatcher implements RequestMatcher, RequestVariablesExtrac
 		return sb.toString();
 	}
 
-	private class DefaultMatcher implements RequestMatcher, RequestVariablesExtractor {
+	private class DefaultMatcher extends AbstractRequestMatcher implements RequestVariablesExtractor {
 
 		private final UrlPathHelper pathHelper = new UrlPathHelper();
 

--- a/web/src/main/java/org/springframework/security/web/util/matcher/AbstractRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/AbstractRequestMatcher.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.web.util.matcher;
+
+
+import java.util.UUID;
+/**
+ * Abstract simple strategy to match an <tt>HttpServletRequest</tt>.
+ *
+ * @author Ankur Pathak
+ * @since 5.2.0
+ */
+public abstract class AbstractRequestMatcher implements RequestMatcher {
+	private final String id;
+
+	public AbstractRequestMatcher(String id) {
+		this.id = id;
+	}
+
+	public AbstractRequestMatcher() {
+		this(UUID.randomUUID().toString().replace("-", "").substring(0, 8));
+	}
+
+	@Override
+	public String getId() {
+		return id;
+	}
+
+	@Override
+	public String toString() {
+		return "RequestMatcher{" +
+				"id='" + id + '\'' +
+				'}';
+	}
+}

--- a/web/src/main/java/org/springframework/security/web/util/matcher/AndRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/AndRequestMatcher.java
@@ -22,7 +22,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
 
 /**
@@ -32,7 +31,7 @@ import org.springframework.util.Assert;
  * @author Rob Winch
  * @since 3.2
  */
-public final class AndRequestMatcher implements RequestMatcher {
+public final class AndRequestMatcher extends AbstractRequestMatcher {
 	private final Log logger = LogFactory.getLog(getClass());
 
 	private final List<RequestMatcher> requestMatchers;
@@ -76,6 +75,6 @@ public final class AndRequestMatcher implements RequestMatcher {
 
 	@Override
 	public String toString() {
-		return "AndRequestMatcher [requestMatchers=" + requestMatchers + "]";
+		return "AndRequestMatcher [requestMatchers=" + requestMatchers + ", id=" + getId()+"]";
 	}
 }

--- a/web/src/main/java/org/springframework/security/web/util/matcher/AntPathRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/AntPathRequestMatcher.java
@@ -53,8 +53,8 @@ import org.springframework.web.util.UrlPathHelper;
  *
  * @see org.springframework.util.AntPathMatcher
  */
-public final class AntPathRequestMatcher
-		implements RequestMatcher, RequestVariablesExtractor {
+public final class AntPathRequestMatcher extends AbstractRequestMatcher
+		implements RequestVariablesExtractor {
 	private static final Log logger = LogFactory.getLog(AntPathRequestMatcher.class);
 	private static final String MATCH_ALL = "/**";
 
@@ -236,6 +236,7 @@ public final class AntPathRequestMatcher
 			sb.append(", ").append(this.httpMethod);
 		}
 
+		sb.append(", id=").append(getId());
 		sb.append("]");
 
 		return sb.toString();

--- a/web/src/main/java/org/springframework/security/web/util/matcher/AnyRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/AnyRequestMatcher.java
@@ -17,15 +17,13 @@ package org.springframework.security.web.util.matcher;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.springframework.security.web.util.matcher.RequestMatcher;
-
 /**
  * Matches any supplied request.
  *
  * @author Luke Taylor
  * @since 3.1
  */
-public final class AnyRequestMatcher implements RequestMatcher {
+public final class AnyRequestMatcher extends AbstractRequestMatcher {
 	public static final RequestMatcher INSTANCE = new AnyRequestMatcher();
 
 	public boolean matches(HttpServletRequest request) {
@@ -46,7 +44,7 @@ public final class AnyRequestMatcher implements RequestMatcher {
 
 	@Override
 	public String toString() {
-		return "any request";
+		return "any request[id=" + getId() + "]";
 	}
 
 	private AnyRequestMatcher() {

--- a/web/src/main/java/org/springframework/security/web/util/matcher/ELRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/ELRequestMatcher.java
@@ -23,7 +23,6 @@ import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.security.web.authentication.DelegatingAuthenticationEntryPoint;
-import org.springframework.security.web.util.matcher.RequestMatcher;
 
 /**
  * A RequestMatcher implementation which uses a SpEL expression
@@ -41,7 +40,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
  * @author Mike Wiesner
  * @since 3.0.2
  */
-public class ELRequestMatcher implements RequestMatcher {
+public class ELRequestMatcher extends AbstractRequestMatcher {
 
 	private final Expression expression;
 
@@ -69,6 +68,7 @@ public class ELRequestMatcher implements RequestMatcher {
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append("EL [el=\"").append(this.expression.getExpressionString()).append("\"");
+		sb.append(", id=").append(getId());
 		sb.append("]");
 		return sb.toString();
 	}

--- a/web/src/main/java/org/springframework/security/web/util/matcher/IpAddressMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/IpAddressMatcher.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.StringUtils;
 
 /**
@@ -34,7 +33,7 @@ import org.springframework.util.StringUtils;
  * @author Luke Taylor
  * @since 3.0.2
  */
-public final class IpAddressMatcher implements RequestMatcher {
+public final class IpAddressMatcher extends AbstractRequestMatcher {
 	private final int nMaskBits;
 	private final InetAddress requiredAddress;
 

--- a/web/src/main/java/org/springframework/security/web/util/matcher/MediaTypeRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/MediaTypeRequestMatcher.java
@@ -138,7 +138,7 @@ import org.springframework.web.context.request.ServletWebRequest;
  * @since 3.2
  */
 
-public final class MediaTypeRequestMatcher implements RequestMatcher {
+public final class MediaTypeRequestMatcher extends AbstractRequestMatcher {
 	private final Log logger = LogFactory.getLog(getClass());
 	private final ContentNegotiationStrategy contentNegotiationStrategy;
 	private final Collection<MediaType> matchingMediaTypes;
@@ -250,6 +250,6 @@ public final class MediaTypeRequestMatcher implements RequestMatcher {
 		return "MediaTypeRequestMatcher [contentNegotiationStrategy="
 				+ this.contentNegotiationStrategy + ", matchingMediaTypes="
 				+ this.matchingMediaTypes + ", useEquals=" + this.useEquals
-				+ ", ignoredMediaTypes=" + this.ignoredMediaTypes + "]";
+				+ ", ignoredMediaTypes=" + this.ignoredMediaTypes + ", id="+ getId()+"]";
 	}
 }

--- a/web/src/main/java/org/springframework/security/web/util/matcher/NegatedRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/NegatedRequestMatcher.java
@@ -19,7 +19,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
 
 /**
@@ -31,7 +30,7 @@ import org.springframework.util.Assert;
  * @author Rob Winch
  * @since 3.2
  */
-public class NegatedRequestMatcher implements RequestMatcher {
+public class NegatedRequestMatcher extends AbstractRequestMatcher {
 	private final Log logger = LogFactory.getLog(getClass());
 
 	private final RequestMatcher requestMatcher;
@@ -55,6 +54,6 @@ public class NegatedRequestMatcher implements RequestMatcher {
 
 	@Override
 	public String toString() {
-		return "NegatedRequestMatcher [requestMatcher=" + requestMatcher + "]";
+		return "NegatedRequestMatcher [requestMatcher=" + requestMatcher + ", id=" +getId()+ "]";
 	}
 }

--- a/web/src/main/java/org/springframework/security/web/util/matcher/OrRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/OrRequestMatcher.java
@@ -22,7 +22,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
 
 /**
@@ -32,7 +31,7 @@ import org.springframework.util.Assert;
  * @author Rob Winch
  * @since 3.2
  */
-public final class OrRequestMatcher implements RequestMatcher {
+public final class OrRequestMatcher extends AbstractRequestMatcher {
 	private final Log logger = LogFactory.getLog(getClass());
 	private final List<RequestMatcher> requestMatchers;
 
@@ -75,6 +74,6 @@ public final class OrRequestMatcher implements RequestMatcher {
 
 	@Override
 	public String toString() {
-		return "OrRequestMatcher [requestMatchers=" + requestMatchers + "]";
+		return "OrRequestMatcher [requestMatchers=" + requestMatchers + ", id="+ getId() + "]";
 	}
 }

--- a/web/src/main/java/org/springframework/security/web/util/matcher/RegexRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/RegexRequestMatcher.java
@@ -22,7 +22,6 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.StringUtils;
 
 /**
@@ -39,7 +38,7 @@ import org.springframework.util.StringUtils;
  * @author Rob Winch
  * @since 3.1
  */
-public final class RegexRequestMatcher implements RequestMatcher {
+public final class RegexRequestMatcher extends AbstractRequestMatcher {
 	private final static Log logger = LogFactory.getLog(RegexRequestMatcher.class);
 
 	private final Pattern pattern;
@@ -140,6 +139,7 @@ public final class RegexRequestMatcher implements RequestMatcher {
 			sb.append(", ").append(this.httpMethod);
 		}
 
+		sb.append(", id=").append(getId());
 		sb.append("]");
 
 		return sb.toString();

--- a/web/src/main/java/org/springframework/security/web/util/matcher/RequestHeaderRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/RequestHeaderRequestMatcher.java
@@ -17,7 +17,6 @@ package org.springframework.security.web.util.matcher;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
 
 /**
@@ -50,7 +49,7 @@ import org.springframework.util.Assert;
  * @author Rob Winch
  * @since 3.2
  */
-public final class RequestHeaderRequestMatcher implements RequestMatcher {
+public final class RequestHeaderRequestMatcher extends AbstractRequestMatcher {
 	private final String expectedHeaderName;
 	private final String expectedHeaderValue;
 
@@ -94,6 +93,6 @@ public final class RequestHeaderRequestMatcher implements RequestMatcher {
 	@Override
 	public String toString() {
 		return "RequestHeaderRequestMatcher [expectedHeaderName=" + expectedHeaderName
-				+ ", expectedHeaderValue=" + expectedHeaderValue + "]";
+				+ ", expectedHeaderValue=" + expectedHeaderValue + ", id=" + getId() + "]";
 	}
 }

--- a/web/src/main/java/org/springframework/security/web/util/matcher/RequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/RequestMatcher.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpServletRequest;
  * @author Luke Taylor
  * @since 3.0.2
  */
+@FunctionalInterface
 public interface RequestMatcher {
 
 	/**
@@ -32,5 +33,15 @@ public interface RequestMatcher {
 	 * @return true if the request matches, false otherwise
 	 */
 	boolean matches(HttpServletRequest request);
+
+	/**
+	 * Helps to identify which rule implemented by the strategy is in use for matching
+	 * supplied request.
+	 *
+	 * @return id
+	 * @since 5.2.0
+	 * @author Ankur Pathak
+	 */
+	default String getId() {return ""; }
 
 }

--- a/web/src/test/java/org/springframework/security/web/savedrequest/HttpSessionRequestCacheTests.java
+++ b/web/src/test/java/org/springframework/security/web/savedrequest/HttpSessionRequestCacheTests.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.web.PortResolverImpl;
-import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.security.web.util.matcher.AbstractRequestMatcher;
 
 /**
  *
@@ -62,7 +62,7 @@ public class HttpSessionRequestCacheTests {
 	@Test
 	public void requestMatcherDefinesCorrectSubsetOfCachedRequests() throws Exception {
 		HttpSessionRequestCache cache = new HttpSessionRequestCache();
-		cache.setRequestMatcher(new RequestMatcher() {
+		cache.setRequestMatcher(new AbstractRequestMatcher() {
 
 			public boolean matches(HttpServletRequest request) {
 				return request.getMethod().equals("GET");

--- a/web/src/test/java/org/springframework/security/web/util/matcher/ELRequestMatcherTests.java
+++ b/web/src/test/java/org/springframework/security/web/util/matcher/ELRequestMatcherTests.java
@@ -94,6 +94,6 @@ public class ELRequestMatcherTests {
 	public void toStringThenFormatted() {
 		ELRequestMatcher requestMatcher = new ELRequestMatcher(
 				"hasHeader('User-Agent','MSIE')");
-		assertThat(requestMatcher.toString()).isEqualTo("EL [el=\"hasHeader('User-Agent','MSIE')\"]");
+		assertThat(requestMatcher.toString()).isEqualTo("EL [el=\"hasHeader('User-Agent','MSIE')\", id="+requestMatcher.getId()+"]");
 	}
 }

--- a/web/src/test/java/org/springframework/security/web/util/matcher/RegexRequestMatcherTests.java
+++ b/web/src/test/java/org/springframework/security/web/util/matcher/RegexRequestMatcherTests.java
@@ -111,7 +111,7 @@ public class RegexRequestMatcherTests {
 	@Test
 	public void toStringThenFormatted() {
 		RegexRequestMatcher matcher = new RegexRequestMatcher("/blah", "GET");
-		assertThat(matcher.toString()).isEqualTo("Regex [pattern='/blah', GET]");
+		assertThat(matcher.toString()).isEqualTo("Regex [pattern='/blah', GET, id="+matcher.getId()+"]");
 	}
 
 	private HttpServletRequest createRequestWithNullMethod(String path) {


### PR DESCRIPTION
1. Added default method getId in RequestMatcher and
marked it as FunctionalInterface
2. Created Class AbstractRequestMatcher with default
support for getId logging things
3. Implemented build in matchers using AbstractRequestMatcher
4. Changed toString methods of build in matchers to reflect
id.

Fixes: gh-6274