### PR TITLE
JdbcUserDetailsManager handles extra UserDetails attributes

### DIFF
--- a/core/src/main/java/org/springframework/security/core/userdetails/jdbc/JdbcDaoImpl.java
+++ b/core/src/main/java/org/springframework/security/core/userdetails/jdbc/JdbcDaoImpl.java
@@ -295,7 +295,8 @@ public class JdbcDaoImpl extends JdbcDaoSupport
 		}
 
 		return new User(returnUsername, userFromUserQuery.getPassword(),
-				userFromUserQuery.isEnabled(), true, true, true, combinedAuthorities);
+				userFromUserQuery.isEnabled(), userFromUserQuery.isAccountNonExpired(),
+				userFromUserQuery.isCredentialsNonExpired(), userFromUserQuery.isAccountNonLocked(), combinedAuthorities);
 	}
 
 	/**


### PR DESCRIPTION
Check `ResutSetMetaData` to see if extra columns are present in order to also handle the `UserDetails` attributes: `accountNonExpired`, `accountNonLocked` and `credentialsNonExpired`.

Fixes gh-4399

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
