### PR TITLE
Make WebClient configurable when requesting jwks URI

### DIFF
--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
@@ -46,6 +46,7 @@ import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
 import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
 import org.springframework.util.Assert;
+import org.springframework.web.reactive.function.client.WebClient;
 
 /**
  * An implementation of a {@link ReactiveJwtDecoder} that &quot;decodes&quot; a
@@ -98,6 +99,16 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 	 * @param jwkSetUrl the JSON Web Key (JWK) Set {@code URL}
 	 */
 	public NimbusReactiveJwtDecoder(String jwkSetUrl) {
+		this(jwkSetUrl, WebClient.create());
+	}
+
+	/**
+	 * Constructs a {@code NimbusJwtDecoderJwkSupport} using the provided parameters.
+	 *
+	 * @param jwkSetUrl the JSON Web Key (JWK) Set {@code URL}
+	 * @param webClient the client to be used to contact jwkSetUrl. For instance you can configure a proxy on it.
+	 */
+	public NimbusReactiveJwtDecoder(String jwkSetUrl, WebClient webClient) {
 		Assert.hasText(jwkSetUrl, "jwkSetUrl cannot be empty");
 		String jwsAlgorithm = JwsAlgorithms.RS256;
 		JWSAlgorithm algorithm = JWSAlgorithm.parse(jwsAlgorithm);
@@ -110,7 +121,7 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 		jwtProcessor.setJWTClaimsSetVerifier((claims, context) -> {});
 		this.jwtProcessor = jwtProcessor;
 
-		this.reactiveJwkSource = new ReactiveRemoteJWKSource(jwkSetUrl);
+		this.reactiveJwkSource = new ReactiveRemoteJWKSource(jwkSetUrl, webClient);
 
 		this.jwkSelectorFactory = new JWKSelectorFactory(algorithm);
 

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/ReactiveRemoteJWKSource.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/ReactiveRemoteJWKSource.java
@@ -40,12 +40,13 @@ class ReactiveRemoteJWKSource implements ReactiveJWKSource {
 	 */
 	private final AtomicReference<Mono<JWKSet>> cachedJWKSet = new AtomicReference<>(Mono.empty());
 
-	private WebClient webClient = WebClient.create();
+	private WebClient webClient;
 
 	private final String jwkSetURL;
 
-	ReactiveRemoteJWKSource(String jwkSetURL) {
+	ReactiveRemoteJWKSource(String jwkSetURL, WebClient webClient) {
 		this.jwkSetURL = jwkSetURL;
+		this.webClient = webClient;
 	}
 
 	public Mono<List<JWK>> get(JWKSelector jwkSelector) {

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/ReactiveRemoteJWKSourceTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/ReactiveRemoteJWKSourceTests.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.Collections;
 import java.util.List;
@@ -89,7 +90,7 @@ public class ReactiveRemoteJWKSourceTests {
 	@Before
 	public void setup() {
 		this.server = new MockWebServer();
-		this.source = new ReactiveRemoteJWKSource(this.server.url("/").toString());
+		this.source = new ReactiveRemoteJWKSource(this.server.url("/").toString(), WebClient.create());
 
 		this.server.enqueue(new MockResponse().setBody(this.keys));
 		this.selector = new JWKSelector(this.matcher);


### PR DESCRIPTION
Add a constructor to NimbusReactiveJwtDecoder class to be able to give a WebClient configured correctly for specific use case (like being  behind corporate proxy). 

This fix #6343
