### PR TITLE
Use X-Forwarded headers during OAuth2 callback

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/server/ServerOAuth2AuthorizationCodeAuthenticationTokenConverter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/server/ServerOAuth2AuthorizationCodeAuthenticationTokenConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,7 +105,7 @@ public class ServerOAuth2AuthorizationCodeAuthenticationTokenConverter
 	private static OAuth2AuthorizationResponse convertResponse(ServerWebExchange exchange) {
 		MultiValueMap<String, String> queryParams = exchange.getRequest()
 				.getQueryParams();
-		String redirectUri = UriComponentsBuilder.fromUri(exchange.getRequest().getURI())
+		String redirectUri = UriComponentsBuilder.fromHttpRequest(exchange.getRequest())
 				.query(null)
 				.build()
 				.toUriString();


### PR DESCRIPTION
X-Forwarded headers are used to compute redirect_uri before redirecting
user to OAuth2 server (DefaultServerOAuth2AuthorizationRequestResolver),
but not when comparing current URI with stored URI.

Fixes #6347

