### PR TITLE
Avoid toString in favor of getName in order to extract sid

### DIFF
--- a/acl/src/main/java/org/springframework/security/acls/domain/PrincipalSid.java
+++ b/acl/src/main/java/org/springframework/security/acls/domain/PrincipalSid.java
@@ -53,7 +53,7 @@ public class PrincipalSid implements Sid {
 			this.principal = ((UserDetails) authentication.getPrincipal()).getUsername();
 		}
 		else {
-			this.principal = authentication.getPrincipal().toString();
+			this.principal = authentication.getName();
 		}
 	}
 


### PR DESCRIPTION
There are some more sophisticated implementations of `getName` in `AbstractAuthenticationToken`, `JwtAuthenticationToken`  and other `Authentication` classes.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
