### PR TITLE
Save original request on oauth2Client filter

### DIFF
--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/server/OAuth2AuthorizationRequestRedirectWebFilterTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/server/OAuth2AuthorizationRequestRedirectWebFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.TestClientRegistrations;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.web.server.savedrequest.ServerRequestCache;
 import org.springframework.test.web.reactive.server.FluxExchangeResult;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.server.handler.FilteringWebHandler;
@@ -52,6 +53,9 @@ public class OAuth2AuthorizationRequestRedirectWebFilterTests {
 
 	@Mock
 	private ServerAuthorizationRequestRepository<OAuth2AuthorizationRequest> authzRequestRepository;
+
+	@Mock
+	private ServerRequestCache requestCache;
 
 	private ClientRegistration registration = TestClientRegistrations.clientRegistration().build();
 
@@ -138,5 +142,34 @@ public class OAuth2AuthorizationRequestRedirectWebFilterTests {
 				.expectStatus()
 				.is3xxRedirection()
 				.returnResult(String.class);
+	}
+
+	@Test
+	public void filterWhenExceptionThenSaveRequestSessionAttribute() {
+		this.filter.setRequestCache(this.requestCache);
+		when(this.requestCache.saveRequest(any())).thenReturn(Mono.empty());
+		FilteringWebHandler webHandler = new FilteringWebHandler(
+				e -> Mono.error(new ClientAuthorizationRequiredException(this.registration.getRegistrationId())),
+				Arrays.asList(this.filter));
+		this.client = WebTestClient.bindToWebHandler(webHandler).build();
+		this.client.get()
+				.uri("https://example.com/foo")
+				.exchange()
+				.expectStatus()
+				.is3xxRedirection()
+				.returnResult(String.class);
+		verify(this.requestCache).saveRequest(any());
+	}
+
+	@Test
+	public void filterWhenPathMatchesThenRequestSessionAttributeNotSaved() {
+		this.filter.setRequestCache(this.requestCache);
+		this.client.get()
+				.uri("https://example.com/oauth2/authorization/registration-id")
+				.exchange()
+				.expectStatus()
+				.is3xxRedirection()
+				.returnResult(String.class);
+		verifyZeroInteractions(this.requestCache);
 	}
 }


### PR DESCRIPTION
When we used the oauth2Client directive and requested an endpoint that
required client authorization on the authorization server, the
SPRING_SECURITY_SAVED_REQUEST was not persisted, and therefore after
creating the authorized client we were redirected to the root page ("/").

Now we are storing the session attribute and getting redirected back to
the original URI as expected.

Note that the attribute is stored only when a
ClientAuthorizationRequiredException is thrown in the chain, we don't
want to store it as a response to the
/oauth2/authorization/{registrationId} endpoint, since we would end
up in an infinite loop

Fixes related Issue: #6341 


