### PR TITLE
Save query parameters in WebSessionServerRequestCache

### DIFF
--- a/web/src/main/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCache.java
+++ b/web/src/main/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCache.java
@@ -90,7 +90,9 @@ public class WebSessionServerRequestCache implements ServerRequestCache {
 	}
 
 	private static String pathInApplication(ServerHttpRequest request) {
-		return request.getPath().pathWithinApplication().value();
+		String path = request.getPath().pathWithinApplication().value();
+		String query = request.getURI().getRawQuery();
+		return path + (query != null ? "?" + query : "");
 	}
 
 	private static ServerWebExchangeMatcher createDefaultRequestMacher() {

--- a/web/src/test/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCacheTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCacheTests.java
@@ -45,6 +45,16 @@ public class WebSessionServerRequestCacheTests {
 	}
 
 	@Test
+	public void saveRequestGetRequestWithQueryParamsWhenGetThenFound() {
+		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/secured/").queryParam("key", "value").accept(MediaType.TEXT_HTML));
+		this.cache.saveRequest(exchange).block();
+
+		URI saved = this.cache.getRedirectUri(exchange).block();
+
+		assertThat(saved).isEqualTo(exchange.getRequest().getURI());
+	}
+
+	@Test
 	public void saveRequestGetRequestWhenFaviconThenNotFound() {
 		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/favicon.png").accept(MediaType.TEXT_HTML));
 		this.cache.saveRequest(exchange).block();


### PR DESCRIPTION
Previously, URL query parameters were lost when saving a request in `WebSessionServerRequestCache`. Now it is properly saved and restored.

Fixes #6421 