### PR TITLE
Missing spring: prefix on jwk-set-uri example

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/reactive/oauth2/resource-server.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/reactive/oauth2/resource-server.adoc
@@ -94,11 +94,12 @@ If the authorization server doesn't support the Provider Configuration endpoint,
 
 [source,yaml]
 ----
-security:
-  oauth2:
-    resourceserver:
-      jwt:
-        jwk-set-uri: https://idp.example.com/.well-known/jwks.json
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: https://idp.example.com/.well-known/jwks.json
 ----
 
 [NOTE]


### PR DESCRIPTION
Debugging an issue today because our jwk properties where not working and discovered that the doc [here](https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#oauth2resourceserver-jwkseturi) should be `spring.security.oauth2.resourceserver.jwt.jwk-set-uri` to align with the spring boot autoconfiguration [here](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/reactive/ReactiveOAuth2ResourceServerJwkConfiguration.java#L46)
