### PR TITLE
parameter 'pricipal' is never used

### DIFF
--- a/samples/boot/oauth2authorizationserver/src/main/java/sample/JwkSetConfiguration.java
+++ b/samples/boot/oauth2authorizationserver/src/main/java/sample/JwkSetConfiguration.java
@@ -18,7 +18,6 @@ package sample;
 import java.math.BigInteger;
 import java.security.KeyFactory;
 import java.security.KeyPair;
-import java.security.Principal;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.RSAPrivateKeySpec;
 import java.security.spec.RSAPublicKeySpec;

--- a/samples/boot/oauth2authorizationserver/src/main/java/sample/JwkSetConfiguration.java
+++ b/samples/boot/oauth2authorizationserver/src/main/java/sample/JwkSetConfiguration.java
@@ -169,7 +169,7 @@ class JwkSetEndpoint {
 
 	@GetMapping("/.well-known/jwks.json")
 	@ResponseBody
-	public Map<String, Object> getKey(Principal principal) {
+	public Map<String, Object> getKey() {
 		RSAPublicKey publicKey = (RSAPublicKey) this.keyPair.getPublic();
 		RSAKey key = new RSAKey.Builder(publicKey).build();
 		return new JWKSet(key).toJSONObject();


### PR DESCRIPTION
parameter 'pricipal' is never used

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
