### PR TITLE
Add client support for PKCE

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationCodeGrantRequestEntityConverter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationCodeGrantRequestEntityConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationExchange;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -74,10 +75,19 @@ public class OAuth2AuthorizationCodeGrantRequestEntityConverter implements Conve
 		MultiValueMap<String, String> formParameters = new LinkedMultiValueMap<>();
 		formParameters.add(OAuth2ParameterNames.GRANT_TYPE, authorizationCodeGrantRequest.getGrantType().getValue());
 		formParameters.add(OAuth2ParameterNames.CODE, authorizationExchange.getAuthorizationResponse().getCode());
-		formParameters.add(OAuth2ParameterNames.REDIRECT_URI, authorizationExchange.getAuthorizationRequest().getRedirectUri());
-		if (ClientAuthenticationMethod.POST.equals(clientRegistration.getClientAuthenticationMethod())) {
+		String redirectUri = authorizationExchange.getAuthorizationRequest().getRedirectUri();
+		String codeVerifier = authorizationExchange.getAuthorizationRequest().getAttribute(PkceParameterNames.CODE_VERIFIER);
+		if (redirectUri != null) {
+			formParameters.add(OAuth2ParameterNames.REDIRECT_URI, redirectUri);
+		}
+		if (!ClientAuthenticationMethod.BASIC.equals(clientRegistration.getClientAuthenticationMethod())) {
 			formParameters.add(OAuth2ParameterNames.CLIENT_ID, clientRegistration.getClientId());
+		}
+		if (ClientAuthenticationMethod.POST.equals(clientRegistration.getClientAuthenticationMethod())) {
 			formParameters.add(OAuth2ParameterNames.CLIENT_SECRET, clientRegistration.getClientSecret());
+		}
+		if (codeVerifier != null) {
+			formParameters.add(PkceParameterNames.CODE_VERIFIER, codeVerifier);
 		}
 
 		return formParameters;

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -500,6 +500,11 @@ public final class ClientRegistration implements Serializable {
 			clientRegistration.clientId = this.clientId;
 			clientRegistration.clientSecret = StringUtils.hasText(this.clientSecret) ? this.clientSecret : "";
 			clientRegistration.clientAuthenticationMethod = this.clientAuthenticationMethod;
+			if (AuthorizationGrantType.AUTHORIZATION_CODE.equals(this.authorizationGrantType) &&
+					!StringUtils.hasText(this.clientSecret)) {
+				clientRegistration.clientAuthenticationMethod = ClientAuthenticationMethod.NONE;
+			}
+
 			clientRegistration.authorizationGrantType = this.authorizationGrantType;
 			clientRegistration.redirectUriTemplate = this.redirectUriTemplate;
 			clientRegistration.scopes = this.scopes;

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistrations.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistrations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,7 +117,10 @@ public final class ClientRegistrations {
 		if (metadataAuthMethods.contains(com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod.CLIENT_SECRET_POST)) {
 			return ClientAuthenticationMethod.POST;
 		}
-		throw new IllegalArgumentException("Only ClientAuthenticationMethod.BASIC and ClientAuthenticationMethod.POST are supported. The issuer \"" + issuer + "\" returned a configuration of " + metadataAuthMethods);
+		if (metadataAuthMethods.contains(com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod.NONE)) {
+			return ClientAuthenticationMethod.NONE;
+		}
+		throw new IllegalArgumentException("Only ClientAuthenticationMethod.BASIC, ClientAuthenticationMethod.POST and ClientAuthenticationMethod.NONE are supported. The issuer \"" + issuer + "\" returned a configuration of " + metadataAuthMethods);
 	}
 
 	private static List<String> getScopes(OIDCProviderMetadata metadata) {

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/DefaultOAuth2AuthorizationRequestResolver.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/DefaultOAuth2AuthorizationRequestResolver.java
@@ -20,14 +20,19 @@ import org.springframework.security.crypto.keygen.StringKeyGenerator;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
 import org.springframework.security.web.util.UrlUtils;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.util.Assert;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
@@ -52,6 +57,7 @@ public final class DefaultOAuth2AuthorizationRequestResolver implements OAuth2Au
 	private final ClientRegistrationRepository clientRegistrationRepository;
 	private final AntPathRequestMatcher authorizationRequestMatcher;
 	private final StringKeyGenerator stateGenerator = new Base64StringKeyGenerator(Base64.getUrlEncoder());
+	private final StringKeyGenerator codeVerifierGenerator = new Base64StringKeyGenerator(Base64.getUrlEncoder().withoutPadding(), 96);
 
 	/**
 	 * Constructs a {@code DefaultOAuth2AuthorizationRequestResolver} using the provided parameters.
@@ -102,9 +108,17 @@ public final class DefaultOAuth2AuthorizationRequestResolver implements OAuth2Au
 			throw new IllegalArgumentException("Invalid Client Registration with Id: " + registrationId);
 		}
 
+		Map<String, Object> attributes = new HashMap<>();
+		attributes.put(OAuth2ParameterNames.REGISTRATION_ID, clientRegistration.getRegistrationId());
+
 		OAuth2AuthorizationRequest.Builder builder;
 		if (AuthorizationGrantType.AUTHORIZATION_CODE.equals(clientRegistration.getAuthorizationGrantType())) {
 			builder = OAuth2AuthorizationRequest.authorizationCode();
+			if (ClientAuthenticationMethod.NONE.equals(clientRegistration.getClientAuthenticationMethod())) {
+				Map<String, Object> additionalParameters = new HashMap<>();
+				addPkceParameters(attributes, additionalParameters);
+				builder.additionalParameters(additionalParameters);
+			}
 		} else if (AuthorizationGrantType.IMPLICIT.equals(clientRegistration.getAuthorizationGrantType())) {
 			builder = OAuth2AuthorizationRequest.implicit();
 		} else {
@@ -114,9 +128,6 @@ public final class DefaultOAuth2AuthorizationRequestResolver implements OAuth2Au
 		}
 
 		String redirectUriStr = this.expandRedirectUri(request, clientRegistration, redirectUriAction);
-
-		Map<String, Object> attributes = new HashMap<>();
-		attributes.put(OAuth2ParameterNames.REGISTRATION_ID, clientRegistration.getRegistrationId());
 
 		OAuth2AuthorizationRequest authorizationRequest = builder
 				.clientId(clientRegistration.getClientId())
@@ -155,5 +166,35 @@ public final class DefaultOAuth2AuthorizationRequestResolver implements OAuth2Au
 		return UriComponentsBuilder.fromUriString(clientRegistration.getRedirectUriTemplate())
 				.buildAndExpand(uriVariables)
 				.toUriString();
+	}
+
+	/**
+	 * Creates and adds additional PKCE parameters for use in the OAuth 2.0 Authorization and Access Token Requests
+	 *
+	 * @param attributes where {@link PkceParameterNames#CODE_VERIFIER} is stored for the token request
+	 * @param additionalParameters where {@link PkceParameterNames#CODE_CHALLENGE} and, usually,
+	 * {@link PkceParameterNames#CODE_CHALLENGE_METHOD} are added to be used in the authorization request.
+	 *
+	 * @since 5.2
+	 * @see <a target="_blank" href="https://tools.ietf.org/html/rfc7636#section-1.1">1.1.  Protocol Flow</a>
+	 * @see <a target="_blank" href="https://tools.ietf.org/html/rfc7636#section-4.1">4.1.  Client Creates a Code Verifier</a>
+	 * @see <a target="_blank" href="https://tools.ietf.org/html/rfc7636#section-4.2">4.2.  Client Creates the Code Challenge</a>
+	 */
+	private void addPkceParameters(Map<String, Object> attributes, Map<String, Object> additionalParameters) {
+		String codeVerifier = codeVerifierGenerator.generateKey();
+		attributes.put(PkceParameterNames.CODE_VERIFIER, codeVerifier);
+		try {
+			String codeChallenge = createCodeChallenge(codeVerifier);
+			additionalParameters.put(PkceParameterNames.CODE_CHALLENGE, codeChallenge);
+			additionalParameters.put(PkceParameterNames.CODE_CHALLENGE_METHOD, "S256");
+		} catch (NoSuchAlgorithmException e) {
+			additionalParameters.put(PkceParameterNames.CODE_CHALLENGE, codeVerifier);
+		}
+	}
+
+	private String createCodeChallenge(String codeVerifier) throws NoSuchAlgorithmException {
+		MessageDigest md = MessageDigest.getInstance("SHA-256");
+		byte[] digest = md.digest(codeVerifier.getBytes(StandardCharsets.US_ASCII));
+		return Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
 	}
 }

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationCodeGrantRequestEntityConverterTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationCodeGrantRequestEntityConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package org.springframework.security.oauth2.client.endpoint;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -28,7 +27,13 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationExch
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponse;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
 import org.springframework.util.MultiValueMap;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
@@ -40,11 +45,8 @@ import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VAL
  */
 public class OAuth2AuthorizationCodeGrantRequestEntityConverterTests {
 	private OAuth2AuthorizationCodeGrantRequestEntityConverter converter = new OAuth2AuthorizationCodeGrantRequestEntityConverter();
-	private OAuth2AuthorizationCodeGrantRequest authorizationCodeGrantRequest;
-
-	@Before
-	public void setup() {
-		ClientRegistration clientRegistration = ClientRegistration.withRegistrationId("registration-1")
+	private ClientRegistration.Builder clientRegistrationBuilder = ClientRegistration
+				.withRegistrationId("registration-1")
 				.clientId("client-1")
 				.clientSecret("secret")
 				.clientAuthenticationMethod(ClientAuthenticationMethod.BASIC)
@@ -55,33 +57,31 @@ public class OAuth2AuthorizationCodeGrantRequestEntityConverterTests {
 				.tokenUri("https://provider.com/oauth2/token")
 				.userInfoUri("https://provider.com/user")
 				.userNameAttributeName("id")
-				.clientName("client-1")
-				.build();
-		OAuth2AuthorizationRequest authorizationRequest = OAuth2AuthorizationRequest
+				.clientName("client-1");
+	private OAuth2AuthorizationRequest.Builder authorizationRequestBuilder = OAuth2AuthorizationRequest
 				.authorizationCode()
-				.clientId(clientRegistration.getClientId())
+				.clientId("client-1")
 				.state("state-1234")
-				.authorizationUri(clientRegistration.getProviderDetails().getAuthorizationUri())
-				.redirectUri(clientRegistration.getRedirectUriTemplate())
-				.scopes(clientRegistration.getScopes())
-				.build();
-		OAuth2AuthorizationResponse authorizationResponse = OAuth2AuthorizationResponse
+				.authorizationUri("https://provider.com/oauth2/authorize")
+				.redirectUri("https://client.com/callback/client-1")
+				.scopes(new HashSet(Arrays.asList("read", "write")));
+	private OAuth2AuthorizationResponse.Builder authorizationResponseBuilder = OAuth2AuthorizationResponse
 				.success("code-1234")
 				.state("state-1234")
-				.redirectUri(clientRegistration.getRedirectUriTemplate())
-				.build();
-		OAuth2AuthorizationExchange authorizationExchange =
-				new OAuth2AuthorizationExchange(authorizationRequest, authorizationResponse);
-		this.authorizationCodeGrantRequest = new OAuth2AuthorizationCodeGrantRequest(
-				clientRegistration, authorizationExchange);
-	}
+				.redirectUri("https://client.com/callback/client-1");
 
 	@SuppressWarnings("unchecked")
 	@Test
 	public void convertWhenGrantRequestValidThenConverts() {
-		RequestEntity<?> requestEntity = this.converter.convert(this.authorizationCodeGrantRequest);
+		ClientRegistration clientRegistration = clientRegistrationBuilder.build();
+		OAuth2AuthorizationRequest authorizationRequest = authorizationRequestBuilder.build();
+		OAuth2AuthorizationResponse authorizationResponse = authorizationResponseBuilder.build();
+		OAuth2AuthorizationExchange authorizationExchange =
+				new OAuth2AuthorizationExchange(authorizationRequest, authorizationResponse);
+		OAuth2AuthorizationCodeGrantRequest authorizationCodeGrantRequest = new OAuth2AuthorizationCodeGrantRequest(
+				clientRegistration, authorizationExchange);
 
-		ClientRegistration clientRegistration = this.authorizationCodeGrantRequest.getClientRegistration();
+		RequestEntity<?> requestEntity = this.converter.convert(authorizationCodeGrantRequest);
 
 		assertThat(requestEntity.getMethod()).isEqualTo(HttpMethod.POST);
 		assertThat(requestEntity.getUrl().toASCIIString()).isEqualTo(
@@ -97,7 +97,55 @@ public class OAuth2AuthorizationCodeGrantRequestEntityConverterTests {
 		assertThat(formParameters.getFirst(OAuth2ParameterNames.GRANT_TYPE)).isEqualTo(
 				AuthorizationGrantType.AUTHORIZATION_CODE.getValue());
 		assertThat(formParameters.getFirst(OAuth2ParameterNames.CODE)).isEqualTo("code-1234");
+		assertThat(formParameters.getFirst(OAuth2ParameterNames.CLIENT_ID)).isNull();
 		assertThat(formParameters.getFirst(OAuth2ParameterNames.REDIRECT_URI)).isEqualTo(
 				clientRegistration.getRedirectUriTemplate());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void convertWhenPkceGrantRequestValidThenConverts() {
+		ClientRegistration clientRegistration = clientRegistrationBuilder
+				.clientSecret(null)
+				.build();
+
+		Map<String, Object> attributes = new HashMap<>();
+		attributes.put(PkceParameterNames.CODE_VERIFIER, "code-verifier-1234");
+
+		Map<String, Object> additionalParameters = new HashMap<>();
+		additionalParameters.put(PkceParameterNames.CODE_CHALLENGE, "code-challenge-1234");
+		additionalParameters.put(PkceParameterNames.CODE_CHALLENGE_METHOD, "S256");
+
+		OAuth2AuthorizationRequest authorizationRequest = authorizationRequestBuilder
+				.attributes(attributes)
+				.additionalParameters(additionalParameters)
+				.build();
+
+		OAuth2AuthorizationResponse authorizationResponse = authorizationResponseBuilder.build();
+		OAuth2AuthorizationExchange authorizationExchange =
+				new OAuth2AuthorizationExchange(authorizationRequest, authorizationResponse);
+		OAuth2AuthorizationCodeGrantRequest authorizationCodeGrantRequest = new OAuth2AuthorizationCodeGrantRequest(
+				clientRegistration, authorizationExchange);
+
+		RequestEntity<?> requestEntity = this.converter.convert(authorizationCodeGrantRequest);
+
+		assertThat(requestEntity.getMethod()).isEqualTo(HttpMethod.POST);
+		assertThat(requestEntity.getUrl().toASCIIString()).isEqualTo(
+				clientRegistration.getProviderDetails().getTokenUri());
+
+		HttpHeaders headers = requestEntity.getHeaders();
+		assertThat(headers.getAccept()).contains(MediaType.APPLICATION_JSON_UTF8);
+		assertThat(headers.getContentType()).isEqualTo(
+				MediaType.valueOf(APPLICATION_FORM_URLENCODED_VALUE + ";charset=UTF-8"));
+		assertThat(headers.getFirst(HttpHeaders.AUTHORIZATION)).isNull();
+
+		MultiValueMap<String, String> formParameters = (MultiValueMap<String, String>) requestEntity.getBody();
+		assertThat(formParameters.getFirst(OAuth2ParameterNames.GRANT_TYPE)).isEqualTo(
+				AuthorizationGrantType.AUTHORIZATION_CODE.getValue());
+		assertThat(formParameters.getFirst(OAuth2ParameterNames.CODE)).isEqualTo("code-1234");
+		assertThat(formParameters.getFirst(OAuth2ParameterNames.REDIRECT_URI)).isEqualTo(
+				clientRegistration.getRedirectUriTemplate());
+		assertThat(formParameters.getFirst(OAuth2ParameterNames.CLIENT_ID)).isEqualTo("client-1");
+		assertThat(formParameters.getFirst(PkceParameterNames.CODE_VERIFIER)).isEqualTo("code-verifier-1234");
 	}
 }

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/ClientRegistrationTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/ClientRegistrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -172,6 +172,41 @@ public class ClientRegistrationTests {
 				.clientName(CLIENT_NAME)
 				.build();
 		assertThat(clientRegistration.getClientAuthenticationMethod()).isEqualTo(ClientAuthenticationMethod.BASIC);
+	}
+
+	@Test
+	public void buildWhenAuthorizationCodeGrantClientAuthenticationMethodNotProvidedAndClientSecretNullThenDefaultToNone() {
+		ClientRegistration clientRegistration = ClientRegistration.withRegistrationId(REGISTRATION_ID)
+				.clientId(CLIENT_ID)
+				.clientSecret(null)
+				.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+				.redirectUriTemplate(REDIRECT_URI)
+				.scope(SCOPES.toArray(new String[0]))
+				.authorizationUri(AUTHORIZATION_URI)
+				.tokenUri(TOKEN_URI)
+				.userInfoAuthenticationMethod(AuthenticationMethod.FORM)
+				.jwkSetUri(JWK_SET_URI)
+				.clientName(CLIENT_NAME)
+				.build();
+		assertThat(clientRegistration.getClientAuthenticationMethod()).isEqualTo(ClientAuthenticationMethod.NONE);
+	}
+
+	@Test
+	public void buildWhenAuthorizationCodeGrantClientAuthenticationMethodNotProvidedAndClientSecretBlankThenDefaultToNone() {
+		ClientRegistration clientRegistration = ClientRegistration.withRegistrationId(REGISTRATION_ID)
+				.clientId(CLIENT_ID)
+				.clientSecret(" ")
+				.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+				.redirectUriTemplate(REDIRECT_URI)
+				.scope(SCOPES.toArray(new String[0]))
+				.authorizationUri(AUTHORIZATION_URI)
+				.tokenUri(TOKEN_URI)
+				.userInfoAuthenticationMethod(AuthenticationMethod.FORM)
+				.jwkSetUri(JWK_SET_URI)
+				.clientName(CLIENT_NAME)
+				.build();
+		assertThat(clientRegistration.getClientAuthenticationMethod()).isEqualTo(ClientAuthenticationMethod.NONE);
+		assertThat(clientRegistration.getClientSecret()).isEqualTo("");
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClientAuthenticationMethod.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClientAuthenticationMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,12 @@ public final class ClientAuthenticationMethod implements Serializable {
 	private static final long serialVersionUID = SpringSecurityCoreVersion.SERIAL_VERSION_UID;
 	public static final ClientAuthenticationMethod BASIC = new ClientAuthenticationMethod("basic");
 	public static final ClientAuthenticationMethod POST = new ClientAuthenticationMethod("post");
+
+	/**
+	 * @since 5.2
+	 */
+	public static final ClientAuthenticationMethod NONE = new ClientAuthenticationMethod("none");
+
 	private final String value;
 
 	/**

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/PkceParameterNames.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/PkceParameterNames.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.core.endpoint;
+
+/**
+ * Standard parameter names defined in the OAuth Parameters Registry
+ * and used by the authorization endpoint and token endpoint.
+ *
+ * @author Stephen Doxsee
+ * @author Kevin Bolduc
+ * @since 5.2
+ * @see <a target="_blank" href="https://tools.ietf.org/html/rfc7636#section-6.1">6.1.  OAuth Parameters Registry</a>
+ */
+public interface PkceParameterNames {
+
+	/**
+	 * {@code code_challenge} - used in Authorization Request.
+	 */
+	String CODE_CHALLENGE = "code_challenge";
+
+	/**
+	 * {@code code_challenge_method} - used in Authorization Request.
+	 */
+	String CODE_CHALLENGE_METHOD = "code_challenge_method";
+
+	/**
+	 * {@code code_verifier} - used in Token Request.
+	 */
+	String CODE_VERIFIER = "code_verifier";
+}

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/ClientAuthenticationMethodTests.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/ClientAuthenticationMethodTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,5 +39,10 @@ public class ClientAuthenticationMethodTests {
 	@Test
 	public void getValueWhenAuthenticationMethodPostThenReturnPost() {
 		assertThat(ClientAuthenticationMethod.POST.getValue()).isEqualTo("post");
+	}
+
+	@Test
+	public void getValueWhenAuthenticationMethodNoneThenReturnNone() {
+		assertThat(ClientAuthenticationMethod.NONE.getValue()).isEqualTo("none");
 	}
 }


### PR DESCRIPTION
This is a PR for #6446 that involves simple extensions to existing spring security that would probably be used by spring desktop apps (swing, javafx, etc.). It is a WIP but wanted to get some early feedback. I made some tweaks to the sample app oauth2webclient just to illustrate how this can be used with spring boot. I omitted the `client-secret` and added `client-authentication-method: none`. Thanks!

Took the discussion in #5652 into account.

Here's a brief overview of the use-cases for client-side PKCE as it pertains to spring security (ref #6446):

1. **Native/Mobile**

    Of course, only JVM-based Mobile OS's (Android). Android uses a "Custom URI scheme" that is registered with the OS to capture the `code`. I'd imagine that you'd probably use a library like https://github.com/openid/AppAuth-Android rather than spring security? It appears there was an effort at one time to connect Spring and Android (https://github.com/spring-projects/spring-android) but the project now seems quite stale (dead?).  In theory, you could probably have a webserver embedded in your native app that, if it used spring security, could handle the code callback but that seems heavy to me. 

    **Bottom line**: I don't think this is the target use-case for spring security client PKCE support but could be used in theory.

2. **Desktop**

    JVM desktop apps with spring exist (we have one!). We'd need some sort of loopback webserver to capture the authorization `code`. This could be a very simple one that spins up, on demand, serves a certain port and then shuts down--but that requires custom code (and could be done at a later time). If I simply make our non-web app a web one (by commenting out `main.web-application-type: none`), we'd get a tomcat and spring security auto configuration just like other web applications. The difference here is that the app needs to be delivered to the users own machines--thereby making the client_secret unviable and PKCE a good fit. Turning non-web apps into web ones feels a bit heavy but simple.

    I think using refresh tokens in spring security clients is safe because it's in memory rather than disk?

    **Bottom line**: Simpler is better, desktops have the resources for a local webserver. Why not leverage spring-boot's embedded server? Any other lighter-weight suggestions?

3. **Client-side browser-based JavaScript clients (SPA)**

    These authorization request are typically all javascript-initiated. The authorization `code` comes back to client and client makes the token call itself. I figure that spring security is necessary. Question: Why are implicit calls created in spring security (e.g. OAuth2AuthorizationRequest.implicit())?

    **Bottom** line: Why is spring supporting this category at all? We probably don't need PKCE support.



