### PR TITLE
AuthenticationSupplier feature for Web Security

### DIFF
--- a/cas/src/main/java/org/springframework/security/cas/web/CasAuthenticationFilter.java
+++ b/cas/src/main/java/org/springframework/security/cas/web/CasAuthenticationFilter.java
@@ -242,7 +242,7 @@ public class CasAuthenticationFilter extends AbstractAuthenticationProcessingFil
 	@Override
 	public Authentication attemptAuthentication(final HttpServletRequest request,
 			final HttpServletResponse response) throws AuthenticationException,
-			IOException {
+			IOException, ServletException {
 		// if the request is a proxy request process it and return null to indicate the
 		// request has been processed
 		if (proxyReceptorRequest(request)) {
@@ -281,9 +281,11 @@ public class CasAuthenticationFilter extends AbstractAuthenticationProcessingFil
 
 	/**
 	 * Overridden to provide proxying capabilities.
+	 * @throws ServletException 
+	 * @throws IOException 
 	 */
 	protected boolean requiresAuthentication(final HttpServletRequest request,
-			final HttpServletResponse response) {
+			final HttpServletResponse response) throws IOException, ServletException {
 		final boolean serviceTicketRequest = serviceTicketRequest(request, response);
 		final boolean result = serviceTicketRequest || proxyReceptorRequest(request)
 				|| (proxyTicketRequest(serviceTicketRequest, request));
@@ -334,9 +336,11 @@ public class CasAuthenticationFilter extends AbstractAuthenticationProcessingFil
 	 * @param request
 	 * @param response
 	 * @return
+	 * @throws ServletException 
+	 * @throws IOException 
 	 */
 	private boolean serviceTicketRequest(final HttpServletRequest request,
-			final HttpServletResponse response) {
+			final HttpServletResponse response) throws IOException, ServletException {
 		boolean result = super.requiresAuthentication(request, response);
 		if (logger.isDebugEnabled()) {
 			logger.debug("serviceTicketRequest = " + result);

--- a/cas/src/main/java/org/springframework/security/cas/web/CasAuthenticationFilter.java
+++ b/cas/src/main/java/org/springframework/security/cas/web/CasAuthenticationFilter.java
@@ -281,8 +281,8 @@ public class CasAuthenticationFilter extends AbstractAuthenticationProcessingFil
 
 	/**
 	 * Overridden to provide proxying capabilities.
-	 * @throws ServletException 
-	 * @throws IOException 
+	 * @throws ServletException
+	 * @throws IOException
 	 */
 	protected boolean requiresAuthentication(final HttpServletRequest request,
 			final HttpServletResponse response) throws IOException, ServletException {
@@ -336,8 +336,8 @@ public class CasAuthenticationFilter extends AbstractAuthenticationProcessingFil
 	 * @param request
 	 * @param response
 	 * @return
-	 * @throws ServletException 
-	 * @throws IOException 
+	 * @throws ServletException
+	 * @throws IOException
 	 */
 	private boolean serviceTicketRequest(final HttpServletRequest request,
 			final HttpServletResponse response) throws IOException, ServletException {

--- a/cas/src/test/java/org/springframework/security/cas/web/CasAuthenticationFilterTests.java
+++ b/cas/src/test/java/org/springframework/security/cas/web/CasAuthenticationFilterTests.java
@@ -94,7 +94,7 @@ public class CasAuthenticationFilterTests {
 	}
 
 	@Test
-	public void testRequiresAuthenticationFilterProcessUrl() {
+	public void testRequiresAuthenticationFilterProcessUrl() throws Exception {
 		String url = "/login/cas";
 		CasAuthenticationFilter filter = new CasAuthenticationFilter();
 		filter.setFilterProcessesUrl(url);
@@ -106,7 +106,7 @@ public class CasAuthenticationFilterTests {
 	}
 
 	@Test
-	public void testRequiresAuthenticationProxyRequest() {
+	public void testRequiresAuthenticationProxyRequest() throws Exception {
 		CasAuthenticationFilter filter = new CasAuthenticationFilter();
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		MockHttpServletResponse response = new MockHttpServletResponse();
@@ -122,7 +122,7 @@ public class CasAuthenticationFilterTests {
 	}
 
 	@Test
-	public void testRequiresAuthenticationAuthAll() {
+	public void testRequiresAuthenticationAuthAll() throws Exception {
 		ServiceProperties properties = new ServiceProperties();
 		properties.setAuthenticateAllArtifacts(true);
 

--- a/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.java
@@ -252,9 +252,12 @@ public abstract class AbstractAuthenticationProcessingFilter extends GenericFilt
 	 *
 	 * @return <code>true</code> if the filter should attempt authentication,
 	 * <code>false</code> otherwise.
+	 * 
+	 * @throws ServletException 
+	 * @throws IOException 
 	 */
 	protected boolean requiresAuthentication(HttpServletRequest request,
-			HttpServletResponse response) {
+			HttpServletResponse response) throws IOException, ServletException {
 		return requiresAuthenticationRequestMatcher.matches(request);
 	}
 

--- a/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.java
@@ -252,9 +252,9 @@ public abstract class AbstractAuthenticationProcessingFilter extends GenericFilt
 	 *
 	 * @return <code>true</code> if the filter should attempt authentication,
 	 * <code>false</code> otherwise.
-	 * 
-	 * @throws ServletException 
-	 * @throws IOException 
+	 *
+	 * @throws ServletException
+	 * @throws IOException
 	 */
 	protected boolean requiresAuthentication(HttpServletRequest request,
 			HttpServletResponse response) throws IOException, ServletException {

--- a/web/src/main/java/org/springframework/security/web/authentication/supply/AuthenticationSupplier.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/supply/AuthenticationSupplier.java
@@ -1,0 +1,39 @@
+package org.springframework.security.web.authentication.supply;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.authentication.www.AuthenticationType;
+
+/**
+ * Used in {@link GenericAuthenticationFilter} to provide requested
+ * {@link Authentication} object, which is further used by
+ * {@link AuthenticationManager} to authenticate user.
+ * 
+ * @author Sergey Bespalov
+ *
+ * @see GenericAuthenticationFilter
+ * @see AuthenticationSupplierRegistry
+ */
+public interface AuthenticationSupplier<T extends Authentication> extends AuthenticationEntryPoint {
+
+	/**
+	 * Supplies requested {@link Authentication}.
+	 * 
+	 * @param request
+	 * @return
+	 * @throws AuthenticationException
+	 */
+	T supply(HttpServletRequest request) throws AuthenticationException;
+
+	/**
+	 * Provides supported {@link AuthenticationType}. 
+	 * 
+	 * @return
+	 */
+	AuthenticationType getAuthenticationType();
+
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/supply/AuthenticationSupplier.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/supply/AuthenticationSupplier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.security.web.authentication.supply;
 
 import javax.servlet.http.HttpServletRequest;
@@ -12,7 +27,7 @@ import org.springframework.security.web.authentication.www.AuthenticationType;
  * Used in {@link GenericAuthenticationFilter} to provide requested
  * {@link Authentication} object, which is further used by
  * {@link AuthenticationManager} to authenticate user.
- * 
+ *
  * @author Sergey Bespalov
  *
  * @see GenericAuthenticationFilter
@@ -22,7 +37,7 @@ public interface AuthenticationSupplier<T extends Authentication> extends Authen
 
 	/**
 	 * Supplies requested {@link Authentication}.
-	 * 
+	 *
 	 * @param request
 	 * @return
 	 * @throws AuthenticationException
@@ -30,8 +45,8 @@ public interface AuthenticationSupplier<T extends Authentication> extends Authen
 	T supply(HttpServletRequest request) throws AuthenticationException;
 
 	/**
-	 * Provides supported {@link AuthenticationType}. 
-	 * 
+	 * Provides supported {@link AuthenticationType}.
+	 *
 	 * @return
 	 */
 	AuthenticationType getAuthenticationType();

--- a/web/src/main/java/org/springframework/security/web/authentication/supply/AuthenticationSupplierMap.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/supply/AuthenticationSupplierMap.java
@@ -1,0 +1,29 @@
+package org.springframework.security.web.authentication.supply;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.www.AuthenticationType;
+
+/**
+ * @author Sergey Bespalov
+ *
+ */
+public class AuthenticationSupplierMap implements AuthenticationSupplierRegistry {
+
+	private Map<AuthenticationType, AuthenticationSupplier<?>> authenticationSupplierMap = new ConcurrentHashMap<>();
+
+	public AuthenticationSupplierMap(Set<AuthenticationSupplier<?>> authenticationSuppliers) {
+		super();
+		authenticationSuppliers.stream().forEach(s -> authenticationSupplierMap.put(s.getAuthenticationType(), s));
+	}
+
+	@Override
+	public <T extends Authentication> AuthenticationSupplier<T> lookupSupplierByAuthenticationType(
+			AuthenticationType authenticationType) {
+		return (AuthenticationSupplier<T>) authenticationSupplierMap.get(authenticationType);
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/supply/AuthenticationSupplierMap.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/supply/AuthenticationSupplierMap.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.security.web.authentication.supply;
 
 import java.util.Map;

--- a/web/src/main/java/org/springframework/security/web/authentication/supply/AuthenticationSupplierRegistry.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/supply/AuthenticationSupplierRegistry.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.security.web.authentication.supply;
 
 import org.springframework.security.core.Authentication;

--- a/web/src/main/java/org/springframework/security/web/authentication/supply/AuthenticationSupplierRegistry.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/supply/AuthenticationSupplierRegistry.java
@@ -1,0 +1,14 @@
+package org.springframework.security.web.authentication.supply;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.www.AuthenticationType;
+
+/**
+ * @author Sergey Bespalov
+ *
+ */
+public interface AuthenticationSupplierRegistry {
+
+	public <T extends Authentication> AuthenticationSupplier<T> lookupSupplierByAuthenticationType(AuthenticationType authenticationType);
+
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/supply/AuthenticationTokenSupplier.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/supply/AuthenticationTokenSupplier.java
@@ -1,0 +1,62 @@
+package org.springframework.security.web.authentication.supply;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.security.web.authentication.www.AuthenticationType;
+
+/**
+ * This class decorates a underlying {@link AuthenticationSupplier} with common
+ * logic needed for {@link AbstractAuthenticationToken}.
+ * 
+ * @author Sergey Bespalov
+ *
+ * @param <T>
+ */
+public class AuthenticationTokenSupplier<T extends AbstractAuthenticationToken> implements AuthenticationSupplier<T> {
+
+	private AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource = new WebAuthenticationDetailsSource();
+
+	private final AuthenticationSupplier<T> delegate;
+
+	public AuthenticationTokenSupplier(AuthenticationSupplier<T> delegate) {
+		super();
+		this.delegate = delegate;
+	}
+
+	public AuthenticationDetailsSource<HttpServletRequest, ?> getAuthenticationDetailsSource() {
+		return authenticationDetailsSource;
+	}
+
+	public void setAuthenticationDetailsSource(
+			AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource) {
+		this.authenticationDetailsSource = authenticationDetailsSource;
+	}
+
+	@Override
+	public T supply(HttpServletRequest request) throws AuthenticationException {
+		T authentication = delegate.supply(request);
+
+		Object authenticationDetails = getAuthenticationDetailsSource().buildDetails(request);
+		authentication.setDetails(authenticationDetails);
+
+		return authentication;
+	}
+
+	public AuthenticationType getAuthenticationType() {
+		return delegate.getAuthenticationType();
+	}
+
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+			AuthenticationException authException) throws IOException, ServletException {
+		delegate.commence(request, response, authException);
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/supply/AuthenticationTokenSupplier.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/supply/AuthenticationTokenSupplier.java
@@ -15,7 +15,7 @@ import org.springframework.security.web.authentication.www.AuthenticationType;
 /**
  * This class decorates a underlying {@link AuthenticationSupplier} with common
  * logic needed for {@link AbstractAuthenticationToken}.
- * 
+ *
  * @author Sergey Bespalov
  *
  * @param <T>

--- a/web/src/main/java/org/springframework/security/web/authentication/supply/AuthenticationTokenSupplier.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/supply/AuthenticationTokenSupplier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.security.web.authentication.supply;
 
 import java.io.IOException;

--- a/web/src/main/java/org/springframework/security/web/authentication/supply/GenericAuthenticationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/supply/GenericAuthenticationFilter.java
@@ -1,0 +1,131 @@
+package org.springframework.security.web.authentication.supply;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.www.AuthenticationType;
+import org.springframework.security.web.authentication.www.AuthenticationTypeParser;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.util.Assert;
+
+/**
+ * @author Sergey Bespalov
+ *
+ */
+public class GenericAuthenticationFilter extends AbstractAuthenticationProcessingFilter
+		implements AuthenticationFailureHandler {
+
+	public static final String ATTRIBUTE_NAME_AUTHENTICATION_TYPE = GenericAuthenticationFilter.class.getName()
+			+ ".authenticationTypeName";
+
+	private AuthenticationSupplierRegistry authenticationSupplierRegistry;
+	private AuthenticationTypeParser authenticationTypeParser = new AuthenticationTypeParser();
+
+	public GenericAuthenticationFilter(RequestMatcher requiresAuthenticationRequestMatcher) {
+		super(requiresAuthenticationRequestMatcher);
+		setAuthenticationFailureHandler(this);
+	}
+
+	public GenericAuthenticationFilter(String defaultFilterProcessesUrl) {
+		super(defaultFilterProcessesUrl);
+		setAuthenticationFailureHandler(this);
+	}
+
+	public AuthenticationTypeParser getAuthenticationTypeParser() {
+		return authenticationTypeParser;
+	}
+
+	public void setAuthenticationTypeParser(AuthenticationTypeParser authenticationTypeParser) {
+		this.authenticationTypeParser = authenticationTypeParser;
+	}
+
+	public AuthenticationSupplierRegistry getAuthenticationSupplierRegistry() {
+		return authenticationSupplierRegistry;
+	}
+
+	public void setAuthenticationSupplierRegistry(AuthenticationSupplierRegistry authenticationSupplierRegistry) {
+		this.authenticationSupplierRegistry = authenticationSupplierRegistry;
+	}
+	
+	@Override
+	public void afterPropertiesSet() {
+		super.afterPropertiesSet();
+		Assert.notNull(authenticationSupplierRegistry, "authenticationSupplierRegistry must not be null");
+	}
+
+	@Override
+	protected boolean requiresAuthentication(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+		if (!super.requiresAuthentication(request, response)) {
+			return false;
+		}
+
+		AuthenticationType authenticationType = getAuthenticationTypeParser().parseAuthenticationType(request);
+		if (authenticationType == null) {
+			return false;
+		}
+
+		request.setAttribute(ATTRIBUTE_NAME_AUTHENTICATION_TYPE, authenticationType);
+		
+		AuthenticationSupplier<?> authenticationSupplier = getAuthenticationSupplierRegistry()
+				.lookupSupplierByAuthenticationType(authenticationType);
+		if (authenticationSupplier == null) {
+			return false;
+		}
+
+		Authentication authentication;
+		try {
+			authentication = authenticationSupplier.supply(request);
+		} catch (AuthenticationException e) {
+			onAuthenticationFailure(request, response, e);
+			
+			return true;
+		}
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		return true;
+	}
+
+	@Override
+	public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+			throws AuthenticationException, IOException, ServletException {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication == null) {
+			return null;
+		}
+
+		if (authentication.isAuthenticated()) {
+			return authentication;
+		}
+
+		return getAuthenticationManager().authenticate(authentication);
+	}
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+			AuthenticationException exception) throws IOException, ServletException {
+		AuthenticationType authenticationType = (AuthenticationType) request.getAttribute(ATTRIBUTE_NAME_AUTHENTICATION_TYPE);
+
+		AuthenticationSupplier<?> authenticationSupplier = getAuthenticationSupplierRegistry()
+				.lookupSupplierByAuthenticationType(authenticationType);
+		authenticationSupplier.commence(request, response, exception);
+	}
+
+	@Override
+	protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
+			Authentication authResult) throws IOException, ServletException {
+		super.successfulAuthentication(request, response, chain, authResult);
+		
+		chain.doFilter(request, response);
+	}
+
+	
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/supply/GenericAuthenticationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/supply/GenericAuthenticationFilter.java
@@ -55,7 +55,7 @@ public class GenericAuthenticationFilter extends AbstractAuthenticationProcessin
 	public void setAuthenticationSupplierRegistry(AuthenticationSupplierRegistry authenticationSupplierRegistry) {
 		this.authenticationSupplierRegistry = authenticationSupplierRegistry;
 	}
-	
+
 	@Override
 	public void afterPropertiesSet() {
 		super.afterPropertiesSet();
@@ -74,7 +74,7 @@ public class GenericAuthenticationFilter extends AbstractAuthenticationProcessin
 		}
 
 		request.setAttribute(ATTRIBUTE_NAME_AUTHENTICATION_TYPE, authenticationType);
-		
+
 		AuthenticationSupplier<?> authenticationSupplier = getAuthenticationSupplierRegistry()
 				.lookupSupplierByAuthenticationType(authenticationType);
 		if (authenticationSupplier == null) {
@@ -86,7 +86,7 @@ public class GenericAuthenticationFilter extends AbstractAuthenticationProcessin
 			authentication = authenticationSupplier.supply(request);
 		} catch (AuthenticationException e) {
 			onAuthenticationFailure(request, response, e);
-			
+
 			return true;
 		}
 		SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -123,9 +123,9 @@ public class GenericAuthenticationFilter extends AbstractAuthenticationProcessin
 	protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
 			Authentication authResult) throws IOException, ServletException {
 		super.successfulAuthentication(request, response, chain, authResult);
-		
+
 		chain.doFilter(request, response);
 	}
 
-	
+
 }

--- a/web/src/main/java/org/springframework/security/web/authentication/supply/GenericAuthenticationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/supply/GenericAuthenticationFilter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.security.web.authentication.supply;
 
 import java.io.IOException;

--- a/web/src/main/java/org/springframework/security/web/authentication/www/AuthenticationType.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/AuthenticationType.java
@@ -2,9 +2,9 @@ package org.springframework.security.web.authentication.www;
 
 /**
  * This class represents a supported Authentication type, which can be `Basic`, `Digest` etc.
- * 
+ *
  * @author Sergey Bespalov
- * 
+ *
  * @see AuthenticationTypeParser
  */
 public class AuthenticationType {

--- a/web/src/main/java/org/springframework/security/web/authentication/www/AuthenticationType.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/AuthenticationType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.security.web.authentication.www;
 
 /**

--- a/web/src/main/java/org/springframework/security/web/authentication/www/AuthenticationType.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/AuthenticationType.java
@@ -1,0 +1,45 @@
+package org.springframework.security.web.authentication.www;
+
+/**
+ * This class represents a supported Authentication type, which can be `Basic`, `Digest` etc.
+ * 
+ * @author Sergey Bespalov
+ * 
+ * @see AuthenticationTypeParser
+ */
+public class AuthenticationType {
+
+	private final String name;
+
+	public AuthenticationType(String name) {
+		if (name == null) {
+			throw new NullPointerException("Authentication type name can not be null.");
+		}
+
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public int hashCode() {
+		return name.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof AuthenticationType)) {
+			return false;
+		}
+		AuthenticationType other = (AuthenticationType) obj;
+		return name.equals(other.name);
+	}
+
+	@Override
+	public String toString() {
+		return name;
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/www/AuthenticationTypeParser.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/AuthenticationTypeParser.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.security.web.authentication.www;
 
 import javax.servlet.http.HttpServletRequest;

--- a/web/src/main/java/org/springframework/security/web/authentication/www/AuthenticationTypeParser.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/AuthenticationTypeParser.java
@@ -9,7 +9,7 @@ import javax.servlet.http.HttpServletRequest;
  * <pre>
  * Authorization: &#60;type&#62; &#60;credentials&#62;
  * </pre>
- * 
+ *
  * @author Sergey Bespalov
  *
  */

--- a/web/src/main/java/org/springframework/security/web/authentication/www/AuthenticationTypeParser.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/AuthenticationTypeParser.java
@@ -1,0 +1,32 @@
+package org.springframework.security.web.authentication.www;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * This class targets to parse Authentication type from `Authorization` HTTP header.
+ * <br>
+ * Supported `Authorization` header syntax:
+ * <pre>
+ * Authorization: &#60;type&#62; &#60;credentials&#62;
+ * </pre>
+ * 
+ * @author Sergey Bespalov
+ *
+ */
+public class AuthenticationTypeParser {
+
+	public static final String AUTHORIZATION_HEADER_NAME = "Authorization";
+
+	public AuthenticationType parseAuthenticationType(HttpServletRequest request) {
+		String header = request.getHeader(AUTHORIZATION_HEADER_NAME);
+		if (header == null) {
+			return null;
+		}
+
+		header = header.trim();
+		String authenticationType = header.substring(0, header.indexOf(" ") + 1);
+
+		return new AuthenticationType(authenticationType.trim());
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationSupplier.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationSupplier.java
@@ -1,0 +1,67 @@
+package org.springframework.security.web.authentication.www;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Base64;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.supply.AuthenticationSupplier;
+
+/**
+ * @author Sergey Bespalov
+ *
+ */
+public class BasicAuthenticationSupplier extends BasicAuthenticationEntryPoint
+		implements AuthenticationSupplier<UsernamePasswordAuthenticationToken> {
+
+	public static final String AUTHENTICATION_TYPE_BASIC_NAME = "Basic";
+	public static final AuthenticationType AUTHENTICATION_TYPE_BASIC = new AuthenticationType(AUTHENTICATION_TYPE_BASIC_NAME);
+	
+	private String credentialsCharset = "UTF-8";
+
+	@Override
+	public UsernamePasswordAuthenticationToken supply(HttpServletRequest request) throws AuthenticationException {
+		String header = request.getHeader(AuthenticationTypeParser.AUTHORIZATION_HEADER_NAME);
+
+		if (header == null || !header.contains(AUTHENTICATION_TYPE_BASIC_NAME)) {
+			throw new AuthenticationCredentialsNotFoundException(
+					String.format("%s authentication header required.", AUTHENTICATION_TYPE_BASIC_NAME));
+		}
+
+		byte[] base64Token = header.substring(6).getBytes();
+		byte[] decoded;
+		try {
+			decoded = Base64.getDecoder().decode(base64Token);
+		} catch (IllegalArgumentException e) {
+			throw new BadCredentialsException("Failed to decode basic authentication token");
+		}
+
+		String token;
+		try {
+			token = new String(decoded, getCredentialsCharset(request));
+		} catch (UnsupportedEncodingException e) {
+			throw new InternalAuthenticationServiceException(e.getMessage(), e);
+		}
+
+		String[] tokens = token.split(":");
+		if (tokens.length != 2) {
+			throw new BadCredentialsException("Invalid basic authentication token");
+		}
+		return new UsernamePasswordAuthenticationToken(tokens[0], tokens[1]);
+	}
+
+	private String getCredentialsCharset(HttpServletRequest request) {
+		return credentialsCharset;
+	}
+
+	@Override
+	public AuthenticationType getAuthenticationType() {
+		return AUTHENTICATION_TYPE_BASIC;
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationSupplier.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationSupplier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.security.web.authentication.www;
 
 import java.io.UnsupportedEncodingException;
@@ -21,7 +36,7 @@ public class BasicAuthenticationSupplier extends BasicAuthenticationEntryPoint
 
 	public static final String AUTHENTICATION_TYPE_BASIC_NAME = "Basic";
 	public static final AuthenticationType AUTHENTICATION_TYPE_BASIC = new AuthenticationType(AUTHENTICATION_TYPE_BASIC_NAME);
-	
+
 	private String credentialsCharset = "UTF-8";
 
 	@Override

--- a/web/src/test/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilterTests.java
@@ -99,7 +99,7 @@ public class AbstractAuthenticationProcessingFilterTests {
 	}
 
 	@Test
-	public void testDefaultProcessesFilterUrlMatchesWithPathParameter() {
+	public void testDefaultProcessesFilterUrlMatchesWithPathParameter() throws Exception {
 		MockHttpServletRequest request = createMockAuthenticationRequest();
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		MockAuthenticationFilter filter = new MockAuthenticationFilter();

--- a/web/src/test/java/org/springframework/security/web/authentication/suply/GenericAuthenticationFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/suply/GenericAuthenticationFilterTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.security.web.authentication.suply;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/web/src/test/java/org/springframework/security/web/authentication/suply/GenericAuthenticationFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/suply/GenericAuthenticationFilterTests.java
@@ -46,11 +46,11 @@ public class GenericAuthenticationFilterTests {
 	private GenericAuthenticationFilter filter;
 	private AuthenticationManager manager;
 	private AuthenticationSupplier<UsernamePasswordAuthenticationToken> basicAuthenticationSupplier;
-	
+
 	@Before
 	public void setUp() throws Exception {
 		SecurityContextHolder.clearContext();
-		
+
 		UsernamePasswordAuthenticationToken requestedAuthentication = new UsernamePasswordAuthenticationToken(
 				"vasya", "pupkin");
 		requestedAuthentication.setDetails(new WebAuthenticationDetails(new MockHttpServletRequest()));
@@ -60,13 +60,13 @@ public class GenericAuthenticationFilterTests {
 		RequestMatcher requestMatcher = mock(RequestMatcher.class);
 		when(requestMatcher.matches(any(HttpServletRequest.class))).thenReturn(true);
 		filter = new GenericAuthenticationFilter(requestMatcher);
-		
+
 		manager = mock(AuthenticationManager.class);
 		when(manager.authenticate(requestedAuthentication)).thenReturn(authenticatedAuthentication);
 		when(manager.authenticate(not(eq(requestedAuthentication)))).thenThrow(
 				new BadCredentialsException(""));
 		filter.setAuthenticationManager(manager);
-		
+
 		BasicAuthenticationSupplier basicAuthenticationSupplier = new BasicAuthenticationSupplier();
 		basicAuthenticationSupplier.setRealmName("springframework.com");
 		AuthenticationTokenSupplier authenticationTokenSupplier = new AuthenticationTokenSupplier<>(basicAuthenticationSupplier);
@@ -76,7 +76,7 @@ public class GenericAuthenticationFilterTests {
 		when(authenticationSupplierRegistry
 				.lookupSupplierByAuthenticationType(not(eq(BasicAuthenticationSupplier.AUTHENTICATION_TYPE_BASIC))))
 						.thenReturn(null);
-		
+
 		filter.setAuthenticationSupplierRegistry(authenticationSupplierRegistry);
 	}
 
@@ -165,7 +165,7 @@ public class GenericAuthenticationFilterTests {
 		verify(chain).doFilter(any(ServletRequest.class), any(ServletResponse.class));
 		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
 	}
-	
+
 	@Test
 	public void testInvalidAuthenticationReturnsUnauthorized()
 			throws Exception {
@@ -187,5 +187,5 @@ public class GenericAuthenticationFilterTests {
 		assertThat(response.getHeader("WWW-Authenticate")).isNotNull();
 		assertThat(response.getHeader("WWW-Authenticate")).isEqualTo("Basic realm=\"springframework.com\"");
 	}
-	
+
 }

--- a/web/src/test/java/org/springframework/security/web/authentication/suply/GenericAuthenticationFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/suply/GenericAuthenticationFilterTests.java
@@ -1,0 +1,191 @@
+package org.springframework.security.web.authentication.suply;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.AdditionalMatchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.codec.binary.Base64;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.security.web.authentication.supply.AuthenticationSupplier;
+import org.springframework.security.web.authentication.supply.AuthenticationSupplierRegistry;
+import org.springframework.security.web.authentication.supply.AuthenticationTokenSupplier;
+import org.springframework.security.web.authentication.supply.GenericAuthenticationFilter;
+import org.springframework.security.web.authentication.www.BasicAuthenticationSupplier;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+/**
+ * Tests {@link GenericAuthenticationFilter}.
+ *
+ * @author Sergey Bespalov
+ */
+public class GenericAuthenticationFilterTests {
+
+	private GenericAuthenticationFilter filter;
+	private AuthenticationManager manager;
+	private AuthenticationSupplier<UsernamePasswordAuthenticationToken> basicAuthenticationSupplier;
+	
+	@Before
+	public void setUp() throws Exception {
+		SecurityContextHolder.clearContext();
+		
+		UsernamePasswordAuthenticationToken requestedAuthentication = new UsernamePasswordAuthenticationToken(
+				"vasya", "pupkin");
+		requestedAuthentication.setDetails(new WebAuthenticationDetails(new MockHttpServletRequest()));
+		Authentication authenticatedAuthentication = new UsernamePasswordAuthenticationToken("vasya", "pupkin",
+				AuthorityUtils.createAuthorityList("ROLE_1"));
+
+		RequestMatcher requestMatcher = mock(RequestMatcher.class);
+		when(requestMatcher.matches(any(HttpServletRequest.class))).thenReturn(true);
+		filter = new GenericAuthenticationFilter(requestMatcher);
+		
+		manager = mock(AuthenticationManager.class);
+		when(manager.authenticate(requestedAuthentication)).thenReturn(authenticatedAuthentication);
+		when(manager.authenticate(not(eq(requestedAuthentication)))).thenThrow(
+				new BadCredentialsException(""));
+		filter.setAuthenticationManager(manager);
+		
+		BasicAuthenticationSupplier basicAuthenticationSupplier = new BasicAuthenticationSupplier();
+		basicAuthenticationSupplier.setRealmName("springframework.com");
+		AuthenticationTokenSupplier authenticationTokenSupplier = new AuthenticationTokenSupplier<>(basicAuthenticationSupplier);
+		AuthenticationSupplierRegistry authenticationSupplierRegistry = mock(AuthenticationSupplierRegistry.class);
+		when(authenticationSupplierRegistry.<UsernamePasswordAuthenticationToken>lookupSupplierByAuthenticationType(
+				eq(BasicAuthenticationSupplier.AUTHENTICATION_TYPE_BASIC))).thenReturn(authenticationTokenSupplier);
+		when(authenticationSupplierRegistry
+				.lookupSupplierByAuthenticationType(not(eq(BasicAuthenticationSupplier.AUTHENTICATION_TYPE_BASIC))))
+						.thenReturn(null);
+		
+		filter.setAuthenticationSupplierRegistry(authenticationSupplierRegistry);
+	}
+
+	@After
+	public void clearContext() throws Exception {
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	public void testFilterIgnoresRequestsContainingNoAuthorizationHeader()
+			throws Exception {
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setServletPath("/some_file.html");
+		final MockHttpServletResponse response = new MockHttpServletResponse();
+
+		FilterChain chain = mock(FilterChain.class);
+		filter.doFilter(request, response, chain);
+
+		verify(chain).doFilter(any(ServletRequest.class), any(ServletResponse.class));
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+	}
+
+	@Test
+	public void testInvalidBasicAuthorizationTokenIsIgnored() throws Exception {
+		String token = "NOT_A_VALID_TOKEN_AS_MISSING_COLON";
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization",
+				"Basic " + new String(Base64.encodeBase64(token.getBytes())));
+		request.setServletPath("/some_file.html");
+		request.setSession(new MockHttpSession());
+		final MockHttpServletResponse response = new MockHttpServletResponse();
+
+		FilterChain chain = mock(FilterChain.class);
+		filter.doFilter(request, response, chain);
+
+		verify(chain, never()).doFilter(any(ServletRequest.class),
+				any(ServletResponse.class));
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+		assertThat(response.getStatus()).isEqualTo(401);
+	}
+
+	@Test
+	public void invalidBase64IsIgnored() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Basic NOT_VALID_BASE64");
+		request.setServletPath("/some_file.html");
+		request.setSession(new MockHttpSession());
+		final MockHttpServletResponse response = new MockHttpServletResponse();
+
+		FilterChain chain = mock(FilterChain.class);
+		filter.doFilter(request, response, chain);
+
+		verify(chain, never()).doFilter(any(ServletRequest.class),
+				any(ServletResponse.class));
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+		assertThat(response.getStatus()).isEqualTo(401);
+	}
+
+	@Test
+	public void testAuthenticationPassed() throws Exception {
+		String token = "vasya:pupkin";
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization",
+				"Basic " + new String(Base64.encodeBase64(token.getBytes())));
+		request.setServletPath("/some_file.html");
+
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+		FilterChain chain = mock(FilterChain.class);
+		filter.doFilter(request, new MockHttpServletResponse(), chain);
+
+		verify(chain).doFilter(any(ServletRequest.class), any(ServletResponse.class));
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+		assertThat(SecurityContextHolder.getContext().getAuthentication().getName())
+				.isEqualTo("vasya");
+	}
+
+	@Test
+	public void testUnsupportedAuthenticationTypeIsIgnored() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Unsupported auth");
+		request.setServletPath("/some_file.html");
+		FilterChain chain = mock(FilterChain.class);
+		filter.doFilter(request, new MockHttpServletResponse(), chain);
+
+		verify(chain).doFilter(any(ServletRequest.class), any(ServletResponse.class));
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+	}
+	
+	@Test
+	public void testInvalidAuthenticationReturnsUnauthorized()
+			throws Exception {
+		String token = "vasya:WRONG_PASSWORD";
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization",
+				"Basic " + new String(Base64.encodeBase64(token.getBytes())));
+		request.setServletPath("/some_file.html");
+		request.setSession(new MockHttpSession());
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		FilterChain chain = mock(FilterChain.class);
+		filter.doFilter(request, response, chain);
+
+		verify(chain, never()).doFilter(any(ServletRequest.class),
+				any(ServletResponse.class));
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+		assertThat(response.getHeader("WWW-Authenticate")).isNotNull();
+		assertThat(response.getHeader("WWW-Authenticate")).isEqualTo("Basic realm=\"springframework.com\"");
+	}
+	
+}


### PR DESCRIPTION
This PR targets to make Authentication Filters implementation to be more *"SOLID"*.
Currently there are set of different Atuhenticaion Filters like `BasicAuthenticationFilter`, `DigestAuthenticationFilter` etc. and most of such filters logic is almost the same:
1. expose `Authentication` from request (supply);
2. proceed filter chain, if there is no supported `Authentication` provided
3. authenticate the `Authentication` object with `AuthenticationManager`, if we have supported `Authentication`

This PR contains following main changes:
1. Added `AuthenticationSupplier` interface;
2. Added `GenericAuthenticationFilter` class;
3. Basic Authentication support implemented with `BasicAuthenticationSupplier` and `GenericAuthenticationFilter`;

If this concept will be accepted in general then additional changes can be provided.