### PR TITLE
Properties should reference scope not scopes

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/reactive/oauth2/access-token.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/reactive/oauth2/access-token.adoc
@@ -14,7 +14,7 @@ spring:
           github:
             client-id: replace-with-client-id
             client-secret: replace-with-client-secret
-            scopes: read:user,public_repo
+            scope: read:user,public_repo
 ----
 
 You will need to replace the `client-id` and `client-secret` with values registered with GitHub.

--- a/samples/boot/oauth2webclient-webflux/README.adoc
+++ b/samples/boot/oauth2webclient-webflux/README.adoc
@@ -40,7 +40,7 @@ spring:
             client-id: replace-with-client-id
             client-secret: replace-with-client-secret
             provider: github
-            scopes: read:user,public_repo
+            scope: read:user,public_repo
 ----
 +
 .OAuth Client properties

--- a/samples/boot/oauth2webclient-webflux/src/main/resources/application.yml
+++ b/samples/boot/oauth2webclient-webflux/src/main/resources/application.yml
@@ -16,6 +16,6 @@ spring:
             client-id: replace-with-client-id
             client-secret: replace-with-client-secret
             provider: github
-            scopes: read:user,public_repo
+            scope: read:user,public_repo
 
 resource-uri: https://api.github.com/user/repos

--- a/samples/boot/oauth2webclient/README.adoc
+++ b/samples/boot/oauth2webclient/README.adoc
@@ -40,7 +40,7 @@ spring:
             client-id: replace-with-client-id
             client-secret: replace-with-client-secret
             provider: github
-            scopes: read:user,public_repo
+            scope: read:user,public_repo
 ----
 +
 .OAuth Client properties

--- a/samples/boot/oauth2webclient/src/main/resources/application.yml
+++ b/samples/boot/oauth2webclient/src/main/resources/application.yml
@@ -16,6 +16,6 @@ spring:
             client-id: replace-with-client-id
             client-secret: replace-with-client-secret
             provider: github
-            scopes: read:user,public_repo
+            scope: read:user,public_repo
 
 resource-uri: https://api.github.com/user/repos


### PR DESCRIPTION
OAuth2ClientProperties.Registration has a member `scope` but not `scopes`. This is the easy fix for the sample but i think it should be `scopes`
