### PR TITLE
Fixed broken link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,7 +18,7 @@ See https://github.com/spring-projects/spring-framework/wiki/Downloading-Spring-
 
 == Documentation
 Be sure to read the http://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/[Spring Security Reference].
-Extensive JavaDoc for the Spring Security code is also available in the http://docs.spring.io/spring-security/site/docs/current/apidocs/[Spring Security API Documentation].
+Extensive JavaDoc for the Spring Security code is also available in the https://docs.spring.io/spring-security/site/docs/current/api/[Spring Security API Documentation].
 
 == Quick Start
 We recommend you visit http://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/[Spring Security Reference] and read the "Getting Started" page.
@@ -59,7 +59,7 @@ Check out the http://stackoverflow.com/questions/tagged/spring-security[Spring S
 http://spring.io/services[Commercial support] is available too.
 
 == Contributing
-http://help.github.com/send-pull-requests[Pull requests] are welcome; see the https://github.com/spring-projects/spring-security/blob/master/CONTRIBUTING.md[contributor guidelines] for details.
+https://help.github.com/articles/creating-a-pull-request[Pull requests] are welcome; see the https://github.com/spring-projects/spring-security/blob/master/CONTRIBUTING.md[contributor guidelines] for details.
 
 == License
 Spring Security is Open Source software released under the


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-security/issues/6521

Summary: Updated the **Pull Request** link in the README.adoc to point to the correct Github article https://help.github.com/articles/creating-a-pull-request instead of https://help.github.com/send-pull-requests which is broken. 

This link https://docs.spring.io/spring-security/site/docs/current/apidocs/ under https://github.com/spring-projects/spring-security/blob/master/README.adoc#documentation as **Spring Security API Documentation** is also broken. Added the correct URL https://docs.spring.io/spring-security/site/docs/current/api/ 

Also noticed that the initial PR had nickname instead of full name. I also squashed the commits to 1. 