### PR TITLE
Replace strange hashCode() implementations

### DIFF
--- a/acl/src/main/java/org/springframework/security/acls/domain/ObjectIdentityImpl.java
+++ b/acl/src/main/java/org/springframework/security/acls/domain/ObjectIdentityImpl.java
@@ -152,11 +152,9 @@ public class ObjectIdentityImpl implements ObjectIdentity {
 	 */
 	@Override
 	public int hashCode() {
-		int code = 31;
-		code ^= this.type.hashCode();
-		code ^= this.identifier.hashCode();
-
-		return code;
+		int result = this.type.hashCode();
+		result = 31 * result + this.identifier.hashCode();
+		return result;
 	}
 
 	@Override

--- a/core/src/main/java/org/springframework/security/authentication/jaas/JaasGrantedAuthority.java
+++ b/core/src/main/java/org/springframework/security/authentication/jaas/JaasGrantedAuthority.java
@@ -55,7 +55,9 @@ public final class JaasGrantedAuthority implements GrantedAuthority {
 
 	@Override
 	public int hashCode() {
-		return 31 ^ principal.hashCode() ^ role.hashCode();
+		int result = this.principal.hashCode();
+		result = 31 * result + this.role.hashCode();
+		return result;
 	}
 
 	@Override

--- a/web/src/main/java/org/springframework/security/web/access/intercept/RequestKey.java
+++ b/web/src/main/java/org/springframework/security/web/access/intercept/RequestKey.java
@@ -42,14 +42,9 @@ public class RequestKey {
 
 	@Override
 	public int hashCode() {
-		int code = 31;
-		code ^= url.hashCode();
-
-		if (method != null) {
-			code ^= method.hashCode();
-		}
-
-		return code;
+		int result = this.url.hashCode();
+		result = 31 * result + (this.method != null ? this.method.hashCode() : 0);
+		return result;
 	}
 
 	@Override

--- a/web/src/main/java/org/springframework/security/web/authentication/switchuser/SwitchUserGrantedAuthority.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/switchuser/SwitchUserGrantedAuthority.java
@@ -67,7 +67,9 @@ public final class SwitchUserGrantedAuthority implements GrantedAuthority {
 
 	@Override
 	public int hashCode() {
-		return 31 ^ source.hashCode() ^ role.hashCode();
+		int result = this.role.hashCode();
+		result = 31 * result + this.source.hashCode();
+		return result;
 	}
 
 	@Override

--- a/web/src/main/java/org/springframework/security/web/util/matcher/AntPathRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/AntPathRequestMatcher.java
@@ -220,11 +220,10 @@ public final class AntPathRequestMatcher
 
 	@Override
 	public int hashCode() {
-		int code = 31 ^ this.pattern.hashCode();
-		if (this.httpMethod != null) {
-			code ^= this.httpMethod.hashCode();
-		}
-		return code;
+		int result = this.pattern != null ? this.pattern.hashCode() : 0;
+		result = 31 * result + (this.httpMethod != null ? this.httpMethod.hashCode() : 0);
+		result = 31 * result + (this.caseSensitive ? 1231 : 1237);
+		return result;
 	}
 
 	@Override


### PR DESCRIPTION
XORing with 31 in these methods seems suspicious as it doesn't affect collision rate, it just flips the last 5 bits. And using bitwise XOR here just feels weird in general.
These are all unlikely to cause collisions but I would replace them with generated ones just in case.
All additions in this commit are generated by Eclipse.
