### PR TITLE
Polish URLs

### DIFF
--- a/acl/pom.xml
+++ b/acl/pom.xml
@@ -6,15 +6,15 @@
   <version>3.2.10.RELEASE</version>
   <name>spring-security-acl</name>
   <description>spring-security-acl</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/aspects/pom.xml
+++ b/aspects/pom.xml
@@ -6,15 +6,15 @@
   <version>3.2.10.RELEASE</version>
   <name>spring-security-aspects</name>
   <description>spring-security-aspects</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ allprojects {
        mavenCentral()
        maven { url "https://repo.spring.io/libs-snapshot" }
        maven { url "https://repo.spring.io/plugins-release" }
-       maven { url "http://repo.terracotta.org/maven2/" }
+       maven { url "https://repo.terracotta.org/maven2/" }
     }
 
     eclipse.project.name = "${project.name}-3.2.x"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -4,11 +4,11 @@ repositories {
     mavenCentral()
     maven {
         name = 'SpringSource Enterprise Release'
-        url = 'http://repository.springsource.com/maven/bundles/release'
+        url = 'https://repository.springsource.com/maven/bundles/release'
     }
     maven {
         name = 'SpringSource Enterprise External'
-        url = 'http://repository.springsource.com/maven/bundles/external'
+        url = 'https://repository.springsource.com/maven/bundles/external'
     }
 }
 

--- a/cas/pom.xml
+++ b/cas/pom.xml
@@ -6,15 +6,15 @@
   <version>3.2.10.RELEASE</version>
   <name>spring-security-cas</name>
   <description>spring-security-cas</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -6,15 +6,15 @@
   <version>3.2.10.RELEASE</version>
   <name>spring-security-config</name>
   <description>spring-security-config</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,15 +6,15 @@
   <version>3.2.10.RELEASE</version>
   <name>spring-security-core</name>
   <description>spring-security-core</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/crypto/pom.xml
+++ b/crypto/pom.xml
@@ -6,15 +6,15 @@
   <version>3.2.10.RELEASE</version>
   <name>spring-security-crypto</name>
   <description>spring-security-crypto</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/docs/docs.gradle
+++ b/docs/docs.gradle
@@ -61,9 +61,9 @@ task apidocs(type: Javadoc) {
 apidocs.options.outputLevel = org.gradle.external.javadoc.JavadocOutputLevel.QUIET
 
 apidocs.options.links = [
-    "http://static.springframework.org/spring/docs/3.2.x/javadoc-api",
-    "http://static.springsource.org/spring-ldap/docs/1.3.x/apidocs/",
-    "http://download.oracle.com/javase/6/docs/api/"
+    "https://docs.spring.io/spring/docs/3.2.x/javadoc-api",
+    "https://docs.spring.io/spring-ldap/docs/1.3.x/apidocs/",
+    "https://download.oracle.com/javase/6/docs/api/"
 ]
 
 apidocs.options.groups = [

--- a/gradle/javaprojects.gradle
+++ b/gradle/javaprojects.gradle
@@ -164,9 +164,9 @@ javadoc {
         header = project.name
         outputLevel = org.gradle.external.javadoc.JavadocOutputLevel.QUIET
         links = [
-            "http://static.springsource.org/spring/docs/3.2.x/javadoc-api/",
-            "http://static.springsource.org/spring-ldap/docs/1.3.x/apidocs/",
-            "http://download.oracle.com/javase/6/docs/api/"
+            "https://docs.spring.io/spring/docs/3.2.x/javadoc-api/",
+            "https://docs.spring.io/spring-ldap/docs/1.3.x/apidocs/",
+            "https://download.oracle.com/javase/6/docs/api/"
         ]
         groups = [
             'Spring Security Core':[
@@ -190,7 +190,7 @@ javadoc {
 
 eclipse.classpath.downloadSources = true
 
-// http://forums.gradle.org/gradle/topics/eclipse_wtp_deploys_testcode_to_server_example_provided
+// https://discuss.gradle.org/gradle/topics/eclipse_wtp_deploys_testcode_to_server_example_provided
 eclipse.classpath {
     defaultOutputDir = file('bin/main')
     file.whenMerged { cp ->

--- a/gradle/maven-deployment.gradle
+++ b/gradle/maven-deployment.gradle
@@ -43,15 +43,15 @@ def customizePom(pom, gradleProject) {
             packaging = "war"
         }
         description = gradleProject.name
-        url = 'http://spring.io/spring-security'
+        url = 'https://spring.io/spring-security'
         organization {
             name = 'spring.io'
-            url = 'http://spring.io/'
+            url = 'https://spring.io/'
         }
         licenses {
             license {
                 name 'The Apache Software License, Version 2.0'
-                url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                 distribution 'repo'
             }
         }
@@ -89,7 +89,7 @@ def customizePom(pom, gradleProject) {
         }
     }
 
-    // http://forums.gradle.org/gradle/topics/after_upgrade_gradle_to_2_0_version_the_maven_pom_not_support_build_property
+    // https://discuss.gradle.org/gradle/topics/after_upgrade_gradle_to_2_0_version_the_maven_pom_not_support_build_property
     pom.withXml {
         def plugins = asNode().appendNode('build').appendNode('plugins')
         plugins

--- a/itest/context/pom.xml
+++ b/itest/context/pom.xml
@@ -6,15 +6,15 @@
   <version>3.2.10.RELEASE</version>
   <name>itest-context</name>
   <description>itest-context</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/itest/web/pom.xml
+++ b/itest/web/pom.xml
@@ -6,15 +6,15 @@
   <version>3.2.10.RELEASE</version>
   <name>itest-web</name>
   <description>itest-web</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/ldap/pom.xml
+++ b/ldap/pom.xml
@@ -6,15 +6,15 @@
   <version>3.2.10.RELEASE</version>
   <name>spring-security-ldap</name>
   <description>spring-security-ldap</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -6,15 +6,15 @@
   <version>3.2.10.RELEASE</version>
   <name>spring-security-openid</name>
   <description>spring-security-openid</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/remoting/pom.xml
+++ b/remoting/pom.xml
@@ -6,15 +6,15 @@
   <version>3.2.10.RELEASE</version>
   <name>spring-security-remoting</name>
   <description>spring-security-remoting</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/aspectj-jc/pom.xml
+++ b/samples/aspectj-jc/pom.xml
@@ -6,15 +6,15 @@
   <version>3.2.10.RELEASE</version>
   <name>spring-security-samples-aspectj-jc</name>
   <description>spring-security-samples-aspectj-jc</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/aspectj-xml/pom.xml
+++ b/samples/aspectj-xml/pom.xml
@@ -6,15 +6,15 @@
   <version>3.2.10.RELEASE</version>
   <name>spring-security-samples-aspectj-xml</name>
   <description>spring-security-samples-aspectj-xml</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/cas/sample-xml/pom.xml
+++ b/samples/cas/sample-xml/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-cassample-xml</name>
   <description>spring-security-samples-cassample-xml</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/cas/server/pom.xml
+++ b/samples/cas/server/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-casserver</name>
   <description>spring-security-samples-casserver</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/concurrency-jc/pom.xml
+++ b/samples/concurrency-jc/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-concurrency-jc</name>
   <description>spring-security-samples-concurrency-jc</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/contacts-xml/pom.xml
+++ b/samples/contacts-xml/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-contacts-xml</name>
   <description>spring-security-samples-contacts-xml</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/dms-xml/pom.xml
+++ b/samples/dms-xml/pom.xml
@@ -6,15 +6,15 @@
   <version>3.2.10.RELEASE</version>
   <name>spring-security-samples-dms-xml</name>
   <description>spring-security-samples-dms-xml</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/form-jc/pom.xml
+++ b/samples/form-jc/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-form-jc</name>
   <description>spring-security-samples-form-jc</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/gae-xml/gae.gradle
+++ b/samples/gae-xml/gae.gradle
@@ -13,7 +13,7 @@ repositories {
     maven {
         // GAE Jars
         name =  'GAE'
-        url = 'http://maven-gae-plugin.googlecode.com/svn/repository'
+        url = 'https://maven-gae-plugin.googlecode.com/svn/repository'
     }
 }
 

--- a/samples/gae-xml/pom.xml
+++ b/samples/gae-xml/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-gae-xml</name>
   <description>spring-security-samples-gae-xml</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/hellojs-jc/pom.xml
+++ b/samples/hellojs-jc/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-hellojs-jc</name>
   <description>spring-security-samples-hellojs-jc</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/hellomvc-jc/pom.xml
+++ b/samples/hellomvc-jc/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-hellomvc-jc</name>
   <description>spring-security-samples-hellomvc-jc</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/helloworld-jc/pom.xml
+++ b/samples/helloworld-jc/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-helloworld-jc</name>
   <description>spring-security-samples-helloworld-jc</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/inmemory-jc/pom.xml
+++ b/samples/inmemory-jc/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-inmemory-jc</name>
   <description>spring-security-samples-inmemory-jc</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/insecure/pom.xml
+++ b/samples/insecure/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-insecure</name>
   <description>spring-security-samples-insecure</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/insecuremvc/pom.xml
+++ b/samples/insecuremvc/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-insecuremvc</name>
   <description>spring-security-samples-insecuremvc</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/jaas-xml/pom.xml
+++ b/samples/jaas-xml/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-jaas-xml</name>
   <description>spring-security-samples-jaas-xml</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/jdbc-jc/pom.xml
+++ b/samples/jdbc-jc/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-jdbc-jc</name>
   <description>spring-security-samples-jdbc-jc</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/ldap-jc/pom.xml
+++ b/samples/ldap-jc/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-ldap-jc</name>
   <description>spring-security-samples-ldap-jc</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/ldap-xml/pom.xml
+++ b/samples/ldap-xml/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-ldap-xml</name>
   <description>spring-security-samples-ldap-xml</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/messages-jc/pom.xml
+++ b/samples/messages-jc/pom.xml
@@ -6,15 +6,15 @@
   <version>3.2.10.RELEASE</version>
   <name>spring-security-samples-messages-jc</name>
   <description>spring-security-samples-messages-jc</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/openid-jc/pom.xml
+++ b/samples/openid-jc/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-openid-jc</name>
   <description>spring-security-samples-openid-jc</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/openid-xml/pom.xml
+++ b/samples/openid-xml/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-openid-xml</name>
   <description>spring-security-samples-openid-xml</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/preauth-jc/pom.xml
+++ b/samples/preauth-jc/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-preauth-jc</name>
   <description>spring-security-samples-preauth-jc</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/preauth-xml/pom.xml
+++ b/samples/preauth-xml/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-preauth-xml</name>
   <description>spring-security-samples-preauth-xml</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/rememberme-jc/pom.xml
+++ b/samples/rememberme-jc/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-rememberme-jc</name>
   <description>spring-security-samples-rememberme-jc</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/servletapi-xml/pom.xml
+++ b/samples/servletapi-xml/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-servletapi-xml</name>
   <description>spring-security-samples-servletapi-xml</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/tutorial-xml/pom.xml
+++ b/samples/tutorial-xml/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-tutorial-xml</name>
   <description>spring-security-samples-tutorial-xml</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/x509-jc/pom.xml
+++ b/samples/x509-jc/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-x509-jc</name>
   <description>spring-security-samples-x509-jc</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/taglibs/pom.xml
+++ b/taglibs/pom.xml
@@ -6,15 +6,15 @@
   <version>3.2.10.RELEASE</version>
   <name>spring-security-taglibs</name>
   <description>spring-security-taglibs</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -6,15 +6,15 @@
   <version>3.2.10.RELEASE</version>
   <name>spring-security-web</name>
   <description>spring-security-web</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
We have performed some polish on your URLs. We do not follow redirects to avoid expanding intentionally shorter URLs (i.e. URL shortened URLs)

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request, so we migrated them. Your review is recommended.

| HTTP URL | Result URL | HTTPS Result | HTTP Result | Count |
| --- | --- | --- | --- | --- |
| http://repo.terracotta.org/maven2/ | https://repo.terracotta.org/maven2/ | HttpResponse(httpStatus = 403 FORBIDDEN) | HttpResponse(httpStatus = 403 FORBIDDEN) | 1 |
| http://maven-gae-plugin.googlecode.com/svn/repository | https://maven-gae-plugin.googlecode.com/svn/repository | HttpResponse(httpStatus = 404 NOT_FOUND) | HttpResponse(httpStatus = 404 NOT_FOUND) | 1 |
| http://repository.springsource.com/maven/bundles/external | https://repository.springsource.com/maven/bundles/external | HttpResponse(httpStatus = 404 NOT_FOUND) | HttpResponse(httpStatus = 404 NOT_FOUND) | 1 |
| http://repository.springsource.com/maven/bundles/release | https://repository.springsource.com/maven/bundles/release | HttpResponse(httpStatus = 404 NOT_FOUND) | HttpResponse(httpStatus = 404 NOT_FOUND) | 1 |
## Fixed Success 
These URLs were fixed successfully.

| HTTP URL | Result URL | HTTPS Result | HTTP Result | Count |
| --- | --- | --- | --- | --- |
| http://docs.spring.io/spring-ldap/docs/1.3.x/apidocs/ | https://docs.spring.io/spring-ldap/docs/1.3.x/apidocs/ | HttpResponse(httpStatus = 200 OK) | null | 2 |
| http://docs.spring.io/spring/docs/3.2.x/javadoc-api | https://docs.spring.io/spring/docs/3.2.x/javadoc-api | HttpResponse(httpStatus = 301 MOVED_PERMANENTLY redirectUrl = http://docs.spring.io/spring/docs/3.2.x/javadoc-api/) | null | 1 |
| http://docs.spring.io/spring/docs/3.2.x/javadoc-api/ | https://docs.spring.io/spring/docs/3.2.x/javadoc-api/ | HttpResponse(httpStatus = 200 OK) | null | 1 |
| http://download.oracle.com/javase/6/docs/api/ | https://download.oracle.com/javase/6/docs/api/ | HttpResponse(httpStatus = 302 FOUND redirectUrl = https://docs.oracle.com/javase/6/docs/api/) | null | 2 |
| http://spring.io/ | https://spring.io/ | HttpResponse(httpStatus = 200 OK) | null | 42 |
| http://spring.io/spring-security | https://spring.io/spring-security | HttpResponse(httpStatus = 302 FOUND redirectUrl = https://projects.spring.io/spring-security) | null | 42 |
| http://www.apache.org/licenses/LICENSE-2.0.txt | https://www.apache.org/licenses/LICENSE-2.0.txt | HttpResponse(httpStatus = 200 OK) | null | 42 |
| http://forums.gradle.org/gradle/topics/after_upgrade_gradle_to_2_0_version_the_maven_pom_not_support_build_property | https://discuss.gradle.org/gradle/topics/after_upgrade_gradle_to_2_0_version_the_maven_pom_not_support_build_property | HttpResponse(httpStatus = 404 NOT_FOUND) | HttpResponse(httpStatus = 301 MOVED_PERMANENTLY redirectUrl = https://discuss.gradle.org/gradle/topics/after_upgrade_gradle_to_2_0_version_the_maven_pom_not_support_build_property) | 1 |
| http://forums.gradle.org/gradle/topics/eclipse_wtp_deploys_testcode_to_server_example_provided | https://discuss.gradle.org/gradle/topics/eclipse_wtp_deploys_testcode_to_server_example_provided | HttpResponse(httpStatus = 404 NOT_FOUND) | HttpResponse(httpStatus = 301 MOVED_PERMANENTLY redirectUrl = https://discuss.gradle.org/gradle/topics/eclipse_wtp_deploys_testcode_to_server_example_provided) | 1 |

# Ignored
These URLs were intentionally ignored so we didn't migrate them.

| HTTP URL |
| --- |
| http://maven.apache.org/POM/4.0.0 | 
| http://maven.apache.org/xsd/maven-4.0.0.xsd | 
| http://www.w3.org/2001/XMLSchema-instance |