### PR TITLE
Polish URLs

### DIFF
--- a/acl/pom.xml
+++ b/acl/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-acl</name>
   <description>spring-security-acl</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/aspects/pom.xml
+++ b/aspects/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-aspects</name>
   <description>spring-security-aspects</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
 	mavenCentral()
 	maven { url "https://repo.spring.io/libs-snapshot" }
 	maven { url "https://repo.spring.io/plugins-release" }
-	maven { url "http://repo.terracotta.org/maven2/" }
+	maven { url "https://repo.terracotta.org/maven2/" }
 	}
 
 	eclipse.project.name = "${project.name}-4.1.x"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -4,11 +4,11 @@ repositories {
 	mavenCentral()
 	maven {
 		name = 'SpringSource Enterprise Release'
-		url = 'http://repository.springsource.com/maven/bundles/release'
+		url = 'https://repository.springsource.com/maven/bundles/release'
 	}
 	maven {
 		name = 'SpringSource Enterprise External'
-		url = 'http://repository.springsource.com/maven/bundles/external'
+		url = 'https://repository.springsource.com/maven/bundles/external'
 	}
 }
 

--- a/cas/pom.xml
+++ b/cas/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-cas</name>
   <description>spring-security-cas</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-config</name>
   <description>spring-security-config</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-core</name>
   <description>spring-security-core</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/crypto/pom.xml
+++ b/crypto/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-crypto</name>
   <description>spring-security-crypto</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-data</name>
   <description>spring-security-data</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/docs/docs.gradle
+++ b/docs/docs.gradle
@@ -77,9 +77,9 @@ task apidocs(type: Javadoc) {
 	options {
 		outputLevel = org.gradle.external.javadoc.JavadocOutputLevel.QUIET
 		links = [
-			"http://static.springframework.org/spring/docs/3.2.x/javadoc-api",
-			"http://static.springsource.org/spring-ldap/docs/1.3.x/apidocs/",
-			"http://download.oracle.com/javase/6/docs/api/"
+			"https://docs.spring.io/spring/docs/3.2.x/javadoc-api",
+			"https://docs.spring.io/spring-ldap/docs/1.3.x/apidocs/",
+			"https://download.oracle.com/javase/6/docs/api/"
 		]
 		groups = [
 			'Spring Security Core':[

--- a/gradle/ide.gradle
+++ b/gradle/ide.gradle
@@ -57,7 +57,7 @@ eclipse {
 	}
 }
 
-// http://forums.gradle.org/gradle/topics/eclipse_wtp_deploys_testcode_to_server_example_provided
+// https://discuss.gradle.org/gradle/topics/eclipse_wtp_deploys_testcode_to_server_example_provided
 eclipse.classpath {
 	defaultOutputDir = file('bin/main')
 	file.whenMerged { cp ->

--- a/gradle/javaprojects.gradle
+++ b/gradle/javaprojects.gradle
@@ -195,9 +195,9 @@ javadoc {
 		header = project.name
 		outputLevel = org.gradle.external.javadoc.JavadocOutputLevel.QUIET
 		links = [
-			"http://static.springsource.org/spring/docs/3.2.x/javadoc-api/",
-			"http://static.springsource.org/spring-ldap/docs/1.3.x/apidocs/",
-			"http://download.oracle.com/javase/6/docs/api/"
+			"https://docs.spring.io/spring/docs/3.2.x/javadoc-api/",
+			"https://docs.spring.io/spring-ldap/docs/1.3.x/apidocs/",
+			"https://download.oracle.com/javase/6/docs/api/"
 		]
 		groups = [
 			'Spring Security Core':[

--- a/gradle/maven-deployment.gradle
+++ b/gradle/maven-deployment.gradle
@@ -46,15 +46,15 @@ def customizePom(pom, gradleProject) {
 			packaging = "war"
 		}
 		description = gradleProject.name
-		url = 'http://spring.io/spring-security'
+		url = 'https://spring.io/spring-security'
 		organization {
 			name = 'spring.io'
-			url = 'http://spring.io/'
+			url = 'https://spring.io/'
 		}
 		licenses {
 			license {
 				name 'The Apache Software License, Version 2.0'
-				url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+				url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 				distribution 'repo'
 			}
 		}
@@ -106,7 +106,7 @@ def customizePom(pom, gradleProject) {
 		}
 	}
 
-	// http://forums.gradle.org/gradle/topics/after_upgrade_gradle_to_2_0_version_the_maven_pom_not_support_build_property
+	// https://discuss.gradle.org/gradle/topics/after_upgrade_gradle_to_2_0_version_the_maven_pom_not_support_build_property
 	pom.withXml {
 		def plugins = asNode().appendNode('build').appendNode('plugins')
 		plugins

--- a/itest/context/pom.xml
+++ b/itest/context/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>itest-context</name>
   <description>itest-context</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/itest/web/pom.xml
+++ b/itest/web/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>itest-web</name>
   <description>itest-web</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/ldap/pom.xml
+++ b/ldap/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-ldap</name>
   <description>spring-security-ldap</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-messaging</name>
   <description>spring-security-messaging</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-openid</name>
   <description>spring-security-openid</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/remoting/pom.xml
+++ b/remoting/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-remoting</name>
   <description>spring-security-remoting</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/boot/helloworld/pom.xml
+++ b/samples/boot/helloworld/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-samples-boot-helloworld</name>
   <description>spring-security-samples-boot-helloworld</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/boot/insecure/pom.xml
+++ b/samples/boot/insecure/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-samples-boot-insecure</name>
   <description>spring-security-samples-boot-insecure</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/javaconfig/aspectj/pom.xml
+++ b/samples/javaconfig/aspectj/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-samples-javaconfig-aspectj</name>
   <description>spring-security-samples-javaconfig-aspectj</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/javaconfig/chat/pom.xml
+++ b/samples/javaconfig/chat/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-chat</name>
   <description>spring-security-samples-javaconfig-chat</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/javaconfig/concurrency/pom.xml
+++ b/samples/javaconfig/concurrency/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-concurrency</name>
   <description>spring-security-samples-javaconfig-concurrency</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/javaconfig/data/pom.xml
+++ b/samples/javaconfig/data/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-samples-javaconfig-data</name>
   <description>spring-security-samples-javaconfig-data</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/javaconfig/form/pom.xml
+++ b/samples/javaconfig/form/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-form</name>
   <description>spring-security-samples-javaconfig-form</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/javaconfig/hellojs/pom.xml
+++ b/samples/javaconfig/hellojs/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-hellojs</name>
   <description>spring-security-samples-javaconfig-hellojs</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/javaconfig/hellomvc/pom.xml
+++ b/samples/javaconfig/hellomvc/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-hellomvc</name>
   <description>spring-security-samples-javaconfig-hellomvc</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/javaconfig/helloworld/pom.xml
+++ b/samples/javaconfig/helloworld/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-helloworld</name>
   <description>spring-security-samples-javaconfig-helloworld</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/javaconfig/inmemory/pom.xml
+++ b/samples/javaconfig/inmemory/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-inmemory</name>
   <description>spring-security-samples-javaconfig-inmemory</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/javaconfig/jdbc/pom.xml
+++ b/samples/javaconfig/jdbc/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-jdbc</name>
   <description>spring-security-samples-javaconfig-jdbc</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/javaconfig/ldap/pom.xml
+++ b/samples/javaconfig/ldap/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-ldap</name>
   <description>spring-security-samples-javaconfig-ldap</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/javaconfig/messages/pom.xml
+++ b/samples/javaconfig/messages/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-samples-javaconfig-messages</name>
   <description>spring-security-samples-javaconfig-messages</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/javaconfig/openid/pom.xml
+++ b/samples/javaconfig/openid/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-openid</name>
   <description>spring-security-samples-javaconfig-openid</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/javaconfig/pom.xml
+++ b/samples/javaconfig/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.0.BUILD-SNAPSHOT</version>
   <name>javaconfig</name>
   <description>javaconfig</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/javaconfig/preauth/pom.xml
+++ b/samples/javaconfig/preauth/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-preauth</name>
   <description>spring-security-samples-javaconfig-preauth</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/javaconfig/rememberme/pom.xml
+++ b/samples/javaconfig/rememberme/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-rememberme</name>
   <description>spring-security-samples-javaconfig-rememberme</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/javaconfig/x509/pom.xml
+++ b/samples/javaconfig/x509/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-javaconfig-x509</name>
   <description>spring-security-samples-javaconfig-x509</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.0.BUILD-SNAPSHOT</version>
   <name>samples</name>
   <description>samples</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/xml/aspectj/pom.xml
+++ b/samples/xml/aspectj/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-samples-xml-aspectj</name>
   <description>spring-security-samples-xml-aspectj</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/xml/cas/cassample/pom.xml
+++ b/samples/xml/cas/cassample/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-xml-cassample</name>
   <description>spring-security-samples-xml-cassample</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/xml/cas/casserver/pom.xml
+++ b/samples/xml/cas/casserver/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-xml-casserver</name>
   <description>spring-security-samples-xml-casserver</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/xml/cas/pom.xml
+++ b/samples/xml/cas/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.0.BUILD-SNAPSHOT</version>
   <name>cas</name>
   <description>cas</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/xml/contacts/pom.xml
+++ b/samples/xml/contacts/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-xml-contacts</name>
   <description>spring-security-samples-xml-contacts</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/xml/dms/pom.xml
+++ b/samples/xml/dms/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-samples-xml-dms</name>
   <description>spring-security-samples-xml-dms</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/xml/gae/pom.xml
+++ b/samples/xml/gae/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-xml-gae</name>
   <description>spring-security-samples-xml-gae</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/xml/helloworld/pom.xml
+++ b/samples/xml/helloworld/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-xml-helloworld</name>
   <description>spring-security-samples-xml-helloworld</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/xml/insecure/pom.xml
+++ b/samples/xml/insecure/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-xml-insecure</name>
   <description>spring-security-samples-xml-insecure</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/xml/insecuremvc/pom.xml
+++ b/samples/xml/insecuremvc/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-xml-insecuremvc</name>
   <description>spring-security-samples-xml-insecuremvc</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/xml/jaas/pom.xml
+++ b/samples/xml/jaas/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-xml-jaas</name>
   <description>spring-security-samples-xml-jaas</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/xml/ldap/pom.xml
+++ b/samples/xml/ldap/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-xml-ldap</name>
   <description>spring-security-samples-xml-ldap</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/xml/openid/pom.xml
+++ b/samples/xml/openid/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-xml-openid</name>
   <description>spring-security-samples-xml-openid</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/xml/pom.xml
+++ b/samples/xml/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.0.BUILD-SNAPSHOT</version>
   <name>xml</name>
   <description>xml</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/xml/preauth/pom.xml
+++ b/samples/xml/preauth/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-xml-preauth</name>
   <description>spring-security-samples-xml-preauth</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/xml/servletapi/pom.xml
+++ b/samples/xml/servletapi/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-xml-servletapi</name>
   <description>spring-security-samples-xml-servletapi</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/samples/xml/tutorial/pom.xml
+++ b/samples/xml/tutorial/pom.xml
@@ -7,15 +7,15 @@
   <packaging>war</packaging>
   <name>spring-security-samples-xml-tutorial</name>
   <description>spring-security-samples-xml-tutorial</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/taglibs/pom.xml
+++ b/taglibs/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-taglibs</name>
   <description>spring-security-taglibs</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-test</name>
   <description>spring-security-test</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -6,15 +6,15 @@
   <version>4.1.5.RELEASE</version>
   <name>spring-security-web</name>
   <description>spring-security-web</description>
-  <url>http://spring.io/spring-security</url>
+  <url>https://spring.io/spring-security</url>
   <organization>
     <name>spring.io</name>
-    <url>http://spring.io/</url>
+    <url>https://spring.io/</url>
   </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
We have performed some polish on your URLs. We do not follow redirects to avoid expanding intentionally shorter URLs (i.e. URL shortened URLs)

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request, so we migrated them. Your review is recommended.

| HTTP URL | Result URL | HTTPS Result | HTTP Result | Count |
| --- | --- | --- | --- | --- |
| http://repo.terracotta.org/maven2/ | https://repo.terracotta.org/maven2/ | HttpResponse(httpStatus = 403 FORBIDDEN) | HttpResponse(httpStatus = 403 FORBIDDEN) | 1 |
| http://repository.springsource.com/maven/bundles/external | https://repository.springsource.com/maven/bundles/external | HttpResponse(httpStatus = 404 NOT_FOUND) | HttpResponse(httpStatus = 404 NOT_FOUND) | 1 |
| http://repository.springsource.com/maven/bundles/release | https://repository.springsource.com/maven/bundles/release | HttpResponse(httpStatus = 404 NOT_FOUND) | HttpResponse(httpStatus = 404 NOT_FOUND) | 1 |
## Fixed Success 
These URLs were fixed successfully.

| HTTP URL | Result URL | HTTPS Result | HTTP Result | Count |
| --- | --- | --- | --- | --- |
| http://docs.spring.io/spring-ldap/docs/1.3.x/apidocs/ | https://docs.spring.io/spring-ldap/docs/1.3.x/apidocs/ | HttpResponse(httpStatus = 200 OK) | null | 2 |
| http://docs.spring.io/spring/docs/3.2.x/javadoc-api | https://docs.spring.io/spring/docs/3.2.x/javadoc-api | HttpResponse(httpStatus = 301 MOVED_PERMANENTLY redirectUrl = http://docs.spring.io/spring/docs/3.2.x/javadoc-api/) | null | 1 |
| http://docs.spring.io/spring/docs/3.2.x/javadoc-api/ | https://docs.spring.io/spring/docs/3.2.x/javadoc-api/ | HttpResponse(httpStatus = 200 OK) | null | 1 |
| http://download.oracle.com/javase/6/docs/api/ | https://download.oracle.com/javase/6/docs/api/ | HttpResponse(httpStatus = 302 FOUND redirectUrl = https://docs.oracle.com/javase/6/docs/api/) | null | 2 |
| http://spring.io/ | https://spring.io/ | HttpResponse(httpStatus = 200 OK) | null | 54 |
| http://spring.io/spring-security | https://spring.io/spring-security | HttpResponse(httpStatus = 302 FOUND redirectUrl = https://projects.spring.io/spring-security) | null | 54 |
| http://www.apache.org/licenses/LICENSE-2.0.txt | https://www.apache.org/licenses/LICENSE-2.0.txt | HttpResponse(httpStatus = 200 OK) | null | 54 |
| http://forums.gradle.org/gradle/topics/after_upgrade_gradle_to_2_0_version_the_maven_pom_not_support_build_property | https://discuss.gradle.org/gradle/topics/after_upgrade_gradle_to_2_0_version_the_maven_pom_not_support_build_property | HttpResponse(httpStatus = 404 NOT_FOUND) | HttpResponse(httpStatus = 301 MOVED_PERMANENTLY redirectUrl = https://discuss.gradle.org/gradle/topics/after_upgrade_gradle_to_2_0_version_the_maven_pom_not_support_build_property) | 1 |
| http://forums.gradle.org/gradle/topics/eclipse_wtp_deploys_testcode_to_server_example_provided | https://discuss.gradle.org/gradle/topics/eclipse_wtp_deploys_testcode_to_server_example_provided | HttpResponse(httpStatus = 404 NOT_FOUND) | HttpResponse(httpStatus = 301 MOVED_PERMANENTLY redirectUrl = https://discuss.gradle.org/gradle/topics/eclipse_wtp_deploys_testcode_to_server_example_provided) | 1 |

# Ignored
These URLs were intentionally ignored so we didn't migrate them.

| HTTP URL |
| --- |
| http://maven.apache.org/POM/4.0.0 | 
| http://maven.apache.org/xsd/maven-4.0.0.xsd | 
| http://www.w3.org/2001/XMLSchema-instance |