### PR TITLE
documentation: remove out-of-date

### DIFF
--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.2.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.2.rnc
@@ -365,9 +365,6 @@ intercept-url.attlist &=
 	attribute method {"GET" | "DELETE" | "HEAD" | "OPTIONS" | "POST" | "PUT" | "PATCH" | "TRACE"}?
 
 intercept-url.attlist &=
-	## The filter list for the path. Currently can be set to "none" to remove a path from having any filters applied. The full filter stack (consisting of all filters created by the namespace configuration, and any added using 'custom-filter'), will be applied to any other paths.
-	attribute filters {"none"}?
-intercept-url.attlist &=
 	## Used to specify that a URL must be accessed over http or https, or that there is no preference. The value should be "http", "https" or "any", respectively.
 	attribute requires-channel {xsd:token}?
 intercept-url.attlist &=

--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.2.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.2.xsd
@@ -1284,20 +1284,6 @@
             </xs:restriction>
          </xs:simpleType>
       </xs:attribute>
-      <xs:attribute name="filters">
-         <xs:annotation>
-            <xs:documentation>The filter list for the path. Currently can be set to "none" to remove a path from having
-                any filters applied. The full filter stack (consisting of all filters created by the
-                namespace configuration, and any added using 'custom-filter'), will be applied to any
-                other paths.
-                </xs:documentation>
-         </xs:annotation>
-         <xs:simpleType>
-            <xs:restriction base="xs:token">
-               <xs:enumeration value="none"/>
-            </xs:restriction>
-         </xs:simpleType>
-      </xs:attribute>
       <xs:attribute name="requires-channel" type="xs:token">
          <xs:annotation>
             <xs:documentation>Used to specify that a URL must be accessed over http or https, or that there is no

--- a/docs/manual/src/docs/asciidoc/_includes/preface/samples.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/preface/samples.adoc
@@ -2,10 +2,9 @@
 
 [[sample-apps]]
 == Sample Applications
-There are several sample web applications that are available with the project.
-To avoid an overly large download, only the "tutorial" and "contacts" samples are included in the distribution zip file.
-The others can be built directly from the source which you can obtain as described in <<get-source,the introduction>>.
-It's easy to build the project yourself and there's more information on the project web site at https://spring.io/spring-security/[https://spring.io/spring-security/].
+There are several {gh-samples-url}[sample web applications] that ship with the project's <<community-source,source code>>.
+You can find the ones described below in the ({gh-samples-url}/xml[samples/xml/] subdirectory of the root project)
+
 All paths referred to in this chapter are relative to the project source directory.
 
 

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/appendix/namespace.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/appendix/namespace.adoc
@@ -950,15 +950,6 @@ Lists the access attributes which will be stored in the `FilterInvocationSecurit
 This should be a comma-separated list of the security configuration attributes (such as role names).
 
 
-[[nsa-intercept-url-filters]]
-* **filters**
-Can only take the value "none".
-This will cause any matching request to bypass the Spring Security filter chain entirely.
-None of the rest of the `<http>` configuration will have any effect on the request and there will be no security context available for its duration.
-Access to secured methods during the request will fail.
-
-NOTE: This property is invalid for <<nsa-filter-security-metadata-source,filter-security-metadata-source>>
-
 [[nsa-intercept-url-method]]
 * **method**
 The HTTP Method which will be used in combination with the pattern and servlet path (optional) to match an incoming request.


### PR DESCRIPTION
- #5553: Documentation on \<intercept-url filters="..."\> is outdated
- #6602: Spring Security 5 docs references distribution zip, which does not exist