### PR TITLE
Throw exception that was created but not thrown

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/www/DigestAuthenticationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/DigestAuthenticationFilter.java
@@ -431,7 +431,7 @@ public class DigestAuthenticationFilter extends GenericFilterBean
 					.md5Hex(this.nonceExpiryTime + ":" + entryPointKey);
 
 			if (!expectedNonceSignature.equals(nonceTokens[1])) {
-				new BadCredentialsException(DigestAuthenticationFilter.this.messages
+				throw new BadCredentialsException(DigestAuthenticationFilter.this.messages
 						.getMessage("DigestAuthenticationFilter.nonceCompromised",
 								new Object[] { nonceAsPlainText },
 								"Nonce token compromised {0}"));


### PR DESCRIPTION
Fixes #5462 

In the `DigestAuthenticationFilter`, a `BadCredentialsException` was created when the nonce signature is invalid, but never thrown.

This case is already covered by a test (`testNonceWithIncorrectSignatureForNumericFieldReturnsForbidden` in the `DigestAuthenticationFilterTests` class), but it was green since an exception was thrown anyway at a later point of the filter, resulting in a 401 status (line 217).
https://github.com/spring-projects/spring-security/blob/ad9dc49d5559ff0b093ee425da57b77d46d69e07/web/src/main/java/org/springframework/security/web/authentication/www/DigestAuthenticationFilter.java#L217)
