### PR TITLE
Enable to expand authorization URI from base url.

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/DefaultOAuth2AuthorizationRequestResolver.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/DefaultOAuth2AuthorizationRequestResolver.java
@@ -98,6 +98,22 @@ public final class DefaultOAuth2AuthorizationRequestResolver implements OAuth2Au
 		return action;
 	}
 
+	private String expandAuthorizationUri(HttpServletRequest request, String authorizationUri) {
+		// Supported URI variables -> baseUrl
+		Map<String, String> uriVariables = new HashMap<>();
+
+		String baseUrl = UriComponentsBuilder.fromHttpUrl(UrlUtils.buildFullRequestUrl(request))
+				.replaceQuery(null)
+				.replacePath(request.getContextPath())
+				.build()
+				.toUriString();
+		uriVariables.put("baseUrl", baseUrl);
+
+		return UriComponentsBuilder.fromUriString(authorizationUri)
+				.buildAndExpand(uriVariables)
+				.toUriString();
+	}
+
 	private OAuth2AuthorizationRequest resolve(HttpServletRequest request, String registrationId, String redirectUriAction) {
 		if (registrationId == null) {
 			return null;
@@ -131,7 +147,8 @@ public final class DefaultOAuth2AuthorizationRequestResolver implements OAuth2Au
 
 		OAuth2AuthorizationRequest authorizationRequest = builder
 				.clientId(clientRegistration.getClientId())
-				.authorizationUri(clientRegistration.getProviderDetails().getAuthorizationUri())
+				.authorizationUri(expandAuthorizationUri(request,
+						clientRegistration.getProviderDetails().getAuthorizationUri()))
 				.redirectUri(redirectUriStr)
 				.scopes(clientRegistration.getScopes())
 				.state(this.stateGenerator.generateKey())

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/TestClientRegistrations.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/TestClientRegistrations.java
@@ -55,6 +55,21 @@ public class TestClientRegistrations {
 				.clientSecret("client-secret");
 	}
 
+	public static ClientRegistration.Builder clientRegistration3() {
+		return ClientRegistration.withRegistrationId("registration-id-3")
+				.redirectUriTemplate("{baseUrl}/{action}/oauth2/code/{registrationId}")
+				.clientAuthenticationMethod(ClientAuthenticationMethod.BASIC)
+				.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+				.scope("read:user")
+				.authorizationUri("{baseUrl}/login/oauth/authorize")
+				.tokenUri("https://example.com/login/oauth/access_token")
+				.userInfoUri("https://api.example.com/user")
+				.userNameAttributeName("id")
+				.clientName("Client Name")
+				.clientId("client-id-3")
+				.clientSecret("client-secret");
+	}
+
 	public static ClientRegistration.Builder clientCredentials() {
 		return clientRegistration()
 				.registrationId("client-credentials")

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/server/DefaultServerOAuth2AuthorizationRequestResolverTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/server/DefaultServerOAuth2AuthorizationRequestResolverTests.java
@@ -85,6 +85,21 @@ public class DefaultServerOAuth2AuthorizationRequestResolverTests {
 				"redirect_uri=/login/oauth2/code/registration-id");
 	}
 
+	@Test
+	public void resolveWhenAuthorizationRequestAuthorizationUriTemplatedThenAuthorizationUriExpanded() {
+		ClientRegistration registration = TestClientRegistrations.clientRegistration3().build();
+
+		when(this.clientRegistrationRepository.findByRegistrationId(any())).thenReturn(
+				Mono.just(registration));
+
+		OAuth2AuthorizationRequest request = resolve("https://example.com/oauth2/authorization/id");
+
+		assertThat(request.getAuthorizationRequestUri()).matches("https://example.com/login/oauth/authorize\\?" +
+				"response_type=code&client_id=client-id-3&" +
+				"scope=read:user&state=.*?&" +
+				"redirect_uri=https://example.com/login/oauth2/code/registration-id-3");
+	}
+
 	private OAuth2AuthorizationRequest resolve(String path) {
 		ServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get(path));
 		return this.resolver.resolve(exchange).block();


### PR DESCRIPTION
We use spring security with spring-cloud-gateway and we expect the oauth2 authorization URI which will be redirected to the user can be expand from incoming request's base url. So that we can determine the host and protocol dynamically and add gateway's context path to authorization URI. This patch add such feature and keep the backward compatibility.