### PR TITLE
URL Cleanup

### DIFF
--- a/acl/src/test/resources/jdbcMutableAclServiceTests-context.xml
+++ b/acl/src/test/resources/jdbcMutableAclServiceTests-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "https://www.springframework.org/dtd/spring-beans.dtd">
 
 <!--
   - Application context containing business beans.

--- a/acl/src/test/resources/jdbcMutableAclServiceTestsWithAclClass-context.xml
+++ b/acl/src/test/resources/jdbcMutableAclServiceTestsWithAclClass-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
   <import resource="jdbcMutableAclServiceTests-context.xml"/>
 

--- a/cas/src/test/resources/org/springframework/security/cas/web/authentication/defaultserviceauthenticationdetails-explicit.xml
+++ b/cas/src/test/resources/org/springframework/security/cas/web/authentication/defaultserviceauthenticationdetails-explicit.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:p="http://www.springframework.org/schema/p" xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-3.0.xsd">
 
 	<bean id="serviceProperties"
 		  class="org.springframework.security.cas.ServiceProperties">

--- a/cas/src/test/resources/org/springframework/security/cas/web/authentication/defaultserviceauthenticationdetails-passivity.xml
+++ b/cas/src/test/resources/org/springframework/security/cas/web/authentication/defaultserviceauthenticationdetails-passivity.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:p="http://www.springframework.org/schema/p" xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-3.0.xsd">
 
 	<bean id="serviceProperties"
 		  class="org.springframework.security.cas.ServiceProperties">

--- a/config/src/main/resources/org/springframework/security/config/catalog.xml
+++ b/config/src/main/resources/org/springframework/security/config/catalog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE catalog PUBLIC "-//OASIS//DTD Entity Resolution XML Catalog V1.0//EN" "http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
+<!DOCTYPE catalog PUBLIC "-//OASIS//DTD Entity Resolution XML Catalog V1.0//EN" "https://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-	<system systemId="http://www.springframework.org/schema/security/spring-security-2.0.xsd" uri="spring-security-2.0.xsd"/>
+	<system systemId="https://www.springframework.org/schema/security/spring-security-2.0.xsd" uri="spring-security-2.0.xsd"/>
 </catalog>

--- a/config/src/test/resources/org/springframework/security/config/annotation/configuration/AutowireBeanFactoryObjectPostProcessorTests-aopconfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/annotation/configuration/AutowireBeanFactoryObjectPostProcessorTests-aopconfig.xml
@@ -4,9 +4,9 @@
 	xmlns:aop="http://www.springframework.org/schema/aop"
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd
-		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.2.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.2.xsd
+		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-3.2.xsd">
 
 	<context:annotation-config/>
 

--- a/config/src/test/resources/org/springframework/security/config/authentication/PasswordEncoderParserTests-bean.xml
+++ b/config/src/test/resources/org/springframework/security/config/authentication/PasswordEncoderParserTests-bean.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns="http://www.springframework.org/schema/security"
 		 xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<b:bean id="passwordEncoder" class="org.springframework.security.crypto.password.NoOpPasswordEncoder" factory-method="getInstance"/>
 

--- a/config/src/test/resources/org/springframework/security/config/authentication/PasswordEncoderParserTests-default.xml
+++ b/config/src/test/resources/org/springframework/security/config/authentication/PasswordEncoderParserTests-default.xml
@@ -1,8 +1,8 @@
 <b:beans xmlns="http://www.springframework.org/schema/security"
 		 xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 	<http />
 
 	<authentication-manager>

--- a/config/src/test/resources/org/springframework/security/config/core/GrantedAuthorityDefaultsXmlTests-context.xml
+++ b/config/src/test/resources/org/springframework/security/config/core/GrantedAuthorityDefaultsXmlTests-context.xml
@@ -3,8 +3,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
 	xmlns:c="http://www.springframework.org/schema/c"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<http use-expressions="true">
 		<intercept-url access="hasRole('USER')" pattern="/**" />

--- a/config/src/test/resources/org/springframework/security/config/debug/SecurityDebugBeanFactoryPostProcessorTests-context.xml
+++ b/config/src/test/resources/org/springframework/security/config/debug/SecurityDebugBeanFactoryPostProcessorTests-context.xml
@@ -19,9 +19,9 @@
 	xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+						http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<debug/>
 

--- a/config/src/test/resources/org/springframework/security/config/http/AccessDeniedConfigTests-AccessDeniedHandler.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/AccessDeniedConfigTests-AccessDeniedHandler.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="true">
 		<access-denied-handler ref="adh"/>

--- a/config/src/test/resources/org/springframework/security/config/http/AccessDeniedConfigTests-NoLeadingSlash.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/AccessDeniedConfigTests-NoLeadingSlash.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<access-denied-handler error-page="noLeadingSlash"/>

--- a/config/src/test/resources/org/springframework/security/config/http/AccessDeniedConfigTests-UsesPathAndRef.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/AccessDeniedConfigTests-UsesPathAndRef.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<access-denied-handler error-page="/go-away" ref="adh"/>

--- a/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-AutoConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-AutoConfig.xml
@@ -19,8 +19,8 @@
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
 		 xmlns:p="http://www.springframework.org/schema/p"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http-firewall ref="firewall"/>
 	<http auto-config="true"/>

--- a/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-CsrfDisabled.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-CsrfDisabled.xml
@@ -18,8 +18,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<csrf disabled="true"/>

--- a/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-CsrfEnabled.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-CsrfEnabled.xml
@@ -19,8 +19,8 @@
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
 		 xmlns:p="http://www.springframework.org/schema/p"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http-firewall ref="firewall"/>
 	<http auto-config="true">

--- a/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-WithAccessDeniedHandler.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-WithAccessDeniedHandler.xml
@@ -18,8 +18,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<access-denied-handler ref="accessDeniedHandler"/>

--- a/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-WithRequestMatcher.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-WithRequestMatcher.xml
@@ -18,8 +18,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<csrf request-matcher-ref="requestMatcher"/>

--- a/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-WithSessionManagement.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-WithSessionManagement.xml
@@ -18,8 +18,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<session-management invalid-session-url="/error/sessionError"/>

--- a/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-mock-csrf-token-repository.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-mock-csrf-token-repository.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:bean id="csrfTokenRepository" class="org.mockito.Mockito" factory-method="mock">
 		<b:constructor-arg value="org.springframework.security.web.csrf.CsrfTokenRepository"/>

--- a/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-mock-request-matcher.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-mock-request-matcher.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:bean id="requestMatcher" class="org.mockito.Mockito" factory-method="mock">
 		<b:constructor-arg value="org.springframework.security.web.util.matcher.RequestMatcher"/>

--- a/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-shared-access-denied-handler.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-shared-access-denied-handler.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:bean id="accessDeniedHandler" class="org.springframework.security.config.http.CsrfConfigTests.TeapotAccessDeniedHandler"/>
 

--- a/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-shared-controllers.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-shared-controllers.xml
@@ -18,9 +18,9 @@
 		 xmlns:mvc="http://www.springframework.org/schema/mvc"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<mvc:annotation-driven>
 		<mvc:argument-resolvers>

--- a/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-shared-csrf-token-repository.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-shared-csrf-token-repository.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:bean id="csrfTokenRepository" class="org.springframework.security.config.http.CsrfConfigTests.TeapotCsrfTokenRepository"/>
 

--- a/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-shared-userservice.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-shared-userservice.xml
@@ -18,8 +18,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 	<user-service>
 		<user name="user" password="{noop}password" authorities="ROLE_USER"/>
 	</user-service>

--- a/config/src/test/resources/org/springframework/security/config/http/FormLoginBeanDefinitionParserTests-AutoConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/FormLoginBeanDefinitionParserTests-AutoConfig.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 	</http>

--- a/config/src/test/resources/org/springframework/security/config/http/FormLoginBeanDefinitionParserTests-Simple.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/FormLoginBeanDefinitionParserTests-Simple.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<csrf disabled="true"/>

--- a/config/src/test/resources/org/springframework/security/config/http/FormLoginBeanDefinitionParserTests-WithAuthenticationFailureForwardUrl.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/FormLoginBeanDefinitionParserTests-WithAuthenticationFailureForwardUrl.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<form-login

--- a/config/src/test/resources/org/springframework/security/config/http/FormLoginBeanDefinitionParserTests-WithAuthenticationSuccessForwardUrl.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/FormLoginBeanDefinitionParserTests-WithAuthenticationSuccessForwardUrl.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<form-login

--- a/config/src/test/resources/org/springframework/security/config/http/FormLoginBeanDefinitionParserTests-WithCustomAttributes.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/FormLoginBeanDefinitionParserTests-WithCustomAttributes.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<form-login

--- a/config/src/test/resources/org/springframework/security/config/http/FormLoginBeanDefinitionParserTests-WithOpenId.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/FormLoginBeanDefinitionParserTests-WithOpenId.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<openid-login/>

--- a/config/src/test/resources/org/springframework/security/config/http/FormLoginBeanDefinitionParserTests-WithOpenIdCustomAttributes.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/FormLoginBeanDefinitionParserTests-WithOpenIdCustomAttributes.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<openid-login

--- a/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-ForSec2919.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-ForSec2919.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<form-login login-page="/login"/>

--- a/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-ForSec3147.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-ForSec3147.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<form-login login-page="/login"/>

--- a/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-NoLeadingSlashDefaultTargetUrl.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-NoLeadingSlashDefaultTargetUrl.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<form-login default-target-url="noLeadingSlash"/>

--- a/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-NoLeadingSlashLoginPage.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-NoLeadingSlashLoginPage.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<form-login login-page="noLeadingSlash"/>

--- a/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-UsingSpel.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-UsingSpel.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<intercept-url pattern="/**" access="ROLE_USER"/>

--- a/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-WithAntRequestMatcher.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-WithAntRequestMatcher.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false" request-matcher="ant">
 		<intercept-url pattern="/**" access="ROLE_USER"/>

--- a/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-WithCsrfDisabled.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-WithCsrfDisabled.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<csrf disabled="true"/>

--- a/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-WithCsrfEnabled.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-WithCsrfEnabled.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<csrf disabled="false"/>

--- a/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-WithDefaultTargetUrl.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-WithDefaultTargetUrl.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<intercept-url pattern="/**" access="ROLE_USER"/>

--- a/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-WithSuccessAndFailureHandlers.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-WithSuccessAndFailureHandlers.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false" request-matcher="ant">
 		<intercept-url pattern="/**" access="ROLE_USER"/>

--- a/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-WithUsernameAndPasswordParameters.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/FormLoginConfigTests-WithUsernameAndPasswordParameters.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<form-login username-parameter="xname" password-parameter="xpass"/>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpConfigTests-Minimal.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpConfigTests-Minimal.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<intercept-url pattern="/**" access="ROLE_USER"/>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpCorsConfigTests-RequiresMvc.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpCorsConfigTests-RequiresMvc.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 
 	<http auto-config="true" use-expressions="false">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpCorsConfigTests-WithCors.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpCorsConfigTests-WithCors.xml
@@ -21,11 +21,11 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/mvc
-			http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+			https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 
 	<mvc:annotation-driven/>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpCorsConfigTests-WithCorsConfigurationSource.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpCorsConfigTests-WithCorsConfigurationSource.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http entry-point-ref="ep">
 		<intercept-url pattern="/**" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpCorsConfigTests-WithCorsFilter.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpCorsConfigTests-WithCorsFilter.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http entry-point-ref="ep">
 		<intercept-url pattern="/**" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-CacheControlDisabled.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-CacheControlDisabled.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-ContentSecurityPolicyWithEmptyDirectives.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-ContentSecurityPolicyWithEmptyDirectives.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<headers>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-ContentSecurityPolicyWithPolicyDirectives.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-ContentSecurityPolicyWithPolicyDirectives.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<headers>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-ContentSecurityPolicyWithReportOnly.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-ContentSecurityPolicyWithReportOnly.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<headers>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-ContentTypeOptionsDisabled.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-ContentTypeOptionsDisabled.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultConfig.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true"/>
 

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithCacheControl.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithCacheControl.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithContentSecurityPolicy.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithContentSecurityPolicy.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithContentTypeOptions.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithContentTypeOptions.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithCustomHeader.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithCustomHeader.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithCustomHeaderWriter.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithCustomHeaderWriter.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithCustomHstsRequestMatcher.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithCustomHstsRequestMatcher.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithEmptyHpkp.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithEmptyHpkp.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithEmptyPins.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithEmptyPins.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithFrameOptions.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithFrameOptions.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithFrameOptionsAllowFrom.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithFrameOptionsAllowFrom.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithFrameOptionsAllowFromBlankOrigin.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithFrameOptionsAllowFromBlankOrigin.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithFrameOptionsAllowFromNoOrigin.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithFrameOptionsAllowFromNoOrigin.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithFrameOptionsAllowFromWhitelist.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithFrameOptionsAllowFromWhitelist.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithFrameOptionsDeny.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithFrameOptionsDeny.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithFrameOptionsSameOrigin.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithFrameOptionsSameOrigin.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithHpkp.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithHpkp.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithHpkpDefaults.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithHpkpDefaults.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithHpkpIncludeSubdomains.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithHpkpIncludeSubdomains.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithHpkpMaxAge.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithHpkpMaxAge.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithHpkpReport.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithHpkpReport.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithHpkpReportUri.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithHpkpReportUri.xml
@@ -20,13 +20,13 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">
-			<hpkp report-uri="http://example.net/pkp-report">
+			<hpkp report-uri="https://example.net/pkp-report">
 				<pins>
 					<pin>d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM=</pin>
 				</pins>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithHsts.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithHsts.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithNoOverride.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithNoOverride.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true"/>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithOnlyHeaderName.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithOnlyHeaderName.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithOnlyHeaderValue.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithOnlyHeaderValue.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithReferrerPolicy.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithReferrerPolicy.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithReferrerPolicySameOrigin.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithReferrerPolicySameOrigin.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithXssProtection.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithXssProtection.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithXssProtectionDisabled.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithXssProtectionDisabled.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithXssProtectionDisabledAndBlockSet.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithXssProtectionDisabledAndBlockSet.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithXssProtectionEnabled.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-DefaultsDisabledWithXssProtectionEnabled.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers defaults-disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-FrameOptionsDisabled.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-FrameOptionsDisabled.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-FrameOptionsDisabledSpecifyingPolicy.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-FrameOptionsDisabledSpecifyingPolicy.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-HeadersDisabled.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-HeadersDisabled.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<headers disabled="true"/>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-HeadersDisabledHavingChildElement.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-HeadersDisabledHavingChildElement.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<headers disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-HeadersDisabledWithContentSecurityPolicy.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-HeadersDisabledWithContentSecurityPolicy.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<headers disabled="true">

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-HeadersEnabled.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-HeadersEnabled.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers/>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-HpkpDisabled.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-HpkpDisabled.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-HstsDisabled.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-HstsDisabled.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-HstsDisabledSpecifyingIncludeSubdomains.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-HstsDisabledSpecifyingIncludeSubdomains.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-HstsDisabledSpecifyingMaxAge.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-HstsDisabledSpecifyingMaxAge.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-HstsDisabledSpecifyingRequestMatcher.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-HstsDisabledSpecifyingRequestMatcher.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-WithFrameOptions.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-WithFrameOptions.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-XssProtectionDisabled.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-XssProtectionDisabled.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-XssProtectionDisabledAndEnabled.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-XssProtectionDisabledAndEnabled.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-XssProtectionDisabledSpecifyingBlock.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpHeadersConfigTests-XssProtectionDisabledSpecifyingBlock.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<headers>

--- a/config/src/test/resources/org/springframework/security/config/http/HttpInterceptUrlTests-interceptUrlWhenRequestMatcherRefThenWorks.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/HttpInterceptUrlTests-interceptUrlWhenRequestMatcherRefThenWorks.xml
@@ -3,8 +3,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
 	xmlns:c="http://www.springframework.org/schema/c"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http>
 		<http-basic/>

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-AntMatcherServletPath.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-AntMatcherServletPath.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http request-matcher="ant">
 		<intercept-url pattern="/path" access="denyAll" servlet-path="/spring"/>

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-CamelCasePathVariables.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-CamelCasePathVariables.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/path/{userName}/**" access="#userName == authentication.name"/>

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-CiRegexMatcherServletPath.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-CiRegexMatcherServletPath.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http request-matcher="ciRegex">
 		<intercept-url pattern="/path" access="denyAll" servlet-path="/spring"/>

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-DefaultMatcherServletPath.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-DefaultMatcherServletPath.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http>
 		<intercept-url pattern="/path" access="denyAll" servlet-path="/spring"/>

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-HasAnyRole.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-HasAnyRole.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/**" access="hasAnyRole('ROLE_DEVELOPER', 'ROLE_USER')"/>

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-MvcMatchers.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-MvcMatchers.xml
@@ -21,11 +21,11 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/mvc
-			http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+			https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<http auto-config="true" request-matcher="mvc">
 		<intercept-url pattern="/path" access="denyAll"/>

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-MvcMatchersPathVariables.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-MvcMatchersPathVariables.xml
@@ -21,11 +21,11 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/mvc
-			http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+			https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/path/{un}/**" access="#un == 'user'"/>

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-MvcMatchersServletPath.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-MvcMatchersServletPath.xml
@@ -21,11 +21,11 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/mvc
-			http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+			https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<http auto-config="true" request-matcher="mvc">
 		<intercept-url pattern="/path" access="denyAll" servlet-path="/spring"/>

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-PatchMethod.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-PatchMethod.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/**" method="PATCH" access="hasRole('ADMIN')"/>

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-PathVariables.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-PathVariables.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/path/{un}/**" access="#un == authentication.name"/>

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-RegexMatcherServletPath.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-RegexMatcherServletPath.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http request-matcher="regex">
 		<intercept-url pattern="/path" access="denyAll" servlet-path="/spring"/>

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-Sec2256.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-Sec2256.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/path" access="hasRole('USER')"/>

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-TypeConversionPathVariables.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-TypeConversionPathVariables.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/path/{un}/**" access="@id.isOne(#un)"/>

--- a/config/src/test/resources/org/springframework/security/config/http/MultiHttpBlockConfigTests-DistinctHttpElements.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/MultiHttpBlockConfigTests-DistinctHttpElements.xml
@@ -19,8 +19,8 @@
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
 		 xsi:schemaLocation="
-				http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-				http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+				http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+				http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http pattern="/first/**" create-session="stateless">
 		<http-basic/>

--- a/config/src/test/resources/org/springframework/security/config/http/MultiHttpBlockConfigTests-IdenticalHttpElements.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/MultiHttpBlockConfigTests-IdenticalHttpElements.xml
@@ -19,8 +19,8 @@
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
 		 xsi:schemaLocation="
-				http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-				http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+				http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+				http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http create-session="stateless">
 		<http-basic/>

--- a/config/src/test/resources/org/springframework/security/config/http/MultiHttpBlockConfigTests-IdenticallyPatternedHttpElements.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/MultiHttpBlockConfigTests-IdenticallyPatternedHttpElements.xml
@@ -19,8 +19,8 @@
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
 		 xsi:schemaLocation="
-				http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-				http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+				http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+				http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http pattern="/first/**" create-session="stateless">
 		<http-basic/>

--- a/config/src/test/resources/org/springframework/security/config/http/MultiHttpBlockConfigTests-Sec1937.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/MultiHttpBlockConfigTests-Sec1937.xml
@@ -19,8 +19,8 @@
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
 		 xsi:schemaLocation="
-				http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-				http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+				http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+				http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http authentication-manager-ref="firstAuthenticationManager" pattern="/first/**" create-session="stateless">
 		<http-basic/>

--- a/config/src/test/resources/org/springframework/security/config/http/OpenIDConfigTests-Sec2919.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/OpenIDConfigTests-Sec2919.xml
@@ -19,8 +19,8 @@
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
 		 xsi:schemaLocation="
-				http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-				http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+				http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+				http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http use-expressions="true">
 		<intercept-url pattern="/login" access="permitAll"/>

--- a/config/src/test/resources/org/springframework/security/config/http/OpenIDConfigTests-WithFormLogin.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/OpenIDConfigTests-WithFormLogin.xml
@@ -19,8 +19,8 @@
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
 		 xsi:schemaLocation="
-				http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-				http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+				http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+				http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http use-expressions="true">
 		<intercept-url pattern="/**" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/OpenIDConfigTests-WithFormLoginAndOpenIDLoginPages.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/OpenIDConfigTests-WithFormLoginAndOpenIDLoginPages.xml
@@ -19,8 +19,8 @@
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
 		 xsi:schemaLocation="
-				http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-				http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+				http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+				http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http use-expressions="true">
 		<intercept-url pattern="/**" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/OpenIDConfigTests-WithFormLoginPage.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/OpenIDConfigTests-WithFormLoginPage.xml
@@ -19,8 +19,8 @@
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
 		 xsi:schemaLocation="
-				http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-				http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+				http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+				http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http use-expressions="true">
 		<intercept-url pattern="/**" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/OpenIDConfigTests-WithOpenIDAttributes.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/OpenIDConfigTests-WithOpenIDAttributes.xml
@@ -19,15 +19,15 @@
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
 		 xsi:schemaLocation="
-				http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-				http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+				http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+				http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http use-expressions="true">
 		<intercept-url pattern="/**" access="denyAll"/>
 		<openid-login>
 			<attribute-exchange>
-				<openid-attribute name="nickname" type="http://schema.openid.net/namePerson/friendly"/>
-				<openid-attribute name="email" type="http://schema.openid.net/contact/email" required="true" count="2"/>
+				<openid-attribute name="nickname" type="https://schema.openid.net/namePerson/friendly"/>
+				<openid-attribute name="email" type="https://schema.openid.net/contact/email" required="true" count="2"/>
 			</attribute-exchange>
 		</openid-login>
 	</http>

--- a/config/src/test/resources/org/springframework/security/config/http/OpenIDConfigTests-WithOpenIDLoginPageAndFormLogin.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/OpenIDConfigTests-WithOpenIDLoginPageAndFormLogin.xml
@@ -19,8 +19,8 @@
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
 		 xsi:schemaLocation="
-				http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-				http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+				http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+				http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http use-expressions="true">
 		<intercept-url pattern="/**" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/OpenIDConfigTests-WithRememberMe.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/OpenIDConfigTests-WithRememberMe.xml
@@ -19,8 +19,8 @@
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
 		 xsi:schemaLocation="
-				http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-				http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+				http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+				http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http use-expressions="true">
 		<intercept-url pattern="/**" access="denyAll"/>

--- a/config/src/test/resources/org/springframework/security/config/http/PlaceHolderAndELConfigTests-AccessDeniedPage.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/PlaceHolderAndELConfigTests-AccessDeniedPage.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<intercept-url pattern="/secured" access="ROLE_NUNYA"/>

--- a/config/src/test/resources/org/springframework/security/config/http/PlaceHolderAndELConfigTests-AccessDeniedPageWithSpEL.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/PlaceHolderAndELConfigTests-AccessDeniedPageWithSpEL.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<intercept-url pattern="/secured" access="ROLE_NUNYA"/>

--- a/config/src/test/resources/org/springframework/security/config/http/PlaceHolderAndELConfigTests-InterceptUrlAndFormLogin.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/PlaceHolderAndELConfigTests-InterceptUrlAndFormLogin.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http use-expressions="false">
 		<intercept-url pattern="${secure.Url}" access="${secure.role}"/>

--- a/config/src/test/resources/org/springframework/security/config/http/PlaceHolderAndELConfigTests-InterceptUrlAndFormLoginWithSpEL.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/PlaceHolderAndELConfigTests-InterceptUrlAndFormLoginWithSpEL.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http use-expressions="false">
 		<intercept-url

--- a/config/src/test/resources/org/springframework/security/config/http/PlaceHolderAndELConfigTests-PortMapping.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/PlaceHolderAndELConfigTests-PortMapping.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<intercept-url pattern="/secured" access="ROLE_USER" requires-channel="https"/>

--- a/config/src/test/resources/org/springframework/security/config/http/PlaceHolderAndELConfigTests-RequiresChannel.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/PlaceHolderAndELConfigTests-RequiresChannel.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<intercept-url pattern="${secure.url}" access="ROLE_USER" requires-channel="${required.channel}"/>

--- a/config/src/test/resources/org/springframework/security/config/http/PlaceHolderAndELConfigTests-UnsecuredPattern.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/PlaceHolderAndELConfigTests-UnsecuredPattern.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http pattern="${pattern.nofilters}" security="none"/>
 

--- a/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-DefaultConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-DefaultConfig.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/authenticated" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-NegativeTokenValidity.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-NegativeTokenValidity.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/authenticated" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-NegativeTokenValidityWithDataSource.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-NegativeTokenValidityWithDataSource.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/authenticated" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-NegativeTokenValidityWithPersistentRepository.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-NegativeTokenValidityWithPersistentRepository.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/authenticated" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-Sec1827.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-Sec1827.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/authenticated" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-Sec2165.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-Sec2165.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/authenticated" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-Sec742.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-Sec742.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http>
 		<intercept-url pattern="/authenticated" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-SecureCookie.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-SecureCookie.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/authenticated" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-TokenValidity.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-TokenValidity.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/authenticated" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-WithAuthenticationSuccessHandler.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-WithAuthenticationSuccessHandler.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/authenticated" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-WithDataSource.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-WithDataSource.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/authenticated" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-WithRememberMeCookie.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-WithRememberMeCookie.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/authenticated" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-WithRememberMeCookieAndServicesRef.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-WithRememberMeCookieAndServicesRef.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/authenticated" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-WithRememberMeParameter.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-WithRememberMeParameter.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/authenticated" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-WithRememberMeParameterAndServicesRef.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-WithRememberMeParameterAndServicesRef.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/authenticated" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-WithServicesRef.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-WithServicesRef.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/authenticated" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-WithTokenRepository.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-WithTokenRepository.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/authenticated" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-WithUserDetailsService.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-WithUserDetailsService.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/authenticated" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/SecurityContextHolderAwareRequestConfigTests-FormLogin.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SecurityContextHolderAwareRequestConfigTests-FormLogin.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http>
 		<form-login/>

--- a/config/src/test/resources/org/springframework/security/config/http/SecurityContextHolderAwareRequestConfigTests-HttpBasic.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SecurityContextHolderAwareRequestConfigTests-HttpBasic.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http>
 		<http-basic entry-point-ref="ep"/>

--- a/config/src/test/resources/org/springframework/security/config/http/SecurityContextHolderAwareRequestConfigTests-Logout.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SecurityContextHolderAwareRequestConfigTests-Logout.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http>
 		<form-login login-page="/signin"/>

--- a/config/src/test/resources/org/springframework/security/config/http/SecurityContextHolderAwareRequestConfigTests-MultiHttp.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SecurityContextHolderAwareRequestConfigTests-MultiHttp.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http authentication-manager-ref="authManager2" pattern="/v2/**">
 		<form-login login-page="/login2"/>

--- a/config/src/test/resources/org/springframework/security/config/http/SecurityContextHolderAwareRequestConfigTests-Simple.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SecurityContextHolderAwareRequestConfigTests-Simple.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="false">
 		<csrf disabled="true"/>

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-ConcurrencyControlCustomLogoutHandler.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-ConcurrencyControlCustomLogoutHandler.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<session-management>

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-ConcurrencyControlExpiredUrl.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-ConcurrencyControlExpiredUrl.xml
@@ -21,11 +21,11 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd
+			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/mvc
-			http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+			https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<http auto-config="true">
 		<session-management>

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-ConcurrencyControlLogoutAndRememberMeHandlers.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-ConcurrencyControlLogoutAndRememberMeHandlers.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<session-management>

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-ConcurrencyControlMaxSessions.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-ConcurrencyControlMaxSessions.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<session-management session-authentication-error-url="/max-exceeded">

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-ConcurrencyControlRememberMeHandler.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-ConcurrencyControlRememberMeHandler.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<session-management>

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-ConcurrencyControlSessionRegistryAlias.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-ConcurrencyControlSessionRegistryAlias.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<session-management>

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-ConcurrencyControlSessionRegistryRef.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-ConcurrencyControlSessionRegistryRef.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<session-management>

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-CreateSessionAlways.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-CreateSessionAlways.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" create-session="always">
 	</http>

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-CreateSessionIfRequired.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-CreateSessionIfRequired.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" create-session="ifRequired" use-expressions="true">
 		<intercept-url pattern="/auth/**" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-CreateSessionNever.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-CreateSessionNever.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" create-session="never" use-expressions="true">
 		<intercept-url pattern="/auth/**" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-CreateSessionStateless.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-CreateSessionStateless.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" create-session="stateless" use-expressions="true">
 		<intercept-url pattern="/auth/**" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-NoSessionManagementFilter.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-NoSessionManagementFilter.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="true">
 		<intercept-url pattern="/auth/**" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-Sec1208.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-Sec1208.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" create-session="ifRequired" use-expressions="true">
 		<intercept-url pattern="/auth/**" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-Sec2137.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-Sec2137.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" create-session="ifRequired" use-expressions="true">
 		<intercept-url pattern="/auth/**" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-SessionAuthenticationStrategyRef.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-SessionAuthenticationStrategyRef.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="true">
 		<intercept-url pattern="/auth/**" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-SessionFixationProtectionMigrateSession.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-SessionFixationProtectionMigrateSession.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="true">
 		<intercept-url pattern="/auth/**" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-SessionFixationProtectionNone.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-SessionFixationProtectionNone.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="true">
 		<intercept-url pattern="/auth/**" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-SessionFixationProtectionNoneWithInvalidSessionUrl.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-SessionFixationProtectionNoneWithInvalidSessionUrl.xml
@@ -20,9 +20,9 @@
 		xmlns="http://www.springframework.org/schema/security"
 		xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" use-expressions="true">
 		<intercept-url pattern="/auth/**" access="authenticated"/>

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTransientAuthenticationTests-CreateSessionAlwaysWithTransientAuthentication.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTransientAuthenticationTests-CreateSessionAlwaysWithTransientAuthentication.xml
@@ -20,9 +20,9 @@
 		 xmlns="http://www.springframework.org/schema/security"
 		 xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true" create-session="always">
 		<csrf disabled="true"/>

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTransientAuthenticationTests-WithTransientAuthentication.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTransientAuthenticationTests-WithTransientAuthentication.xml
@@ -20,9 +20,9 @@
 		 xmlns="http://www.springframework.org/schema/security"
 		 xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<csrf disabled="true"/>

--- a/config/src/test/resources/org/springframework/security/config/http/userservice.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/userservice.xml
@@ -20,9 +20,9 @@
 		 xmlns="http://www.springframework.org/schema/security"
 		 xsi:schemaLocation="
 			http://www.springframework.org/schema/security
-			http://www.springframework.org/schema/security/spring-security.xsd
+			https://www.springframework.org/schema/security/spring-security.xsd
 			http://www.springframework.org/schema/beans
-			http://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 	<user-service id="us">
 		<user name="user" password="{noop}password" authorities="ROLE_USER"/>
 		<user name="admin" password="{noop}password" authorities="ROLE_ADMIN"/>

--- a/config/src/test/resources/org/springframework/security/config/method-security.xml
+++ b/config/src/test/resources/org/springframework/security/config/method-security.xml
@@ -4,9 +4,9 @@
 	xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:tx="http://www.springframework.org/schema/tx"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
-		http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx.xsd
+		http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<tx:annotation-driven />
 

--- a/config/src/test/resources/org/springframework/security/config/method/PreAuthorizeTests-context.xml
+++ b/config/src/test/resources/org/springframework/security/config/method/PreAuthorizeTests-context.xml
@@ -3,8 +3,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
 	xmlns:c="http://www.springframework.org/schema/c"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<global-method-security pre-post-annotations="enabled"/>
 

--- a/config/src/test/resources/org/springframework/security/config/method/SecuredTests-context.xml
+++ b/config/src/test/resources/org/springframework/security/config/method/SecuredTests-context.xml
@@ -3,8 +3,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
 	xmlns:c="http://www.springframework.org/schema/c"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<global-method-security secured-annotations="enabled"/>
 

--- a/config/src/test/resources/org/springframework/security/config/method/sec2136/sec2136.xml
+++ b/config/src/test/resources/org/springframework/security/config/method/sec2136/sec2136.xml
@@ -5,11 +5,11 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:security="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd
-		http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
-		http://www.springframework.org/schema/data/jpa http://www.springframework.org/schema/data/jpa/spring-jpa.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd
+		http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+		http://www.springframework.org/schema/data/jpa https://www.springframework.org/schema/data/jpa/spring-jpa.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
 	<context:annotation-config />
 

--- a/config/src/test/resources/org/springframework/security/config/method/sec2499/child.xml
+++ b/config/src/test/resources/org/springframework/security/config/method/sec2499/child.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<global-method-security pre-post-annotations="enabled">
 		<expression-handler ref="expressionHandler"/>

--- a/config/src/test/resources/org/springframework/security/config/method/sec2499/parent.xml
+++ b/config/src/test/resources/org/springframework/security/config/method/sec2499/parent.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="expressionHandler"
 		class="org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler"/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-ConnectAckInterceptTypeConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-ConnectAckInterceptTypeConfig.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:import resource="classpath:org/springframework/security/config/websocket/controllers.xml"/>
 	<b:import resource="classpath:org/springframework/security/config/websocket/websocket.xml"/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-ConnectInterceptTypeConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-ConnectInterceptTypeConfig.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:import resource="classpath:org/springframework/security/config/websocket/controllers.xml"/>
 	<b:import resource="classpath:org/springframework/security/config/websocket/websocket.xml"/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-CustomExpressionHandlerConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-CustomExpressionHandlerConfig.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:import resource="classpath:org/springframework/security/config/websocket/controllers.xml"/>
 	<b:import resource="classpath:org/springframework/security/config/websocket/websocket.xml"/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-CustomInterceptorConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-CustomInterceptorConfig.xml
@@ -18,9 +18,9 @@
 		 xmlns:websocket="http://www.springframework.org/schema/websocket"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
 	<websocket:message-broker application-destination-prefix="/app" user-destination-prefix="/user">
 		<websocket:transport/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-CustomPathMatcherConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-CustomPathMatcherConfig.xml
@@ -18,9 +18,9 @@
 		 xmlns:websocket="http://www.springframework.org/schema/websocket"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
 	<b:import resource="classpath:org/springframework/security/config/websocket/controllers.xml"/>
 

--- a/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-DisconnectAckInterceptTypeConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-DisconnectAckInterceptTypeConfig.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:import resource="classpath:org/springframework/security/config/websocket/controllers.xml"/>
 	<b:import resource="classpath:org/springframework/security/config/websocket/websocket.xml"/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-DisconnectInterceptTypeConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-DisconnectInterceptTypeConfig.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:import resource="classpath:org/springframework/security/config/websocket/controllers.xml"/>
 	<b:import resource="classpath:org/springframework/security/config/websocket/websocket.xml"/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-HeartbeatInterceptTypeConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-HeartbeatInterceptTypeConfig.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:import resource="classpath:org/springframework/security/config/websocket/controllers.xml"/>
 	<b:import resource="classpath:org/springframework/security/config/websocket/websocket.xml"/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-IdConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-IdConfig.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:import resource="classpath:org/springframework/security/config/websocket/controllers.xml"/>
 	<b:import resource="classpath:org/springframework/security/config/websocket/websocket.xml"/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-IdIntegratedConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-IdIntegratedConfig.xml
@@ -18,9 +18,9 @@
 		 xmlns:websocket="http://www.springframework.org/schema/websocket"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
 	<websocket:message-broker>
 		<websocket:transport/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-MessageInterceptTypeConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-MessageInterceptTypeConfig.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:import resource="classpath:org/springframework/security/config/websocket/controllers.xml"/>
 	<b:import resource="classpath:org/springframework/security/config/websocket/websocket.xml"/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-NoIdConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-NoIdConfig.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:import resource="classpath:org/springframework/security/config/websocket/controllers.xml"/>
 	<b:import resource="classpath:org/springframework/security/config/websocket/websocket.xml"/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-OtherInterceptTypeConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-OtherInterceptTypeConfig.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:import resource="classpath:org/springframework/security/config/websocket/controllers.xml"/>
 	<b:import resource="classpath:org/springframework/security/config/websocket/websocket.xml"/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-SubscribeInterceptTypeConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-SubscribeInterceptTypeConfig.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:import resource="classpath:org/springframework/security/config/websocket/controllers.xml"/>
 	<b:import resource="classpath:org/springframework/security/config/websocket/websocket.xml"/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-SyncConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-SyncConfig.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:import resource="classpath:org/springframework/security/config/websocket/controllers.xml"/>
 	<b:import resource="classpath:org/springframework/security/config/websocket/sync.xml"/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-SyncCustomArgumentResolverConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-SyncCustomArgumentResolverConfig.xml
@@ -18,9 +18,9 @@
 		xmlns:websocket="http://www.springframework.org/schema/websocket"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns="http://www.springframework.org/schema/security"
-		xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
 	<b:import resource="classpath:org/springframework/security/config/websocket/controllers.xml"/>
 	<b:import resource="classpath:org/springframework/security/config/websocket/sync.xml"/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-SyncSameOriginDisabledConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-SyncSameOriginDisabledConfig.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:import resource="classpath:org/springframework/security/config/websocket/controllers.xml"/>
 	<b:import resource="classpath:org/springframework/security/config/websocket/sync.xml"/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-SyncSockJsConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-SyncSockJsConfig.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:import resource="classpath:org/springframework/security/config/websocket/controllers.xml"/>
 	<b:import resource="classpath:org/springframework/security/config/websocket/sync.xml"/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-UnsubscribeInterceptTypeConfig.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/WebSocketMessageBrokerConfigTests-UnsubscribeInterceptTypeConfig.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<b:import resource="classpath:org/springframework/security/config/websocket/controllers.xml"/>
 	<b:import resource="classpath:org/springframework/security/config/websocket/websocket.xml"/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/controllers.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/controllers.xml
@@ -16,7 +16,7 @@
   -->
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns="http://www.springframework.org/schema/beans"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean class="org.springframework.security.config.websocket.WebSocketMessageBrokerConfigTests.MessageController"/>
 	<bean class="org.springframework.security.config.websocket.WebSocketMessageBrokerConfigTests.MessageWithArgumentController"/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/sync.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/sync.xml
@@ -16,7 +16,7 @@
   -->
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns="http://www.springframework.org/schema/beans"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean class="org.springframework.security.config.websocket.WebSocketMessageBrokerConfigTests.InboundExecutorPostProcessor"/>
 </beans>

--- a/config/src/test/resources/org/springframework/security/config/websocket/websocket-sockjs.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/websocket-sockjs.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns="http://www.springframework.org/schema/websocket"
-		 xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
 	<message-broker>
 		<transport/>

--- a/config/src/test/resources/org/springframework/security/config/websocket/websocket.xml
+++ b/config/src/test/resources/org/springframework/security/config/websocket/websocket.xml
@@ -17,8 +17,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns="http://www.springframework.org/schema/websocket"
-		 xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/websocket http://www.springframework.org/schema/websocket/spring-websocket.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
 	<message-broker>
 		<transport/>

--- a/config/src/test/resources/org/springframework/security/util/filtertest-valid.xml
+++ b/config/src/test/resources/org/springframework/security/util/filtertest-valid.xml
@@ -22,9 +22,9 @@
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.0.xsd
-		http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-3.0.xsd
+		http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<bean id="mockFilter" class="org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter"/>
 

--- a/core/src/test/resources/org/springframework/security/authentication/jaas/DefaultJaasAuthenticationProviderTests.xml
+++ b/core/src/test/resources/org/springframework/security/authentication/jaas/DefaultJaasAuthenticationProviderTests.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-3.0.xsd">
 
 	<bean id="jaasAuthProvider"
 		class="org.springframework.security.authentication.jaas.DefaultJaasAuthenticationProvider">

--- a/core/src/test/resources/org/springframework/security/authentication/jaas/JaasAuthenticationProviderTests.xml
+++ b/core/src/test/resources/org/springframework/security/authentication/jaas/JaasAuthenticationProviderTests.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "https://www.springframework.org/dtd/spring-beans.dtd">
 
 
 <beans>

--- a/docs/articles/src/docbook/codebase-structure.xml
+++ b/docs/articles/src/docbook/codebase-structure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?oxygen RNGSchema="http://www.oasis-open.org/docbook/xml/5.0/rng/docbook.rng" type="xml"?>
+<?oxygen RNGSchema="https://www.oasis-open.org/docbook/xml/5.0/rng/docbook.rng" type="xml"?>
 <article xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
 	version="5.0">
 	<info>
@@ -44,7 +44,7 @@
 			Structure101 tool<footnote>
 				<para>Structure101 is an excellent tool for analyzing your own code or for
 					understanding someone else's. It is developed by <link
-						xlink:href="http://www.headwaysoftware.com">Headway Software</link>. </para>
+						xlink:href="https://www.headwaysoftware.com">Headway Software</link>. </para>
 			</footnote>. You don't have to be an expert in code structure to realise that there is a
 			bit of a problem here. There are a lot of circular references and no clear overall
 			dependency structure within the packages. There are also some issues with packages being
@@ -54,9 +54,9 @@
 					the topic where he shares some of the insights gained from maintaining the
 					Spring Framework through multiple versions. You can find him discussing the
 					topic in an online interview <link
-						xlink:href="http://www.se-radio.net/transcript-82-organization-large-code-bases-juergen-hoeller"
+						xlink:href="https://www.se-radio.net/transcript-82-organization-large-code-bases-juergen-hoeller"
 						>transcript</link> and an <link
-						xlink:href="http://www.infoq.com/presentations/code-organization-large-projects"
+						xlink:href="https://www.infoq.com/presentations/code-organization-large-projects"
 						>InfoQ video</link>. </para>
 			</footnote>. This fragility in the code structure would likely have caused a maintenance
 			overhead as Spring Security evolved, so the decision was made to restructure the code

--- a/etc/checkstyle/checkstyle.xml
+++ b/etc/checkstyle/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-		"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+		"https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
 	<!-- Suppressions -->
 	<module name="SuppressionFilter">

--- a/etc/checkstyle/suppressions.xml
+++ b/etc/checkstyle/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-		"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+		"https://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
 	<suppress files=".+Application\.java" checks="HideUtilityClassConstructor"/>
 	<suppress files=".+Configuration\.java" checks="HideUtilityClassConstructor"/>

--- a/itest/context/src/integration-test/resources/filter-chain-performance-app-context.xml
+++ b/itest/context/src/integration-test/resources/filter-chain-performance-app-context.xml
@@ -7,8 +7,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:sec="http://www.springframework.org/schema/security"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+						http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<bean id="fcpMinimalStack" class="org.springframework.security.web.FilterChainProxy">
 		<sec:filter-chain-map request-matcher="ant">

--- a/itest/context/src/integration-test/resources/http-extra-fsi-app-context.xml
+++ b/itest/context/src/integration-test/resources/http-extra-fsi-app-context.xml
@@ -7,8 +7,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:sec="http://www.springframework.org/schema/security"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+						http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<sec:http>
 		<!-- Slip in a bean property name EL test -->

--- a/itest/context/src/integration-test/resources/http-path-param-stripping-app-context.xml
+++ b/itest/context/src/integration-test/resources/http-path-param-stripping-app-context.xml
@@ -7,8 +7,8 @@
 <b:beans xmlns="http://www.springframework.org/schema/security"
 	xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+						http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<http pattern="/secured/**" use-expressions="false">
 		<intercept-url pattern="/secured/*user.html" access="ROLE_USER" />

--- a/itest/context/src/integration-test/resources/multi-sec-annotation-app-context.xml
+++ b/itest/context/src/integration-test/resources/multi-sec-annotation-app-context.xml
@@ -5,9 +5,9 @@
 	xmlns:tx="http://www.springframework.org/schema/tx"
 	xmlns:security="http://www.springframework.org/schema/security"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
-		http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+		http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<global-method-security pre-post-annotations="enabled" secured-annotations="enabled" />
 

--- a/itest/context/src/integration-test/resources/protect-pointcut-performance-app-context.xml
+++ b/itest/context/src/integration-test/resources/protect-pointcut-performance-app-context.xml
@@ -1,8 +1,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:sec="http://www.springframework.org/schema/security"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+						http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<sec:global-method-security>
 		<sec:protect-pointcut expression="execution(* org.springframework.security.core.session.SessionRegistry.refreshLastRequest(..))" access="ROLE_ADMIN" />

--- a/itest/context/src/integration-test/resources/python-method-access-app-context.xml
+++ b/itest/context/src/integration-test/resources/python-method-access-app-context.xml
@@ -5,9 +5,9 @@
 	xmlns:tx="http://www.springframework.org/schema/tx"
 	xmlns:security="http://www.springframework.org/schema/security"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
-		http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+		http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<global-method-security pre-post-annotations="enabled">
 		<pre-post-annotation-handling>

--- a/itest/context/src/integration-test/resources/sec-933-app-context.xml
+++ b/itest/context/src/integration-test/resources/sec-933-app-context.xml
@@ -4,10 +4,10 @@
 	xmlns:tx="http://www.springframework.org/schema/tx"
 	xmlns:security="http://www.springframework.org/schema/security"
 	xsi:schemaLocation="
-	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
-	http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+	http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 
 	<bean id="userRepository" class="org.springframework.security.integration.StubUserRepository"/>

--- a/itest/context/src/integration-test/resources/sec-936-app-context.xml
+++ b/itest/context/src/integration-test/resources/sec-936-app-context.xml
@@ -3,9 +3,9 @@
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:security="http://www.springframework.org/schema/security"
 	xsi:schemaLocation="
-	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.0.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-3.0.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<security:authentication-manager alias="authenticationManager">
 		<security:authentication-provider>

--- a/itest/web/src/integration-test/resources/spring/http-security-basic.xml
+++ b/itest/web/src/integration-test/resources/spring/http-security-basic.xml
@@ -3,8 +3,8 @@
 <beans:beans xmlns="http://www.springframework.org/schema/security"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+						http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<http use-expressions="false">
 		<intercept-url pattern="/**" access="ROLE_DEVELOPER,ROLE_USER" />

--- a/itest/web/src/integration-test/resources/spring/http-security-concurrency.xml
+++ b/itest/web/src/integration-test/resources/spring/http-security-concurrency.xml
@@ -3,8 +3,8 @@
 <beans:beans xmlns="http://www.springframework.org/schema/security"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+						http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<debug />
 

--- a/itest/web/src/integration-test/resources/spring/http-security.xml
+++ b/itest/web/src/integration-test/resources/spring/http-security.xml
@@ -3,8 +3,8 @@
 <beans:beans xmlns="http://www.springframework.org/schema/security"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+						http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<!--
 	   Http App Context to test form login, remember-me and concurrent session control.

--- a/itest/web/src/integration-test/resources/spring/in-memory-provider.xml
+++ b/itest/web/src/integration-test/resources/spring/in-memory-provider.xml
@@ -3,8 +3,8 @@
 <beans:beans xmlns="http://www.springframework.org/schema/security"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+						http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<authentication-manager alias="authenticationManager">
 		<authentication-provider>

--- a/itest/web/src/integration-test/resources/spring/testapp-servlet.xml
+++ b/itest/web/src/integration-test/resources/spring/testapp-servlet.xml
@@ -1,7 +1,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:p="http://www.springframework.org/schema/p" xmlns:context="http://www.springframework.org/schema/context"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 	<context:component-scan base-package="org.springframework.security.itest.web"/>
 	<context:annotation-config />

--- a/samples/javaconfig/preauth/src/main/webapp/WEB-INF/web.xml
+++ b/samples/javaconfig/preauth/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
 
 	<login-config>
 		<auth-method>FORM</auth-method>

--- a/samples/xml/aspectj/src/main/resources/aspectj-context.xml
+++ b/samples/xml/aspectj/src/main/resources/aspectj-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:sec="http://www.springframework.org/schema/security"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<sec:global-method-security secured-annotations="enabled" mode="aspectj" />
 <!--

--- a/samples/xml/cas/cassample/src/main/webapp/WEB-INF/applicationContext-security.xml
+++ b/samples/xml/cas/cassample/src/main/webapp/WEB-INF/applicationContext-security.xml
@@ -5,10 +5,10 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<http entry-point-ref="casEntryPoint">
 		<intercept-url pattern="/" access="permitAll"/>

--- a/samples/xml/cas/cassample/src/main/webapp/WEB-INF/web.xml
+++ b/samples/xml/cas/cassample/src/main/webapp/WEB-INF/web.xml
@@ -6,7 +6,7 @@
 
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
 	<display-name>Spring Security CAS Demo Application</display-name>
 
 	<!--

--- a/samples/xml/cas/casserver/src/main/webapp/WEB-INF/deployerConfigContext.xml
+++ b/samples/xml/cas/casserver/src/main/webapp/WEB-INF/deployerConfigContext.xml
@@ -38,8 +38,8 @@
 	   xmlns:p="http://www.springframework.org/schema/p"
 	   xmlns:c="http://www.springframework.org/schema/c"
 	   xmlns:util="http://www.springframework.org/schema/util"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<!--
 	   | The authentication manager defines security policy for authentication by specifying at a minimum

--- a/samples/xml/cas/casserver/src/main/webapp/WEB-INF/spring-configuration/applicationContext.xml
+++ b/samples/xml/cas/casserver/src/main/webapp/WEB-INF/spring-configuration/applicationContext.xml
@@ -25,9 +25,9 @@
 	   xmlns:c="http://www.springframework.org/schema/c"
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 	<description>
 		This is the main Spring configuration file with some of the main "core" classes defined. You shouldn't really
 		modify this unless you

--- a/samples/xml/contacts/client/clientContext.xml
+++ b/samples/xml/contacts/client/clientContext.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "https://www.springframework.org/dtd/spring-beans.dtd">
 
 <!--
   - Contacts web application

--- a/samples/xml/contacts/src/main/resources/applicationContext-common-authorization.xml
+++ b/samples/xml/contacts/src/main/resources/applicationContext-common-authorization.xml
@@ -2,7 +2,7 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 <!--
   - Application context containing the ACL beans.

--- a/samples/xml/contacts/src/main/resources/applicationContext-common-business.xml
+++ b/samples/xml/contacts/src/main/resources/applicationContext-common-business.xml
@@ -10,8 +10,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:tx="http://www.springframework.org/schema/tx"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx.xsd">
 
 	<bean id="messageSource" class="org.springframework.context.support.ReloadableResourceBundleMessageSource">
 		<property name="basename" value="classpath:org/springframework/security/messages"/>

--- a/samples/xml/contacts/src/main/resources/applicationContext-security.xml
+++ b/samples/xml/contacts/src/main/resources/applicationContext-security.xml
@@ -10,8 +10,8 @@
 <b:beans xmlns="http://www.springframework.org/schema/security"
 	xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<global-method-security pre-post-annotations="enabled">
 		<expression-handler ref="expressionHandler"/>

--- a/samples/xml/contacts/src/main/webapp/WEB-INF/contacts-servlet.xml
+++ b/samples/xml/contacts/src/main/webapp/WEB-INF/contacts-servlet.xml
@@ -2,9 +2,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:mvc="http://www.springframework.org/schema/mvc"
-	xsi:schemaLocation="http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<!-- ========================== WEB DEFINITIONS ======================= -->
 

--- a/samples/xml/contacts/src/main/webapp/WEB-INF/remoting-servlet.xml
+++ b/samples/xml/contacts/src/main/webapp/WEB-INF/remoting-servlet.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "https://www.springframework.org/dtd/spring-beans.dtd">
 
 <!--
   - Contacts web application

--- a/samples/xml/contacts/src/main/webapp/WEB-INF/web.xml
+++ b/samples/xml/contacts/src/main/webapp/WEB-INF/web.xml
@@ -7,7 +7,7 @@
 
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
 	<display-name>Contacts Sample Application</display-name>
 
 	<!--

--- a/samples/xml/dms/src/main/resources/applicationContext-dms-insecure.xml
+++ b/samples/xml/dms/src/main/resources/applicationContext-dms-insecure.xml
@@ -6,7 +6,7 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="jdbcTemplate" class="org.springframework.jdbc.core.JdbcTemplate">
 		<property name="dataSource" ref="dataSource"/>

--- a/samples/xml/dms/src/main/resources/applicationContext-dms-secure.xml
+++ b/samples/xml/dms/src/main/resources/applicationContext-dms-secure.xml
@@ -8,8 +8,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:s="http://www.springframework.org/schema/security"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<bean id="jdbcTemplate" class="org.springframework.jdbc.core.JdbcTemplate">
 		<property name="dataSource" ref="dataSource"/>

--- a/samples/xml/dms/src/main/resources/applicationContext-dms-shared.xml
+++ b/samples/xml/dms/src/main/resources/applicationContext-dms-shared.xml
@@ -5,7 +5,7 @@
   -->
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
 		<property name="dataSource" ref="dataSource"/>

--- a/samples/xml/gae/src/main/webapp/WEB-INF/applicationContext-security.xml
+++ b/samples/xml/gae/src/main/webapp/WEB-INF/applicationContext-security.xml
@@ -3,8 +3,8 @@
 <b:beans xmlns="http://www.springframework.org/schema/security"
 	xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<http pattern="/_ah/**" security="none"/>
 	<http pattern="/static/**" security="none" />

--- a/samples/xml/gae/src/main/webapp/WEB-INF/gae-servlet.xml
+++ b/samples/xml/gae/src/main/webapp/WEB-INF/gae-servlet.xml
@@ -1,9 +1,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
 		xmlns:mvc="http://www.springframework.org/schema/mvc"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
-				http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
+				http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
 	<!-- Enables JSR-303 -->
 	<mvc:annotation-driven/>

--- a/samples/xml/gae/src/main/webapp/WEB-INF/web.xml
+++ b/samples/xml/gae/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://java.sun.com/xml/ns/javaee"
-	xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="2.5">
+	xmlns:web="https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="2.5">
 
 	<context-param>
 		<param-name>contextConfigLocation</param-name>

--- a/samples/xml/helloworld/src/main/webapp/WEB-INF/spring/security.xml
+++ b/samples/xml/helloworld/src/main/webapp/WEB-INF/spring/security.xml
@@ -1,8 +1,8 @@
 <b:beans xmlns="http://www.springframework.org/schema/security"
 		 xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 	<http />
 
 	<user-service>

--- a/samples/xml/helloworld/src/main/webapp/WEB-INF/web.xml
+++ b/samples/xml/helloworld/src/main/webapp/WEB-INF/web.xml
@@ -2,7 +2,7 @@
 <web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
-  http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+  https://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
 
 	<!--
 		Loads the Spring configurations from contextConfigLocation

--- a/samples/xml/jaas/src/main/resources/applicationContext-security.xml
+++ b/samples/xml/jaas/src/main/resources/applicationContext-security.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:sec="http://www.springframework.org/schema/security"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 
 	<sec:http auto-config="true" jaas-api-provision="true">

--- a/samples/xml/jaas/src/main/webapp/WEB-INF/web.xml
+++ b/samples/xml/jaas/src/main/webapp/WEB-INF/web.xml
@@ -7,7 +7,7 @@
 
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
 	<display-name>JAAS Sample Application</display-name>
 
 	<!--

--- a/samples/xml/ldap/src/main/webapp/WEB-INF/applicationContext-security.xml
+++ b/samples/xml/ldap/src/main/webapp/WEB-INF/applicationContext-security.xml
@@ -1,8 +1,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:s="http://www.springframework.org/schema/security"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<s:http>
 		<s:intercept-url pattern="/secure/extreme/**" access="hasRole('ROLE_SUPERVISOR')"/>

--- a/samples/xml/ldap/src/main/webapp/WEB-INF/web.xml
+++ b/samples/xml/ldap/src/main/webapp/WEB-INF/web.xml
@@ -2,7 +2,7 @@
 
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
 
 	<display-name>Spring Security LDAP Demo Application</display-name>
 

--- a/samples/xml/openid/src/main/webapp/WEB-INF/applicationContext-security.xml
+++ b/samples/xml/openid/src/main/webapp/WEB-INF/applicationContext-security.xml
@@ -7,8 +7,8 @@
 <b:beans xmlns="http://www.springframework.org/schema/security"
 	xmlns:b="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<http>
 		<intercept-url pattern="/openidlogin.jsp*" access="permitAll"/>
@@ -20,17 +20,17 @@
 		<openid-login login-page="/openidlogin.jsp" user-service-ref="registeringUserService"
 				authentication-failure-url="/openidlogin.jsp?login_error=true">
 			<attribute-exchange identifier-match="https://www.google.com/.*">
-				<openid-attribute name="email" type="http://axschema.org/contact/email" required="true" count="1"/>
-				<openid-attribute name="firstname" type="http://axschema.org/namePerson/first" required="true" />
-				<openid-attribute name="lastname" type="http://axschema.org/namePerson/last" required="true" />
+				<openid-attribute name="email" type="https://axschema.org/contact/email" required="true" count="1"/>
+				<openid-attribute name="firstname" type="https://axschema.org/namePerson/first" required="true" />
+				<openid-attribute name="lastname" type="https://axschema.org/namePerson/last" required="true" />
 			</attribute-exchange>
 			<attribute-exchange identifier-match=".*yahoo.com.*">
-				<openid-attribute name="email" type="http://axschema.org/contact/email" required="true"/>
-				<openid-attribute name="fullname" type="http://axschema.org/namePerson" required="true" />
+				<openid-attribute name="email" type="https://axschema.org/contact/email" required="true"/>
+				<openid-attribute name="fullname" type="https://axschema.org/namePerson" required="true" />
 			</attribute-exchange>
 			<attribute-exchange identifier-match=".*myopenid.com.*">
-				<openid-attribute name="email" type="http://schema.openid.net/contact/email" required="true"/>
-				<openid-attribute name="fullname" type="http://schema.openid.net/namePerson" required="true" />
+				<openid-attribute name="email" type="https://schema.openid.net/contact/email" required="true"/>
+				<openid-attribute name="fullname" type="https://schema.openid.net/namePerson" required="true" />
 			</attribute-exchange>
 		</openid-login>
 		<remember-me token-repository-ref="tokenRepo"/>
@@ -53,10 +53,10 @@
  -->
 <!--
 	<user-service id="userService">
-		<user name="http://luke.taylor.myopenid.com/" authorities="ROLE_SUPERVISOR,ROLE_USER" />
+		<user name="https://luke.taylor.myopenid.com/" authorities="ROLE_SUPERVISOR,ROLE_USER" />
 		<user name="http://luke.taylor.openid.cn/" authorities="ROLE_SUPERVISOR,ROLE_USER" />
-		<user name="http://raykrueger.blogspot.com/" authorities="ROLE_SUPERVISOR,ROLE_USER" />
-		<user name="http://spring.security.test.myopenid.com/" authorities="ROLE_SUPERVISOR,ROLE_USER" />
+		<user name="https://raykrueger.blogspot.com/" authorities="ROLE_SUPERVISOR,ROLE_USER" />
+		<user name="https://spring.security.test.myopenid.com/" authorities="ROLE_SUPERVISOR,ROLE_USER" />
 	</user-service>
  -->
 </b:beans>

--- a/samples/xml/openid/src/main/webapp/WEB-INF/web.xml
+++ b/samples/xml/openid/src/main/webapp/WEB-INF/web.xml
@@ -2,7 +2,7 @@
 
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
 
 	<display-name>Spring Security OpenID Demo Application</display-name>
 

--- a/samples/xml/preauth/src/main/webapp/WEB-INF/applicationContext-security.xml
+++ b/samples/xml/preauth/src/main/webapp/WEB-INF/applicationContext-security.xml
@@ -8,8 +8,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:sec="http://www.springframework.org/schema/security"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<sec:http>
 		<sec:intercept-url pattern="/secure/extreme/**" access="hasRole('ROLE_SUPERVISOR')"/>

--- a/samples/xml/preauth/src/main/webapp/WEB-INF/web.xml
+++ b/samples/xml/preauth/src/main/webapp/WEB-INF/web.xml
@@ -2,7 +2,7 @@
 
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
 
 	<display-name>Spring Security Preauthentication Demo Application</display-name>
 

--- a/samples/xml/servletapi/src/main/resources/applicationContext-security.xml
+++ b/samples/xml/servletapi/src/main/resources/applicationContext-security.xml
@@ -2,8 +2,8 @@
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
-		 xsi:schemaLocation="http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd
-	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
 		<intercept-url pattern="/**" access="permitAll"/>

--- a/samples/xml/servletapi/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/samples/xml/servletapi/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -4,9 +4,9 @@
   xmlns:b="http://www.springframework.org/schema/beans"
   xmlns:p="http://www.springframework.org/schema/p"
   xmlns:context="http://www.springframework.org/schema/context"
-  xsi:schemaLocation="http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
-	http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+  xsi:schemaLocation="http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd
+	http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
   <context:component-scan base-package="org.springframework.security.samples.servletapi.mvc" />
 

--- a/samples/xml/servletapi/src/main/webapp/WEB-INF/web.xml
+++ b/samples/xml/servletapi/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
 	  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+	  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
 	  version="3.0">
 
 	<!--

--- a/samples/xml/tutorial/src/main/resources/applicationContext-business.xml
+++ b/samples/xml/tutorial/src/main/resources/applicationContext-business.xml
@@ -3,8 +3,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:security="http://www.springframework.org/schema/security"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<bean id="bankDao" class="bigbank.BankDaoStub"/>
 

--- a/samples/xml/tutorial/src/main/webapp/WEB-INF/applicationContext-security.xml
+++ b/samples/xml/tutorial/src/main/webapp/WEB-INF/applicationContext-security.xml
@@ -8,8 +8,8 @@
 <beans:beans xmlns="http://www.springframework.org/schema/security"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
 	<debug />
 

--- a/samples/xml/tutorial/src/main/webapp/WEB-INF/bank-servlet.xml
+++ b/samples/xml/tutorial/src/main/webapp/WEB-INF/bank-servlet.xml
@@ -2,7 +2,7 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean name="/listAccounts.html" class="bigbank.web.ListAccounts">
 		<constructor-arg ref="bankService"/>

--- a/samples/xml/tutorial/src/main/webapp/WEB-INF/web.xml
+++ b/samples/xml/tutorial/src/main/webapp/WEB-INF/web.xml
@@ -6,7 +6,7 @@
 
 <web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
 
 	<display-name>Spring Security Tutorial Application</display-name>
 

--- a/web/src/test/resources/org/springframework/security/web/authentication/DelegatingAuthenticationEntryPointTest-context.xml
+++ b/web/src/test/resources/org/springframework/security/web/authentication/DelegatingAuthenticationEntryPointTest-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<bean id="daep" class="org.springframework.security.web.authentication.DelegatingAuthenticationEntryPoint">
 		<constructor-arg>

--- a/web/src/test/resources/webxml/NoRoles.web.xml
+++ b/web/src/test/resources/webxml/NoRoles.web.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
+<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "https://java.sun.com/dtd/web-app_2_3.dtd">
 <web-app id="WebApp">
 	<display-name>poc-acegi-web</display-name>
 	<context-param>

--- a/web/src/test/resources/webxml/Role1-4.web.xml
+++ b/web/src/test/resources/webxml/Role1-4.web.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
+<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "https://java.sun.com/dtd/web-app_2_3.dtd">
 <web-app id="WebApp">
 	<display-name>poc-acegi-web</display-name>
 	<context-param>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://luke.taylor.openid.cn/ (200) with 1 occurrences could not be migrated:  
   ([https](https://luke.taylor.openid.cn/) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://axschema.org/contact/email (UnknownHostException) with 2 occurrences migrated to:  
  https://axschema.org/contact/email ([https](https://axschema.org/contact/email) result UnknownHostException).
* [ ] http://axschema.org/namePerson (UnknownHostException) with 1 occurrences migrated to:  
  https://axschema.org/namePerson ([https](https://axschema.org/namePerson) result UnknownHostException).
* [ ] http://axschema.org/namePerson/first (UnknownHostException) with 1 occurrences migrated to:  
  https://axschema.org/namePerson/first ([https](https://axschema.org/namePerson/first) result UnknownHostException).
* [ ] http://axschema.org/namePerson/last (UnknownHostException) with 1 occurrences migrated to:  
  https://axschema.org/namePerson/last ([https](https://axschema.org/namePerson/last) result UnknownHostException).
* [ ] http://luke.taylor.myopenid.com/ (UnknownHostException) with 1 occurrences migrated to:  
  https://luke.taylor.myopenid.com/ ([https](https://luke.taylor.myopenid.com/) result UnknownHostException).
* [ ] http://schema.openid.net/contact/email (UnknownHostException) with 2 occurrences migrated to:  
  https://schema.openid.net/contact/email ([https](https://schema.openid.net/contact/email) result UnknownHostException).
* [ ] http://schema.openid.net/namePerson (UnknownHostException) with 1 occurrences migrated to:  
  https://schema.openid.net/namePerson ([https](https://schema.openid.net/namePerson) result UnknownHostException).
* [ ] http://schema.openid.net/namePerson/friendly (UnknownHostException) with 1 occurrences migrated to:  
  https://schema.openid.net/namePerson/friendly ([https](https://schema.openid.net/namePerson/friendly) result UnknownHostException).
* [ ] http://spring.security.test.myopenid.com/ (UnknownHostException) with 1 occurrences migrated to:  
  https://spring.security.test.myopenid.com/ ([https](https://spring.security.test.myopenid.com/) result UnknownHostException).
* [ ] http://example.net/pkp-report (404) with 1 occurrences migrated to:  
  https://example.net/pkp-report ([https](https://example.net/pkp-report) result 404).
* [ ] http://www.oasis-open.org/docbook/xml/5.0/rng/docbook.rng (404) with 1 occurrences migrated to:  
  https://www.oasis-open.org/docbook/xml/5.0/rng/docbook.rng ([https](https://www.oasis-open.org/docbook/xml/5.0/rng/docbook.rng) result 404).
* [ ] http://www.puppycrawl.com/dtds/configuration_1_3.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/configuration_1_3.dtd ([https](https://www.puppycrawl.com/dtds/configuration_1_3.dtd) result 404).
* [ ] http://www.puppycrawl.com/dtds/suppressions_1_1.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/suppressions_1_1.dtd ([https](https://www.puppycrawl.com/dtds/suppressions_1_1.dtd) result 404).
* [ ] http://www.se-radio.net/transcript-82-organization-large-code-bases-juergen-hoeller (404) with 1 occurrences migrated to:  
  https://www.se-radio.net/transcript-82-organization-large-code-bases-juergen-hoeller ([https](https://www.se-radio.net/transcript-82-organization-large-code-bases-juergen-hoeller) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://raykrueger.blogspot.com/ with 1 occurrences migrated to:  
  https://raykrueger.blogspot.com/ ([https](https://raykrueger.blogspot.com/) result 200).
* [ ] http://www.infoq.com/presentations/code-organization-large-projects with 1 occurrences migrated to:  
  https://www.infoq.com/presentations/code-organization-large-projects ([https](https://www.infoq.com/presentations/code-organization-large-projects) result 200).
* [ ] http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd with 1 occurrences migrated to:  
  https://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd ([https](https://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd) result 200).
* [ ] http://www.springframework.org/dtd/spring-beans.dtd with 4 occurrences migrated to:  
  https://www.springframework.org/dtd/spring-beans.dtd ([https](https://www.springframework.org/dtd/spring-beans.dtd) result 200).
* [ ] http://www.springframework.org/schema/aop/spring-aop-3.0.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/aop/spring-aop-3.0.xsd ([https](https://www.springframework.org/schema/aop/spring-aop-3.0.xsd) result 200).
* [ ] http://www.springframework.org/schema/aop/spring-aop-3.2.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/aop/spring-aop-3.2.xsd ([https](https://www.springframework.org/schema/aop/spring-aop-3.2.xsd) result 200).
* [ ] http://www.springframework.org/schema/aop/spring-aop.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/aop/spring-aop.xsd ([https](https://www.springframework.org/schema/aop/spring-aop.xsd) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans-3.0.xsd with 20 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.0.xsd) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans-3.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.1.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.1.xsd) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 221 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/context/spring-context-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.0.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.0.xsd) result 200).
* [ ] http://www.springframework.org/schema/context/spring-context-3.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.1.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.1.xsd) result 200).
* [ ] http://www.springframework.org/schema/context/spring-context-3.2.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.2.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.2.xsd) result 200).
* [ ] http://www.springframework.org/schema/context/spring-context.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* [ ] http://www.springframework.org/schema/data/jpa/spring-jpa.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/data/jpa/spring-jpa.xsd ([https](https://www.springframework.org/schema/data/jpa/spring-jpa.xsd) result 200).
* [ ] http://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd ([https](https://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd) result 200).
* [ ] http://www.springframework.org/schema/mvc/spring-mvc.xsd with 9 occurrences migrated to:  
  https://www.springframework.org/schema/mvc/spring-mvc.xsd ([https](https://www.springframework.org/schema/mvc/spring-mvc.xsd) result 200).
* [ ] http://www.springframework.org/schema/security/spring-security-2.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/security/spring-security-2.0.xsd ([https](https://www.springframework.org/schema/security/spring-security-2.0.xsd) result 200).
* [ ] http://www.springframework.org/schema/security/spring-security.xsd with 220 occurrences migrated to:  
  https://www.springframework.org/schema/security/spring-security.xsd ([https](https://www.springframework.org/schema/security/spring-security.xsd) result 200).
* [ ] http://www.springframework.org/schema/tx/spring-tx-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/tx/spring-tx-3.0.xsd ([https](https://www.springframework.org/schema/tx/spring-tx-3.0.xsd) result 200).
* [ ] http://www.springframework.org/schema/tx/spring-tx.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/tx/spring-tx.xsd ([https](https://www.springframework.org/schema/tx/spring-tx.xsd) result 200).
* [ ] http://www.springframework.org/schema/util/spring-util-3.0.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util-3.0.xsd ([https](https://www.springframework.org/schema/util/spring-util-3.0.xsd) result 200).
* [ ] http://www.springframework.org/schema/util/spring-util.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util.xsd ([https](https://www.springframework.org/schema/util/spring-util.xsd) result 200).
* [ ] http://www.springframework.org/schema/websocket/spring-websocket.xsd with 6 occurrences migrated to:  
  https://www.springframework.org/schema/websocket/spring-websocket.xsd ([https](https://www.springframework.org/schema/websocket/spring-websocket.xsd) result 200).
* [ ] http://www.headwaysoftware.com with 1 occurrences migrated to:  
  https://www.headwaysoftware.com ([https](https://www.headwaysoftware.com) result 301).
* [ ] http://java.sun.com/dtd/web-app_2_3.dtd with 2 occurrences migrated to:  
  https://java.sun.com/dtd/web-app_2_3.dtd ([https](https://java.sun.com/dtd/web-app_2_3.dtd) result 302).
* [ ] http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd with 10 occurrences migrated to:  
  https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd ([https](https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd) result 302).
* [ ] http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd with 2 occurrences migrated to:  
  https://java.sun.com/xml/ns/javaee/web-app_3_0.xsd ([https](https://java.sun.com/xml/ns/javaee/web-app_3_0.xsd) result 302).

# Ignored
These URLs were intentionally ignored.

* http://appengine.google.com/ns/1.0 with 1 occurrences
* http://docbook.org/ns/docbook with 1 occurrences
* http://jakarta.apache.org/log4j/ with 1 occurrences
* http://java.sun.com/xml/ns/javaee with 22 occurrences
* http://somehost/someUrl with 1 occurrences
* http://www.springframework.org/schema/aop with 14 occurrences
* http://www.springframework.org/schema/beans with 484 occurrences
* http://www.springframework.org/schema/c with 6 occurrences
* http://www.springframework.org/schema/context with 16 occurrences
* http://www.springframework.org/schema/data/jpa with 2 occurrences
* http://www.springframework.org/schema/jdbc with 2 occurrences
* http://www.springframework.org/schema/mvc with 18 occurrences
* http://www.springframework.org/schema/p with 10 occurrences
* http://www.springframework.org/schema/security with 442 occurrences
* http://www.springframework.org/schema/tx with 8 occurrences
* http://www.springframework.org/schema/util with 14 occurrences
* http://www.springframework.org/schema/websocket with 12 occurrences
* http://www.w3.org/1999/xlink with 1 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 253 occurrences