### PR TITLE
Fixed NPE in HttpsRedirectWebFilter

### DIFF
--- a/web/src/main/java/org/springframework/security/web/server/transport/HttpsRedirectWebFilter.java
+++ b/web/src/main/java/org/springframework/security/web/server/transport/HttpsRedirectWebFilter.java
@@ -17,6 +17,7 @@
 package org.springframework.security.web.server.transport;
 
 import java.net.URI;
+import java.util.Optional;
 
 import reactor.core.publisher.Mono;
 
@@ -101,8 +102,9 @@ public final class HttpsRedirectWebFilter implements WebFilter {
 				UriComponentsBuilder.fromUri(exchange.getRequest().getURI());
 
 		if (port > 0) {
-			port = this.portMapper.lookupHttpsPort(port);
-			builder.port(port);
+			builder.port(Optional.ofNullable(this.portMapper.lookupHttpsPort(port))
+									.orElseThrow(() -> new IllegalStateException(
+										"HTTP Port '" + port + "' does not have a corresponding HTTPS Port")));
 		}
 
 		return builder.scheme("https").build().toUri();

--- a/web/src/test/java/org/springframework/security/web/server/transport/HttpsRedirectWebFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/transport/HttpsRedirectWebFilterTests.java
@@ -112,6 +112,12 @@ public class HttpsRedirectWebFilterTests {
 		verify(portMapper).lookupHttpsPort(314);
 	}
 
+	@Test
+	public void filterWhenRequestIsInsecureAndNoPortMappingThenThrowsIllegalState() {
+		ServerWebExchange exchange = get("http://localhost:1234");
+		assertThatCode(() -> this.filter.filter(exchange, this.chain).block())
+				.isInstanceOf(IllegalStateException.class);
+	}
 
 	@Test
 	public void filterWhenInsecureRequestHasAPathThenRedirects() {


### PR DESCRIPTION
A more descriptive IllegalStateException is now thrown instead
in the case that no such port mapping exists.

Fixes Issue https://github.com/spring-projects/spring-security/issues/6639