### PR TITLE
Defer downstream filter execution if no OAuth2AuthorizedClient is found

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServerOAuth2AuthorizedClientExchangeFilterFunction.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServerOAuth2AuthorizedClientExchangeFilterFunction.java
@@ -227,7 +227,7 @@ public final class ServerOAuth2AuthorizedClientExchangeFilterFunction implements
 		return authorizedClient(request, next)
 				.map(authorizedClient -> bearer(request, authorizedClient))
 				.flatMap(next::exchange)
-				.switchIfEmpty(next.exchange(request));
+				.switchIfEmpty(Mono.defer(() -> next.exchange(request)));
 	}
 
 	private Mono<OAuth2AuthorizedClient> authorizedClient(ClientRequest request, ExchangeFunction next) {


### PR DESCRIPTION
Prior to this change, ServerOAuth2AuthorizedClientExchangeFilterFunction would invoke next.exchange:
- first at assembly time inside the .switchIfEmpty call.
- second at execution time inside .flatMap when a OAuth2AuthorizedClient is found.

While this double-call should not technically cause any functional problems, since the Mono returned by the first call will not be subscribed if a OAuth2AuthorizedClient is found,
it does result in a lot of unnecessary execution and object creation.  There is no technical need to invoke the downstream filters twice.

This change defers the call inside .switchIfEmpty, so that it will only execute at execution time if an OAuth2AuthorizedClient is not found.

After this change, ServerOAuth2AuthorizedClientExchangeFilterFunction will not invoke next.exchange at assembly time, and will only execute next.exchange once per subscription at execution time.

Please backport this change to 5.1.x if possible