### PR TITLE
Eliminates redundant method calls

### DIFF
--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServerOAuth2AuthorizedClientExchangeFilterFunctionTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServerOAuth2AuthorizedClientExchangeFilterFunctionTests.java
@@ -172,8 +172,6 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 		when(this.authorizedClientResolver.clientCredentials(any(), any(), any())).thenReturn(Mono.just(newAuthorizedClient));
 		when(this.authorizedClientResolver.createDefaultedRequest(any(), any(), any())).thenReturn(Mono.just(r));
 
-		when(this.authorizedClientRepository.saveAuthorizedClient(any(), any(), any())).thenReturn(Mono.empty());
-
 		Instant issuedAt = Instant.now().minus(Duration.ofDays(1));
 		Instant accessTokenExpiresAt = issuedAt.plus(Duration.ofHours(1));
 
@@ -194,7 +192,6 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(authentication))
 				.block();
 
-		verify(this.authorizedClientRepository).saveAuthorizedClient(any(), eq(authentication), any());
 		verify(this.authorizedClientResolver).clientCredentials(any(), any(), any());
 		verify(this.authorizedClientResolver).createDefaultedRequest(any(), any(), any());
 


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

Hello, 
Thank you in advance for your review!
I made some changes to avoid redundant method calls.

1. ServerOAuth2AuthorizedClientExchangeFilterFunction class

(1) changed **authorizeWithClientCredentials()**
- authorizeWithClientCredentials()
: I removed the redundant code that calls 'this.authorizedClientRepository.saveAuthorizedClient()', 
because the method is already executed after the 'this.authorizedClientResolver.clientCredentials()' is called in OAuth2AuthorizedClientResolver class.
`clientCredentials() -> getTokenResponse() -> clientCredentialsResponse() -> 'authorizedClientRepository.saveAuthorizedClient()'`

(2) changed **refreshIfNecessary()** and **shouldRefreshToken()**
- refreshIfNecessary() method execution flow
> hasTokenExpired()?
-> Yes, shouldRefreshToken()?
&ensp;&ensp;&ensp; -> Yes - authorizeWithRefreshToken()
&ensp;&ensp;&ensp; -> No - authorizeWithClientCredentials()
-> No - End
- shouldRefreshToken()
: Just checks the grant types and whether the refresh token exists. Because the refresh token would not be used in client credentials grant type, I added the grant type check code here.
Due to the changes of refreshIfNecessary() method, the shouldRefreshToken() no longer needs to call the hasTokenExpired().
This change removes redundant call of 'hasTokenExpired()' when the refresh token is used.

(3) Removed **isClientCredentialsGrantType()**
- isClientCredentialsGrantType()
: This method was used to check the type to avoid using the refresh token in client credentials grant type. Because the grant type will be checked in the updated shouldRefreshToken() method, I removed this one.

2. ServerOAuth2AuthorizedClientExchangeFilterFunctionTests class
- filterWhenClientCredentialsTokenExpiredThenGetNewToken()
: I have also modified the test class according to above changes.

