### PR TITLE
Extract default metatdata sources from methodSecurityMetadataSource()

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfiguration.java
@@ -357,6 +357,17 @@ public class GlobalMethodSecurityConfiguration
 	 */
 	@Bean
 	public MethodSecurityMetadataSource methodSecurityMetadataSource() {
+		List<MethodSecurityMetadataSource> sources = defaultMethodSecurityMetadataSources();
+		return new DelegatingMethodSecurityMetadataSource(sources);
+	}
+
+	/**
+	 * Creates a list of {@link MethodSecurityMetadataSource} for supported Spring Security annotations. This method
+	 * can be overridden to add one or more additional metadata sources.
+	 *
+	 * @return list of {@link MethodSecurityMetadataSource}
+	 */
+	protected List<MethodSecurityMetadataSource> defaultMethodSecurityMetadataSources() {
 		List<MethodSecurityMetadataSource> sources = new ArrayList<>();
 		ExpressionBasedAnnotationAttributeFactory attributeFactory = new ExpressionBasedAnnotationAttributeFactory(
 				getExpressionHandler());
@@ -391,7 +402,7 @@ public class GlobalMethodSecurityConfiguration
 			}
 			sources.add(jsr250MethodSecurityMetadataSource);
 		}
-		return new DelegatingMethodSecurityMetadataSource(sources);
+		return sources;
 	}
 
 	/**


### PR DESCRIPTION
Allows a custom replacement for DelgatingSecurityMetdataSource to be easily configured while giving easy re-use of the default sources that implement Spring Security annotations. 

This also allows customMethodSecurityMetadataSource to be deprecated as this new method can be overridden to add one or more custom sources.  Less code. Yay!

See #5907 for reasons.

I think this is also a candidate for cherry-pick to maintenance branches. 
