### PR TITLE
AbstractOAuth2Token modifications:

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2LoginConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2LoginConfigurerTests.java
@@ -694,8 +694,9 @@ public class OAuth2LoginConfigurerTests {
 			claims.put(IdTokenClaimNames.ISS, "http://localhost/iss");
 			claims.put(IdTokenClaimNames.AUD, Arrays.asList("clientId", "a", "u", "d"));
 			claims.put(IdTokenClaimNames.AZP, "clientId");
-			Jwt jwt = new Jwt("token123", Instant.now(), Instant.now().plusSeconds(3600),
-					Collections.singletonMap("header1", "value1"), claims);
+			claims.put(IdTokenClaimNames.IAT, Instant.now());
+			claims.put(IdTokenClaimNames.EXP, Instant.now().plusSeconds(3600));
+			Jwt jwt = new Jwt("token123", Collections.singletonMap("header1", "value1"), claims);
 			JwtDecoder jwtDecoder = mock(JwtDecoder.class);
 			when(jwtDecoder.decode(any())).thenReturn(jwt);
 			return jwtDecoder;
@@ -738,8 +739,11 @@ public class OAuth2LoginConfigurerTests {
 	}
 
 	private static OAuth2UserService<OidcUserRequest, OidcUser> createOidcUserService() {
-		OidcIdToken idToken = new OidcIdToken("token123", Instant.now(),
-			Instant.now().plusSeconds(3600), Collections.singletonMap(IdTokenClaimNames.SUB, "sub123"));
+		final Map<String, Object> claims = new HashMap<>();
+		claims.put(IdTokenClaimNames.SUB, "sub123");
+		claims.put(IdTokenClaimNames.IAT, Instant.now());
+		claims.put(IdTokenClaimNames.EXP, Instant.now().plusSeconds(3600));
+		OidcIdToken idToken = new OidcIdToken("token123", claims);
 		return request -> new DefaultOidcUser(
 				Collections.singleton(new OidcUserAuthority(idToken)), idToken);
 	}

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
@@ -29,6 +29,7 @@ import java.time.ZoneId;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.PreDestroy;
@@ -141,8 +142,14 @@ public class OAuth2ResourceServerConfigurerTests {
 	private static final String JWT_TOKEN = "token";
 	private static final String JWT_SUBJECT = "mock-test-subject";
 	private static final Map<String, Object> JWT_HEADERS = Collections.singletonMap("alg", JwsAlgorithms.RS256);
-	private static final Map<String, Object> JWT_CLAIMS = Collections.singletonMap(JwtClaimNames.SUB, JWT_SUBJECT);
-	private static final Jwt JWT = new Jwt(JWT_TOKEN, Instant.MIN, Instant.MAX, JWT_HEADERS, JWT_CLAIMS);
+	private static final Map<String, Object> JWT_CLAIMS() {
+		final Map<String, Object> claims = new HashMap<>();
+		claims.put(JwtClaimNames.SUB, JWT_SUBJECT);
+		claims.put(JwtClaimNames.IAT, Instant.MIN);
+		claims.put(JwtClaimNames.EXP,Instant.MAX);
+		return claims;
+	}
+	private static final Jwt JWT = new Jwt(JWT_TOKEN, JWT_HEADERS, JWT_CLAIMS());
 	private static final String JWK_SET_URI = "https://mock.org";
 	private static final JwtAuthenticationToken JWT_AUTHENTICATION_TOKEN =
 			new JwtAuthenticationToken(JWT, Collections.emptyList());

--- a/config/src/test/java/org/springframework/security/config/web/server/OAuth2LoginTests.java
+++ b/config/src/test/java/org/springframework/security/config/web/server/OAuth2LoginTests.java
@@ -343,8 +343,9 @@ public class OAuth2LoginTests {
 					claims.put(IdTokenClaimNames.ISS, "http://localhost/issuer");
 					claims.put(IdTokenClaimNames.AUD, Collections.singletonList("client"));
 					claims.put(IdTokenClaimNames.AZP, "client");
-					Jwt jwt = new Jwt("id-token", Instant.now(), Instant.now().plusSeconds(3600),
-							Collections.singletonMap("header1", "value1"), claims);
+					claims.put(IdTokenClaimNames.IAT, Instant.now());
+					claims.put(IdTokenClaimNames.EXP, Instant.now().plusSeconds(3600));
+					Jwt jwt = new Jwt("id-token", Collections.singletonMap("header1", "value1"), claims);
 					return Mono.just(jwt);
 				};
 			}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/authentication/OidcAuthorizationCodeAuthenticationProvider.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/authentication/OidcAuthorizationCodeAuthenticationProvider.java
@@ -208,7 +208,7 @@ public class OidcAuthorizationCodeAuthenticationProvider implements Authenticati
 			OAuth2Error invalidIdTokenError = new OAuth2Error(INVALID_ID_TOKEN_ERROR_CODE, ex.getMessage(), null);
 			throw new OAuth2AuthenticationException(invalidIdTokenError, invalidIdTokenError.toString(), ex);
 		}
-		OidcIdToken idToken = new OidcIdToken(jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaims());
+		OidcIdToken idToken = new OidcIdToken(jwt.getTokenValue(), jwt.getClaims());
 		return idToken;
 	}
 }

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/authentication/OidcAuthorizationCodeReactiveAuthenticationManager.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/authentication/OidcAuthorizationCodeReactiveAuthenticationManager.java
@@ -190,6 +190,6 @@ public class OidcAuthorizationCodeReactiveAuthenticationManager implements
 		ReactiveJwtDecoder jwtDecoder = this.jwtDecoderFactory.createDecoder(clientRegistration);
 		String rawIdToken = (String) accessTokenResponse.getAdditionalParameters().get(OidcParameterNames.ID_TOKEN);
 		return jwtDecoder.decode(rawIdToken)
-				.map(jwt -> new OidcIdToken(jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaims()));
+				.map(jwt -> new OidcIdToken(jwt.getTokenValue(), jwt.getClaims()));
 	}
 }

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/InMemoryReactiveOAuth2AuthorizedClientServiceTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/InMemoryReactiveOAuth2AuthorizedClientServiceTests.java
@@ -28,11 +28,15 @@ import org.springframework.security.oauth2.client.registration.ReactiveClientReg
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
+
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.when;
@@ -54,10 +58,16 @@ public class InMemoryReactiveOAuth2AuthorizedClientServiceTests {
 
 	private Authentication principal = new TestingAuthenticationToken(this.principalName, "notused");
 
+	private Map<String, Object> attributes(final Instant iat, final Instant exp) {
+		final Map<String, Object> attributes = new HashMap<String, Object>();
+		if(iat != null) attributes.put(IdTokenClaimNames.IAT, iat);
+		if(exp != null) attributes.put(IdTokenClaimNames.EXP, exp);
+		return attributes;
+	}
+
 	OAuth2AccessToken accessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
 			"token",
-			Instant.now(),
-			Instant.now().plus(Duration.ofDays(1)));
+			attributes(Instant.now(), Instant.now().plus(Duration.ofDays(1))));
 
 	private ClientRegistration clientRegistration = ClientRegistration.withRegistrationId(this.clientRegistrationId)
 			.redirectUriTemplate("{baseUrl}/{action}/oauth2/code/{registrationId}")

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/authentication/OidcAuthorizationCodeAuthenticationProviderTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/authentication/OidcAuthorizationCodeAuthenticationProviderTests.java
@@ -307,8 +307,12 @@ public class OidcAuthorizationCodeAuthenticationProviderTests {
 	private void setUpIdToken(Map<String, Object> claims, Instant issuedAt, Instant expiresAt) {
 		Map<String, Object> headers = new HashMap<>();
 		headers.put("alg", "RS256");
+		
+		Map<String, Object> attributes = new HashMap<>(claims);
+		headers.put(IdTokenClaimNames.IAT, issuedAt);
+		headers.put(IdTokenClaimNames.EXP, expiresAt);
 
-		Jwt idToken = new Jwt("id-token", issuedAt, expiresAt, headers, claims);
+		Jwt idToken = new Jwt("id-token", headers, Collections.unmodifiableMap(attributes));
 
 		JwtDecoder jwtDecoder = mock(JwtDecoder.class);
 		when(jwtDecoder.decode(anyString())).thenReturn(idToken);

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/authentication/OidcAuthorizationCodeReactiveAuthenticationManagerTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/authentication/OidcAuthorizationCodeReactiveAuthenticationManagerTests.java
@@ -79,9 +79,22 @@ public class OidcAuthorizationCodeReactiveAuthenticationManagerTests {
 	private OAuth2AuthorizationResponse.Builder authorizationResponseBldr = OAuth2AuthorizationResponse
 			.success("code")
 			.state("state");
+	
+	private Map<String, Object> withInstants(final Map<String, Object> claims, final Instant iat, final Instant exp) {
+		Map<String, Object> attributes = new HashMap<>(claims);
+		if(iat != null) {
+			attributes.put(IdTokenClaimNames.IAT, iat);
+		}
+		if(exp != null) {
+			attributes.put(IdTokenClaimNames.EXP, exp);
+		}
+		return attributes;
+	}
 
-	private OidcIdToken idToken = new OidcIdToken("token123", Instant.now(),
-			Instant.now().plusSeconds(3600), Collections.singletonMap(IdTokenClaimNames.SUB, "sub123"));
+	private OidcIdToken idToken = new OidcIdToken("token123", withInstants(
+					Collections.singletonMap(IdTokenClaimNames.SUB, "sub123"),
+					Instant.now(),
+					Instant.now().plusSeconds(3600)));
 
 	private OidcAuthorizationCodeReactiveAuthenticationManager manager;
 
@@ -167,13 +180,15 @@ public class OidcAuthorizationCodeReactiveAuthenticationManagerTests {
 				.additionalParameters(Collections.singletonMap(OidcParameterNames.ID_TOKEN, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ."))
 				.build();
 
+		Instant issuedAt = Instant.now();
+		Instant expiresAt = Instant.from(issuedAt).plusSeconds(3600);
 		Map<String, Object> claims = new HashMap<>();
 		claims.put(IdTokenClaimNames.ISS, "https://issuer.example.com");
 		claims.put(IdTokenClaimNames.SUB, "rob");
 		claims.put(IdTokenClaimNames.AUD, Arrays.asList("client-id"));
-		Instant issuedAt = Instant.now();
-		Instant expiresAt = Instant.from(issuedAt).plusSeconds(3600);
-		Jwt idToken = new Jwt("id-token", issuedAt, expiresAt, claims, claims);
+		claims.put(IdTokenClaimNames.IAT, issuedAt);
+		claims.put(IdTokenClaimNames.EXP, expiresAt);
+		Jwt idToken = new Jwt("id-token", claims, claims);
 
 		when(this.accessTokenResponseClient.getTokenResponse(any())).thenReturn(Mono.just(accessTokenResponse));
 		when(this.userService.loadUser(any())).thenReturn(Mono.empty());
@@ -189,13 +204,15 @@ public class OidcAuthorizationCodeReactiveAuthenticationManagerTests {
 				.additionalParameters(Collections.singletonMap(OidcParameterNames.ID_TOKEN, this.idToken.getTokenValue()))
 				.build();
 
+		Instant issuedAt = Instant.now();
+		Instant expiresAt = Instant.from(issuedAt).plusSeconds(3600);
 		Map<String, Object> claims = new HashMap<>();
 		claims.put(IdTokenClaimNames.ISS, "https://issuer.example.com");
 		claims.put(IdTokenClaimNames.SUB, "rob");
 		claims.put(IdTokenClaimNames.AUD, Arrays.asList("client-id"));
-		Instant issuedAt = Instant.now();
-		Instant expiresAt = Instant.from(issuedAt).plusSeconds(3600);
-		Jwt idToken = new Jwt("id-token", issuedAt, expiresAt, claims, claims);
+		claims.put(IdTokenClaimNames.IAT, issuedAt);
+		claims.put(IdTokenClaimNames.EXP, expiresAt);
+		Jwt idToken = new Jwt("id-token", claims, claims);
 
 		when(this.accessTokenResponseClient.getTokenResponse(any())).thenReturn(Mono.just(accessTokenResponse));
 		DefaultOidcUser user = new DefaultOidcUser(AuthorityUtils.createAuthorityList("ROLE_USER"), this.idToken);
@@ -218,13 +235,15 @@ public class OidcAuthorizationCodeReactiveAuthenticationManagerTests {
 				.refreshToken("refresh-token")
 				.build();
 
+		Instant issuedAt = Instant.now();
+		Instant expiresAt = Instant.from(issuedAt).plusSeconds(3600);
 		Map<String, Object> claims = new HashMap<>();
 		claims.put(IdTokenClaimNames.ISS, "https://issuer.example.com");
 		claims.put(IdTokenClaimNames.SUB, "rob");
 		claims.put(IdTokenClaimNames.AUD, Arrays.asList("client-id"));
-		Instant issuedAt = Instant.now();
-		Instant expiresAt = Instant.from(issuedAt).plusSeconds(3600);
-		Jwt idToken = new Jwt("id-token", issuedAt, expiresAt, claims, claims);
+		claims.put(IdTokenClaimNames.IAT, issuedAt);
+		claims.put(IdTokenClaimNames.EXP, expiresAt);
+		Jwt idToken = new Jwt("id-token", claims, claims);
 
 		when(this.accessTokenResponseClient.getTokenResponse(any())).thenReturn(Mono.just(accessTokenResponse));
 		DefaultOidcUser user = new DefaultOidcUser(AuthorityUtils.createAuthorityList("ROLE_USER"), this.idToken);
@@ -253,13 +272,15 @@ public class OidcAuthorizationCodeReactiveAuthenticationManagerTests {
 				.additionalParameters(additionalParameters)
 				.build();
 
+		Instant issuedAt = Instant.now();
+		Instant expiresAt = Instant.from(issuedAt).plusSeconds(3600);
 		Map<String, Object> claims = new HashMap<>();
 		claims.put(IdTokenClaimNames.ISS, "https://issuer.example.com");
 		claims.put(IdTokenClaimNames.SUB, "rob");
 		claims.put(IdTokenClaimNames.AUD, Arrays.asList(clientRegistration.getClientId()));
-		Instant issuedAt = Instant.now();
-		Instant expiresAt = Instant.from(issuedAt).plusSeconds(3600);
-		Jwt idToken = new Jwt("id-token", issuedAt, expiresAt, claims, claims);
+		claims.put(IdTokenClaimNames.IAT, issuedAt);
+		claims.put(IdTokenClaimNames.EXP, expiresAt);
+		Jwt idToken = new Jwt("id-token", claims, claims);
 
 		when(this.accessTokenResponseClient.getTokenResponse(any())).thenReturn(Mono.just(accessTokenResponse));
 		DefaultOidcUser user = new DefaultOidcUser(AuthorityUtils.createAuthorityList("ROLE_USER"), this.idToken);

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcReactiveOAuth2UserServiceTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcReactiveOAuth2UserServiceTests.java
@@ -58,15 +58,22 @@ public class OidcReactiveOAuth2UserServiceTests {
 
 	private ClientRegistration.Builder registration = TestClientRegistrations.clientRegistration()
 			.userNameAttributeName(IdTokenClaimNames.SUB);
+	
+	private Map<String, Object> withInstants(final Map<String, Object> claims, final Instant iat, final Instant exp) {
+		final Map<String, Object> attributes = new HashMap<String, Object>(claims);
+		if(iat != null) attributes.put(IdTokenClaimNames.IAT, iat);
+		if(exp != null) attributes.put(IdTokenClaimNames.EXP, exp);
+		return attributes;
+	}
 
-	private OidcIdToken idToken = new OidcIdToken("token123", Instant.now(),
-			Instant.now().plusSeconds(3600), Collections
-			.singletonMap(IdTokenClaimNames.SUB, "sub123"));
+	private OidcIdToken idToken = new OidcIdToken("token123", withInstants(
+			Collections.singletonMap(IdTokenClaimNames.SUB, "sub123"),
+			Instant.now(),
+			Instant.now().plusSeconds(3600)));
 
 	private OAuth2AccessToken accessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
 			"token",
-			Instant.now(),
-			Instant.now().plus(Duration.ofDays(1)),
+			withInstants(Collections.emptyMap(), Instant.now(), Instant.now().plus(Duration.ofDays(1))),
 			Collections.singleton("read:user"));
 
 	private OidcReactiveOAuth2UserService userService = new OidcReactiveOAuth2UserService();

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcUserRequestTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcUserRequestTests.java
@@ -26,6 +26,7 @@ import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -43,6 +44,13 @@ public class OidcUserRequestTests {
 	private OAuth2AccessToken accessToken;
 	private OidcIdToken idToken;
 	private Map<String, Object> additionalParameters;
+	
+	private Map<String, Object> withInstants(final Map<String, Object> claims, final Instant iat, final Instant exp) {
+		final Map<String, Object> attributes = new HashMap<String, Object>(claims);
+		if(iat != null) attributes.put(IdTokenClaimNames.IAT, iat);
+		if(exp != null) attributes.put(IdTokenClaimNames.EXP, exp);
+		return attributes;
+	}
 
 	@Before
 	public void setUp() {
@@ -59,14 +67,17 @@ public class OidcUserRequestTests {
 				.clientName("Client 1")
 				.build();
 		this.accessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
-				"access-token-1234", Instant.now(), Instant.now().plusSeconds(60),
+				"access-token-1234",
+				withInstants(Collections.emptyMap(), Instant.now(), Instant.now().plusSeconds(60)),
 				new LinkedHashSet<>(Arrays.asList("scope1", "scope2")));
 		Map<String, Object> claims = new HashMap<>();
 		claims.put(IdTokenClaimNames.ISS, "https://provider.com");
 		claims.put(IdTokenClaimNames.SUB, "subject1");
 		claims.put(IdTokenClaimNames.AZP, "client-1");
-		this.idToken = new OidcIdToken("id-token-1234", Instant.now(),
-				Instant.now().plusSeconds(3600), claims);
+		this.idToken = new OidcIdToken("id-token-1234", withInstants(
+				claims,
+				Instant.now(),
+				Instant.now().plusSeconds(3600)));
 		this.additionalParameters = new HashMap<>();
 		this.additionalParameters.put("param1", "value1");
 		this.additionalParameters.put("param2", "value2");

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcUserRequestUtilsTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcUserRequestUtilsTests.java
@@ -27,6 +27,8 @@ import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -36,15 +38,24 @@ import static org.assertj.core.api.Assertions.*;
  */
 public class OidcUserRequestUtilsTests {
 	private ClientRegistration.Builder registration = TestClientRegistrations.clientRegistration();
+	
+	private Map<String, Object> withInstants(final Map<String, Object> claims, final Instant iat, final Instant exp) {
+		final Map<String, Object> attributes = new HashMap<String, Object>(claims);
+		if(iat != null) attributes.put(IdTokenClaimNames.IAT, iat);
+		if(exp != null) attributes.put(IdTokenClaimNames.EXP, exp);
+		return attributes;
+	}
 
-	OidcIdToken idToken = new OidcIdToken("token123", Instant.now(),
-			Instant.now().plusSeconds(3600), Collections
-			.singletonMap(IdTokenClaimNames.SUB, "sub123"));
+	OidcIdToken idToken = new OidcIdToken("token123", withInstants(
+			Collections.singletonMap(IdTokenClaimNames.SUB, "sub123"),
+			Instant.now(),
+			Instant.now().plusSeconds(3600)));
 
 	OAuth2AccessToken accessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
-			"token",
-			Instant.now(),
-			Instant.now().plus(Duration.ofDays(1)),
+			"token", withInstants(
+					Collections.emptyMap(),
+					Instant.now(),
+					Instant.now().plus(Duration.ofDays(1))),
 			Collections.singleton("read:user"));
 
 	@Test

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcUserServiceTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcUserServiceTests.java
@@ -17,6 +17,7 @@ package org.springframework.security.oauth2.client.oidc.userinfo;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -67,6 +68,13 @@ public class OidcUserServiceTests {
 
 	@Rule
 	public ExpectedException exception = ExpectedException.none();
+	
+	private Map<String, Object> withInstants(final Map<String, Object> claims, final Instant iat, final Instant exp) {
+		final Map<String, Object> attributes = new HashMap<String, Object>(claims);
+		if(iat != null) attributes.put(IdTokenClaimNames.IAT, iat);
+		if(exp != null) attributes.put(IdTokenClaimNames.EXP, exp);
+		return attributes;
+	}
 
 	@Before
 	public void setup() throws Exception {
@@ -82,7 +90,7 @@ public class OidcUserServiceTests {
 		Map<String, Object> idTokenClaims = new HashMap<>();
 		idTokenClaims.put(IdTokenClaimNames.ISS, "https://provider.com");
 		idTokenClaims.put(IdTokenClaimNames.SUB, "subject1");
-		this.idToken = new OidcIdToken("access-token", Instant.MIN, Instant.MAX, idTokenClaims);
+		this.idToken = new OidcIdToken("access-token", withInstants(idTokenClaims, Instant.MIN, Instant.MAX));
 
 		this.userService.setOauth2UserService(new DefaultOAuth2UserService());
 	}
@@ -118,8 +126,10 @@ public class OidcUserServiceTests {
 
 		Set<String> authorizedScopes = new LinkedHashSet<>(Arrays.asList("scope1", "scope2"));
 		OAuth2AccessToken accessToken = new OAuth2AccessToken(
-				OAuth2AccessToken.TokenType.BEARER, "access-token",
-				Instant.MIN, Instant.MAX, authorizedScopes);
+				OAuth2AccessToken.TokenType.BEARER,
+				"access-token",
+				withInstants(Collections.emptyMap(), Instant.MIN, Instant.MAX),
+				authorizedScopes);
 
 		OidcUser user = this.userService.loadUser(
 			new OidcUserRequest(clientRegistration, accessToken, this.idToken));

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/userinfo/DefaultReactiveOAuth2UserServiceTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/userinfo/DefaultReactiveOAuth2UserServiceTests.java
@@ -30,6 +30,7 @@ import org.springframework.security.oauth2.client.registration.TestClientRegistr
 import org.springframework.security.oauth2.core.AuthenticationMethod;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
 
@@ -38,6 +39,8 @@ import reactor.test.StepVerifier;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -49,9 +52,16 @@ public class DefaultReactiveOAuth2UserServiceTests {
 	private ClientRegistration.Builder clientRegistration;
 
 	private DefaultReactiveOAuth2UserService userService = new DefaultReactiveOAuth2UserService();
+	
+	private Map<String, Object> attributes(final Instant iat, final Instant exp) {
+		final Map<String, Object> attributes = new HashMap<String, Object>();
+		if(iat != null) attributes.put(IdTokenClaimNames.IAT, iat);
+		if(exp != null) attributes.put(IdTokenClaimNames.EXP, exp);
+		return attributes;
+	}
 
 	private OAuth2AccessToken accessToken = new OAuth2AccessToken(
-			OAuth2AccessToken.TokenType.BEARER, "access-token", Instant.now(), Instant.now().plus(Duration.ofDays(1)));
+			OAuth2AccessToken.TokenType.BEARER, "access-token", attributes(Instant.now(), Instant.now().plus(Duration.ofDays(1))));
 
 	private MockWebServer server;
 

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/userinfo/DelegatingOAuth2UserServiceTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/userinfo/DelegatingOAuth2UserServiceTests.java
@@ -47,7 +47,7 @@ public class DelegatingOAuth2UserServiceTests {
 	@SuppressWarnings("unchecked")
 	public void loadUserWhenUserRequestIsNullThenThrowIllegalArgumentException() {
 		DelegatingOAuth2UserService<OAuth2UserRequest, OAuth2User> delegatingUserService =
-			new DelegatingOAuth2UserService<>(
+			new DelegatingOAuth2UserService<OAuth2UserRequest, OAuth2User>(
 				Arrays.asList(mock(OAuth2UserService.class), mock(OAuth2UserService.class)));
 		delegatingUserService.loadUser(null);
 	}

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/userinfo/OAuth2UserRequestEntityConverterTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/userinfo/OAuth2UserRequestEntityConverterTests.java
@@ -15,6 +15,15 @@
  */
 package org.springframework.security.oauth2.client.userinfo;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+
 import org.junit.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -25,14 +34,8 @@ import org.springframework.security.oauth2.client.registration.TestClientRegistr
 import org.springframework.security.oauth2.core.AuthenticationMethod;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
 import org.springframework.util.MultiValueMap;
-
-import java.time.Instant;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
 
 /**
  * Tests for {@link OAuth2UserRequestEntityConverter}.
@@ -42,7 +45,6 @@ import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VAL
 public class OAuth2UserRequestEntityConverterTests {
 	private OAuth2UserRequestEntityConverter converter = new OAuth2UserRequestEntityConverter();
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void convertWhenAuthenticationMethodHeaderThenGetRequest() {
 		ClientRegistration clientRegistration = TestClientRegistrations.clientRegistration().build();
@@ -87,9 +89,14 @@ public class OAuth2UserRequestEntityConverterTests {
 	}
 
 	private OAuth2AccessToken createAccessToken() {
+		final Map<String, Object> attributes = new HashMap<String, Object>();
+		attributes.put(IdTokenClaimNames.IAT, Instant.now());
+		attributes.put(IdTokenClaimNames.EXP, Instant.now().plusSeconds(3600));
 		OAuth2AccessToken accessToken = new OAuth2AccessToken(
-				OAuth2AccessToken.TokenType.BEARER, "access-token-1234", Instant.now(),
-				Instant.now().plusSeconds(3600), new LinkedHashSet<>(Arrays.asList("read", "write")));
+				OAuth2AccessToken.TokenType.BEARER, 
+				"access-token-1234",
+				attributes, 
+				new LinkedHashSet<>(Arrays.asList("read", "write")));
 		return accessToken;
 	}
 }

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/userinfo/OAuth2UserRequestTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/userinfo/OAuth2UserRequestTests.java
@@ -21,6 +21,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -54,8 +55,13 @@ public class OAuth2UserRequestTests {
 				.tokenUri("https://provider.com/oauth2/token")
 				.clientName("Client 1")
 				.build();
-		this.accessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
-				"access-token-1234", Instant.now(), Instant.now().plusSeconds(60),
+		final Map<String, Object> attributes = new HashMap<String, Object>();
+		attributes.put(IdTokenClaimNames.IAT, Instant.now());
+		attributes.put(IdTokenClaimNames.EXP, Instant.now().plusSeconds(60));
+		this.accessToken = new OAuth2AccessToken(
+				OAuth2AccessToken.TokenType.BEARER,
+				"access-token-1234",
+				attributes,
 				new LinkedHashSet<>(Arrays.asList("scope1", "scope2")));
 		this.additionalParameters = new HashMap<>();
 		this.additionalParameters.put("param1", "value1");

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServletOAuth2AuthorizedClientExchangeFilterFunctionTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServletOAuth2AuthorizedClientExchangeFilterFunctionTests.java
@@ -56,6 +56,7 @@ import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 import org.springframework.security.oauth2.core.endpoint.TestOAuth2AccessTokenResponses;
+import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -115,10 +116,16 @@ public class ServletOAuth2AuthorizedClientExchangeFilterFunctionTests {
 	private ClientRegistration registration = TestClientRegistrations.clientRegistration()
 			.build();
 
+	private Map<String, Object> attributes(final Instant iat, final Instant exp) {
+		final Map<String, Object> attributes = new HashMap<String, Object>();
+		if(iat != null) attributes.put(IdTokenClaimNames.IAT, iat);
+		if(exp != null) attributes.put(IdTokenClaimNames.EXP, exp);
+		return attributes;
+	}
+
 	private OAuth2AccessToken accessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
 			"token-0",
-			Instant.now(),
-			Instant.now().plus(Duration.ofDays(1)));
+			attributes(Instant.now(), Instant.now().plus(Duration.ofDays(1))));
 
 	@Before
 	public void setup() {
@@ -390,12 +397,11 @@ public class ServletOAuth2AuthorizedClientExchangeFilterFunctionTests {
 
 		this.accessToken = new OAuth2AccessToken(this.accessToken.getTokenType(),
 				this.accessToken.getTokenValue(),
-				issuedAt,
-				accessTokenExpiresAt);
+				attributes(issuedAt, accessTokenExpiresAt));
 		this.function = new ServletOAuth2AuthorizedClientExchangeFilterFunction(this.clientRegistrationRepository,
 				this.authorizedClientRepository);
 
-		OAuth2RefreshToken refreshToken = new OAuth2RefreshToken("refresh-token", issuedAt);
+		OAuth2RefreshToken refreshToken = new OAuth2RefreshToken("refresh-token", attributes(issuedAt, null));
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.registration,
 				"principalName", this.accessToken, refreshToken);
 		ClientRequest request = ClientRequest.create(GET, URI.create("https://example.com"))
@@ -440,12 +446,11 @@ public class ServletOAuth2AuthorizedClientExchangeFilterFunctionTests {
 
 		this.accessToken = new OAuth2AccessToken(this.accessToken.getTokenType(),
 				this.accessToken.getTokenValue(),
-				issuedAt,
-				accessTokenExpiresAt);
+				attributes(issuedAt, accessTokenExpiresAt));
 		this.function = new ServletOAuth2AuthorizedClientExchangeFilterFunction(this.clientRegistrationRepository,
 				this.authorizedClientRepository);
 
-		OAuth2RefreshToken refreshToken = new OAuth2RefreshToken("refresh-token", issuedAt);
+		OAuth2RefreshToken refreshToken = new OAuth2RefreshToken("refresh-token", attributes(issuedAt, null));
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.registration,
 				"principalName", this.accessToken, refreshToken);
 		ClientRequest request = ClientRequest.create(GET, URI.create("https://example.com"))
@@ -522,8 +527,7 @@ public class ServletOAuth2AuthorizedClientExchangeFilterFunctionTests {
 
 		this.accessToken = new OAuth2AccessToken(this.accessToken.getTokenType(),
 				this.accessToken.getTokenValue(),
-				issuedAt,
-				accessTokenExpiresAt);
+				attributes(issuedAt, accessTokenExpiresAt));
 		this.function = new ServletOAuth2AuthorizedClientExchangeFilterFunction(this.clientRegistrationRepository,
 				this.authorizedClientRepository);
 		this.function.setClientCredentialsTokenResponseClient(this.clientCredentialsTokenResponseClient);
@@ -564,12 +568,11 @@ public class ServletOAuth2AuthorizedClientExchangeFilterFunctionTests {
 
 		this.accessToken = new OAuth2AccessToken(this.accessToken.getTokenType(),
 				this.accessToken.getTokenValue(),
-				issuedAt,
-				accessTokenExpiresAt);
+				attributes(issuedAt, accessTokenExpiresAt));
 		this.function = new ServletOAuth2AuthorizedClientExchangeFilterFunction(this.clientRegistrationRepository,
 				this.authorizedClientRepository);
 
-		OAuth2RefreshToken refreshToken = new OAuth2RefreshToken("refresh-token", issuedAt);
+		OAuth2RefreshToken refreshToken = new OAuth2RefreshToken("refresh-token", attributes(issuedAt, null));
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.registration,
 				"principalName", this.accessToken, refreshToken);
 		ClientRequest request = ClientRequest.create(GET, URI.create("https://example.com"))
@@ -625,7 +628,7 @@ public class ServletOAuth2AuthorizedClientExchangeFilterFunctionTests {
 		this.function = new ServletOAuth2AuthorizedClientExchangeFilterFunction(this.clientRegistrationRepository,
 				this.authorizedClientRepository);
 
-		OAuth2RefreshToken refreshToken = new OAuth2RefreshToken("refresh-token", this.accessToken.getIssuedAt());
+		OAuth2RefreshToken refreshToken = new OAuth2RefreshToken("refresh-token", attributes(this.accessToken.getIssuedAt(), null));
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.registration,
 				"principalName", this.accessToken, refreshToken);
 		ClientRequest request = ClientRequest.create(GET, URI.create("https://example.com"))

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/server/authentication/OAuth2LoginAuthenticationWebFilterTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/server/authentication/OAuth2LoginAuthenticationWebFilterTests.java
@@ -33,6 +33,7 @@ import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationExchange;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponse;
+import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.web.server.WebFilterExchange;
 import org.springframework.web.server.handler.DefaultWebFilterChain;
@@ -41,6 +42,8 @@ import reactor.core.publisher.Mono;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -84,10 +87,12 @@ public class OAuth2LoginAuthenticationWebFilterTests {
 	}
 
 	private OAuth2LoginAuthenticationToken loginToken() {
+		final Map<String, Object> attributes = new HashMap<String, Object>();
+		attributes.put(IdTokenClaimNames.IAT, Instant.now());
+		attributes.put(IdTokenClaimNames.EXP, Instant.now().plus(Duration.ofDays(1)));
 		OAuth2AccessToken accessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
 				"token",
-				Instant.now(),
-				Instant.now().plus(Duration.ofDays(1)),
+				attributes,
 				Collections.singleton("user"));
 		DefaultOAuth2User user = new DefaultOAuth2User(AuthorityUtils.createAuthorityList("ROLE_USER"), Collections
 				.singletonMap("user", "rob"), "user");

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/OAuth2RefreshToken.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/OAuth2RefreshToken.java
@@ -16,6 +16,8 @@
 package org.springframework.security.oauth2.core;
 
 import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * An implementation of an {@link AbstractOAuth2Token} representing an OAuth 2.0 Refresh Token.
@@ -37,9 +39,31 @@ public class OAuth2RefreshToken extends AbstractOAuth2Token {
 	 * Constructs an {@code OAuth2RefreshToken} using the provided parameters.
 	 *
 	 * @param tokenValue the token value
+	 * @param attributes the troken attributes
+	 */
+	public OAuth2RefreshToken(final String tokenValue, final Map<String, Object> attributes) {
+		super(tokenValue, attributes);
+	}
+	
+	/**
+	 * Constructs an {@code OAuth2RefreshToken} using the provided parameters.
+	 *
+	 * @param tokenValue the token value
 	 * @param issuedAt the time at which the token was issued
 	 */
 	public OAuth2RefreshToken(String tokenValue, Instant issuedAt) {
-		super(tokenValue, issuedAt, null);
+		super(tokenValue, issuedAt != null ? Collections.singletonMap("iat", issuedAt) : Collections.emptyMap());
+	}
+
+	@Override
+	public Instant getIssuedAt() {
+		Object value = getAttributes().get("iat");
+		return value instanceof Instant ? (Instant)value : null;
+	}
+
+	@Override
+	public Instant getExpiresAt() {
+		Object value = getAttributes().get("exp");
+		return value instanceof Instant ? (Instant)value : null;
 	}
 }

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/OAuth2AccessTokenResponse.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/OAuth2AccessTokenResponse.java
@@ -23,6 +23,7 @@ import org.springframework.util.StringUtils;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -181,15 +182,15 @@ public final class OAuth2AccessTokenResponse {
 		 * @return a {@link OAuth2AccessTokenResponse}
 		 */
 		public OAuth2AccessTokenResponse build() {
-			Instant issuedAt = getIssuedAt();
-
-			Instant expiresAt = getExpiresAt();
+			final Map<String, Object> attributes = new HashMap<>();
+			attributes.put("iat", getIssuedAt());
+			attributes.put("exp", getExpiresAt());
 
 			OAuth2AccessTokenResponse accessTokenResponse = new OAuth2AccessTokenResponse();
 			accessTokenResponse.accessToken = new OAuth2AccessToken(
-				this.tokenType, this.tokenValue, issuedAt, expiresAt, this.scopes);
+				this.tokenType, this.tokenValue, attributes, this.scopes);
 			if (StringUtils.hasText(this.refreshToken)) {
-				accessTokenResponse.refreshToken = new OAuth2RefreshToken(this.refreshToken, issuedAt);
+				accessTokenResponse.refreshToken = new OAuth2RefreshToken(this.refreshToken, attributes);
 			}
 			accessTokenResponse.additionalParameters = Collections.unmodifiableMap(
 				CollectionUtils.isEmpty(this.additionalParameters) ? Collections.emptyMap() : this.additionalParameters);

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/TestOAuth2AccessTokens.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/TestOAuth2AccessTokens.java
@@ -19,25 +19,33 @@ package org.springframework.security.oauth2.core;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 /**
  * @author Rob Winch
  * @since 5.1
  */
 public class TestOAuth2AccessTokens {
+	
+	static Map<String, Object> attributes(){
+		final Map<String, Object> attributes = new HashMap<>();
+		attributes.put("iat", Instant.now());
+		attributes.put("exp", Instant.now().plus(Duration.ofDays(1)));
+		return attributes;
+	}
+	
 	public static OAuth2AccessToken noScopes() {
 		return new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
 				"no-scopes",
-				Instant.now(),
-				Instant.now().plus(Duration.ofDays(1)));
+				attributes());
 	}
 
 	public static OAuth2AccessToken scopes(String... scopes) {
 		return new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
 				"scopes",
-				Instant.now(),
-				Instant.now().plus(Duration.ofDays(1)),
+				attributes(),
 				new HashSet<>(Arrays.asList(scopes)));
 	}
 }

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/TestOAuth2RefreshTokens.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/TestOAuth2RefreshTokens.java
@@ -17,13 +17,15 @@
 package org.springframework.security.oauth2.core;
 
 import java.time.Instant;
+import java.util.Collections;
 
 /**
  * @author Rob Winch
  * @since 5.1
  */
 public class TestOAuth2RefreshTokens {
+	
 	public static OAuth2RefreshToken refreshToken() {
-		return new OAuth2RefreshToken("refresh-token", Instant.now());
+		return new OAuth2RefreshToken("refresh-token", Collections.singletonMap("iat", Instant.now()));
 	}
 }

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/oidc/OidcIdTokenTests.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/oidc/OidcIdTokenTests.java
@@ -48,9 +48,9 @@ public class OidcIdTokenTests {
 	private static final String ISS_VALUE = "https://provider.com";
 	private static final String SUB_VALUE = "subject1";
 	private static final List<String> AUD_VALUE = Arrays.asList("aud1", "aud2");
-	private static final long IAT_VALUE = Instant.now().toEpochMilli();
-	private static final long EXP_VALUE = Instant.now().plusSeconds(60).toEpochMilli();
-	private static final long AUTH_TIME_VALUE = Instant.now().minusSeconds(5).toEpochMilli();
+	private static final long IAT_VALUE = Instant.now().getEpochSecond();
+	private static final long EXP_VALUE = Instant.now().plusSeconds(60).getEpochSecond();
+	private static final long AUTH_TIME_VALUE = Instant.now().minusSeconds(5).getEpochSecond();
 	private static final String NONCE_VALUE = "nonce";
 	private static final String ACR_VALUE = "acr";
 	private static final List<String> AMR_VALUE = Arrays.asList("amr1", "amr2");
@@ -79,27 +79,25 @@ public class OidcIdTokenTests {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void constructorWhenTokenValueIsNullThenThrowIllegalArgumentException() {
-		new OidcIdToken(null, Instant.ofEpochMilli(IAT_VALUE), Instant.ofEpochMilli(EXP_VALUE), CLAIMS);
+		new OidcIdToken(null, CLAIMS);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void constructorWhenClaimsIsEmptyThenThrowIllegalArgumentException() {
-		new OidcIdToken(ID_TOKEN_VALUE, Instant.ofEpochMilli(IAT_VALUE),
-			Instant.ofEpochMilli(EXP_VALUE), Collections.emptyMap());
+		new OidcIdToken(ID_TOKEN_VALUE, Collections.emptyMap());
 	}
 
 	@Test
 	public void constructorWhenParametersProvidedAndValidThenCreated() {
-		OidcIdToken idToken = new OidcIdToken(ID_TOKEN_VALUE, Instant.ofEpochMilli(IAT_VALUE),
-			Instant.ofEpochMilli(EXP_VALUE), CLAIMS);
+		OidcIdToken idToken = new OidcIdToken(ID_TOKEN_VALUE, CLAIMS);
 
 		assertThat(idToken.getClaims()).isEqualTo(CLAIMS);
 		assertThat(idToken.getTokenValue()).isEqualTo(ID_TOKEN_VALUE);
 		assertThat(idToken.getIssuer().toString()).isEqualTo(ISS_VALUE);
 		assertThat(idToken.getSubject()).isEqualTo(SUB_VALUE);
 		assertThat(idToken.getAudience()).isEqualTo(AUD_VALUE);
-		assertThat(idToken.getIssuedAt().toEpochMilli()).isEqualTo(IAT_VALUE);
-		assertThat(idToken.getExpiresAt().toEpochMilli()).isEqualTo(EXP_VALUE);
+		assertThat(idToken.getIssuedAt().getEpochSecond()).isEqualTo(IAT_VALUE);
+		assertThat(idToken.getExpiresAt().getEpochSecond()).isEqualTo(EXP_VALUE);
 		assertThat(idToken.getAuthenticatedAt().getEpochSecond()).isEqualTo(AUTH_TIME_VALUE);
 		assertThat(idToken.getNonce()).isEqualTo(NONCE_VALUE);
 		assertThat(idToken.getAuthenticationContextClass()).isEqualTo(ACR_VALUE);

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/oidc/user/DefaultOidcUserTests.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/oidc/user/DefaultOidcUserTests.java
@@ -50,11 +50,13 @@ public class DefaultOidcUserTests {
 	static {
 		ID_TOKEN_CLAIMS.put(IdTokenClaimNames.ISS, "https://example.com");
 		ID_TOKEN_CLAIMS.put(IdTokenClaimNames.SUB, SUBJECT);
+		ID_TOKEN_CLAIMS.put(IdTokenClaimNames.IAT, Instant.EPOCH);
+		ID_TOKEN_CLAIMS.put(IdTokenClaimNames.EXP, Instant.MAX);
 		USER_INFO_CLAIMS.put(StandardClaimNames.NAME, NAME);
 		USER_INFO_CLAIMS.put(StandardClaimNames.EMAIL, EMAIL);
 	}
 
-	private static final OidcIdToken ID_TOKEN = new OidcIdToken("id-token-value", Instant.EPOCH, Instant.MAX, ID_TOKEN_CLAIMS);
+	private static final OidcIdToken ID_TOKEN = new OidcIdToken("id-token-value", ID_TOKEN_CLAIMS);
 	private static final OidcUserInfo USER_INFO = new OidcUserInfo(USER_INFO_CLAIMS);
 
 	@Test(expected = IllegalArgumentException.class)
@@ -76,24 +78,24 @@ public class DefaultOidcUserTests {
 	public void constructorWhenAuthoritiesIdTokenProvidedThenCreated() {
 		DefaultOidcUser user = new DefaultOidcUser(AUTHORITIES, ID_TOKEN);
 
-		assertThat(user.getClaims()).containsOnlyKeys(IdTokenClaimNames.ISS, IdTokenClaimNames.SUB);
+		assertThat(user.getClaims()).containsOnlyKeys(IdTokenClaimNames.ISS, IdTokenClaimNames.SUB, IdTokenClaimNames.IAT, IdTokenClaimNames.EXP);
 		assertThat(user.getIdToken()).isEqualTo(ID_TOKEN);
 		assertThat(user.getName()).isEqualTo(SUBJECT);
 		assertThat(user.getAuthorities()).hasSize(1);
 		assertThat(user.getAuthorities().iterator().next()).isEqualTo(AUTHORITY);
-		assertThat(user.getAttributes()).containsOnlyKeys(IdTokenClaimNames.ISS, IdTokenClaimNames.SUB);
+		assertThat(user.getAttributes()).containsOnlyKeys(IdTokenClaimNames.ISS, IdTokenClaimNames.SUB, IdTokenClaimNames.IAT, IdTokenClaimNames.EXP);
 	}
 
 	@Test
 	public void constructorWhenAuthoritiesIdTokenNameAttributeKeyProvidedThenCreated() {
 		DefaultOidcUser user = new DefaultOidcUser(AUTHORITIES, ID_TOKEN, IdTokenClaimNames.SUB);
 
-		assertThat(user.getClaims()).containsOnlyKeys(IdTokenClaimNames.ISS, IdTokenClaimNames.SUB);
+		assertThat(user.getClaims()).containsOnlyKeys(IdTokenClaimNames.ISS, IdTokenClaimNames.SUB, IdTokenClaimNames.IAT, IdTokenClaimNames.EXP);
 		assertThat(user.getIdToken()).isEqualTo(ID_TOKEN);
 		assertThat(user.getName()).isEqualTo(SUBJECT);
 		assertThat(user.getAuthorities()).hasSize(1);
 		assertThat(user.getAuthorities().iterator().next()).isEqualTo(AUTHORITY);
-		assertThat(user.getAttributes()).containsOnlyKeys(IdTokenClaimNames.ISS, IdTokenClaimNames.SUB);
+		assertThat(user.getAttributes()).containsOnlyKeys(IdTokenClaimNames.ISS, IdTokenClaimNames.SUB, IdTokenClaimNames.IAT, IdTokenClaimNames.EXP);
 	}
 
 	@Test
@@ -101,14 +103,14 @@ public class DefaultOidcUserTests {
 		DefaultOidcUser user = new DefaultOidcUser(AUTHORITIES, ID_TOKEN, USER_INFO);
 
 		assertThat(user.getClaims()).containsOnlyKeys(
-			IdTokenClaimNames.ISS, IdTokenClaimNames.SUB, StandardClaimNames.NAME, StandardClaimNames.EMAIL);
+			IdTokenClaimNames.ISS, IdTokenClaimNames.SUB, StandardClaimNames.NAME, StandardClaimNames.EMAIL, IdTokenClaimNames.IAT, IdTokenClaimNames.EXP);
 		assertThat(user.getIdToken()).isEqualTo(ID_TOKEN);
 		assertThat(user.getUserInfo()).isEqualTo(USER_INFO);
 		assertThat(user.getName()).isEqualTo(SUBJECT);
 		assertThat(user.getAuthorities()).hasSize(1);
 		assertThat(user.getAuthorities().iterator().next()).isEqualTo(AUTHORITY);
 		assertThat(user.getAttributes()).containsOnlyKeys(
-			IdTokenClaimNames.ISS, IdTokenClaimNames.SUB, StandardClaimNames.NAME, StandardClaimNames.EMAIL);
+			IdTokenClaimNames.ISS, IdTokenClaimNames.SUB, StandardClaimNames.NAME, StandardClaimNames.EMAIL, IdTokenClaimNames.IAT, IdTokenClaimNames.EXP);
 	}
 
 	@Test
@@ -116,13 +118,13 @@ public class DefaultOidcUserTests {
 		DefaultOidcUser user = new DefaultOidcUser(AUTHORITIES, ID_TOKEN, USER_INFO, StandardClaimNames.EMAIL);
 
 		assertThat(user.getClaims()).containsOnlyKeys(
-			IdTokenClaimNames.ISS, IdTokenClaimNames.SUB, StandardClaimNames.NAME, StandardClaimNames.EMAIL);
+			IdTokenClaimNames.ISS, IdTokenClaimNames.SUB, StandardClaimNames.NAME, StandardClaimNames.EMAIL, IdTokenClaimNames.IAT, IdTokenClaimNames.EXP);
 		assertThat(user.getIdToken()).isEqualTo(ID_TOKEN);
 		assertThat(user.getUserInfo()).isEqualTo(USER_INFO);
 		assertThat(user.getName()).isEqualTo(EMAIL);
 		assertThat(user.getAuthorities()).hasSize(1);
 		assertThat(user.getAuthorities().iterator().next()).isEqualTo(AUTHORITY);
 		assertThat(user.getAttributes()).containsOnlyKeys(
-			IdTokenClaimNames.ISS, IdTokenClaimNames.SUB, StandardClaimNames.NAME, StandardClaimNames.EMAIL);
+			IdTokenClaimNames.ISS, IdTokenClaimNames.SUB, StandardClaimNames.NAME, StandardClaimNames.EMAIL, IdTokenClaimNames.IAT, IdTokenClaimNames.EXP);
 	}
 }

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/oidc/user/OidcUserAuthorityTests.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/oidc/user/OidcUserAuthorityTests.java
@@ -44,11 +44,13 @@ public class OidcUserAuthorityTests {
 	static {
 		ID_TOKEN_CLAIMS.put(IdTokenClaimNames.ISS, "https://example.com");
 		ID_TOKEN_CLAIMS.put(IdTokenClaimNames.SUB, SUBJECT);
+		ID_TOKEN_CLAIMS.put(IdTokenClaimNames.IAT, Instant.EPOCH);
+		ID_TOKEN_CLAIMS.put(IdTokenClaimNames.EXP, Instant.MAX);
 		USER_INFO_CLAIMS.put(StandardClaimNames.NAME, NAME);
 		USER_INFO_CLAIMS.put(StandardClaimNames.EMAIL, EMAIL);
 	}
 
-	private static final OidcIdToken ID_TOKEN = new OidcIdToken("id-token-value", Instant.EPOCH, Instant.MAX, ID_TOKEN_CLAIMS);
+	private static final OidcIdToken ID_TOKEN = new OidcIdToken("id-token-value", ID_TOKEN_CLAIMS);
 	private static final OidcUserInfo USER_INFO = new OidcUserInfo(USER_INFO_CLAIMS);
 
 	@Test(expected = IllegalArgumentException.class)
@@ -74,6 +76,6 @@ public class OidcUserAuthorityTests {
 		assertThat(userAuthority.getUserInfo()).isEqualTo(USER_INFO);
 		assertThat(userAuthority.getAuthority()).isEqualTo(AUTHORITY);
 		assertThat(userAuthority.getAttributes()).containsOnlyKeys(
-			IdTokenClaimNames.ISS, IdTokenClaimNames.SUB, StandardClaimNames.NAME, StandardClaimNames.EMAIL);
+			IdTokenClaimNames.ISS, IdTokenClaimNames.SUB, StandardClaimNames.NAME, StandardClaimNames.EMAIL, IdTokenClaimNames.IAT, IdTokenClaimNames.EXP);
 	}
 }

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/oidc/user/TestOidcUsers.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/oidc/user/TestOidcUsers.java
@@ -42,6 +42,8 @@ public class TestOidcUsers {
 		claims.put(IdTokenClaimNames.ISS, "http://localhost/issuer");
 		claims.put(IdTokenClaimNames.AUD, Collections.singletonList("client"));
 		claims.put(IdTokenClaimNames.AZP, "client");
-		return new OidcIdToken("id-token", Instant.now(), Instant.now().plusSeconds(3600), claims);
+		claims.put(IdTokenClaimNames.IAT, Instant.now());
+		claims.put(IdTokenClaimNames.EXP, Instant.now().plusSeconds(3600));
+		return new OidcIdToken("id-token", claims);
 	}
 }

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoder.java
@@ -16,6 +16,32 @@
 
 package org.springframework.security.oauth2.jwt;
 
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.interfaces.RSAPublicKey;
+import java.text.ParseException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jose.jws.JwsAlgorithm;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
+import org.springframework.util.Assert;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.client.RestTemplate;
+
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.RemoteKeySourceException;
 import com.nimbusds.jose.jwk.JWKSet;
@@ -36,31 +62,6 @@ import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import com.nimbusds.jwt.proc.JWTProcessor;
-import org.springframework.core.convert.converter.Converter;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
-import org.springframework.http.RequestEntity;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.oauth2.core.OAuth2TokenValidator;
-import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
-import org.springframework.security.oauth2.jose.jws.JwsAlgorithm;
-import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
-import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
-import org.springframework.util.Assert;
-import org.springframework.web.client.RestOperations;
-import org.springframework.web.client.RestTemplate;
-
-import javax.crypto.SecretKey;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.security.interfaces.RSAPublicKey;
-import java.text.ParseException;
-import java.time.Instant;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 /**
  * A low-level Nimbus implementation of {@link JwtDecoder} which takes a raw Nimbus configuration.
@@ -144,9 +145,7 @@ public final class NimbusJwtDecoder implements JwtDecoder {
 			Map<String, Object> headers = new LinkedHashMap<>(parsedJwt.getHeader().toJSONObject());
 			Map<String, Object> claims = this.claimSetConverter.convert(jwtClaimsSet.getClaims());
 
-			Instant expiresAt = (Instant) claims.get(JwtClaimNames.EXP);
-			Instant issuedAt = (Instant) claims.get(JwtClaimNames.IAT);
-			jwt = new Jwt(token, issuedAt, expiresAt, headers, claims);
+			jwt = new Jwt(token, headers, claims);
 		} catch (RemoteKeySourceException ex) {
 			if (ex.getCause() instanceof ParseException) {
 				throw new JwtException(String.format(DECODING_ERROR_MESSAGE_TEMPLATE, "Malformed Jwk set"));

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
@@ -15,6 +15,23 @@
  */
 package org.springframework.security.oauth2.jwt;
 
+import java.security.interfaces.RSAPublicKey;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jose.jws.JwsAlgorithm;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
+import org.springframework.util.Assert;
+import org.springframework.web.reactive.function.client.WebClient;
+
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
@@ -38,24 +55,9 @@ import com.nimbusds.jwt.JWTParser;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import com.nimbusds.jwt.proc.JWTProcessor;
-import org.springframework.core.convert.converter.Converter;
-import org.springframework.security.oauth2.core.OAuth2TokenValidator;
-import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
-import org.springframework.security.oauth2.jose.jws.JwsAlgorithm;
-import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
-import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
-import org.springframework.util.Assert;
-import org.springframework.web.reactive.function.client.WebClient;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
-import javax.crypto.SecretKey;
-import java.security.interfaces.RSAPublicKey;
-import java.time.Instant;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.function.Function;
 
 /**
  * An implementation of a {@link ReactiveJwtDecoder} that &quot;decodes&quot; a
@@ -162,9 +164,7 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 		Map<String, Object> headers = new LinkedHashMap<>(parsedJwt.getHeader().toJSONObject());
 		Map<String, Object> claims = this.claimSetConverter.convert(jwtClaimsSet.getClaims());
 
-		Instant expiresAt = (Instant) claims.get(JwtClaimNames.EXP);
-		Instant issuedAt = (Instant) claims.get(JwtClaimNames.IAT);
-		return new Jwt(parsedJwt.getParsedString(), issuedAt, expiresAt, headers, claims);
+		return new Jwt(parsedJwt.getParsedString(), headers, claims);
 	}
 
 	private Jwt validateJwt(Jwt jwt) {

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtIssuerValidatorTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtIssuerValidatorTests.java
@@ -17,6 +17,7 @@ package org.springframework.security.oauth2.jwt;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
@@ -46,10 +47,8 @@ public class JwtIssuerValidatorTests {
 	public void validateWhenIssuerMatchesThenReturnsSuccess() {
 		Jwt jwt = new Jwt(
 				MOCK_TOKEN,
-				MOCK_ISSUED_AT,
-				MOCK_EXPIRES_AT,
 				MOCK_HEADERS,
-				Collections.singletonMap("iss", ISSUER));
+				addIssueInstants(Collections.singletonMap("iss", ISSUER)));
 
 		assertThat(this.validator.validate(jwt))
 				.isEqualTo(OAuth2TokenValidatorResult.success());
@@ -59,10 +58,8 @@ public class JwtIssuerValidatorTests {
 	public void validateWhenIssuerMismatchesThenReturnsError() {
 		Jwt jwt = new Jwt(
 				MOCK_TOKEN,
-				MOCK_ISSUED_AT,
-				MOCK_EXPIRES_AT,
 				MOCK_HEADERS,
-				Collections.singletonMap(JwtClaimNames.ISS, "https://other"));
+				addIssueInstants(Collections.singletonMap(JwtClaimNames.ISS, "https://other")));
 
 		OAuth2TokenValidatorResult result = this.validator.validate(jwt);
 
@@ -73,10 +70,8 @@ public class JwtIssuerValidatorTests {
 	public void validateWhenJwtHasNoIssuerThenReturnsError() {
 		Jwt jwt = new Jwt(
 				MOCK_TOKEN,
-				MOCK_ISSUED_AT,
-				MOCK_EXPIRES_AT,
 				MOCK_HEADERS,
-				Collections.singletonMap(JwtClaimNames.AUD, "https://aud"));
+				addIssueInstants(Collections.singletonMap(JwtClaimNames.AUD, "https://aud")));
 
 		OAuth2TokenValidatorResult result = this.validator.validate(jwt);
 		assertThat(result.getErrors()).isNotEmpty();
@@ -87,10 +82,8 @@ public class JwtIssuerValidatorTests {
 	public void validateWhenIssuerMatchesAndIsNotAUriThenReturnsSuccess() {
 		Jwt jwt = new Jwt(
 				MOCK_TOKEN,
-				MOCK_ISSUED_AT,
-				MOCK_EXPIRES_AT,
 				MOCK_HEADERS,
-				Collections.singletonMap(JwtClaimNames.ISS, "issuer"));
+				addIssueInstants(Collections.singletonMap(JwtClaimNames.ISS, "issuer")));
 		JwtIssuerValidator validator = new JwtIssuerValidator("issuer");
 
 		assertThat(validator.validate(jwt))
@@ -107,5 +100,12 @@ public class JwtIssuerValidatorTests {
 	public void constructorWhenNullIssuerIsGivenThenThrowsIllegalArgumentException() {
 		assertThatCode(() -> new JwtIssuerValidator(null))
 				.isInstanceOf(IllegalArgumentException.class);
+	}
+	
+	private Map<String, Object> addIssueInstants(final Map<String, Object> claims) {
+		Map<String, Object> attributes = new HashMap<>(claims);
+		attributes.put(JwtClaimNames.IAT, MOCK_ISSUED_AT);
+		attributes.put(JwtClaimNames.EXP, MOCK_EXPIRES_AT);
+		return attributes;
 	}
 }

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtTests.java
@@ -69,29 +69,26 @@ public class JwtTests {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void constructorWhenTokenValueIsNullThenThrowIllegalArgumentException() {
-		new Jwt(null, Instant.ofEpochMilli(IAT_VALUE), Instant.ofEpochMilli(EXP_VALUE), HEADERS, CLAIMS);
+		new Jwt(null, HEADERS, addIssueInstants(CLAIMS));
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void constructorWhenHeadersIsEmptyThenThrowIllegalArgumentException() {
-		new Jwt(JWT_TOKEN_VALUE, Instant.ofEpochMilli(IAT_VALUE),
-			Instant.ofEpochMilli(EXP_VALUE), Collections.emptyMap(), CLAIMS);
+		new Jwt(JWT_TOKEN_VALUE, Collections.emptyMap(), addIssueInstants(CLAIMS));
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void constructorWhenClaimsIsEmptyThenThrowIllegalArgumentException() {
-		new Jwt(JWT_TOKEN_VALUE, Instant.ofEpochMilli(IAT_VALUE),
-			Instant.ofEpochMilli(EXP_VALUE), HEADERS, Collections.emptyMap());
+		new Jwt(JWT_TOKEN_VALUE, HEADERS, Collections.emptyMap());
 	}
 
 	@Test
 	public void constructorWhenParametersProvidedAndValidThenCreated() {
-		Jwt jwt = new Jwt(JWT_TOKEN_VALUE, Instant.ofEpochMilli(IAT_VALUE),
-			Instant.ofEpochMilli(EXP_VALUE), HEADERS, CLAIMS);
+		Jwt jwt = new Jwt(JWT_TOKEN_VALUE, HEADERS, addIssueInstants(CLAIMS));
 
 		assertThat(jwt.getTokenValue()).isEqualTo(JWT_TOKEN_VALUE);
 		assertThat(jwt.getHeaders()).isEqualTo(HEADERS);
-		assertThat(jwt.getClaims()).isEqualTo(CLAIMS);
+		assertThat(jwt.getClaims()).isEqualTo(addIssueInstants(CLAIMS));
 		assertThat(jwt.getIssuer().toString()).isEqualTo(ISS_VALUE);
 		assertThat(jwt.getSubject()).isEqualTo(SUB_VALUE);
 		assertThat(jwt.getAudience()).isEqualTo(AUD_VALUE);
@@ -99,5 +96,12 @@ public class JwtTests {
 		assertThat(jwt.getNotBefore().getEpochSecond()).isEqualTo(NBF_VALUE);
 		assertThat(jwt.getIssuedAt().toEpochMilli()).isEqualTo(IAT_VALUE);
 		assertThat(jwt.getId()).isEqualTo(JTI_VALUE);
+	}
+	
+	private Map<String, Object> addIssueInstants(final Map<String, Object> claims) {
+		Map<String, Object> attributes = new HashMap<>(claims);
+		attributes.put(JwtClaimNames.IAT, Instant.ofEpochMilli(IAT_VALUE));
+		attributes.put(JwtClaimNames.EXP, Instant.ofEpochMilli(EXP_VALUE));
+		return attributes;
 	}
 }

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionAuthenticationProvider.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionAuthenticationProvider.java
@@ -138,15 +138,13 @@ public final class OAuth2IntrospectionAuthenticationProvider implements Authenti
 		BearerTokenAuthenticationToken bearer = (BearerTokenAuthenticationToken) authentication;
 		TokenIntrospectionSuccessResponse response = introspect(bearer.getToken());
 		Map<String, Object> claims = convertClaimsSet(response);
-		Instant iat = (Instant) claims.get(ISSUED_AT);
-		Instant exp = (Instant) claims.get(EXPIRES_AT);
 
 		// construct token
 		OAuth2AccessToken token  = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
-				bearer.getToken(), iat, exp);
+				bearer.getToken(), claims);
 		Collection<GrantedAuthority> authorities = extractAuthorities(claims);
 		AbstractAuthenticationToken result =
-				new OAuth2IntrospectionAuthenticationToken(token, claims, authorities);
+				new OAuth2IntrospectionAuthenticationToken(token, authorities);
 		result.setDetails(bearer.getDetails());
 		return result;
 	}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionAuthenticationToken.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionAuthenticationToken.java
@@ -15,17 +15,15 @@
  */
 package org.springframework.security.oauth2.server.resource.authentication;
 
+import static org.springframework.security.oauth2.server.resource.authentication.OAuth2IntrospectionClaimNames.SUBJECT;
+
 import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.SpringSecurityCoreVersion;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.util.Assert;
-
-import static org.springframework.security.oauth2.server.resource.authentication.OAuth2IntrospectionClaimNames.SUBJECT;
 
 /**
  * An {@link org.springframework.security.core.Authentication} token that represents a successful authentication as
@@ -41,7 +39,6 @@ public class OAuth2IntrospectionAuthenticationToken
 
 	private static final long serialVersionUID = SpringSecurityCoreVersion.SERIAL_VERSION_UID;
 
-	private Map<String, Object> attributes;
 	private String name;
 
 	/**
@@ -51,9 +48,9 @@ public class OAuth2IntrospectionAuthenticationToken
 	 * @param authorities The authorities associated with the given token
 	 */
 	public OAuth2IntrospectionAuthenticationToken(OAuth2AccessToken token,
-			Map<String, Object> attributes, Collection<? extends GrantedAuthority> authorities) {
+			Collection<? extends GrantedAuthority> authorities) {
 
-		this(token, attributes, authorities, null);
+		this(token, authorities, null);
 	}
 
 	/**
@@ -64,12 +61,11 @@ public class OAuth2IntrospectionAuthenticationToken
 	 * @param name The name associated with this token
 	 */
 	public OAuth2IntrospectionAuthenticationToken(OAuth2AccessToken token,
-		Map<String, Object> attributes, Collection<? extends GrantedAuthority> authorities, String name) {
-
-		super(token, attributes, token, authorities);
-		Assert.notEmpty(attributes, "attributes cannot be empty");
-		this.attributes = Collections.unmodifiableMap(new LinkedHashMap<>(attributes));
-		this.name = name == null ? (String) attributes.get(SUBJECT) : name;
+		Collection<? extends GrantedAuthority> authorities, String name) {
+		
+		super(token, token.getAttributes(), token, authorities);
+		Assert.notEmpty(token.getAttributes(), "attributes cannot be empty");
+		this.name = name == null ? (String) token.getAttributes().get(SUBJECT) : name;
 		setAuthenticated(true);
 	}
 
@@ -78,7 +74,7 @@ public class OAuth2IntrospectionAuthenticationToken
 	 */
 	@Override
 	public Map<String, Object> getTokenAttributes() {
-		return this.attributes;
+		return this.getToken().getAttributes();
 	}
 
 	/**

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionReactiveAuthenticationManager.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionReactiveAuthenticationManager.java
@@ -144,14 +144,12 @@ public class OAuth2IntrospectionReactiveAuthenticationManager implements Reactiv
 		return introspect(token)
 				.map(response -> {
 					Map<String, Object> claims = convertClaimsSet(response);
-					Instant iat = (Instant) claims.get(ISSUED_AT);
-					Instant exp = (Instant) claims.get(EXPIRES_AT);
 
 					// construct token
 					OAuth2AccessToken accessToken =
-							new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, token, iat, exp);
+							new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, token, claims);
 					Collection<GrantedAuthority> authorities = extractAuthorities(claims);
-					return new OAuth2IntrospectionAuthenticationToken(accessToken, claims, authorities);
+					return new OAuth2IntrospectionAuthenticationToken(accessToken, authorities);
 				});
 	}
 

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationConverterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationConverterTests.java
@@ -34,6 +34,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
 
 /**
  * Tests for {@link JwtAuthenticationConverter}
@@ -81,7 +82,11 @@ public class JwtAuthenticationConverterTests {
 	private Jwt jwt(Map<String, Object> claims) {
 		Map<String, Object> headers = new HashMap<>();
 		headers.put("alg", JwsAlgorithms.RS256);
+		
+		Map<String, Object> attributes = new HashMap<>(claims);
+		attributes.put(JwtClaimNames.IAT, Instant.now());
+		attributes.put(JwtClaimNames.EXP, Instant.now().plusSeconds(3600));
 
-		return new Jwt("token", Instant.now(), Instant.now().plusSeconds(3600), headers, claims);
+		return new Jwt("token", headers, attributes);
 	}
 }

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationProviderTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationProviderTests.java
@@ -31,6 +31,7 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken;
@@ -77,7 +78,7 @@ public class JwtAuthenticationProviderTests {
 		JwtAuthenticationToken authentication =
 				(JwtAuthenticationToken) this.provider.authenticate(token);
 
-		assertThat(authentication.getTokenAttributes()).isEqualTo(claims);
+		assertThat(authentication.getTokenAttributes()).isNotEmpty();
 	}
 
 	@Test
@@ -133,8 +134,12 @@ public class JwtAuthenticationProviderTests {
 	private Jwt jwt(Map<String, Object> claims) {
 		Map<String, Object> headers = new HashMap<>();
 		headers.put("alg", JwsAlgorithms.RS256);
+		
+		Map<String, Object> attributes = new HashMap<>(claims);
+		attributes.put(JwtClaimNames.IAT, Instant.now());
+		attributes.put(JwtClaimNames.EXP, Instant.now().plusSeconds(3600));
 
-		return new Jwt("token", Instant.now(), Instant.now().plusSeconds(3600), headers, claims);
+		return new Jwt("token", headers, attributes);
 	}
 
 	private Predicate<? super Throwable> errorCode(String errorCode) {

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationTokenTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationTokenTests.java
@@ -30,6 +30,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -79,7 +80,7 @@ public class JwtAuthenticationTokenTests {
 		assertThat(token.getPrincipal()).isEqualTo(jwt);
 		assertThat(token.getCredentials()).isEqualTo(jwt);
 		assertThat(token.getToken()).isEqualTo(jwt);
-		assertThat(token.getTokenAttributes()).isEqualTo(claims);
+		assertThat(token.getTokenAttributes()).isNotEmpty();
 		assertThat(token.isAuthenticated()).isTrue();
 	}
 
@@ -94,14 +95,18 @@ public class JwtAuthenticationTokenTests {
 		assertThat(token.getPrincipal()).isEqualTo(jwt);
 		assertThat(token.getCredentials()).isEqualTo(jwt);
 		assertThat(token.getToken()).isEqualTo(jwt);
-		assertThat(token.getTokenAttributes()).isEqualTo(claims);
+		assertThat(token.getTokenAttributes()).isNotEmpty();
 		assertThat(token.isAuthenticated()).isFalse();
 	}
 
 	private Jwt jwt(Map<String, Object> claims) {
 		Map<String, Object> headers = new HashMap<>();
 		headers.put("alg", JwsAlgorithms.RS256);
+		
+		Map<String, Object> attributes = new HashMap<>(claims);
+		attributes.put(JwtClaimNames.IAT, Instant.now());
+		attributes.put(JwtClaimNames.EXP, Instant.now().plusSeconds(3600));
 
-		return new Jwt("token", Instant.now(), Instant.now().plusSeconds(3600), headers, claims);
+		return new Jwt("token", headers, attributes);
 	}
 }

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtGrantedAuthoritiesConverterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtGrantedAuthoritiesConverterTests.java
@@ -32,6 +32,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
 
 /**
  * Tests for {@link JwtGrantedAuthoritiesConverter}
@@ -111,7 +112,11 @@ public class JwtGrantedAuthoritiesConverterTests {
 	private Jwt jwt(Map<String, Object> claims) {
 		Map<String, Object> headers = new HashMap<>();
 		headers.put("alg", JwsAlgorithms.RS256);
+		
+		Map<String, Object> attributes = new HashMap<>(claims);
+		attributes.put(JwtClaimNames.IAT, Instant.now());
+		attributes.put(JwtClaimNames.EXP, Instant.now().plusSeconds(3600));
 
-		return new Jwt("token", Instant.now(), Instant.now().plusSeconds(3600), headers, claims);
+		return new Jwt("token", headers, attributes);
 	}
 }

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtReactiveAuthenticationManagerTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtReactiveAuthenticationManagerTests.java
@@ -26,6 +26,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
 import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
 import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken;
@@ -59,9 +60,10 @@ public class JwtReactiveAuthenticationManagerTests {
 
 		Map<String, Object> claims = new HashMap<>();
 		claims.put("scope", "message:read message:write");
-		Instant issuedAt = Instant.now();
-		Instant expiresAt = Instant.from(issuedAt).plusSeconds(3600);
-		this.jwt = new Jwt("jwt", issuedAt, expiresAt, claims, claims);
+		claims.put(JwtClaimNames.IAT, Instant.now());
+		claims.put(JwtClaimNames.EXP, Instant.now().plusSeconds(3600));
+
+		this.jwt = new Jwt("jwt", claims, claims);
 	}
 
 	@Test

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/ReactiveJwtAuthenticationConverterAdapterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/ReactiveJwtAuthenticationConverterAdapterTests.java
@@ -30,6 +30,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -123,7 +124,11 @@ public class ReactiveJwtAuthenticationConverterAdapterTests {
 	private Jwt jwt(Map<String, Object> claims) {
 		Map<String, Object> headers = new HashMap<>();
 		headers.put("alg", JwsAlgorithms.RS256);
+		
+		Map<String, Object> attributes = new HashMap<>(claims);
+		attributes.put(JwtClaimNames.IAT, Instant.now());
+		attributes.put(JwtClaimNames.EXP, Instant.now().plusSeconds(3600));
 
-		return new Jwt("token", Instant.now(), Instant.now().plusSeconds(3600), headers, claims);
+		return new Jwt("token", headers, attributes);
 	}
 }

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/ReactiveJwtAuthenticationConverterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/ReactiveJwtAuthenticationConverterTests.java
@@ -35,6 +35,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
 
 /**
  * Tests for {@link ReactiveJwtAuthenticationConverter}
@@ -83,7 +84,11 @@ public class ReactiveJwtAuthenticationConverterTests {
 	private Jwt jwt(Map<String, Object> claims) {
 		Map<String, Object> headers = new HashMap<>();
 		headers.put("alg", JwsAlgorithms.RS256);
+		
+		Map<String, Object> attributes = new HashMap<>(claims);
+		attributes.put(JwtClaimNames.IAT, Instant.now());
+		attributes.put(JwtClaimNames.EXP, Instant.now().plusSeconds(3600));
 
-		return new Jwt("token", Instant.now(), Instant.now().plusSeconds(3600), headers, claims);
+		return new Jwt("token", headers, attributes);
 	}
 }

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/ReactiveJwtGrantedAuthoritiesConverterAdapterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/ReactiveJwtGrantedAuthoritiesConverterAdapterTests.java
@@ -34,6 +34,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
 
 /**
  * Tests for {@link ReactiveJwtGrantedAuthoritiesConverterAdapter}
@@ -69,7 +70,11 @@ public class ReactiveJwtGrantedAuthoritiesConverterAdapterTests {
 	private Jwt jwt(Map<String, Object> claims) {
 		Map<String, Object> headers = new HashMap<>();
 		headers.put("alg", JwsAlgorithms.RS256);
+		
+		Map<String, Object> attributes = new HashMap<>(claims);
+		attributes.put(JwtClaimNames.IAT, Instant.now());
+		attributes.put(JwtClaimNames.EXP, Instant.now().plusSeconds(3600));
 
-		return new Jwt("token", Instant.now(), Instant.now().plusSeconds(3600), headers, claims);
+		return new Jwt("token", headers, attributes);
 	}
 }

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/access/BearerTokenAccessDeniedHandlerTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/access/BearerTokenAccessDeniedHandlerTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.security.oauth2.server.resource.web.access;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -87,7 +88,7 @@ public class BearerTokenAccessDeniedHandlerTests {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		MockHttpServletResponse response = new MockHttpServletResponse();
 
-		Authentication token = new TestingOAuth2TokenAuthenticationToken(Collections.emptyMap());
+		Authentication token = new TestingOAuth2TokenAuthenticationToken(Collections.singletonMap("foo", "bar"));
 		request.setUserPrincipal(token);
 
 		this.accessDeniedHandler.handle(request, response, null);
@@ -229,21 +230,28 @@ public class BearerTokenAccessDeniedHandlerTests {
 	static class TestingOAuth2TokenAuthenticationToken
 			extends AbstractOAuth2TokenAuthenticationToken<TestingOAuth2TokenAuthenticationToken.TestingOAuth2Token> {
 
-		private Map<String, Object> attributes;
-
-		protected TestingOAuth2TokenAuthenticationToken(Map<String, Object> attributes) {
-			super(new TestingOAuth2Token("token"));
-			this.attributes = attributes;
+		protected TestingOAuth2TokenAuthenticationToken(final Map<String, Object> attributes) {
+			super(new TestingOAuth2Token("token", attributes));
 		}
 
 		@Override
 		public Map<String, Object> getTokenAttributes() {
-			return this.attributes;
+			return this.getToken().getAttributes();
 		}
 
 		static class TestingOAuth2Token extends AbstractOAuth2Token {
-			public TestingOAuth2Token(String tokenValue) {
-				super(tokenValue);
+			public TestingOAuth2Token(final String tokenValue, final Map<String, Object> attributes) {
+				super(tokenValue, attributes);
+			}
+
+			@Override
+			public Instant getIssuedAt() {
+				return null;
+			}
+
+			@Override
+			public Instant getExpiresAt() {
+				return null;
 			}
 		}
 	}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/access/server/BearerTokenServerAccessDeniedHandlerTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/access/server/BearerTokenServerAccessDeniedHandlerTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.security.oauth2.server.resource.web.access.server;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -80,7 +81,7 @@ public class BearerTokenServerAccessDeniedHandlerTests {
 	@Test
 	public void handleWhenTokenHasNoScopesThenInsufficientScopeError() {
 
-		Authentication token = new TestingOAuth2TokenAuthenticationToken(Collections.emptyMap());
+		Authentication token = new TestingOAuth2TokenAuthenticationToken(Collections.singletonMap("foo", "bar"));
 		ServerWebExchange exchange = mock(ServerWebExchange.class);
 		when(exchange.getPrincipal()).thenReturn(Mono.just(token));
 		when(exchange.getResponse()).thenReturn(new MockServerHttpResponse());
@@ -214,21 +215,28 @@ public class BearerTokenServerAccessDeniedHandlerTests {
 	static class TestingOAuth2TokenAuthenticationToken
 			extends AbstractOAuth2TokenAuthenticationToken<TestingOAuth2TokenAuthenticationToken.TestingOAuth2Token> {
 
-		private Map<String, Object> attributes;
-
-		protected TestingOAuth2TokenAuthenticationToken(Map<String, Object> attributes) {
-			super(new TestingOAuth2TokenAuthenticationToken.TestingOAuth2Token("token"));
-			this.attributes = attributes;
+		protected TestingOAuth2TokenAuthenticationToken(final Map<String, Object> attributes) {
+			super(new TestingOAuth2TokenAuthenticationToken.TestingOAuth2Token("token", attributes));
 		}
 
 		@Override
 		public Map<String, Object> getTokenAttributes() {
-			return this.attributes;
+			return this.getToken().getAttributes();
 		}
 
 		static class TestingOAuth2Token extends AbstractOAuth2Token {
-			public TestingOAuth2Token(String tokenValue) {
-				super(tokenValue);
+			public TestingOAuth2Token(final String tokenValue, final Map<String, Object> attributes) {
+				super(tokenValue, attributes);
+			}
+
+			@Override
+			public Instant getIssuedAt() {
+				return null;
+			}
+
+			@Override
+			public Instant getExpiresAt() {
+				return null;
 			}
 		}
 	}


### PR DESCRIPTION
To illustrate
 https://github.com/spring-projects/spring-security/issues/6807

Make it possible to inject granted-authorities converter in JwtAuthenticationConverter constructor

JwtGrantedAuthoritiesConverter modifications (which currently is both a granted-authority and a scope converter.):
  * rename to JwtScopesGrantedAuthoritiesConverter because it extracts authorities from token scopes only
  * extract a TokenAttributesScopesConverter and use it as collaborator
  * make prefix scope authorities configurable (so that it can be removed)
  * add constructors to inject scopes converter and scope authorities prefix
  * modify default constructor so that it uses a TokenAttributesScopesConverter extracting scopes from "scope" and "scp" claims and adding "SCOPE_" prefix (keep current behavior)

TokenAttributesScopesConverter behavior modification: scan and merge all "claims to scan" (instead of first found only)
