### PR TITLE
Fix javadoc typo

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/HttpStatusEntryPoint.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/HttpStatusEntryPoint.java
@@ -40,7 +40,7 @@ public final class HttpStatusEntryPoint implements AuthenticationEntryPoint {
 	/**
 	 * Creates a new instance.
 	 *
-	 * @param httpStatus the HttpSatus to set
+	 * @param httpStatus the HttpStatus to set
 	 */
 	public HttpStatusEntryPoint(HttpStatus httpStatus) {
 		Assert.notNull(httpStatus, "httpStatus cannot be null");


### PR DESCRIPTION
Just fixes a typo in a javadoc. (Obvious Fix)
