### PR TITLE
Reactive JwkSource Builder Parameter Type  Changed the parameter type from JWT to SignedJWT  Fixes: gh-6771

### DIFF
--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
@@ -223,7 +223,7 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 	 *
 	 * @since 5.2
 	 */
-	public static JwkSourceReactiveJwtDecoderBuilder withJwkSource(Function<JWT, Flux<JWK>> source) {
+	public static JwkSourceReactiveJwtDecoderBuilder withJwkSource(Function<SignedJWT, Flux<JWK>> source) {
 		return new JwkSourceReactiveJwtDecoderBuilder(source);
 	}
 
@@ -434,10 +434,10 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 	 * @since 5.2
 	 */
 	public static final class JwkSourceReactiveJwtDecoderBuilder {
-		private final Function<JWT, Flux<JWK>> jwkSource;
+		private final Function<SignedJWT, Flux<JWK>> jwkSource;
 		private JWSAlgorithm jwsAlgorithm = JWSAlgorithm.RS256;
 
-		private JwkSourceReactiveJwtDecoderBuilder(Function<JWT, Flux<JWK>> jwkSource) {
+		private JwkSourceReactiveJwtDecoderBuilder(Function<SignedJWT, Flux<JWK>> jwkSource) {
 			Assert.notNull(jwkSource, "jwkSource cannot be null");
 			this.jwkSource = jwkSource;
 		}


### PR DESCRIPTION
Reactive JwkSource Builder Parameter Type

Changed the parameter type from JWT to SignedJWT

Fixes: gh-6771