### PR TITLE
OAuth 2.0 Discovery Clients

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistrations.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistrations.java
@@ -16,21 +16,30 @@
 
 package org.springframework.security.oauth2.client.registration;
 
-import com.nimbusds.oauth2.sdk.GrantType;
-import com.nimbusds.oauth2.sdk.ParseException;
-import com.nimbusds.oauth2.sdk.Scope;
-import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
-import org.springframework.security.oauth2.core.AuthorizationGrantType;
-import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
-import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
-import org.springframework.security.oauth2.core.oidc.OidcScopes;
-import org.springframework.web.client.RestTemplate;
-
 import java.net.URI;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import com.nimbusds.oauth2.sdk.GrantType;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.as.AuthorizationServerMetadata;
+import net.minidev.json.JSONObject;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.RequestEntity;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2MetadataClientBuilder;
+import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
+import org.springframework.security.oauth2.core.oidc.OidcScopes;
+import org.springframework.web.client.RestTemplate;
 
 /**
  * Allows creating a {@link ClientRegistration.Builder} from an
@@ -69,13 +78,47 @@ public final class ClientRegistrations {
 	 * @return a {@link ClientRegistration.Builder} that was initialized by the OpenID Provider Configuration.
 	 */
 	public static ClientRegistration.Builder fromOidcIssuerLocation(String issuer) {
-		String openidConfiguration = getOpenidConfiguration(issuer);
-		OIDCProviderMetadata metadata = parse(openidConfiguration);
-		String metadataIssuer = metadata.getIssuer().getValue();
-		if (!issuer.equals(metadataIssuer)) {
-			throw new IllegalStateException("The Issuer \"" + metadataIssuer + "\" provided in the OpenID Configuration did not match the requested issuer \"" + issuer + "\"");
-		}
+		Function<URI, Map<String, Object>> client =
+				new OAuth2MetadataClientBuilder(client(new RestTemplate()))
+						.useOidcDiscovery().build();
+		return fromIssuerLocation(client, issuer).apply(issuer);
+	}
 
+	public static ClientRegistration.Builder fromIssuerLocation(String issuer,
+			Consumer<OAuth2MetadataClientBuilder> metadataClientBuilderConsumer) {
+		OAuth2MetadataClientBuilder metadataClientBuilder =
+				new OAuth2MetadataClientBuilder(client(new RestTemplate()));
+		metadataClientBuilderConsumer.accept(metadataClientBuilder);
+		return fromIssuerLocation(metadataClientBuilder.build(), issuer).apply(issuer);
+	}
+
+	private static Function<URI, Map<String, Object>> client(RestTemplate rest) {
+		ParameterizedTypeReference<Map<String, Object>> typeReference =
+				new ParameterizedTypeReference<Map<String, Object>>() {};
+		return uri -> {
+			RequestEntity<Void> request = RequestEntity.get(uri).build();
+			return rest.exchange(request, typeReference).getBody();
+		};
+	}
+
+	private static Function<String, ClientRegistration.Builder> fromIssuerLocation(
+			Function<URI, Map<String, Object>> client, String issuer) {
+
+		Function<String, URI> toUri = URI::create;
+		return toUri.andThen(client)
+				.andThen(ClientRegistrations::parseAuthorizationServer)
+				.andThen(metadata -> fromProviderConfiguration(metadata, issuer));
+	}
+
+	private static AuthorizationServerMetadata parseAuthorizationServer(Map<String, Object> body) {
+		try {
+			return AuthorizationServerMetadata.parse(new JSONObject(body));
+		} catch (ParseException ex) {
+			throw new RuntimeException(ex);
+		}
+	}
+
+	private static ClientRegistration.Builder fromProviderConfiguration(AuthorizationServerMetadata metadata, String issuer) {
 		String name = URI.create(issuer).getHost();
 		ClientAuthenticationMethod method = getClientAuthenticationMethod(issuer, metadata.getTokenEndpointAuthMethods());
 		List<GrantType> grantTypes = metadata.getGrantTypes();
@@ -86,7 +129,7 @@ public final class ClientRegistrations {
 		List<String> scopes = getScopes(metadata);
 		Map<String, Object> configurationMetadata = new LinkedHashMap<>(metadata.toJSONObject());
 
-		return ClientRegistration.withRegistrationId(name)
+		ClientRegistration.Builder builder = ClientRegistration.withRegistrationId(name)
 				.userNameAttributeName(IdTokenClaimNames.SUB)
 				.scope(scopes)
 				.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
@@ -95,19 +138,15 @@ public final class ClientRegistrations {
 				.authorizationUri(metadata.getAuthorizationEndpointURI().toASCIIString())
 				.jwkSetUri(metadata.getJWKSetURI().toASCIIString())
 				.providerConfigurationMetadata(configurationMetadata)
-				.userInfoUri(metadata.getUserInfoEndpointURI().toASCIIString())
 				.tokenUri(metadata.getTokenEndpointURI().toASCIIString())
 				.clientName(issuer);
+
+		return getUserInfoEndpoint(configurationMetadata)
+				.map(builder::userInfoUri)
+				.orElse(builder);
+
 	}
 
-	private static String getOpenidConfiguration(String issuer) {
-		RestTemplate rest = new RestTemplate();
-		try {
-			return rest.getForObject(issuer + "/.well-known/openid-configuration", String.class);
-		} catch(RuntimeException e) {
-			throw new IllegalArgumentException("Unable to resolve the OpenID Configuration with the provided Issuer of \"" + issuer + "\"", e);
-		}
-	}
 
 	private static ClientAuthenticationMethod getClientAuthenticationMethod(String issuer, List<com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod> metadataAuthMethods) {
 		if (metadataAuthMethods == null || metadataAuthMethods.contains(com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod.CLIENT_SECRET_BASIC)) {
@@ -123,7 +162,7 @@ public final class ClientRegistrations {
 		throw new IllegalArgumentException("Only ClientAuthenticationMethod.BASIC, ClientAuthenticationMethod.POST and ClientAuthenticationMethod.NONE are supported. The issuer \"" + issuer + "\" returned a configuration of " + metadataAuthMethods);
 	}
 
-	private static List<String> getScopes(OIDCProviderMetadata metadata) {
+	private static List<String> getScopes(AuthorizationServerMetadata metadata) {
 		Scope scope = metadata.getScopes();
 		if (scope == null) {
 			// If null, default to "openid" which must be supported
@@ -133,13 +172,11 @@ public final class ClientRegistrations {
 		}
 	}
 
-	private static OIDCProviderMetadata parse(String body) {
-		try {
-			return OIDCProviderMetadata.parse(body);
-		}
-		catch (ParseException e) {
-			throw new RuntimeException(e);
-		}
+	private static Optional<String> getUserInfoEndpoint(Map<String, Object> metadata) {
+		return Optional.ofNullable(metadata.get("userinfo_endpoint"))
+				.map(Objects::toString)
+				.map(URI::create)
+				.map(URI::toASCIIString);
 	}
 
 	private ClientRegistrations() {}

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/ClientRegistrationsTest.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/ClientRegistrationsTest.java
@@ -16,6 +16,9 @@
 
 package org.springframework.security.oauth2.client.registration;
 
+import java.util.Arrays;
+import java.util.Map;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.mockwebserver.MockResponse;
@@ -23,13 +26,11 @@ import okhttp3.mockwebserver.MockWebServer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
-
-import java.util.Arrays;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -224,7 +225,7 @@ public class ClientRegistrationsTest {
 	@Test
 	public void issuerWhenEmptyStringThenMeaningfulErrorMessage() {
 		assertThatThrownBy(() -> ClientRegistrations.fromOidcIssuerLocation(""))
-				.hasMessageContaining("Unable to resolve the OpenID Configuration with the provided Issuer of \"\"");
+				.hasMessageContaining("Unable to resolve configuration with the provided issuer of \"\"");
 	}
 
 	@Test
@@ -236,7 +237,7 @@ public class ClientRegistrationsTest {
 				.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
 		this.server.enqueue(mockResponse);
 		assertThatThrownBy(() -> ClientRegistrations.fromOidcIssuerLocation(this.issuer))
-				.hasMessageContaining("The Issuer \"https://example.com\" provided in the OpenID Configuration did not match the requested issuer \"" + this.issuer + "\"");
+				.hasStackTraceContaining("The issuer \"https://example.com\" provided in the configuration response did not match the requested issuer \"" + this.issuer + "\"");
 	}
 
 	private ClientRegistration.Builder registration(String path) throws Exception {

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/OAuth2MetadataClientBuilder.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/OAuth2MetadataClientBuilder.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.core;
+
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.springframework.util.Assert;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+public class OAuth2MetadataClientBuilder {
+	private final Function<URI, Map<String, Object>> oauth2AuthorizationMetadataClient;
+
+	private Map<String, List<DiscoveryClient>> clientsMap = new LinkedHashMap<>();
+
+	// for added readability
+	private interface DiscoveryClient extends Function<URI, Map<String, Object>> {}
+
+	public OAuth2MetadataClientBuilder(
+			Function<URI, Map<String, Object>> oauth2AuthorizationServerMetadataClient) {
+		this.oauth2AuthorizationMetadataClient = oauth2AuthorizationServerMetadataClient;
+	}
+
+	public OAuth2MetadataClientBuilder useOAuth2Discovery() {
+		this.clientsMap.put("oauth2", Arrays.asList(client(this::injectOAuth2Path)));
+		return this;
+	}
+
+	public OAuth2MetadataClientBuilder useOAuth2Discovery(String oauth2MetadataUri) {
+		this.clientsMap.put("oauth2", Arrays.asList(client(issuer -> URI.create(oauth2MetadataUri))));
+		return this;
+	}
+
+	public OAuth2MetadataClientBuilder useOidcDiscovery() {
+		return useOidcDiscovery(true);
+	}
+
+	public OAuth2MetadataClientBuilder useOidcDiscovery(String oidcMetadataUri) {
+		this.clientsMap.put("openid", Arrays.asList(client(issuer -> URI.create(oidcMetadataUri))));
+		return this;
+	}
+
+	public OAuth2MetadataClientBuilder useOidcDiscovery(boolean useRfc8414) {
+		List<DiscoveryClient> clients = new ArrayList<>();
+		if (useRfc8414) {
+			clients.add(client(this::injectOidcPath));
+		}
+		clients.add(client(this::appendOidcPath));
+		this.clientsMap.put("openid", clients);
+		return this;
+	}
+
+	public OAuth2MetadataClientBuilder useDiscoveryEndpoint(String uri, Function<URI, Map<String, Object>> client) {
+		this.clientsMap.put(uri, Arrays.asList(client(issuer -> URI.create(uri))));
+		return this;
+	}
+
+	private DiscoveryClient client(Function<URI, URI> uriResolver) {
+		return issuer -> {
+			URI uri = uriResolver.apply(issuer);
+			return validate(this.oauth2AuthorizationMetadataClient.apply(uri), issuer);
+		};
+	}
+
+	public Function<URI, Map<String, Object>> build() {
+		Assert.notEmpty(this.clientsMap, "Must configure at least one client");
+		return issuer -> {
+			List<DiscoveryClient> clients = new ArrayList<>();
+			for (List<DiscoveryClient> clientList : this.clientsMap.values()) {
+				clients.addAll(clientList);
+			}
+
+			for (DiscoveryClient client : clients) {
+				try {
+					return client.apply(issuer);
+				} catch (HttpClientErrorException ex) {
+					if (!ex.getStatusCode().is4xxClientError()) {
+						throw ex;
+					}
+				} catch (RuntimeException ex) {
+					throw new IllegalStateException("Unable to resolve configuration with the provided issuer of \"" + issuer + "\"", ex);
+				}
+			}
+
+			throw new IllegalStateException("Unable to resolve configuration with the provided issuer of \"" + issuer + "\"");
+		};
+	}
+
+	private Map<String, Object> validate(Map<String, Object> metadata, URI issuer) {
+		String metadataIssuer = Optional.ofNullable(metadata.get("issuer"))
+				.map(Objects::toString)
+				.orElseThrow(() -> new IllegalStateException("No issuer specified in configuration response from the requested issuer \"" + issuer + "\""));
+		if (!issuer.toASCIIString().equals(metadataIssuer)) {
+			throw new IllegalStateException("The issuer \"" + metadataIssuer + "\" provided in the configuration response did not match the requested issuer \"" + issuer + "\"");
+		}
+		return metadata;
+	}
+
+	private URI appendOidcPath(URI uri) {
+		String path = uri.getPath();
+		return UriComponentsBuilder.fromUri(uri)
+				.replacePath("/.well-known/openid-configuration" + path).build().toUri();
+	}
+
+	private URI injectOidcPath(URI uri) {
+		String path = uri.getPath();
+		return UriComponentsBuilder.fromUri(uri)
+				.replacePath(path + "/.well-known/openid-configuration").build().toUri();
+	}
+
+	private URI injectOAuth2Path(URI uri) {
+		String path = uri.getPath();
+		return UriComponentsBuilder.fromUri(uri)
+				.replacePath("/.well-known/oauth2-authorization-server" + path).build().toUri();
+	}
+}

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtDecodersTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtDecodersTests.java
@@ -131,7 +131,7 @@ public class JwtDecodersTests {
 		this.server.shutdown();
 
 		assertThatCode(() -> JwtDecoders.fromOidcIssuerLocation("https://issuer"))
-				.isInstanceOf(IllegalArgumentException.class);
+				.isInstanceOf(IllegalStateException.class);
 	}
 
 	private void prepareOpenIdConfigurationResponse() {

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/ReactiveJwtDecodersTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/ReactiveJwtDecodersTests.java
@@ -122,7 +122,7 @@ public class ReactiveJwtDecodersTests {
 		this.server.shutdown();
 
 		assertThatCode(() -> ReactiveJwtDecoders.fromOidcIssuerLocation("https://issuer"))
-				.isInstanceOf(IllegalArgumentException.class);
+				.isInstanceOf(IllegalStateException.class);
 	}
 
 	private void prepareOpenIdConfigurationResponse() {


### PR DESCRIPTION
A support class for configuration that is common to the various
builders that use discovery.

The following is how you would configure ClientRegistrations to use
oauth-authorization-server discovery:

```java
ClientRegistrations.fromIssuerLocation("https://idp.example.org",
        OAuth2MetadataClientBuilder::oauth2Discovery);
```

Or to use OIDC Discovery as well as OAuth 2.0 Discovery do:

```java
ClientRegistrations.fromIssuerLocation("http://idp.example.org",
        client -> client.oidcDiscovery().oauth2Discovery());
```