### PR TITLE
OAuth2LoginAuthenticationFilter sets AuthenticationDetails

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/OAuth2LoginAuthenticationFilter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/OAuth2LoginAuthenticationFilter.java
@@ -178,9 +178,10 @@ public class OAuth2LoginAuthenticationFilter extends AbstractAuthenticationProce
 				.toUriString();
 		OAuth2AuthorizationResponse authorizationResponse = OAuth2AuthorizationResponseUtils.convert(params, redirectUri);
 
+		Object authenticationDetails = this.authenticationDetailsSource.buildDetails(request);
 		OAuth2LoginAuthenticationToken authenticationRequest = new OAuth2LoginAuthenticationToken(
 				clientRegistration, new OAuth2AuthorizationExchange(authorizationRequest, authorizationResponse));
-		authenticationRequest.setDetails(this.authenticationDetailsSource.buildDetails(request));
+		authenticationRequest.setDetails(authenticationDetails);
 
 		OAuth2LoginAuthenticationToken authenticationResult =
 			(OAuth2LoginAuthenticationToken) this.getAuthenticationManager().authenticate(authenticationRequest);
@@ -189,6 +190,7 @@ public class OAuth2LoginAuthenticationFilter extends AbstractAuthenticationProce
 			authenticationResult.getPrincipal(),
 			authenticationResult.getAuthorities(),
 			authenticationResult.getClientRegistration().getRegistrationId());
+		oauth2Authentication.setDetails(authenticationDetails);
 
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(
 			authenticationResult.getClientRegistration(),


### PR DESCRIPTION
[GH-6866] OAuth2LoginAuthenticationFilter should set AuthenticationDetails

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
