### PR TITLE
Add constructor to JwtAuthenticationToken that takes a principal name

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationToken.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationToken.java
@@ -36,6 +36,8 @@ import org.springframework.security.oauth2.jwt.Jwt;
 public class JwtAuthenticationToken extends AbstractOAuth2TokenAuthenticationToken<Jwt> {
 	private static final long serialVersionUID = SpringSecurityCoreVersion.SERIAL_VERSION_UID;
 
+	private final String name;
+
 	/**
 	 * Constructs a {@code JwtAuthenticationToken} using the provided parameters.
 	 *
@@ -43,6 +45,7 @@ public class JwtAuthenticationToken extends AbstractOAuth2TokenAuthenticationTok
 	 */
 	public JwtAuthenticationToken(Jwt jwt) {
 		super(jwt);
+		this.name = jwt.getSubject();
 	}
 
 	/**
@@ -54,6 +57,20 @@ public class JwtAuthenticationToken extends AbstractOAuth2TokenAuthenticationTok
 	public JwtAuthenticationToken(Jwt jwt, Collection<? extends GrantedAuthority> authorities) {
 		super(jwt, authorities);
 		this.setAuthenticated(true);
+		this.name = jwt.getSubject();
+	}
+
+	/**
+	 * Constructs a {@code JwtAuthenticationToken} using the provided parameters.
+	 *
+	 * @param jwt the JWT
+	 * @param authorities the authorities assigned to the JWT
+	 * @param name the principal name
+	 */
+	public JwtAuthenticationToken(Jwt jwt, Collection<? extends GrantedAuthority> authorities, String name) {
+		super(jwt, authorities);
+		this.setAuthenticated(true);
+		this.name = name;
 	}
 
 	/**
@@ -69,6 +86,6 @@ public class JwtAuthenticationToken extends AbstractOAuth2TokenAuthenticationTok
 	 */
 	@Override
 	public String getName() {
-		return this.getToken().getSubject();
+		return this.name;
 	}
 }

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationTokenTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationTokenTests.java
@@ -98,6 +98,28 @@ public class JwtAuthenticationTokenTests {
 		assertThat(token.isAuthenticated()).isFalse();
 	}
 
+	@Test
+	public void constructorWhenProvidingJwtAndAuthoritiesThenSetsNameCorrectly() {
+		Map claims = Maps.newHashMap("sub", "Hayden");
+		Jwt jwt = this.jwt(claims);
+
+		JwtAuthenticationToken token = new JwtAuthenticationToken(jwt);
+
+		assertThat(token.getName()).isEqualTo("Hayden");
+	}
+
+	@Test
+	public void constructorWhenUsingAllParametersThenReturnsCorrectName() {
+
+		Collection authorities = Arrays.asList(new SimpleGrantedAuthority("test"));
+		Map claims = Maps.newHashMap("claim", "value");
+		Jwt jwt = this.jwt(claims);
+
+		JwtAuthenticationToken token = new JwtAuthenticationToken(jwt, authorities, "Hayden");
+
+		assertThat(token.getName()).isEqualTo("Hayden");
+	}
+
 	private Jwt jwt(Map<String, Object> claims) {
 		Map<String, Object> headers = new HashMap<>();
 		headers.put("alg", JwsAlgorithms.RS256);


### PR DESCRIPTION
Closes #6865 
I added two constructors to allow a custom principal name to be passed to the class. Otherwise the constructor will just set the name value to be token's subject.