### PR TITLE
Support URI vars in formLogin and logout MockMvc requests

### DIFF
--- a/test/src/main/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestBuilders.java
+++ b/test/src/main/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestBuilders.java
@@ -23,6 +23,7 @@ import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -71,6 +72,8 @@ public final class SecurityMockMvcRequestBuilders {
 	 * Creates a logout request (including any necessary {@link CsrfToken}) to the
 	 * specified {@code logoutUrl}
 	 *
+	 * @param logoutUrl the logout request URL
+	 *
 	 * @return the LogoutRequestBuilder for additional customizations
 	 */
 	public static LogoutRequestBuilder logout(String logoutUrl) {
@@ -103,6 +106,19 @@ public final class SecurityMockMvcRequestBuilders {
 		 */
 		public LogoutRequestBuilder logoutUrl(String logoutUrl) {
 			this.logoutUrl = logoutUrl;
+			return this;
+		}
+
+		/**
+		 * Specifies the logout URL to POST to.
+		 *
+		 * @param logoutUrl the logout URL to POST to.
+		 * @param uriVars the URI variables
+		 * @return the {@link LogoutRequestBuilder} for additional customizations
+		 */
+		public LogoutRequestBuilder logoutUrl(String logoutUrl, Object... uriVars) {
+			this.logoutUrl = UriComponentsBuilder.fromPath(logoutUrl)
+					.buildAndExpand(uriVars).encode().toString();
 			return this;
 		}
 
@@ -143,6 +159,19 @@ public final class SecurityMockMvcRequestBuilders {
 		 */
 		public FormLoginRequestBuilder loginProcessingUrl(String loginProcessingUrl) {
 			this.loginProcessingUrl = loginProcessingUrl;
+			return this;
+		}
+
+		/**
+		 * Specifies the URL to POST to.
+		 *
+		 * @param loginProcessingUrl the URL to POST to
+		 * @param uriVars the URI variables
+		 * @return the {@link FormLoginRequestBuilder} for additional customizations
+		 */
+		public FormLoginRequestBuilder loginProcessingUrl(String loginProcessingUrl, Object... uriVars) {
+			this.loginProcessingUrl = UriComponentsBuilder.fromPath(loginProcessingUrl)
+					.buildAndExpand(uriVars).encode().toString();
 			return this;
 		}
 

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestBuildersFormLoginTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestBuildersFormLoginTests.java
@@ -66,6 +66,22 @@ public class SecurityMockMvcRequestBuildersFormLoginTests {
 		assertThat(request.getRequestURI()).isEqualTo("/login");
 	}
 
+	@Test
+	public void customWithUriVars() {
+		MockHttpServletRequest request = formLogin().loginProcessingUrl("/uri-login/{var1}/{var2}", "val1", "val2")
+				.user("username", "admin").password("password", "secret").buildRequest(this.servletContext);
+
+		CsrfToken token = (CsrfToken) request
+				.getAttribute(CsrfRequestPostProcessor.TestCsrfTokenRepository.TOKEN_ATTR_NAME);
+
+		assertThat(request.getParameter("username")).isEqualTo("admin");
+		assertThat(request.getParameter("password")).isEqualTo("secret");
+		assertThat(request.getMethod()).isEqualTo("POST");
+		assertThat(request.getParameter(token.getParameterName()))
+				.isEqualTo(token.getToken());
+		assertThat(request.getRequestURI()).isEqualTo("/uri-login/val1/val2");
+	}
+
 	// gh-3920
 	@Test
 	public void usesAcceptMediaForContentNegotiation() throws Exception {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestBuildersFormLogoutTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestBuildersFormLogoutTests.java
@@ -58,4 +58,17 @@ public class SecurityMockMvcRequestBuildersFormLogoutTests {
 		assertThat(request.getRequestURI()).isEqualTo("/admin/logout");
 	}
 
+	@Test
+	public void customWithUriVars() {
+		MockHttpServletRequest request = logout().logoutUrl("/uri-logout/{var1}/{var2}", "val1", "val2").buildRequest(
+				servletContext);
+
+		CsrfToken token = (CsrfToken) request.getAttribute(CsrfRequestPostProcessor.TestCsrfTokenRepository.TOKEN_ATTR_NAME);
+
+		assertThat(request.getMethod()).isEqualTo("POST");
+		assertThat(request.getParameter(token.getParameterName())).isEqualTo(
+				token.getToken());
+		assertThat(request.getRequestURI()).isEqualTo("/uri-logout/val1/val2");
+	}
+
 }


### PR DESCRIPTION
Allows URI variables in `formLogin` and `logout` requests of `MockMvc`

login example:
```
mockMvc.perform(formLogin("{basePath}/admin/login", "/api")
        .user("username")
        .password("password"))
        .andExpect(authenticated()
             ...
        .andExpect(status().isOk())
        .andExpect(...);
```
yields `/api/admin/login` as the `formLogin` URL.

logout example:
```
mockMvc.perform(logout("{basePath}/admin/logout", "/api"))
        .andExpect(unauthenticated()
        .andExpect(status().isOk())
        .andExpect(...);
```
yields `/api/admin/logout` as the `logout` URL.
