### PR TITLE
Updates OAuth2ResourceServer configuration tests

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
@@ -27,7 +27,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Base64;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -1484,12 +1483,11 @@ public class OAuth2ResourceServerConfigurerTests {
 		}
 
 		Converter<Jwt, AbstractAuthenticationToken> getJwtAuthenticationConverter() {
-			return new JwtAuthenticationConverter() {
-				@Override
-				protected Collection<GrantedAuthority> extractAuthorities(Jwt jwt) {
-					return Collections.singletonList(new SimpleGrantedAuthority("message:read"));
-				}
-			};
+			JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+			converter.setJwtGrantedAuthoritiesConverter(jwt ->
+					Collections.singletonList(new SimpleGrantedAuthority("message:read"))
+			);
+			return converter;
 		}
 	}
 

--- a/config/src/test/java/org/springframework/security/config/web/server/OAuth2ResourceServerSpecTests.java
+++ b/config/src/test/java/org/springframework/security/config/web/server/OAuth2ResourceServerSpecTests.java
@@ -25,7 +25,6 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPublicKeySpec;
 import java.time.Instant;
 import java.util.Base64;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -56,7 +55,6 @@ import org.springframework.security.authentication.ReactiveAuthenticationManager
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.test.SpringTestRule;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
@@ -556,13 +554,12 @@ public class OAuth2ResourceServerSpecTests {
 
 		@Bean
 		Converter<Jwt, Mono<AbstractAuthenticationToken>> jwtAuthenticationConverter() {
-			JwtAuthenticationConverter converter = new JwtAuthenticationConverter() {
-				@Override
-				protected Collection<GrantedAuthority> extractAuthorities(Jwt jwt) {
+
+			JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+			converter.setJwtGrantedAuthoritiesConverter(jwt -> {
 					String[] claims = ((String) jwt.getClaims().get("scope")).split(" ");
 					return Stream.of(claims).map(SimpleGrantedAuthority::new).collect(Collectors.toList());
-				}
-			};
+				});
 
 			return new ReactiveJwtAuthenticationConverterAdapter(converter);
 		}


### PR DESCRIPTION

As per #6516, `OAuth2ResourceConfiguration#extractAuthorities` was deprecated

This PR updates `OAuth2ResourceServerConfigurerTests` and `OAuth2ResourceServerSpecTests` to use `setJwtGrantedAuthoritiesConverter` instead of `extractAuthorities`