### PR TITLE
Added null checks and tests to constructors

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/jaas/JaasGrantedAuthority.java
+++ b/core/src/main/java/org/springframework/security/authentication/jaas/JaasGrantedAuthority.java
@@ -18,6 +18,7 @@ package org.springframework.security.authentication.jaas;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.SpringSecurityCoreVersion;
+import org.springframework.util.Assert;
 
 import java.security.Principal;
 
@@ -37,6 +38,8 @@ public final class JaasGrantedAuthority implements GrantedAuthority {
 	private final Principal principal;
 
 	public JaasGrantedAuthority(String role, Principal principal) {
+		Assert.notNull(role, "role cannot be null");
+		Assert.notNull(principal, "principal cannot be null");
 		this.role = role;
 		this.principal = principal;
 	}

--- a/core/src/test/java/org/springframework/security/authentication/jaas/JaasGrantedAuthorityTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/jaas/JaasGrantedAuthorityTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authentication.jaas;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.springframework.security.authentication.jaas.JaasGrantedAuthority;
+
+/**
+ *
+ * @author Clement Ng
+ *
+ */
+public class JaasGrantedAuthorityTests {
+
+	/**
+	 * @throws Exception
+	 */
+	@Test
+	public void authorityWithNullRoleFailsAssertion() throws Exception {
+		assertThatThrownBy(() -> new JaasGrantedAuthority(null, null))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("role cannot be null");
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	@Test
+	public void authorityWithNullPrincipleFailsAssertion() throws Exception {
+		assertThatThrownBy(() -> new JaasGrantedAuthority("role", null))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("principal cannot be null");
+	}
+}

--- a/web/src/main/java/org/springframework/security/web/access/intercept/RequestKey.java
+++ b/web/src/main/java/org/springframework/security/web/access/intercept/RequestKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package org.springframework.security.web.access.intercept;
 
+import org.springframework.util.Assert;
+
 /**
  * @author Luke Taylor
  * @since 2.0
@@ -28,6 +30,7 @@ public class RequestKey {
 	}
 
 	public RequestKey(String url, String method) {
+		Assert.notNull(url, "url cannot be null");
 		this.url = url;
 		this.method = method;
 	}

--- a/web/src/main/java/org/springframework/security/web/authentication/switchuser/SwitchUserGrantedAuthority.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/switchuser/SwitchUserGrantedAuthority.java
@@ -19,6 +19,7 @@ package org.springframework.security.web.authentication.switchuser;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.SpringSecurityCoreVersion;
+import org.springframework.util.Assert;
 
 /**
  * Custom {@code GrantedAuthority} used by
@@ -44,6 +45,8 @@ public final class SwitchUserGrantedAuthority implements GrantedAuthority {
 	// ===================================================================================================
 
 	public SwitchUserGrantedAuthority(String role, Authentication source) {
+		Assert.notNull(role, "role cannot be null");
+		Assert.notNull(source, "source cannot be null");
 		this.role = role;
 		this.source = source;
 	}

--- a/web/src/test/java/org/springframework/security/web/access/intercept/RequestKeyTests.java
+++ b/web/src/test/java/org/springframework/security/web/access/intercept/RequestKeyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
  */
 package org.springframework.security.web.access.intercept;
 
-import static org.assertj.core.api.Assertions.*;
-
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.springframework.security.web.access.intercept.RequestKey;
 
 /**
@@ -62,5 +63,15 @@ public class RequestKeyTests {
 
 		assertThat(key1.equals(key2)).isFalse();
 		assertThat(key2.equals(key1)).isFalse();
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	@Test
+	public void keysWithNullUrlFailsAssertion() throws Exception {
+		assertThatThrownBy(() -> new RequestKey(null, null))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("url cannot be null");
 	}
 }

--- a/web/src/test/java/org/springframework/security/web/authentication/switchuser/SwitchUserGrantedAuthorityTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/switchuser/SwitchUserGrantedAuthorityTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.web.authentication.switchuser;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.springframework.security.web.authentication.switchuser.SwitchUserGrantedAuthority;
+
+/**
+ *
+ * @author Clement Ng
+ *
+ */
+public class SwitchUserGrantedAuthorityTests {
+
+	/**
+	 * @throws Exception
+	 */
+	@Test
+	public void authorityWithNullRoleFailsAssertion() throws Exception {
+		assertThatThrownBy(() -> new SwitchUserGrantedAuthority(null, null))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("role cannot be null");
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	@Test
+	public void authorityWithNullSourceFailsAssertion() throws Exception {
+		assertThatThrownBy(() -> new SwitchUserGrantedAuthority("role", null))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("source cannot be null");
+	}
+}


### PR DESCRIPTION
RequestKey, JaasGrantedAuthority, and SwitchUserGrantedAuthority
assume certain final members are non-null.

Issue: gh-6892

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
