### PR TITLE
Added support for char arrays and CharSequences to BCrypt

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCrypt.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCrypt.java
@@ -14,6 +14,9 @@
 package org.springframework.security.crypto.bcrypt;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.security.SecureRandom;
 
@@ -740,6 +743,30 @@ public class BCrypt {
 		return hashpw(passwordb, salt);
 	}
 
+	public static String hashpw(CharSequence password, String salt) {
+		byte passwordb[];
+		char[] pass = new char[password.length()];
+		for(int i =0; i < password.length(); i++) {
+			pass[i] = password.charAt(i);
+		}
+		passwordb = toBytes(pass);
+		return hashpw(passwordb, salt);
+	}
+
+	public static String hashpw(char[] password, String salt) {
+		byte passwordb[];
+		passwordb = toBytes(password);
+		return hashpw(passwordb, salt);
+	}
+
+	private static byte[] toBytes(char[] chars) {
+		CharBuffer charBuffer = CharBuffer.wrap(chars);
+		ByteBuffer byteBuffer = Charset.forName("UTF-8").encode(charBuffer);
+		byte[] bytes = Arrays.copyOfRange(byteBuffer.array(), byteBuffer.position(), byteBuffer.limit());
+		Arrays.fill(byteBuffer.array(), (byte) 0); // clear sensitive data
+		return bytes;
+	}
+
 	/**
 	 * Hash a password using the OpenBSD bcrypt scheme
 	 * @param passwordb	the password to hash, as a byte array
@@ -904,6 +931,14 @@ public class BCrypt {
 	 * @return	true if the passwords match, false otherwise
 	 */
 	public static boolean checkpw(String plaintext, String hashed) {
+		return equalsNoEarlyReturn(hashed, hashpw(plaintext, hashed));
+	}
+
+	public static boolean checkpw(char[] plaintext, String hashed) {
+		return equalsNoEarlyReturn(hashed, hashpw(plaintext, hashed));
+	}
+
+	public static boolean checkpw(CharSequence plaintext, String hashed) {
 		return equalsNoEarlyReturn(hashed, hashpw(plaintext, hashed));
 	}
 

--- a/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoder.java
@@ -108,7 +108,7 @@ public class BCryptPasswordEncoder implements PasswordEncoder {
 		} else {
 			salt = BCrypt.gensalt(version.getVersion());
 		}
-		return BCrypt.hashpw(rawPassword.toString(), salt);
+		return BCrypt.hashpw(rawPassword, salt);
 	}
 
 	public boolean matches(CharSequence rawPassword, String encodedPassword) {
@@ -122,7 +122,21 @@ public class BCryptPasswordEncoder implements PasswordEncoder {
 			return false;
 		}
 
-		return BCrypt.checkpw(rawPassword.toString(), encodedPassword);
+		return BCrypt.checkpw(rawPassword, encodedPassword);
+	}
+
+	public boolean matches(char[] rawPassword, String encodedPassword) {
+		if (encodedPassword == null || encodedPassword.length() == 0) {
+			logger.warn("Empty encoded password");
+			return false;
+		}
+
+		if (!BCRYPT_PATTERN.matcher(encodedPassword).matches()) {
+			logger.warn("Encoded password does not look like BCrypt");
+			return false;
+		}
+
+		return BCrypt.checkpw(rawPassword, encodedPassword);
 	}
 
 	/**


### PR DESCRIPTION
https://github.com/spring-projects/spring-security/issues/6917
Added support for char arrays and CharSequences to BCrypt password encoder/internal methods to allow a flow without using String. Security guidelines recommend you don't use strings for sensitive data like password, but the current BCrypt implementation relied on it.
Noticed this when upgrading a hashing/password encoding mechanism, it had been decided to make sure to prevent leaking sensible info in our logs by switching all passwords to a private string implementing charsequence, reliant on an internal, autowiped with closeable, char array. We were pretty disappointed to see BCrypt break the guidelines and use strings.