### PR TITLE
Update AssertJ to version 3.12.2

### DIFF
--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -143,7 +143,7 @@ dependencyManagement {
 		dependency 'org.aspectj:aspectjrt:1.9.3'
 		dependency 'org.aspectj:aspectjtools:1.9.3'
 		dependency 'org.aspectj:aspectjweaver:1.9.3'
-		dependency 'org.assertj:assertj-core:3.11.1'
+		dependency 'org.assertj:assertj-core:3.12.2'
 		dependency 'org.attoparser:attoparser:2.0.4.RELEASE'
 		dependency 'org.bouncycastle:bcpkix-jdk15on:1.61'
 		dependency 'org.bouncycastle:bcprov-jdk15on:1.61'

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/InMemoryClientRegistrationRepositoryTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/InMemoryClientRegistrationRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,6 +91,6 @@ public class InMemoryClientRegistrationRepositoryTests {
 
 	@Test
 	public void iteratorWhenGetThenContainsAll() {
-		assertThat(this.clients.iterator()).containsOnly(this.registration);
+		assertThat(this.clients).containsOnly(this.registration);
 	}
 }

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/InMemoryReactiveClientRegistrationRepositoryTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/InMemoryReactiveClientRegistrationRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,17 @@
 
 package org.springframework.security.oauth2.client.registration;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.Before;
+import org.junit.Test;
+import reactor.test.StepVerifier;
 
-import java.util.HashMap;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import reactor.test.StepVerifier;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Rob Winch
@@ -107,7 +106,6 @@ public class InMemoryReactiveClientRegistrationRepositoryTests {
 
 	@Test
 	public void iteratorWhenContainsGithubThenContains() {
-		assertThat(this.repository.iterator())
-			.containsOnly(this.registration);
+		assertThat(this.repository).containsOnly(this.registration);
 	}
 }


### PR DESCRIPTION
Update the AssertJ dependency to version 3.12.2. Additionally fix
some tests not compiling due to API changes of AssertJ.

Fixes #6786 