### PR TITLE
Fix typo in OAuth2TokenValidator doc

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/reactive/oauth2/resource-server.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/reactive/oauth2/resource-server.adoc
@@ -341,7 +341,7 @@ Resource Server uses `JwtTimestampValidator` to verify a token's validity window
 @Bean
 ReactiveJwtDecoder jwtDecoder() {
      NimbusReactiveJwtDecoder jwtDecoder = (NimbusReactiveJwtDecoder)
-             ReactiveJwtDecoders.withOidcIssuerLocation(issuerUri);
+             ReactiveJwtDecoders.fromOidcIssuerLocation(issuerUri);
 
      OAuth2TokenValidator<Jwt> withClockSkew = new DelegatingOAuth2TokenValidator<>(
             new JwtTimestampValidator(Duration.ofSeconds(60)),
@@ -383,7 +383,7 @@ Then, to add into a resource server, it's a matter of specifying the `ReactiveJw
 @Bean
 ReactiveJwtDecoder jwtDecoder() {
     NimbusReactiveJwtDecoder jwtDecoder = (NimbusReactiveJwtDecoder)
-            ReactiveJwtDecoders.withOidcIssuerLocation(issuerUri);
+            ReactiveJwtDecoders.fromOidcIssuerLocation(issuerUri);
 
     OAuth2TokenValidator<Jwt> audienceValidator = new AudienceValidator();
     OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(issuerUri);

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/preface/java-configuration.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/preface/java-configuration.adoc
@@ -721,7 +721,7 @@ Resource Server uses `JwtTimestampValidator` to verify a token's validity window
 @Bean
 JwtDecoder jwtDecoder() {
      NimbusJwtDecoder jwtDecoder = (NimbusJwtDecoder)
-             JwtDecoders.withOidcIssuerLocation(issuerUri);
+             JwtDecoders.fromOidcIssuerLocation(issuerUri);
 
      OAuth2TokenValidator<Jwt> withClockSkew = new DelegatingOAuth2TokenValidator<>(
             new JwtTimestampValidator(Duration.ofSeconds(60)),
@@ -761,7 +761,7 @@ Then, to add into a resource server, it's a matter of specifying the `JwtDecoder
 @Bean
 JwtDecoder jwtDecoder() {
     NimbusJwtDecoder jwtDecoder = (NimbusJwtDecoder)
-        JwtDecoders.withOidcIssuerLocation(issuerUri);
+        JwtDecoders.fromOidcIssuerLocation(issuerUri);
 
     OAuth2TokenValidator<Jwt> audienceValidator = new AudienceValidator();
     OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(issuerUri);


### PR DESCRIPTION
Use correct method names for creating JwtDecoder like described in gh-6925

Obvious Fix