### PR TITLE
Accept Converter in ReactiveJwtAuthenticationConverterAdapter

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/ReactiveJwtAuthenticationConverterAdapter.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/ReactiveJwtAuthenticationConverterAdapter.java
@@ -30,9 +30,9 @@ import org.springframework.util.Assert;
  * @since 5.1.1
  */
 public class ReactiveJwtAuthenticationConverterAdapter implements Converter<Jwt, Mono<AbstractAuthenticationToken>> {
-	private final JwtAuthenticationConverter delegate;
+	private final Converter<Jwt, AbstractAuthenticationToken> delegate;
 
-	public ReactiveJwtAuthenticationConverterAdapter(JwtAuthenticationConverter delegate) {
+	public ReactiveJwtAuthenticationConverterAdapter(Converter<Jwt, AbstractAuthenticationToken> delegate) {
 		Assert.notNull(delegate, "delegate cannot be null");
 		this.delegate = delegate;
 	}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/ReactiveJwtAuthenticationConverterAdapterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/ReactiveJwtAuthenticationConverterAdapterTests.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -39,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Josh Cummings
  */
 public class ReactiveJwtAuthenticationConverterAdapterTests {
-	JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+	Converter<Jwt, AbstractAuthenticationToken> converter = new JwtAuthenticationConverter();
 	ReactiveJwtAuthenticationConverterAdapter jwtAuthenticationConverter =
 			new ReactiveJwtAuthenticationConverterAdapter(converter);
 


### PR DESCRIPTION
Currently, `ReactiveJwtAuthenticationConverterAdapter` takes `JwtAuthenticationConverter` as its constructor argument. However, this limits the usage of this adapter.
In this commit, widen the constructor to take `Converter<Jwt, AbstractAuthenticationToken>` and allow this adapter to be used by generic converters.
