### PR TITLE
Add "getJwtValidator" on JwtDecoder implementations

### DIFF
--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoder.java
@@ -100,6 +100,16 @@ public final class NimbusJwtDecoder implements JwtDecoder {
 	}
 
 	/**
+	 * Get {@link Jwt} validator.
+	 * 
+	 * @since 5.2
+	 * @return jwt validator
+	 */
+	public OAuth2TokenValidator<Jwt> getJwtValidator() {
+		return this.jwtValidator;
+	}
+
+	/**
 	 * Use the following {@link Converter} for manipulating the JWT's claim set
 	 *
 	 * @param claimSetConverter the {@link Converter} to use

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
@@ -121,6 +121,16 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 	}
 
 	/**
+	 * Get {@link OAuth2TokenValidator} that validates incoming {@link Jwt}s.
+	 * 
+	 * @since 5.2
+	 * @return jwt validator
+	 */
+	public OAuth2TokenValidator<Jwt> getJwtValidator() {
+		return this.jwtValidator;
+	}
+
+	/**
 	 * Use the following {@link Converter} for manipulating the JWT's claim set
 	 *
 	 * @param claimSetConverter the {@link Converter} to use


### PR DESCRIPTION
Currently, once `JwtDecoder` is created, there is no way to retrieve the validator in it.

This is a problem when `JwtDecoder` is created via `JwtDecoders#fromOidcIssuerLocation()`(or via `OAuth2ResourceServerAutoConfiguration` in boot).
Since oidc flow creates a validator that checks issuer, that validator needs to be in place.
It can replace the validators via `setJwtValidator()` but no way to **add** to existing ones except using reflection to obtain it.

This PR adds `NimbusJwtDecoder#getJwtValidator` and `NimbusReactiveJwtDecoder#getJwtValidator`.
With combining getter and setter, new validator can be added on existing ones.(still bit hacky, but at least it can add to existing one)
