### PR TITLE
Move log statement in SessionRegistryImpl

### DIFF
--- a/core/src/main/java/org/springframework/security/core/session/SessionRegistryImpl.java
+++ b/core/src/main/java/org/springframework/security/core/session/SessionRegistryImpl.java
@@ -120,13 +120,13 @@ public class SessionRegistryImpl implements SessionRegistry,
 		Assert.hasText(sessionId, "SessionId required as per interface contract");
 		Assert.notNull(principal, "Principal required as per interface contract");
 
+		if (getSessionInformation(sessionId) != null) {
+			removeSessionInformation(sessionId);
+		}
+
 		if (logger.isDebugEnabled()) {
 			logger.debug("Registering session " + sessionId + ", for principal "
 					+ principal);
-		}
-
-		if (getSessionInformation(sessionId) != null) {
-			removeSessionInformation(sessionId);
 		}
 
 		sessionIds.put(sessionId,


### PR DESCRIPTION
Moved a log statement in `SessionRegistryImpl#registerNewSession` after `removeSessionInformation()` is called for comprehensible output to the logger.

The log statements are now printed in the same order as the logic is executed. Before the change, this could be confusing when debugging an application, since it seemed that the registered session was immediately removed when only looking at the logs.

Before:
```
> Registering session 500B7FEE4F10F1CFD5C69561FB40C2EC, for principal examplePrincipal
> Removing session 500B7FEE4F10F1CFD5C69561FB40C2EC from principal's set of registered sessions
> Removing principal examplePrincipal from registry
```

After:
```
> Removing session E40C41AD72989210A64B1CA2436D7A54 from principal's set of registered sessions
> Removing principal examplePrincipal from registry
> Registering session E40C41AD72989210A64B1CA2436D7A54, for principal examplePrincipal
```

NB: I did not create a ticket for this.