### PR TITLE
Added jwt injection for reactive test mocks

### DIFF
--- a/test/src/main/java/org/springframework/security/test/web/reactive/server/SecurityMockServerConfigurers.java
+++ b/test/src/main/java/org/springframework/security/test/web/reactive/server/SecurityMockServerConfigurers.java
@@ -152,6 +152,21 @@ public class SecurityMockServerConfigurers {
 		return new JwtMutator(jwtBuilder.build());
 	}
 
+	/**
+	 * Updates the ServerWebExchange to establish a {@link SecurityContext} that has a
+	 * {@link JwtAuthenticationToken} for the
+	 * {@link Authentication} and a {@link Jwt} for the
+	 * {@link Authentication#getPrincipal()}. All details are
+	 * declarative and do not require the JWT to be valid.
+	 *
+	 * @param jwt The preliminary constructed {@link Jwt}
+	 * @return the {@link JwtMutator} to further configure or use
+	 * @since 5.2
+	 */
+	public static JwtMutator mockJwt(Jwt jwt) {
+		return new JwtMutator(jwt);
+	}
+
 	public static CsrfMutator csrf() {
 		return new CsrfMutator();
 	}


### PR DESCRIPTION
Added new implementation of jwt() method that
makes it possible to directly provide a previously
prepared JWT token to WebTestClient mutator.

Fixes: spring-projectsgh-6896

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
