### PR TITLE
 Add generic getClaim() method in ClaimAccessor

### DIFF
--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClaimAccessor.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClaimAccessor.java
@@ -40,6 +40,20 @@ public interface ClaimAccessor {
 	Map<String, Object> getClaims();
 
 	/**
+	 * Returns the claim value as a {@code T} type.
+	 * It assumes that the given claim has already been converted to type {@code T}.
+	 *
+	 * @since 5.2
+	 * @param claim the name of the claim
+	 * @param <T> the type of the claim
+	 * @return the claim value
+	 */
+	@SuppressWarnings("unchecked")
+	default <T> T getClaim(String claim) {
+		return !containsClaim(claim) ? null : (T) this.getClaims().get(claim);
+	}
+
+	/**
 	 * Returns {@code true} if the claim exists in {@link #getClaims()}, otherwise {@code false}.
 	 *
 	 * @param claim the name of the claim
@@ -158,18 +172,5 @@ public interface ClaimAccessor {
 					"' of type '" + claimValue.getClass() + "' to List.");
 		}
 		return convertedValue;
-	}
-
-	/**
-	 * Returns the claim value as a {@code T} type.
-	 * It assumes that the given claim has already been converted to type {@code T}.
-	 *
-	 * @param claim the name of the claim
-	 * @param <T> the type of the claim
-	 * @return the claim value
-	 */
-	@SuppressWarnings("unchecked")
-	default <T> T getClaim(String claim) {
-		return (T) this.getClaims().get(claim);
 	}
 }

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClaimAccessor.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClaimAccessor.java
@@ -159,4 +159,17 @@ public interface ClaimAccessor {
 		}
 		return convertedValue;
 	}
+
+	/**
+	 * Returns the claim value as a {@code T} type.
+	 * It assumes that the given claim has already been converted to type {@code T}.
+	 *
+	 * @param claim the name of the claim
+	 * @param <T> the type of the claim
+	 * @return the claim value
+	 */
+	@SuppressWarnings("unchecked")
+	default <T> T getClaim(String claim) {
+		return (T) this.getClaims().get(claim);
+	}
 }

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/ClaimAccessorTests.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/ClaimAccessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,14 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Tests for {@link ClaimAccessor}.
@@ -100,5 +103,38 @@ public class ClaimAccessorTests {
 		this.claims.put(claimName, null);
 
 		assertThat(this.claimAccessor.getClaimAsString(claimName)).isNull();
+	}
+
+	@Test
+	public void getClaimWhenValueIsConvertedToList() {
+		List<String> expectedClaimValue = Arrays.asList("item1", "item2");
+		String claimName = "list";
+		this.claims.put(claimName, expectedClaimValue);
+
+		List<String> actualClaimValue = this.claimAccessor.getClaim(claimName);
+
+		assertThat(actualClaimValue).containsOnlyElementsOf(expectedClaimValue);
+	}
+
+	@Test
+	public void getClaimWhenValueIsConvertedToBoolean() {
+		boolean expectedClaimValue = true;
+		String claimName = "boolean";
+		this.claims.put(claimName, expectedClaimValue);
+
+		boolean actualClaimValue = this.claimAccessor.getClaim(claimName);
+
+		assertThat(actualClaimValue).isEqualTo((expectedClaimValue));
+	}
+
+	@Test
+	public void getClaimWhenValueIsNotConvertedToType() {
+		String expectedClaimValue = "true";
+		String claimName = "boolean";
+		this.claims.put(claimName, expectedClaimValue);
+
+		Throwable thrown = catchThrowable(() -> { boolean actualClaimValue = this.claimAccessor.getClaim(claimName); });
+
+		assertThat(thrown).isInstanceOf(ClassCastException.class);
 	}
 }

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/ClaimAccessorTests.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/ClaimAccessorTests.java
@@ -106,7 +106,14 @@ public class ClaimAccessorTests {
 	}
 
 	@Test
-	public void getClaimWhenValueIsConvertedToList() {
+	public void getClaimWhenNotExistingThenReturnNull() {
+		String claimName = "list";
+		List<String> actualClaimValue = this.claimAccessor.getClaim(claimName);
+		assertThat(actualClaimValue).isNull();
+	}
+
+	@Test
+	public void getClaimWhenValueIsConvertedThenReturnList() {
 		List<String> expectedClaimValue = Arrays.asList("item1", "item2");
 		String claimName = "list";
 		this.claims.put(claimName, expectedClaimValue);
@@ -117,18 +124,18 @@ public class ClaimAccessorTests {
 	}
 
 	@Test
-	public void getClaimWhenValueIsConvertedToBoolean() {
+	public void getClaimWhenValueIsConvertedThenReturnBoolean() {
 		boolean expectedClaimValue = true;
 		String claimName = "boolean";
 		this.claims.put(claimName, expectedClaimValue);
 
 		boolean actualClaimValue = this.claimAccessor.getClaim(claimName);
 
-		assertThat(actualClaimValue).isEqualTo((expectedClaimValue));
+		assertThat(actualClaimValue).isEqualTo(expectedClaimValue);
 	}
 
 	@Test
-	public void getClaimWhenValueIsNotConvertedToType() {
+	public void getClaimWhenValueIsNotConvertedThenThrowClassCastException() {
 		String expectedClaimValue = "true";
 		String claimName = "boolean";
 		this.claims.put(claimName, expectedClaimValue);


### PR DESCRIPTION
- New `getClaim()` method added in ClaimAccessor
- Unit tests for the new method added in ClaimAccessorTests

Fixes gh-6947