### PR TITLE
Validate token passed in query parameters same as headers

### DIFF
--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
@@ -165,4 +165,28 @@ public class DefaultBearerTokenResolverTests {
 
 		assertThat(this.resolver.resolve(request)).isNull();
 	}
+
+	@Test
+	public void resolveWhenQueryParameterIsPresentWithMissingTokenThenAuthenticationExceptionIsThrown() {
+		this.resolver.setAllowUriQueryParameter(true);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("GET");
+		request.addParameter("access_token", "");
+
+		assertThatCode(() -> this.resolver.resolve(request)).isInstanceOf(OAuth2AuthenticationException.class)
+				.hasMessageContaining(("Bearer token is malformed"));
+	}
+
+	@Test
+	public void resolveWhenQueryParameterWithInvalidCharactersIsPresentThenAuthenticationExceptionIsThrown() {
+		this.resolver.setAllowUriQueryParameter(true);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("GET");
+		request.addParameter("access_token", "an\"invalid\"token");
+
+		assertThatCode(() -> this.resolver.resolve(request)).isInstanceOf(OAuth2AuthenticationException.class)
+				.hasMessageContaining(("Bearer token is malformed"));
+	}
 }


### PR DESCRIPTION
Validates access tokens passed through query parameters in the same manner as if they were passed in Authorization HTTP header as a bearer token.

This resolves #7011 