### PR TITLE
Added OAuth2TokenAttributes to wrap attributes

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
@@ -79,6 +79,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenAttributes;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
 import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
@@ -159,7 +160,7 @@ public class OAuth2ResourceServerConfigurerTests {
 	private static final String CLIENT_ID = "client-id";
 	private static final String CLIENT_SECRET = "client-secret";
 	private static final OAuth2IntrospectionAuthenticationToken INTROSPECTION_AUTHENTICATION_TOKEN =
-			new OAuth2IntrospectionAuthenticationToken(noScopes(), JWT_CLAIMS, Collections.emptyList());
+			new OAuth2IntrospectionAuthenticationToken(noScopes(), new OAuth2TokenAttributes(JWT_CLAIMS), Collections.emptyList());
 
 	@Autowired(required = false)
 	MockMvc mvc;

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/OAuth2TokenAttributes.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/OAuth2TokenAttributes.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.core;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * A domain object that wraps the attributes of an OAuth 2.0 token.
+ *
+ * @author Clement Ng
+ * @since 5.2
+ */
+public final class OAuth2TokenAttributes {
+	private final Map<String, Object> attributes;
+
+	/**
+	 * Constructs an {@code OAuth2TokenAttributes} using the provided parameters.
+	 *
+	 * @param attributes the attributes of the OAuth 2.0 token
+	 */
+	public OAuth2TokenAttributes(Map<String, Object> attributes) {
+		this.attributes = Collections.unmodifiableMap(attributes);
+	}
+
+	/**
+	 * Gets the attributes of the OAuth 2.0 token in map form.
+	 *
+	 * @return a {@link Map} of the attribute's objects keyed by the attribute's names
+	 */
+	public Map<String, Object> getAttributes() {
+		return attributes;
+	}
+
+	/**
+	 * Gets the attribute of the OAuth 2.0 token corresponding to the name.
+	 *
+	 * @param name the name to lookup in the attributes
+	 * @return the object corresponding to the name in the attributes
+	 */
+	public <A> A getAttribute(String name) {
+		return (A) this.attributes.get(name);
+	}
+}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionAuthenticationProvider.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionAuthenticationProvider.java
@@ -32,6 +32,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenAttributes;
 import org.springframework.security.oauth2.server.resource.introspection.OAuth2IntrospectionException;
 import org.springframework.security.oauth2.server.resource.introspection.OAuth2TokenIntrospectionClient;
 import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken;
@@ -123,7 +124,7 @@ public final class OAuth2IntrospectionAuthenticationProvider implements Authenti
 		OAuth2AccessToken accessToken  = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
 				token, iat, exp);
 		Collection<GrantedAuthority> authorities = extractAuthorities(claims);
-		return new OAuth2IntrospectionAuthenticationToken(accessToken, claims, authorities);
+		return new OAuth2IntrospectionAuthenticationToken(accessToken, new OAuth2TokenAttributes(claims), authorities);
 	}
 
 	private Collection<GrantedAuthority> extractAuthorities(Map<String, Object> claims) {

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionAuthenticationToken.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionAuthenticationToken.java
@@ -69,7 +69,7 @@ public class OAuth2IntrospectionAuthenticationToken
 	public OAuth2IntrospectionAuthenticationToken(OAuth2AccessToken token, OAuth2TokenAttributes attributes,
 		Collection<? extends GrantedAuthority> authorities, String name) {
 
-		super(token, attributes(attributes), token, authorities);
+		super(token, attributes, token, authorities);
 		this.attributes = attributes(attributes);
 		this.name = name == null ? (String) this.attributes.get(SUBJECT) : name;
 		setAuthenticated(true);

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionAuthenticationToken.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionAuthenticationToken.java
@@ -24,6 +24,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.SpringSecurityCoreVersion;
 import org.springframework.security.core.Transient;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2TokenAttributes;
 import org.springframework.util.Assert;
 
 import static org.springframework.security.oauth2.server.resource.introspection.OAuth2IntrospectionClaimNames.SUBJECT;
@@ -53,7 +54,7 @@ public class OAuth2IntrospectionAuthenticationToken
 	 * @param authorities The authorities associated with the given token
 	 */
 	public OAuth2IntrospectionAuthenticationToken(OAuth2AccessToken token,
-			Map<String, Object> attributes, Collection<? extends GrantedAuthority> authorities) {
+			OAuth2TokenAttributes attributes, Collection<? extends GrantedAuthority> authorities) {
 
 		this(token, attributes, authorities, null);
 	}
@@ -65,18 +66,20 @@ public class OAuth2IntrospectionAuthenticationToken
 	 * @param authorities The authorities associated with the given token
 	 * @param name The name associated with this token
 	 */
-	public OAuth2IntrospectionAuthenticationToken(OAuth2AccessToken token,
-		Map<String, Object> attributes, Collection<? extends GrantedAuthority> authorities, String name) {
+	public OAuth2IntrospectionAuthenticationToken(OAuth2AccessToken token, OAuth2TokenAttributes attributes,
+		Collection<? extends GrantedAuthority> authorities, String name) {
 
 		super(token, attributes(attributes), token, authorities);
 		this.attributes = attributes(attributes);
-		this.name = name == null ? (String) attributes.get(SUBJECT) : name;
+		this.name = name == null ? (String) this.attributes.get(SUBJECT) : name;
 		setAuthenticated(true);
 	}
 
-	private static Map<String, Object> attributes(Map<String, Object> attributes) {
-		Assert.notEmpty(attributes, "attributes cannot be empty");
-		return Collections.unmodifiableMap(new LinkedHashMap<>(attributes));
+	private static Map<String, Object> attributes(OAuth2TokenAttributes attributes) {
+		Assert.notNull(attributes, "attributes cannot be empty");
+		Map<String, Object> attr = attributes.getAttributes();
+		Assert.notEmpty(attr, "attributes cannot be empty");
+		return Collections.unmodifiableMap(new LinkedHashMap<>(attr));
 	}
 
 	/**

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionReactiveAuthenticationManager.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionReactiveAuthenticationManager.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.springframework.security.oauth2.core.OAuth2TokenAttributes;
 import reactor.core.publisher.Mono;
 
 import org.springframework.http.HttpStatus;
@@ -101,7 +102,7 @@ public class OAuth2IntrospectionReactiveAuthenticationManager implements Reactiv
 					OAuth2AccessToken accessToken =
 							new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, token, iat, exp);
 					Collection<GrantedAuthority> authorities = extractAuthorities(claims);
-					return new OAuth2IntrospectionAuthenticationToken(accessToken, claims, authorities);
+					return new OAuth2IntrospectionAuthenticationToken(accessToken, new OAuth2TokenAttributes(claims), authorities);
 				})
 				.onErrorMap(OAuth2IntrospectionException.class, this::onError);
 	}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionAuthenticationProviderTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionAuthenticationProviderTests.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2TokenAttributes;
 import org.springframework.security.oauth2.server.resource.introspection.OAuth2IntrospectionClaimNames;
 import org.springframework.security.oauth2.server.resource.introspection.OAuth2IntrospectionException;
 import org.springframework.security.oauth2.server.resource.introspection.OAuth2TokenIntrospectionClient;
@@ -63,9 +64,9 @@ public class OAuth2IntrospectionAuthenticationProviderTests {
 		Authentication result =
 				provider.authenticate(new BearerTokenAuthenticationToken("token"));
 
-		assertThat(result.getPrincipal()).isInstanceOf(Map.class);
+		assertThat(result.getPrincipal()).isInstanceOf(OAuth2TokenAttributes.class);
 
-		Map<String, Object> attributes = (Map<String, Object>) result.getPrincipal();
+		Map<String, Object> attributes = ((OAuth2TokenAttributes) result.getPrincipal()).getAttributes();
 		assertThat(attributes)
 				.isNotNull()
 				.containsEntry(ACTIVE, true)
@@ -94,9 +95,9 @@ public class OAuth2IntrospectionAuthenticationProviderTests {
 
 		Authentication result =
 				provider.authenticate(new BearerTokenAuthenticationToken("token"));
-		assertThat(result.getPrincipal()).isInstanceOf(Map.class);
+		assertThat(result.getPrincipal()).isInstanceOf(OAuth2TokenAttributes.class);
 
-		Map<String, Object> attributes = (Map<String, Object>) result.getPrincipal();
+		Map<String, Object> attributes = ((OAuth2TokenAttributes) result.getPrincipal()).getAttributes();
 		assertThat(attributes)
 				.isNotNull()
 				.doesNotContainKey(SCOPE);

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionAuthenticationTokenTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionAuthenticationTokenTests.java
@@ -93,7 +93,7 @@ public class OAuth2IntrospectionAuthenticationTokenTests {
 	public void constructorWhenAttributesAreNullOrEmptyThenThrowsException() {
 		assertThatCode(() -> new OAuth2IntrospectionAuthenticationToken(this.token, null, null))
 				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessageContaining("attributes cannot be empty");
+				.hasMessageContaining("principal cannot be null");
 
 		assertThatCode(() -> new OAuth2IntrospectionAuthenticationToken(this.token,
 									new OAuth2TokenAttributes(Collections.emptyMap()), null))

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionReactiveAuthenticationManagerTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionReactiveAuthenticationManagerTests.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Map;
 
 import org.junit.Test;
+import org.springframework.security.oauth2.core.OAuth2TokenAttributes;
 import reactor.core.publisher.Mono;
 
 import org.springframework.security.core.Authentication;
@@ -62,9 +63,9 @@ public class OAuth2IntrospectionReactiveAuthenticationManagerTests {
 		Authentication result =
 				provider.authenticate(new BearerTokenAuthenticationToken("token")).block();
 
-		assertThat(result.getPrincipal()).isInstanceOf(Map.class);
+		assertThat(result.getPrincipal()).isInstanceOf(OAuth2TokenAttributes.class);
 
-		Map<String, Object> attributes = (Map<String, Object>) result.getPrincipal();
+		Map<String, Object> attributes = ((OAuth2TokenAttributes) result.getPrincipal()).getAttributes();
 		assertThat(attributes)
 				.isNotNull()
 				.containsEntry(ACTIVE, true)
@@ -93,9 +94,9 @@ public class OAuth2IntrospectionReactiveAuthenticationManagerTests {
 
 		Authentication result =
 				provider.authenticate(new BearerTokenAuthenticationToken("token")).block();
-		assertThat(result.getPrincipal()).isInstanceOf(Map.class);
+		assertThat(result.getPrincipal()).isInstanceOf(OAuth2TokenAttributes.class);
 
-		Map<String, Object> attributes = (Map<String, Object>) result.getPrincipal();
+		Map<String, Object> attributes = ((OAuth2TokenAttributes) result.getPrincipal()).getAttributes();
 		assertThat(attributes)
 				.isNotNull()
 				.doesNotContainKey(SCOPE);

--- a/samples/boot/oauth2resourceserver-opaque/src/main/java/sample/OAuth2ResourceServerController.java
+++ b/samples/boot/oauth2resourceserver-opaque/src/main/java/sample/OAuth2ResourceServerController.java
@@ -16,6 +16,7 @@
 package sample;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.OAuth2TokenAttributes;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,8 +27,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class OAuth2ResourceServerController {
 
 	@GetMapping("/")
-	public String index(@AuthenticationPrincipal(expression="['sub']") String subject) {
-		return String.format("Hello, %s!", subject);
+	public String index(@AuthenticationPrincipal OAuth2TokenAttributes attributes) {
+		return String.format("Hello, %s!", (String) attributes.getAttribute("sub"));
 	}
 
 	@GetMapping("/message")


### PR DESCRIPTION
To simplify access to OAuth 2.0 token attributes

Fixes gh-6498

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
