### PR TITLE
Allow custom ReactiveAuthenticationManager for basic and form auth

### DIFF
--- a/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
@@ -1667,11 +1667,15 @@ public class ServerHttpSecurity {
 			this.cors.configure(this);
 		}
 		if (this.httpBasic != null) {
-			this.httpBasic.authenticationManager(this.authenticationManager);
+			if (this.httpBasic.authenticationManager == null) {
+				this.httpBasic.authenticationManager(this.authenticationManager);
+			}
 			this.httpBasic.configure(this);
 		}
 		if (this.formLogin != null) {
-			this.formLogin.authenticationManager(this.authenticationManager);
+			if (this.formLogin.authenticationManager == null) {
+				this.formLogin.authenticationManager(this.authenticationManager);
+			}
 			if (this.securityContextRepository != null) {
 				this.formLogin.securityContextRepository(this.securityContextRepository);
 			}


### PR DESCRIPTION
I just stumbled upon this issue(#5660), so fixing it.

----

Prior to this change, `HttpBasicSpec#authenticationManager` and
`FormLoginSpec#authenticationManager` were always overridden by
`ServerHttpSecurity#authenticationManager`.

This commit makes sure override only happens when custom authentication
manager was not specified.

Fixes: gh-5660