### PR TITLE
Throws exception when passed IP address with too long mask

### DIFF
--- a/web/src/main/java/org/springframework/security/web/util/matcher/IpAddressMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/IpAddressMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.StringUtils;
+import org.springframework.util.Assert;
 
 /**
  * Matches a request based on IP Address or subnet mask matching against the remote
@@ -55,6 +56,9 @@ public final class IpAddressMatcher implements RequestMatcher {
 			nMaskBits = -1;
 		}
 		requiredAddress = parseAddress(ipAddress);
+		Assert.isTrue(requiredAddress.getAddress().length * 8 >= nMaskBits,
+				String.format("IP address %s is too short for bitmask of length %d",
+						ipAddress, nMaskBits));
 	}
 
 	public boolean matches(HttpServletRequest request) {

--- a/web/src/test/java/org/springframework/security/web/util/matcher/IpAddressMatcherTests.java
+++ b/web/src/test/java/org/springframework/security/web/util/matcher/IpAddressMatcherTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,5 +83,25 @@ public class IpAddressMatcherTests {
 		matcher = new IpAddressMatcher("192.168.0.159/0");
 		assertThat(matcher.matches("123.4.5.6")).isTrue();
 		assertThat(matcher.matches("192.168.0.159")).isTrue();
+	}
+
+	// SEC-2576
+	@Test
+	public void ipv4RequiredAddressMaskTooLongThenIllegalArgumentException() {
+		String ipv4AddressWithTooLongMask = "192.168.1.104/33";
+		assertThatCode(() -> new IpAddressMatcher(ipv4AddressWithTooLongMask))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage(String.format("IP address %s is too short for bitmask of " +
+						"length %d", "192.168.1.104", 33));
+	}
+
+	// SEC-2576
+	@Test
+	public void ipv6RequiredAddressMaskTooLongThenIllegalArgumentException() {
+		String ipv6AddressWithTooLongMask = "fe80::21f:5bff:fe33:bd68/129";
+		assertThatCode(() -> new IpAddressMatcher(ipv6AddressWithTooLongMask))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage(String.format("IP address %s is too short for bitmask of " +
+						"length %d", "fe80::21f:5bff:fe33:bd68", 129));
 	}
 }


### PR DESCRIPTION
Originally, `matches(String address)` would first call `parse` on an address, when I believe the correct behavior is to first check for the validity of the subnet mask (an invalid mask for an IP address is invalid regardless of what method it's a part of). This is why invalid masks could be passed into the constructor but then throw exceptions on valid calls to `matches`. So I changed both the constructor and the `matches` method to first validate that the mask in the IP address passed in is not too long.

Draft b/c I'm not sure if my assumption fully holds for all cases.

Fixes gh-2790

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
