### PR TITLE
Add unbounid support in xml

### DIFF
--- a/config/spring-security-config.gradle
+++ b/config/spring-security-config.gradle
@@ -71,6 +71,7 @@ dependencies {
 
 	testRuntime 'cglib:cglib-nodep'
 	testRuntime 'org.hsqldb:hsqldb'
+    testCompile "com.unboundid:unboundid-ldapsdk"
 }
 
 

--- a/config/spring-security-config.gradle
+++ b/config/spring-security-config.gradle
@@ -71,7 +71,6 @@ dependencies {
 
 	testRuntime 'cglib:cglib-nodep'
 	testRuntime 'org.hsqldb:hsqldb'
-    testCompile "com.unboundid:unboundid-ldapsdk"
 }
 
 

--- a/config/src/main/java/org/springframework/security/config/BeanIds.java
+++ b/config/src/main/java/org/springframework/security/config/BeanIds.java
@@ -53,6 +53,8 @@ public abstract class BeanIds {
 			+ "methodSecurityMetadataSourceAdvisor";
 	public static final String EMBEDDED_APACHE_DS = PREFIX
 			+ "apacheDirectoryServerContainer";
+	public static final String EMBEDDED_UNBOUNDID = PREFIX
+			+ "unboundidServerContainer";
 	public static final String CONTEXT_SOURCE = PREFIX + "securityContextSource";
 
 	public static final String DEBUG_FILTER = PREFIX + "debugFilter";

--- a/config/src/main/java/org/springframework/security/config/SecurityNamespaceHandler.java
+++ b/config/src/main/java/org/springframework/security/config/SecurityNamespaceHandler.java
@@ -86,7 +86,7 @@ public final class SecurityNamespaceHandler implements NamespaceHandler {
 		if (!namespaceMatchesVersion(element)) {
 			pc.getReaderContext()
 					.fatal("You cannot use a spring-security-2.0.xsd or spring-security-3.0.xsd or spring-security-3.1.xsd schema or spring-security-3.2.xsd schema or spring-security-4.0.xsd schema "
-							+ "with Spring Security 4.2. Please update your schema declarations to the 4.2 schema.",
+							+ "with Spring Security 5.2. Please update your schema declarations to the 5.2 schema.",
 							element);
 		}
 		String name = pc.getDelegate().getLocalName(element);
@@ -221,7 +221,7 @@ public final class SecurityNamespaceHandler implements NamespaceHandler {
 	private boolean matchesVersionInternal(Element element) {
 		String schemaLocation = element.getAttributeNS(
 				"http://www.w3.org/2001/XMLSchema-instance", "schemaLocation");
-		return schemaLocation.matches("(?m).*spring-security-4\\.2.*.xsd.*")
+		return schemaLocation.matches("(?m).*spring-security-5\\.2.*.xsd.*")
 				|| schemaLocation.matches("(?m).*spring-security.xsd.*")
 				|| !schemaLocation.matches("(?m).*spring-security.*");
 	}

--- a/config/src/main/resources/META-INF/spring.schemas
+++ b/config/src/main/resources/META-INF/spring.schemas
@@ -1,5 +1,5 @@
-http\://www.springframework.org/schema/security/spring-security.xsd=org/springframework/security/config/spring-security-5.2.xsd
-http\://www.springframework.org/schema/security/spring-security-5.2.xsd=org/springframework/security/config/spring-security-5.2.xsd
+https\://www.springframework.org/schema/security/spring-security.xsd=org/springframework/security/config/spring-security-5.2.xsd
+https\://www.springframework.org/schema/security/spring-security-5.2.xsd=org/springframework/security/config/spring-security-5.2.xsd
 http\://www.springframework.org/schema/security/spring-security-5.1.xsd=org/springframework/security/config/spring-security-5.1.xsd
 http\://www.springframework.org/schema/security/spring-security-5.0.xsd=org/springframework/security/config/spring-security-5.0.xsd
 http\://www.springframework.org/schema/security/spring-security-4.2.xsd=org/springframework/security/config/spring-security-4.2.xsd

--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.2.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.2.rnc
@@ -83,6 +83,9 @@ ldap-server.attlist &=
 ldap-server.attlist &=
 	## Optional root suffix for the embedded LDAP server. Default is "dc=springframework,dc=org"
 	attribute root { xsd:string }?
+ldap-server.attlist &=
+	## Explicitly specifies which embedded ldap server should use. Values are `apacheds` and `unboundid`. By default, it will depends if the library is available in the classpath.
+	attribute mode { "apacheds" | "unboundid" }?
 
 ldap-server-ref-attribute =
 	## The optional server to use. If omitted, and a default LDAP server is registered (using <ldap-server> with no Id), that server will be used.

--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.2.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.2.rnc
@@ -84,7 +84,7 @@ ldap-server.attlist &=
 	## Optional root suffix for the embedded LDAP server. Default is "dc=springframework,dc=org"
 	attribute root { xsd:string }?
 ldap-server.attlist &=
-	## Explicitly specifies which embedded ldap server should use. Values are `apacheds` and `unboundid`. By default, it will depends if the library is available in the classpath.
+	## Explicitly specifies which embedded ldap server should use. Values are 'apacheds' and 'unboundid'. By default, it will depends if the library is available in the classpath.
 	attribute mode { "apacheds" | "unboundid" }?
 
 ldap-server-ref-attribute =

--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.2.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.2.xsd
@@ -124,7 +124,7 @@
       </xs:annotation>
       <xs:complexType/>
    </xs:element>
-  
+
   <xs:attributeGroup name="password-encoder.attlist">
       <xs:attribute name="ref" type="xs:token">
          <xs:annotation>
@@ -221,6 +221,19 @@
             <xs:documentation>Optional root suffix for the embedded LDAP server. Default is "dc=springframework,dc=org"
                 </xs:documentation>
          </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="mode">
+         <xs:annotation>
+            <xs:documentation>Explicitly specifies which embedded ldap server should use. Values are `apacheds` and
+                `unboundid`. By default, it will depends if the library is available in the classpath.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="apacheds"/>
+               <xs:enumeration value="unboundid"/>
+            </xs:restriction>
+         </xs:simpleType>
       </xs:attribute>
   </xs:attributeGroup>
   <xs:attributeGroup name="ldap-server-ref-attribute">
@@ -395,7 +408,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="ldap-ap.attlist">
       <xs:attribute name="server-ref" type="xs:token">
          <xs:annotation>
@@ -475,7 +488,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="password-compare.attlist">
       <xs:attribute name="password-attribute" type="xs:token">
          <xs:annotation>
@@ -528,7 +541,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="protect.attlist">
       <xs:attribute name="method" use="required" type="xs:token">
          <xs:annotation>
@@ -772,13 +785,13 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
   <xs:attributeGroup name="protect-pointcut.attlist">
       <xs:attribute name="expression" use="required" type="xs:string">
          <xs:annotation>
@@ -1220,7 +1233,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="access-denied-handler.attlist">
       <xs:attribute name="ref" type="xs:token">
          <xs:annotation>
@@ -1245,7 +1258,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="intercept-url.attlist">
       <xs:attribute name="pattern" type="xs:token">
          <xs:annotation>
@@ -1302,7 +1315,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="logout.attlist">
       <xs:attribute name="logout-url" type="xs:token">
          <xs:annotation>
@@ -1349,7 +1362,7 @@
          <xs:attributeGroup ref="security:ref"/>
       </xs:complexType>
    </xs:element>
-  
+
   <xs:attributeGroup name="form-login.attlist">
       <xs:attribute name="login-processing-url" type="xs:token">
          <xs:annotation>
@@ -1437,7 +1450,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:element name="attribute-exchange">
       <xs:annotation>
          <xs:documentation>Sets up an attribute exchange configuration to request specified attributes from the
@@ -1636,7 +1649,7 @@
          </xs:simpleType>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="http-basic.attlist">
       <xs:attribute name="entry-point-ref" type="xs:token">
          <xs:annotation>
@@ -1652,7 +1665,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="session-management.attlist">
       <xs:attribute name="session-fixation-protection">
          <xs:annotation>
@@ -1708,7 +1721,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="concurrency-control.attlist">
       <xs:attribute name="max-sessions" type="xs:integer">
          <xs:annotation>
@@ -1755,7 +1768,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="remember-me.attlist">
       <xs:attribute name="key" type="xs:token">
          <xs:annotation>
@@ -1853,7 +1866,7 @@
   <xs:attributeGroup name="remember-me-data-source-ref">
       <xs:attributeGroup ref="security:data-source-ref"/>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="anonymous.attlist">
       <xs:attribute name="key" type="xs:token">
          <xs:annotation>
@@ -1886,8 +1899,8 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
-  
+
+
   <xs:attributeGroup name="http-port">
       <xs:attribute name="http" use="required" type="xs:token">
          <xs:annotation>
@@ -1904,7 +1917,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="x509.attlist">
       <xs:attribute name="subject-principal-regex" type="xs:token">
          <xs:annotation>
@@ -2041,7 +2054,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="ap.attlist">
       <xs:attribute name="ref" type="xs:token">
          <xs:annotation>
@@ -2093,7 +2106,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="user.attlist">
       <xs:attribute name="name" use="required" type="xs:token">
          <xs:annotation>

--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.2.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.2.xsd
@@ -124,7 +124,7 @@
       </xs:annotation>
       <xs:complexType/>
    </xs:element>
-
+  
   <xs:attributeGroup name="password-encoder.attlist">
       <xs:attribute name="ref" type="xs:token">
          <xs:annotation>
@@ -224,8 +224,8 @@
       </xs:attribute>
       <xs:attribute name="mode">
          <xs:annotation>
-            <xs:documentation>Explicitly specifies which embedded ldap server should use. Values are `apacheds` and
-                `unboundid`. By default, it will depends if the library is available in the classpath.
+            <xs:documentation>Explicitly specifies which embedded ldap server should use. Values are 'apacheds' and
+                'unboundid'. By default, it will depends if the library is available in the classpath.
                 </xs:documentation>
          </xs:annotation>
          <xs:simpleType>
@@ -408,7 +408,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-
+  
   <xs:attributeGroup name="ldap-ap.attlist">
       <xs:attribute name="server-ref" type="xs:token">
          <xs:annotation>
@@ -488,7 +488,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-
+  
   <xs:attributeGroup name="password-compare.attlist">
       <xs:attribute name="password-attribute" type="xs:token">
          <xs:annotation>
@@ -541,7 +541,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-
+  
   <xs:attributeGroup name="protect.attlist">
       <xs:attribute name="method" use="required" type="xs:token">
          <xs:annotation>
@@ -785,13 +785,13 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-
-
-
-
-
-
-
+  
+  
+  
+  
+  
+  
+  
   <xs:attributeGroup name="protect-pointcut.attlist">
       <xs:attribute name="expression" use="required" type="xs:string">
          <xs:annotation>
@@ -1233,7 +1233,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-
+  
   <xs:attributeGroup name="access-denied-handler.attlist">
       <xs:attribute name="ref" type="xs:token">
          <xs:annotation>
@@ -1258,7 +1258,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-
+  
   <xs:attributeGroup name="intercept-url.attlist">
       <xs:attribute name="pattern" type="xs:token">
          <xs:annotation>
@@ -1315,7 +1315,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-
+  
   <xs:attributeGroup name="logout.attlist">
       <xs:attribute name="logout-url" type="xs:token">
          <xs:annotation>
@@ -1362,7 +1362,7 @@
          <xs:attributeGroup ref="security:ref"/>
       </xs:complexType>
    </xs:element>
-
+  
   <xs:attributeGroup name="form-login.attlist">
       <xs:attribute name="login-processing-url" type="xs:token">
          <xs:annotation>
@@ -1450,7 +1450,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-
+  
   <xs:element name="attribute-exchange">
       <xs:annotation>
          <xs:documentation>Sets up an attribute exchange configuration to request specified attributes from the
@@ -1649,7 +1649,7 @@
          </xs:simpleType>
       </xs:attribute>
   </xs:attributeGroup>
-
+  
   <xs:attributeGroup name="http-basic.attlist">
       <xs:attribute name="entry-point-ref" type="xs:token">
          <xs:annotation>
@@ -1665,7 +1665,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-
+  
   <xs:attributeGroup name="session-management.attlist">
       <xs:attribute name="session-fixation-protection">
          <xs:annotation>
@@ -1721,7 +1721,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-
+  
   <xs:attributeGroup name="concurrency-control.attlist">
       <xs:attribute name="max-sessions" type="xs:integer">
          <xs:annotation>
@@ -1768,7 +1768,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-
+  
   <xs:attributeGroup name="remember-me.attlist">
       <xs:attribute name="key" type="xs:token">
          <xs:annotation>
@@ -1866,7 +1866,7 @@
   <xs:attributeGroup name="remember-me-data-source-ref">
       <xs:attributeGroup ref="security:data-source-ref"/>
   </xs:attributeGroup>
-
+  
   <xs:attributeGroup name="anonymous.attlist">
       <xs:attribute name="key" type="xs:token">
          <xs:annotation>
@@ -1899,8 +1899,8 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-
-
+  
+  
   <xs:attributeGroup name="http-port">
       <xs:attribute name="http" use="required" type="xs:token">
          <xs:annotation>
@@ -1917,7 +1917,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-
+  
   <xs:attributeGroup name="x509.attlist">
       <xs:attribute name="subject-principal-regex" type="xs:token">
          <xs:annotation>
@@ -2054,7 +2054,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-
+  
   <xs:attributeGroup name="ap.attlist">
       <xs:attribute name="ref" type="xs:token">
          <xs:annotation>
@@ -2106,7 +2106,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-
+  
   <xs:attributeGroup name="user.attlist">
       <xs:attribute name="name" use="required" type="xs:token">
          <xs:annotation>

--- a/config/src/test/java/org/springframework/security/config/ldap/LdapServerBeanDefinitionParserTest.java
+++ b/config/src/test/java/org/springframework/security/config/ldap/LdapServerBeanDefinitionParserTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import org.springframework.security.config.BeanIds;
 import org.springframework.security.config.util.InMemoryXmlApplicationContext;
 import org.springframework.security.ldap.server.ApacheDSContainer;
-import org.springframework.security.ldap.server.UnboundIdContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -57,11 +56,4 @@ public class LdapServerBeanDefinitionParserTest {
 		assertThat(beanNames[0]).isEqualTo(BeanIds.EMBEDDED_APACHE_DS);
 	}
 
-	@Test
-	public void unboundidIsStartedWhenModeIsSet() {
-		this.context = new InMemoryXmlApplicationContext("<ldap-user-service user-search-filter='(uid={0})' /><ldap-server mode='unboundid'/>", "5.2", null);
-		String[] beanNames = this.context.getBeanNamesForType(UnboundIdContainer.class);
-		assertThat(beanNames).hasSize(1);
-		assertThat(beanNames[0]).isEqualTo(BeanIds.EMBEDDED_UNBOUNDID);
-	}
 }

--- a/config/src/test/java/org/springframework/security/config/ldap/LdapServerBeanDefinitionParserTest.java
+++ b/config/src/test/java/org/springframework/security/config/ldap/LdapServerBeanDefinitionParserTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.config.ldap;
+
+import org.junit.After;
+import org.junit.Test;
+
+import org.springframework.security.config.BeanIds;
+import org.springframework.security.config.util.InMemoryXmlApplicationContext;
+import org.springframework.security.ldap.server.ApacheDSContainer;
+import org.springframework.security.ldap.server.UnboundIdContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Eddú Meléndez
+ */
+public class LdapServerBeanDefinitionParserTest {
+
+	private InMemoryXmlApplicationContext context;
+
+	@After
+	public void closeAppContext() {
+		if (this.context != null) {
+			this.context.close();
+			this.context = null;
+		}
+	}
+
+	@Test
+	public void apacheDirectoryServerIsStartedByDefault() {
+		this.context = new InMemoryXmlApplicationContext("<ldap-user-service user-search-filter='(uid={0})'/><ldap-server/>", "5.2", null);
+		String[] beanNames = this.context.getBeanNamesForType(ApacheDSContainer.class);
+		assertThat(beanNames).hasSize(1);
+		assertThat(beanNames[0]).isEqualTo(BeanIds.EMBEDDED_APACHE_DS);
+	}
+
+	@Test
+	public void apacheDirectoryServerIsStartedWhenIsSet() {
+		this.context = new InMemoryXmlApplicationContext("<ldap-user-service user-search-filter='(uid={0})' /><ldap-server mode='apacheds'/>", "5.2", null);
+		String[] beanNames = this.context.getBeanNamesForType(ApacheDSContainer.class);
+		assertThat(beanNames).hasSize(1);
+		assertThat(beanNames[0]).isEqualTo(BeanIds.EMBEDDED_APACHE_DS);
+	}
+
+	@Test
+	public void unboundidIsStartedWhenModeIsSet() {
+		this.context = new InMemoryXmlApplicationContext("<ldap-user-service user-search-filter='(uid={0})' /><ldap-server mode='unboundid'/>", "5.2", null);
+		String[] beanNames = this.context.getBeanNamesForType(UnboundIdContainer.class);
+		assertThat(beanNames).hasSize(1);
+		assertThat(beanNames[0]).isEqualTo(BeanIds.EMBEDDED_UNBOUNDID);
+	}
+}

--- a/config/src/test/java/org/springframework/security/config/util/InMemoryXmlApplicationContext.java
+++ b/config/src/test/java/org/springframework/security/config/util/InMemoryXmlApplicationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2013 the original author or authors.
+ * Copyright 2009-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.security.util.InMemoryResource;
 
 /**
  * @author Luke Taylor
+ * @author Eddú Meléndez
  */
 public class InMemoryXmlApplicationContext extends AbstractXmlApplicationContext {
 	static final String BEANS_OPENING = "<b:beans xmlns='http://www.springframework.org/schema/security'\n"
@@ -40,7 +41,7 @@ public class InMemoryXmlApplicationContext extends AbstractXmlApplicationContext
 			+ "http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-";
 	static final String BEANS_CLOSE = "</b:beans>\n";
 
-	static final String SPRING_SECURITY_VERSION = "4.2";
+	static final String SPRING_SECURITY_VERSION = "5.2";
 
 	Resource inMemoryXml;
 

--- a/config/src/test/java/org/springframework/security/config/util/InMemoryXmlApplicationContext.java
+++ b/config/src/test/java/org/springframework/security/config/util/InMemoryXmlApplicationContext.java
@@ -38,7 +38,7 @@ public class InMemoryXmlApplicationContext extends AbstractXmlApplicationContext
 			+ "http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd\n"
 			+ "http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd\n"
 			+ "http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd\n"
-			+ "http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-";
+			+ "http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security-";
 	static final String BEANS_CLOSE = "</b:beans>\n";
 
 	static final String SPRING_SECURITY_VERSION = "5.2";

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/additional-topics/ldap.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/additional-topics/ldap.adoc
@@ -47,6 +47,8 @@ This can be configured to point at an external LDAP server, using the `url` attr
 <ldap-server url="ldap://springframework.org:389/dc=springframework,dc=org" />
 ----
 
+NOTE: `spring-security` provides integration with `apacheds` and `unboundid` as a embedded ldap servers. You can choose between them using the attribute `mode` in `ldap-server`.
+
 ==== Using an Embedded Test Server
 The `<ldap-server>` element can also be used to create an embedded server, which can be very useful for testing and demonstrations.
 In this case you use it without the `url` attribute:

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/appendix/namespace.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/appendix/namespace.adoc
@@ -2360,6 +2360,9 @@ This is actually the bean `id` of the `ContextSource` instance, if you want to u
 [[nsa-ldap-server-attributes]]
 ===== <ldap-server> Attributes
 
+[[nsa-ldap-server-mode]]
+* **mode**
+Explicitly specifies which embedded ldap server should use. Values are `apacheds` and `unboundid`. By default, it will depends if the library is available in the classpath.
 
 [[nsa-ldap-server-id]]
 * **id**

--- a/docs/manual/src/docs/asciidoc/index.adoc
+++ b/docs/manual/src/docs/asciidoc/index.adoc
@@ -1,5 +1,5 @@
 = Spring Security Reference
-Ben Alex; Luke Taylor; Rob Winch; Gunnar Hillert; Joe Grandja; Jay Bryant
+Ben Alex; Luke Taylor; Rob Winch; Gunnar Hillert; Joe Grandja; Jay Bryant; Eddú Meléndez
 :include-dir: _includes
 :security-api-url: https://docs.spring.io/spring-security/site/docs/current/api/
 :source-indent: 0

--- a/itest/ldap/embedded-ldap-apacheds-default/spring-security-itest-ldap-embedded-apacheds-default.gradle
+++ b/itest/ldap/embedded-ldap-apacheds-default/spring-security-itest-ldap-embedded-apacheds-default.gradle
@@ -1,0 +1,13 @@
+apply plugin: 'io.spring.convention.spring-test'
+
+dependencies {
+    compile project(':spring-security-core')
+    compile 'org.springframework:spring-beans'
+    compile 'org.springframework:spring-context'
+    compile 'org.springframework:spring-core'
+    compile 'org.springframework:spring-tx'
+    compile project(':spring-security-config')
+    compile project(':spring-security-ldap')
+
+    runtime apachedsDependencies
+}

--- a/itest/ldap/embedded-ldap-apacheds-default/src/integration-test/java/org/springframework/security/LdapServerBeanDefinitionParserTests.java
+++ b/itest/ldap/embedded-ldap-apacheds-default/src/integration-test/java/org/springframework/security/LdapServerBeanDefinitionParserTests.java
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package org.springframework.security.config.ldap;
+package org.springframework.security;
 
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.security.config.BeanIds;
-import org.springframework.security.config.util.InMemoryXmlApplicationContext;
 import org.springframework.security.ldap.server.ApacheDSContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,9 +29,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Eddú Meléndez
  */
-public class LdapServerBeanDefinitionParserTest {
+public class LdapServerBeanDefinitionParserTests {
 
-	private InMemoryXmlApplicationContext context;
+	private ClassPathXmlApplicationContext context;
+
+	@Before
+	public void setup() {
+		this.context = new ClassPathXmlApplicationContext("applicationContext-security.xml");
+	}
 
 	@After
 	public void closeAppContext() {
@@ -42,15 +48,6 @@ public class LdapServerBeanDefinitionParserTest {
 
 	@Test
 	public void apacheDirectoryServerIsStartedByDefault() {
-		this.context = new InMemoryXmlApplicationContext("<ldap-user-service user-search-filter='(uid={0})'/><ldap-server/>", "5.2", null);
-		String[] beanNames = this.context.getBeanNamesForType(ApacheDSContainer.class);
-		assertThat(beanNames).hasSize(1);
-		assertThat(beanNames[0]).isEqualTo(BeanIds.EMBEDDED_APACHE_DS);
-	}
-
-	@Test
-	public void apacheDirectoryServerIsStartedWhenIsSet() {
-		this.context = new InMemoryXmlApplicationContext("<ldap-user-service user-search-filter='(uid={0})' /><ldap-server mode='apacheds'/>", "5.2", null);
 		String[] beanNames = this.context.getBeanNamesForType(ApacheDSContainer.class);
 		assertThat(beanNames).hasSize(1);
 		assertThat(beanNames[0]).isEqualTo(BeanIds.EMBEDDED_APACHE_DS);

--- a/itest/ldap/embedded-ldap-apacheds-default/src/integration-test/resources/applicationContext-security.xml
+++ b/itest/ldap/embedded-ldap-apacheds-default/src/integration-test/resources/applicationContext-security.xml
@@ -1,0 +1,9 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:s="http://www.springframework.org/schema/security"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
+
+	<s:ldap-server ldif="classpath:users.ldif"/>
+
+</beans>

--- a/itest/ldap/embedded-ldap-apacheds-default/src/integration-test/resources/users.ldif
+++ b/itest/ldap/embedded-ldap-apacheds-default/src/integration-test/resources/users.ldif
@@ -1,0 +1,60 @@
+dn: ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: groups
+
+dn: ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: people
+
+dn: uid=rod,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: Rod Johnson
+sn: Johnson
+uid: rod
+userPassword: koala
+
+dn: uid=dianne,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: Dianne Emu
+sn: Emu
+uid: dianne
+userPassword: emu
+
+dn: uid=scott,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: Scott
+sn: Wombat
+uid: scott
+userPassword: wombat
+
+dn: cn=user,ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: user
+member: uid=rod,ou=people,dc=springframework,dc=org
+member: uid=dianne,ou=people,dc=springframework,dc=org
+member: uid=scott,ou=people,dc=springframework,dc=org
+
+dn: cn=teller,ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: teller
+member: uid=rod,ou=people,dc=springframework,dc=org
+member: uid=dianne,ou=people,dc=springframework,dc=org
+
+dn: cn=supervisor,ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: supervisor
+member: uid=rod,ou=people,dc=springframework,dc=org

--- a/itest/ldap/embedded-ldap-mode-apacheds/spring-security-itest-ldap-embedded-mode-apacheds.gradle
+++ b/itest/ldap/embedded-ldap-mode-apacheds/spring-security-itest-ldap-embedded-mode-apacheds.gradle
@@ -1,0 +1,13 @@
+apply plugin: 'io.spring.convention.spring-test'
+
+dependencies {
+    compile project(':spring-security-core')
+    compile 'org.springframework:spring-beans'
+    compile 'org.springframework:spring-context'
+    compile 'org.springframework:spring-core'
+    compile 'org.springframework:spring-tx'
+    compile project(':spring-security-config')
+    compile project(':spring-security-ldap')
+
+    runtime apachedsDependencies
+}

--- a/itest/ldap/embedded-ldap-mode-apacheds/src/integration-test/java/org/springframework/security/LdapServerBeanDefinitionParserTests.java
+++ b/itest/ldap/embedded-ldap-mode-apacheds/src/integration-test/java/org/springframework/security/LdapServerBeanDefinitionParserTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.security.config.BeanIds;
+import org.springframework.security.ldap.server.ApacheDSContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Eddú Meléndez
+ */
+public class LdapServerBeanDefinitionParserTests {
+
+	private ClassPathXmlApplicationContext context;
+
+	@Before
+	public void setup() {
+		this.context = new ClassPathXmlApplicationContext("applicationContext-security.xml");
+	}
+
+	@After
+	public void closeAppContext() {
+		if (this.context != null) {
+			this.context.close();
+			this.context = null;
+		}
+	}
+
+	@Test
+	public void apacheDirectoryServerIsStartedByDefault() {
+		String[] beanNames = this.context.getBeanNamesForType(ApacheDSContainer.class);
+		assertThat(beanNames).hasSize(1);
+		assertThat(beanNames[0]).isEqualTo(BeanIds.EMBEDDED_APACHE_DS);
+	}
+
+}

--- a/itest/ldap/embedded-ldap-mode-apacheds/src/integration-test/resources/applicationContext-security.xml
+++ b/itest/ldap/embedded-ldap-mode-apacheds/src/integration-test/resources/applicationContext-security.xml
@@ -1,0 +1,9 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:s="http://www.springframework.org/schema/security"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
+
+	<s:ldap-server mode="apacheds" ldif="classpath:users.ldif"/>
+
+</beans>

--- a/itest/ldap/embedded-ldap-mode-apacheds/src/integration-test/resources/users.ldif
+++ b/itest/ldap/embedded-ldap-mode-apacheds/src/integration-test/resources/users.ldif
@@ -1,0 +1,60 @@
+dn: ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: groups
+
+dn: ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: people
+
+dn: uid=rod,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: Rod Johnson
+sn: Johnson
+uid: rod
+userPassword: koala
+
+dn: uid=dianne,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: Dianne Emu
+sn: Emu
+uid: dianne
+userPassword: emu
+
+dn: uid=scott,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: Scott
+sn: Wombat
+uid: scott
+userPassword: wombat
+
+dn: cn=user,ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: user
+member: uid=rod,ou=people,dc=springframework,dc=org
+member: uid=dianne,ou=people,dc=springframework,dc=org
+member: uid=scott,ou=people,dc=springframework,dc=org
+
+dn: cn=teller,ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: teller
+member: uid=rod,ou=people,dc=springframework,dc=org
+member: uid=dianne,ou=people,dc=springframework,dc=org
+
+dn: cn=supervisor,ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: supervisor
+member: uid=rod,ou=people,dc=springframework,dc=org

--- a/itest/ldap/embedded-ldap-mode-unboundid/spring-security-itest-ldap-embedded-mode-unboundid.gradle
+++ b/itest/ldap/embedded-ldap-mode-unboundid/spring-security-itest-ldap-embedded-mode-unboundid.gradle
@@ -1,0 +1,13 @@
+apply plugin: 'io.spring.convention.spring-test'
+
+dependencies {
+    compile project(':spring-security-core')
+    compile 'org.springframework:spring-beans'
+    compile 'org.springframework:spring-context'
+    compile 'org.springframework:spring-core'
+    compile 'org.springframework:spring-tx'
+    compile project(':spring-security-config')
+    compile project(':spring-security-ldap')
+
+    testCompile "com.unboundid:unboundid-ldapsdk"
+}

--- a/itest/ldap/embedded-ldap-mode-unboundid/src/integration-test/java/org/springframework/security/LdapServerBeanDefinitionParserTests.java
+++ b/itest/ldap/embedded-ldap-mode-unboundid/src/integration-test/java/org/springframework/security/LdapServerBeanDefinitionParserTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.security.config.BeanIds;
+import org.springframework.security.ldap.server.UnboundIdContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Eddú Meléndez
+ */
+public class LdapServerBeanDefinitionParserTests {
+
+	private ClassPathXmlApplicationContext context;
+
+	@Before
+	public void setup() {
+		this.context = new ClassPathXmlApplicationContext("applicationContext-security.xml");
+	}
+
+	@After
+	public void closeAppContext() {
+		if (this.context != null) {
+			this.context.close();
+			this.context = null;
+		}
+	}
+
+	@Test
+	public void apacheDirectoryServerIsStartedByDefault() {
+		String[] beanNames = this.context.getBeanNamesForType(UnboundIdContainer.class);
+		assertThat(beanNames).hasSize(1);
+		assertThat(beanNames[0]).isEqualTo(BeanIds.EMBEDDED_UNBOUNDID);
+	}
+
+}

--- a/itest/ldap/embedded-ldap-mode-unboundid/src/integration-test/resources/applicationContext-security.xml
+++ b/itest/ldap/embedded-ldap-mode-unboundid/src/integration-test/resources/applicationContext-security.xml
@@ -1,0 +1,9 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:s="http://www.springframework.org/schema/security"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
+
+	<s:ldap-server mode="unboundid" ldif="classpath:users.ldif"/>
+
+</beans>

--- a/itest/ldap/embedded-ldap-mode-unboundid/src/integration-test/resources/users.ldif
+++ b/itest/ldap/embedded-ldap-mode-unboundid/src/integration-test/resources/users.ldif
@@ -1,0 +1,60 @@
+dn: ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: groups
+
+dn: ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: people
+
+dn: uid=rod,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: Rod Johnson
+sn: Johnson
+uid: rod
+userPassword: koala
+
+dn: uid=dianne,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: Dianne Emu
+sn: Emu
+uid: dianne
+userPassword: emu
+
+dn: uid=scott,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: Scott
+sn: Wombat
+uid: scott
+userPassword: wombat
+
+dn: cn=user,ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: user
+member: uid=rod,ou=people,dc=springframework,dc=org
+member: uid=dianne,ou=people,dc=springframework,dc=org
+member: uid=scott,ou=people,dc=springframework,dc=org
+
+dn: cn=teller,ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: teller
+member: uid=rod,ou=people,dc=springframework,dc=org
+member: uid=dianne,ou=people,dc=springframework,dc=org
+
+dn: cn=supervisor,ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: supervisor
+member: uid=rod,ou=people,dc=springframework,dc=org

--- a/itest/ldap/embedded-ldap-none/spring-security-itest-ldap-embedded-none.gradle
+++ b/itest/ldap/embedded-ldap-none/spring-security-itest-ldap-embedded-none.gradle
@@ -1,0 +1,11 @@
+apply plugin: 'io.spring.convention.spring-test'
+
+dependencies {
+    compile project(':spring-security-core')
+    compile 'org.springframework:spring-beans'
+    compile 'org.springframework:spring-context'
+    compile 'org.springframework:spring-core'
+    compile 'org.springframework:spring-tx'
+    compile project(':spring-security-config')
+    compile project(':spring-security-ldap')
+}

--- a/itest/ldap/embedded-ldap-none/src/integration-test/java/org/springframework/security/LdapServerBeanDefinitionParserTests.java
+++ b/itest/ldap/embedded-ldap-none/src/integration-test/java/org/springframework/security/LdapServerBeanDefinitionParserTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+/**
+ * @author Eddú Meléndez
+ */
+public class LdapServerBeanDefinitionParserTests {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private ClassPathXmlApplicationContext context;
+
+	@After
+	public void closeAppContext() {
+		if (this.context != null) {
+			this.context.close();
+			this.context = null;
+		}
+	}
+
+	@Test
+	public void apacheDirectoryServerIsStartedByDefault() {
+		this.thrown.expect(BeanDefinitionStoreException.class);
+		this.thrown.expectMessage("Embedded LDAP server is not provided");
+
+		this.context = new ClassPathXmlApplicationContext("applicationContext-security.xml");
+	}
+
+}

--- a/itest/ldap/embedded-ldap-none/src/integration-test/resources/applicationContext-security.xml
+++ b/itest/ldap/embedded-ldap-none/src/integration-test/resources/applicationContext-security.xml
@@ -1,0 +1,9 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:s="http://www.springframework.org/schema/security"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
+
+	<s:ldap-server ldif="classpath:users.ldif"/>
+
+</beans>

--- a/itest/ldap/embedded-ldap-none/src/integration-test/resources/users.ldif
+++ b/itest/ldap/embedded-ldap-none/src/integration-test/resources/users.ldif
@@ -1,0 +1,60 @@
+dn: ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: groups
+
+dn: ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: people
+
+dn: uid=rod,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: Rod Johnson
+sn: Johnson
+uid: rod
+userPassword: koala
+
+dn: uid=dianne,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: Dianne Emu
+sn: Emu
+uid: dianne
+userPassword: emu
+
+dn: uid=scott,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: Scott
+sn: Wombat
+uid: scott
+userPassword: wombat
+
+dn: cn=user,ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: user
+member: uid=rod,ou=people,dc=springframework,dc=org
+member: uid=dianne,ou=people,dc=springframework,dc=org
+member: uid=scott,ou=people,dc=springframework,dc=org
+
+dn: cn=teller,ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: teller
+member: uid=rod,ou=people,dc=springframework,dc=org
+member: uid=dianne,ou=people,dc=springframework,dc=org
+
+dn: cn=supervisor,ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: supervisor
+member: uid=rod,ou=people,dc=springframework,dc=org

--- a/itest/ldap/embedded-ldap-unboundid-default/spring-security-itest-ldap-embedded-unboundid-default.gradle
+++ b/itest/ldap/embedded-ldap-unboundid-default/spring-security-itest-ldap-embedded-unboundid-default.gradle
@@ -1,0 +1,13 @@
+apply plugin: 'io.spring.convention.spring-test'
+
+dependencies {
+    compile project(':spring-security-core')
+    compile 'org.springframework:spring-beans'
+    compile 'org.springframework:spring-context'
+    compile 'org.springframework:spring-core'
+    compile 'org.springframework:spring-tx'
+    compile project(':spring-security-config')
+    compile project(':spring-security-ldap')
+
+    testCompile "com.unboundid:unboundid-ldapsdk"
+}

--- a/itest/ldap/embedded-ldap-unboundid-default/src/integration-test/java/org/springframework/security/LdapServerBeanDefinitionParserTests.java
+++ b/itest/ldap/embedded-ldap-unboundid-default/src/integration-test/java/org/springframework/security/LdapServerBeanDefinitionParserTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.security.config.BeanIds;
+import org.springframework.security.ldap.server.UnboundIdContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Eddú Meléndez
+ */
+public class LdapServerBeanDefinitionParserTests {
+
+	private ClassPathXmlApplicationContext context;
+
+	@Before
+	public void setup() {
+		this.context = new ClassPathXmlApplicationContext("applicationContext-security.xml");
+	}
+
+	@After
+	public void closeAppContext() {
+		if (this.context != null) {
+			this.context.close();
+			this.context = null;
+		}
+	}
+
+	@Test
+	public void apacheDirectoryServerIsStartedByDefault() {
+		String[] beanNames = this.context.getBeanNamesForType(UnboundIdContainer.class);
+		assertThat(beanNames).hasSize(1);
+		assertThat(beanNames[0]).isEqualTo(BeanIds.EMBEDDED_UNBOUNDID);
+	}
+
+}

--- a/itest/ldap/embedded-ldap-unboundid-default/src/integration-test/resources/applicationContext-security.xml
+++ b/itest/ldap/embedded-ldap-unboundid-default/src/integration-test/resources/applicationContext-security.xml
@@ -1,0 +1,9 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:s="http://www.springframework.org/schema/security"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
+
+	<s:ldap-server ldif="classpath:users.ldif"/>
+
+</beans>

--- a/itest/ldap/embedded-ldap-unboundid-default/src/integration-test/resources/users.ldif
+++ b/itest/ldap/embedded-ldap-unboundid-default/src/integration-test/resources/users.ldif
@@ -1,0 +1,60 @@
+dn: ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: groups
+
+dn: ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: people
+
+dn: uid=rod,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: Rod Johnson
+sn: Johnson
+uid: rod
+userPassword: koala
+
+dn: uid=dianne,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: Dianne Emu
+sn: Emu
+uid: dianne
+userPassword: emu
+
+dn: uid=scott,ou=people,dc=springframework,dc=org
+objectclass: top
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+cn: Scott
+sn: Wombat
+uid: scott
+userPassword: wombat
+
+dn: cn=user,ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: user
+member: uid=rod,ou=people,dc=springframework,dc=org
+member: uid=dianne,ou=people,dc=springframework,dc=org
+member: uid=scott,ou=people,dc=springframework,dc=org
+
+dn: cn=teller,ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: teller
+member: uid=rod,ou=people,dc=springframework,dc=org
+member: uid=dianne,ou=people,dc=springframework,dc=org
+
+dn: cn=supervisor,ou=groups,dc=springframework,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: supervisor
+member: uid=rod,ou=people,dc=springframework,dc=org


### PR DESCRIPTION
Currently, unboundid was added as a support for embbeded LDAP and it
is used on the Java Config. This commit introduces support from XML side.
Also, give the chance to users to move from apacheds to unboundid using
a new attribute `mode`.

Fixes gh-6011

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
