### PR TITLE
(fix) enable public access for DigestAuthUtils so it can be used

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/www/DigestAuthUtils.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/DigestAuthUtils.java
@@ -26,7 +26,7 @@ import org.springframework.security.crypto.codec.Hex;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
-final class DigestAuthUtils {
+public final class DigestAuthUtils {
 
 	private static final String[] EMPTY_STRING_ARRAY = new String[0];
 


### PR DESCRIPTION
I'm guessing there might be some reasons for why `DigestAuthUtils` isn't already publicly accessible, but decided to file this pull request in case it is doable.

Sometimes developers need access to lower level tools to create a digest for digest auth, this pull request addresses this by making the class publicly available for use. 

Some questions:
1. Does this expose any vulnerabilities?
2. If made public, do the signatures of any of the methods in this util need to change?

Thanks!