### PR TITLE
Rename OAuth2TokenIntrospectionClient

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
@@ -92,8 +92,8 @@ import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.security.oauth2.server.resource.authentication.OAuth2IntrospectionAuthenticationToken;
-import org.springframework.security.oauth2.server.resource.introspection.NimbusOAuth2TokenIntrospectionClient;
-import org.springframework.security.oauth2.server.resource.introspection.OAuth2TokenIntrospectionClient;
+import org.springframework.security.oauth2.server.resource.introspection.NimbusOpaqueTokenIntrospector;
+import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationEntryPoint;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
@@ -1182,38 +1182,38 @@ public class OAuth2ResourceServerConfigurerTests {
 		OAuth2ResourceServerConfigurer.OpaqueTokenConfigurer opaqueTokenConfigurer =
 				new OAuth2ResourceServerConfigurer(context).opaqueToken();
 
-		OAuth2TokenIntrospectionClient client = mock(OAuth2TokenIntrospectionClient.class);
+		OpaqueTokenIntrospector client = mock(OpaqueTokenIntrospector.class);
 
 		opaqueTokenConfigurer.introspectionUri(INTROSPECTION_URI);
 		opaqueTokenConfigurer.introspectionClientCredentials(CLIENT_ID, CLIENT_SECRET);
-		opaqueTokenConfigurer.introspectionClient(client);
+		opaqueTokenConfigurer.introspector(client);
 
-		assertThat(opaqueTokenConfigurer.getIntrospectionClient()).isEqualTo(client);
+		assertThat(opaqueTokenConfigurer.getIntrospector()).isEqualTo(client);
 
 		opaqueTokenConfigurer =
 				new OAuth2ResourceServerConfigurer(context).opaqueToken();
 
-		opaqueTokenConfigurer.introspectionClient(client);
+		opaqueTokenConfigurer.introspector(client);
 		opaqueTokenConfigurer.introspectionUri(INTROSPECTION_URI);
 		opaqueTokenConfigurer.introspectionClientCredentials(CLIENT_ID, CLIENT_SECRET);
 
-		assertThat(opaqueTokenConfigurer.getIntrospectionClient())
-				.isInstanceOf(NimbusOAuth2TokenIntrospectionClient.class);
+		assertThat(opaqueTokenConfigurer.getIntrospector())
+				.isInstanceOf(NimbusOpaqueTokenIntrospector.class);
 
 	}
 
 	@Test
 	public void getIntrospectionClientWhenDslAndBeanWiredThenDslTakesPrecedence() {
 		GenericApplicationContext context = new GenericApplicationContext();
-		registerMockBean(context, "introspectionClientOne", OAuth2TokenIntrospectionClient.class);
-		registerMockBean(context, "introspectionClientTwo", OAuth2TokenIntrospectionClient.class);
+		registerMockBean(context, "introspectionClientOne", OpaqueTokenIntrospector.class);
+		registerMockBean(context, "introspectionClientTwo", OpaqueTokenIntrospector.class);
 
 		OAuth2ResourceServerConfigurer.OpaqueTokenConfigurer opaqueToken =
 				new OAuth2ResourceServerConfigurer(context).opaqueToken();
 		opaqueToken.introspectionUri(INTROSPECTION_URI);
 		opaqueToken.introspectionClientCredentials(CLIENT_ID, CLIENT_SECRET);
 
-		assertThat(opaqueToken.getIntrospectionClient()).isNotNull();
+		assertThat(opaqueToken.getIntrospector()).isNotNull();
 	}
 
 	// -- In combination with other authentication providers
@@ -1327,7 +1327,7 @@ public class OAuth2ResourceServerConfigurerTests {
 		oauth2ResourceServer
 			.opaqueToken()
 				.authenticationManager(authenticationManager)
-				.introspectionClient(mock(OAuth2TokenIntrospectionClient.class));
+				.introspector(mock(OpaqueTokenIntrospector.class));
 		assertThat(oauth2ResourceServer.getAuthenticationManager(http)).isSameAs(authenticationManager);
 		verify(http, never()).authenticationProvider(any(AuthenticationProvider.class));
 	}
@@ -2164,8 +2164,8 @@ public class OAuth2ResourceServerConfigurerTests {
 		}
 
 		@Bean
-		NimbusOAuth2TokenIntrospectionClient tokenIntrospectionClient() {
-			return new NimbusOAuth2TokenIntrospectionClient("https://example.org/introspect", this.rest);
+		NimbusOpaqueTokenIntrospector tokenIntrospectionClient() {
+			return new NimbusOpaqueTokenIntrospector("https://example.org/introspect", this.rest);
 		}
 	}
 

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionAuthenticationProvider.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionAuthenticationProvider.java
@@ -34,7 +34,7 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2TokenAttributes;
 import org.springframework.security.oauth2.server.resource.introspection.OAuth2IntrospectionException;
-import org.springframework.security.oauth2.server.resource.introspection.OAuth2TokenIntrospectionClient;
+import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
 import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken;
 import org.springframework.security.oauth2.server.resource.BearerTokenError;
 import org.springframework.util.Assert;
@@ -69,14 +69,14 @@ public final class OAuth2IntrospectionAuthenticationProvider implements Authenti
 	private static final BearerTokenError DEFAULT_INVALID_TOKEN =
 			invalidToken("An error occurred while attempting to introspect the token: Invalid token");
 
-	private OAuth2TokenIntrospectionClient introspectionClient;
+	private OpaqueTokenIntrospector introspectionClient;
 
 	/**
 	 * Creates a {@code OAuth2IntrospectionAuthenticationProvider} with the provided parameters
 	 *
-	 * @param introspectionClient The {@link OAuth2TokenIntrospectionClient} to use
+	 * @param introspectionClient The {@link OpaqueTokenIntrospector} to use
 	 */
-	public OAuth2IntrospectionAuthenticationProvider(OAuth2TokenIntrospectionClient introspectionClient) {
+	public OAuth2IntrospectionAuthenticationProvider(OpaqueTokenIntrospector introspectionClient) {
 		Assert.notNull(introspectionClient, "introspectionClient cannot be null");
 		this.introspectionClient = introspectionClient;
 	}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionReactiveAuthenticationManager.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionReactiveAuthenticationManager.java
@@ -35,7 +35,7 @@ import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.server.resource.introspection.OAuth2IntrospectionException;
-import org.springframework.security.oauth2.server.resource.introspection.ReactiveOAuth2TokenIntrospectionClient;
+import org.springframework.security.oauth2.server.resource.introspection.ReactiveOpaqueTokenIntrospector;
 import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken;
 import org.springframework.security.oauth2.server.resource.BearerTokenError;
 import org.springframework.util.Assert;
@@ -70,14 +70,14 @@ public class OAuth2IntrospectionReactiveAuthenticationManager implements Reactiv
 	private static final BearerTokenError DEFAULT_INVALID_TOKEN =
 			invalidToken("An error occurred while attempting to introspect the token: Invalid token");
 
-	private ReactiveOAuth2TokenIntrospectionClient introspectionClient;
+	private ReactiveOpaqueTokenIntrospector introspectionClient;
 
 	/**
 	 * Creates a {@code OAuth2IntrospectionReactiveAuthenticationManager} with the provided parameters
 	 *
-	 * @param introspectionClient The {@link ReactiveOAuth2TokenIntrospectionClient} to use
+	 * @param introspectionClient The {@link ReactiveOpaqueTokenIntrospector} to use
 	 */
-	public OAuth2IntrospectionReactiveAuthenticationManager(ReactiveOAuth2TokenIntrospectionClient introspectionClient) {
+	public OAuth2IntrospectionReactiveAuthenticationManager(ReactiveOpaqueTokenIntrospector introspectionClient) {
 		Assert.notNull(introspectionClient, "introspectionClient cannot be null");
 		this.introspectionClient = introspectionClient;
 	}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/NimbusOpaqueTokenIntrospector.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/NimbusOpaqueTokenIntrospector.java
@@ -52,13 +52,15 @@ import static org.springframework.security.oauth2.server.resource.introspection.
 import static org.springframework.security.oauth2.server.resource.introspection.OAuth2IntrospectionClaimNames.SCOPE;
 
 /**
- * A Nimbus implementation of {@link OAuth2TokenIntrospectionClient}.
+ * A Nimbus implementation of {@link OpaqueTokenIntrospector} that verifies and introspects
+ * a token using the configured
+ * <a href="https://tools.ietf.org/html/rfc7662" target="_blank">OAuth 2.0 Introspection Endpoint</a>.
  *
  * @author Josh Cummings
  * @author MD Sayem Ahmed
  * @since 5.2
  */
-public class NimbusOAuth2TokenIntrospectionClient implements OAuth2TokenIntrospectionClient {
+public class NimbusOpaqueTokenIntrospector implements OpaqueTokenIntrospector {
 	private Converter<String, RequestEntity<?>> requestEntityConverter;
 	private RestOperations restOperations;
 
@@ -69,7 +71,7 @@ public class NimbusOAuth2TokenIntrospectionClient implements OAuth2TokenIntrospe
 	 * @param clientId The client id authorized to introspect
 	 * @param clientSecret The client's secret
 	 */
-	public NimbusOAuth2TokenIntrospectionClient(String introspectionUri, String clientId, String clientSecret) {
+	public NimbusOpaqueTokenIntrospector(String introspectionUri, String clientId, String clientSecret) {
 		Assert.notNull(introspectionUri, "introspectionUri cannot be null");
 		Assert.notNull(clientId, "clientId cannot be null");
 		Assert.notNull(clientSecret, "clientSecret cannot be null");
@@ -89,7 +91,7 @@ public class NimbusOAuth2TokenIntrospectionClient implements OAuth2TokenIntrospe
 	 * @param introspectionUri The introspection endpoint uri
 	 * @param restOperations The client for performing the introspection request
 	 */
-	public NimbusOAuth2TokenIntrospectionClient(String introspectionUri, RestOperations restOperations) {
+	public NimbusOpaqueTokenIntrospector(String introspectionUri, RestOperations restOperations) {
 		Assert.notNull(introspectionUri, "introspectionUri cannot be null");
 		Assert.notNull(restOperations, "restOperations cannot be null");
 

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/NimbusReactiveOpaqueTokenIntrospector.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/NimbusReactiveOpaqueTokenIntrospector.java
@@ -46,12 +46,14 @@ import static org.springframework.security.oauth2.server.resource.introspection.
 import static org.springframework.security.oauth2.server.resource.introspection.OAuth2IntrospectionClaimNames.SCOPE;
 
 /**
- * A Nimbus implementation of {@link ReactiveOAuth2TokenIntrospectionClient}
+ * A Nimbus implementation of {@link ReactiveOpaqueTokenIntrospector} that verifies and introspects
+ * a token using the configured
+ * <a href="https://tools.ietf.org/html/rfc7662" target="_blank">OAuth 2.0 Introspection Endpoint</a>.
  *
  * @author Josh Cummings
  * @since 5.2
  */
-public class NimbusReactiveOAuth2TokenIntrospectionClient implements ReactiveOAuth2TokenIntrospectionClient {
+public class NimbusReactiveOpaqueTokenIntrospector implements ReactiveOpaqueTokenIntrospector {
 	private URI introspectionUri;
 	private WebClient webClient;
 
@@ -62,7 +64,7 @@ public class NimbusReactiveOAuth2TokenIntrospectionClient implements ReactiveOAu
 	 * @param clientId The client id authorized to introspect
 	 * @param clientSecret The client secret for the authorized client
 	 */
-	public NimbusReactiveOAuth2TokenIntrospectionClient(String introspectionUri, String clientId, String clientSecret) {
+	public NimbusReactiveOpaqueTokenIntrospector(String introspectionUri, String clientId, String clientSecret) {
 		Assert.hasText(introspectionUri, "introspectionUri cannot be empty");
 		Assert.hasText(clientId, "clientId cannot be empty");
 		Assert.notNull(clientSecret, "clientSecret cannot be null");
@@ -79,7 +81,7 @@ public class NimbusReactiveOAuth2TokenIntrospectionClient implements ReactiveOAu
 	 * @param introspectionUri The introspection endpoint uri
 	 * @param webClient The client for performing the introspection request
 	 */
-	public NimbusReactiveOAuth2TokenIntrospectionClient(String introspectionUri, WebClient webClient) {
+	public NimbusReactiveOpaqueTokenIntrospector(String introspectionUri, WebClient webClient) {
 		Assert.hasText(introspectionUri, "introspectionUri cannot be null");
 		Assert.notNull(webClient, "webClient cannot be null");
 

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/OpaqueTokenIntrospector.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/OpaqueTokenIntrospector.java
@@ -19,25 +19,27 @@ package org.springframework.security.oauth2.server.resource.introspection;
 import java.util.Map;
 
 /**
- * A client to an
- * <a href="https://tools.ietf.org/html/rfc7662" target="_blank">OAuth 2.0 Introspection Endpoint</a>.
+ * A contract for introspecting and verifying an OAuth 2.0 token.
  *
- * Basically, this client is handy when a resource server authenticates opaque OAuth 2.0 tokens.
- * It's also nice when a resource server simply can't decode tokens - whether the tokens are opaque or not -
- * and would prefer to delegate that task to an authorization server.
+ * A typical implementation of this interface will make a request to an
+ * <a href="https://tools.ietf.org/html/rfc7662" target="_blank">OAuth 2.0 Introspection Endpoint</a>
+ * to verify the token and return its attributes, indicating a successful verification.
+ *
+ * Another sensible implementation of this interface would be to query a backing store
+ * of tokens, for example a distributed cache.
  *
  * @author Josh Cummings
  * @since 5.2
  */
-public interface OAuth2TokenIntrospectionClient {
+public interface OpaqueTokenIntrospector {
 
 	/**
-	 * Request that the configured
-	 * <a href="https://tools.ietf.org/html/rfc7662" target="_blank">OAuth 2.0 Introspection Endpoint</a>
-	 * introspect the given token and return its associated attributes.
+	 * Introspect and verify the given token, returning its attributes.
+	 *
+	 * Returning a {@link Map} is indicative that the token is valid.
 	 *
 	 * @param token the token to introspect
-	 * @return the token's attributes, including whether or not the token is active
+	 * @return the token's attributes
 	 */
 	Map<String, Object> introspect(String token);
 }

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/ReactiveOpaqueTokenIntrospector.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/ReactiveOpaqueTokenIntrospector.java
@@ -21,25 +21,27 @@ import java.util.Map;
 import reactor.core.publisher.Mono;
 
 /**
- * A reactive client to an
- * <a href="https://tools.ietf.org/html/rfc7662" target="_blank">OAuth 2.0 Introspection Endpoint</a>.
+ * A contract for introspecting and verifying an OAuth 2.0 token.
  *
- * Basically, this client is handy when a resource server authenticates opaque OAuth 2.0 tokens.
- * It's also nice when a resource server simply can't decode tokens - whether the tokens are opaque or not -
- * and would prefer to delegate that task to an authorization server.
+ * A typical implementation of this interface will make a request to an
+ * <a href="https://tools.ietf.org/html/rfc7662" target="_blank">OAuth 2.0 Introspection Endpoint</a>
+ * to verify the token and return its attributes, indicating a successful verification.
+ *
+ * Another sensible implementation of this interface would be to query a backing store
+ * of tokens, for example a distributed cache.
  *
  * @author Josh Cummings
  * @since 5.2
  */
-public interface ReactiveOAuth2TokenIntrospectionClient {
+public interface ReactiveOpaqueTokenIntrospector {
 
 	/**
-	 * Request that the configured
-	 * <a href="https://tools.ietf.org/html/rfc7662" target="_blank">OAuth 2.0 Introspection Endpoint</a>
-	 * introspect the given token and return its associated attributes.
+	 * Introspect and verify the given token, returning its attributes.
+	 *
+	 * Returning a {@link Map} is indicative that the token is valid.
 	 *
 	 * @param token the token to introspect
-	 * @return the token's attributes, including whether or not the token is active
+	 * @return the token's attributes
 	 */
 	Mono<Map<String, Object>> introspect(String token);
 }

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionAuthenticationProviderTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionAuthenticationProviderTests.java
@@ -27,7 +27,7 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2TokenAttributes;
 import org.springframework.security.oauth2.server.resource.introspection.OAuth2IntrospectionClaimNames;
 import org.springframework.security.oauth2.server.resource.introspection.OAuth2IntrospectionException;
-import org.springframework.security.oauth2.server.resource.introspection.OAuth2TokenIntrospectionClient;
+import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
 import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,7 +56,7 @@ public class OAuth2IntrospectionAuthenticationProviderTests {
 	public void authenticateWhenActiveTokenThenOk() throws Exception {
 		Map<String, Object> claims = active();
 		claims.put("extension_field", "twenty-seven");
-		OAuth2TokenIntrospectionClient introspectionClient = mock(OAuth2TokenIntrospectionClient.class);
+		OpaqueTokenIntrospector introspectionClient = mock(OpaqueTokenIntrospector.class);
 		when(introspectionClient.introspect(any())).thenReturn(claims);
 		OAuth2IntrospectionAuthenticationProvider provider =
 				new OAuth2IntrospectionAuthenticationProvider(introspectionClient);
@@ -88,7 +88,7 @@ public class OAuth2IntrospectionAuthenticationProviderTests {
 	public void authenticateWhenMissingScopeAttributeThenNoAuthorities() {
 		Map<String, Object> claims = active();
 		claims.remove(SCOPE);
-		OAuth2TokenIntrospectionClient introspectionClient = mock(OAuth2TokenIntrospectionClient.class);
+		OpaqueTokenIntrospector introspectionClient = mock(OpaqueTokenIntrospector.class);
 		when(introspectionClient.introspect(any())).thenReturn(claims);
 		OAuth2IntrospectionAuthenticationProvider provider =
 				new OAuth2IntrospectionAuthenticationProvider(introspectionClient);
@@ -107,7 +107,7 @@ public class OAuth2IntrospectionAuthenticationProviderTests {
 
 	@Test
 	public void authenticateWhenIntrospectionEndpointThrowsExceptionThenInvalidToken() {
-		OAuth2TokenIntrospectionClient introspectionClient = mock(OAuth2TokenIntrospectionClient.class);
+		OpaqueTokenIntrospector introspectionClient = mock(OpaqueTokenIntrospector.class);
 		when(introspectionClient.introspect(any())).thenThrow(new OAuth2IntrospectionException("with \"invalid\" chars"));
 		OAuth2IntrospectionAuthenticationProvider provider =
 				new OAuth2IntrospectionAuthenticationProvider(introspectionClient);

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionReactiveAuthenticationManagerTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/OAuth2IntrospectionReactiveAuthenticationManagerTests.java
@@ -29,7 +29,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.server.resource.introspection.OAuth2IntrospectionClaimNames;
 import org.springframework.security.oauth2.server.resource.introspection.OAuth2IntrospectionException;
-import org.springframework.security.oauth2.server.resource.introspection.ReactiveOAuth2TokenIntrospectionClient;
+import org.springframework.security.oauth2.server.resource.introspection.ReactiveOpaqueTokenIntrospector;
 import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,7 +55,7 @@ public class OAuth2IntrospectionReactiveAuthenticationManagerTests {
 	public void authenticateWhenActiveTokenThenOk() throws Exception {
 		Map<String, Object> claims = active();
 		claims.put("extension_field", "twenty-seven");
-		ReactiveOAuth2TokenIntrospectionClient introspectionClient = mock(ReactiveOAuth2TokenIntrospectionClient.class);
+		ReactiveOpaqueTokenIntrospector introspectionClient = mock(ReactiveOpaqueTokenIntrospector.class);
 		when(introspectionClient.introspect(any())).thenReturn(Mono.just(claims));
 		OAuth2IntrospectionReactiveAuthenticationManager provider =
 				new OAuth2IntrospectionReactiveAuthenticationManager(introspectionClient);
@@ -87,7 +87,7 @@ public class OAuth2IntrospectionReactiveAuthenticationManagerTests {
 	public void authenticateWhenMissingScopeAttributeThenNoAuthorities() {
 		Map<String, Object> claims = active();
 		claims.remove(SCOPE);
-		ReactiveOAuth2TokenIntrospectionClient introspectionClient = mock(ReactiveOAuth2TokenIntrospectionClient.class);
+		ReactiveOpaqueTokenIntrospector introspectionClient = mock(ReactiveOpaqueTokenIntrospector.class);
 		when(introspectionClient.introspect(any())).thenReturn(Mono.just(claims));
 		OAuth2IntrospectionReactiveAuthenticationManager provider =
 				new OAuth2IntrospectionReactiveAuthenticationManager(introspectionClient);
@@ -106,7 +106,7 @@ public class OAuth2IntrospectionReactiveAuthenticationManagerTests {
 
 	@Test
 	public void authenticateWhenIntrospectionEndpointThrowsExceptionThenInvalidToken() {
-		ReactiveOAuth2TokenIntrospectionClient introspectionClient = mock(ReactiveOAuth2TokenIntrospectionClient.class);
+		ReactiveOpaqueTokenIntrospector introspectionClient = mock(ReactiveOpaqueTokenIntrospector.class);
 		when(introspectionClient.introspect(any()))
 				.thenReturn(Mono.error(new OAuth2IntrospectionException("with \"invalid\" chars")));
 		OAuth2IntrospectionReactiveAuthenticationManager provider =

--- a/samples/boot/oauth2resourceserver-multitenancy/src/main/java/sample/OAuth2ResourceServerSecurityConfiguration.java
+++ b/samples/boot/oauth2resourceserver-multitenancy/src/main/java/sample/OAuth2ResourceServerSecurityConfiguration.java
@@ -30,8 +30,8 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
 import org.springframework.security.oauth2.server.resource.authentication.OAuth2IntrospectionAuthenticationProvider;
-import org.springframework.security.oauth2.server.resource.introspection.NimbusOAuth2TokenIntrospectionClient;
-import org.springframework.security.oauth2.server.resource.introspection.OAuth2TokenIntrospectionClient;
+import org.springframework.security.oauth2.server.resource.introspection.NimbusOpaqueTokenIntrospector;
+import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
 
 import static org.springframework.security.web.authentication.MultiTenantAuthenticationManagerResolver.resolveFromPath;
 
@@ -77,8 +77,8 @@ public class OAuth2ResourceServerSecurityConfiguration extends WebSecurityConfig
 	}
 
 	AuthenticationManager opaque() {
-		OAuth2TokenIntrospectionClient introspectionClient =
-				new NimbusOAuth2TokenIntrospectionClient(this.introspectionUri, "client", "secret");
+		OpaqueTokenIntrospector introspectionClient =
+				new NimbusOpaqueTokenIntrospector(this.introspectionUri, "client", "secret");
 		return new OAuth2IntrospectionAuthenticationProvider(introspectionClient)::authenticate;
 	}
 }


### PR DESCRIPTION
Renamed to OpaqueTokenIntrospector

Fixes gh-7245

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
