### PR TITLE
Fix NPE in TokenBasedRememberMeServices with null UserDetails

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/rememberme/TokenBasedRememberMeServices.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/rememberme/TokenBasedRememberMeServices.java
@@ -123,6 +123,11 @@ public class TokenBasedRememberMeServices extends AbstractRememberMeServices {
 		UserDetails userDetails = getUserDetailsService().loadUserByUsername(
 				cookieTokens[0]);
 
+		if (userDetails == null) {
+			throw new InvalidCookieException("Cookie token[0] contained username '"
+					+ cookieTokens[0] + "' that does not exist.");
+		}
+
 		// Check signature of token matches remaining details.
 		// Must do this after user lookup, as we need the DAO-derived password.
 		// If efficiency was a major issue, just add in a UserCache implementation,


### PR DESCRIPTION
Fixes  #7251

Checks to see if the userService found a userDetails or not.  If the user has since been deleted, this will end up with an uncaught null pointer exception and result in the user not being able to visit the site.