### PR TITLE
Add setContentLengthLong detection to OnCommittedResponseWrapper.

### DIFF
--- a/web/src/main/java/org/springframework/security/web/util/OnCommittedResponseWrapper.java
+++ b/web/src/main/java/org/springframework/security/web/util/OnCommittedResponseWrapper.java
@@ -69,6 +69,12 @@ public abstract class OnCommittedResponseWrapper extends HttpServletResponseWrap
 		super.setContentLength(len);
 	}
 
+	@Override
+	public void setContentLengthLong(long len) {
+		setContentLength(len);
+		super.setContentLengthLong(len);
+	}
+
 	private void setContentLength(long len) {
 		this.contentLength = len;
 		checkContentLength(0);

--- a/web/src/test/java/org/springframework/security/web/util/OnCommittedResponseWrapperTests.java
+++ b/web/src/test/java/org/springframework/security/web/util/OnCommittedResponseWrapperTests.java
@@ -1101,6 +1101,17 @@ public class OnCommittedResponseWrapperTests {
 		assertThat(committed).isTrue();
 	}
 
+	// gh-7261
+	@Test
+	public void contentLengthLongOutputStreamWriteStringCommits() throws IOException {
+		String body = "something";
+		response.setContentLengthLong(body.length());
+
+		response.getOutputStream().print(body);
+
+		assertThat(committed).isTrue();
+	}
+
 	@Test
 	public void addHeaderContentLengthPrintWriterWriteStringCommits() throws Exception {
 		int expected = 1234;


### PR DESCRIPTION
Fixes gh-#7261

Trivial implementation.