### PR TITLE
Removes the need for a CSRF token with mock JWT

### DIFF
--- a/samples/boot/oauth2resourceserver/src/test/java/sample/OAuth2ResourceServerControllerTests.java
+++ b/samples/boot/oauth2resourceserver/src/test/java/sample/OAuth2ResourceServerControllerTests.java
@@ -25,7 +25,6 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.security.oauth2.jwt.Jwt;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
@@ -33,8 +32,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
 
 /**
  *
@@ -77,41 +74,32 @@ public class OAuth2ResourceServerControllerTests {
 
 	@Test
 	public void messageCanNotBeCreatedWithoutAnyScope() throws Exception {
-		Jwt jwt = Jwt.withTokenValue("token")
-				.header("alg", "none")
-				.claim("scope", "")
-				.build();
-		when(jwtDecoder.decode(anyString())).thenReturn(jwt);
 		mockMvc.perform(post("/message")
 				.content("Hello message")
-				.header("Authorization", "Bearer " + jwt.getTokenValue()))
+				.with(jwt(jwt -> jwt.claim("scope", "message:read"))))
 				.andExpect(status().isForbidden());
 	}
 
 	@Test
 	public void messageCanNotBeCreatedWithScopeMessageReadAuthority() throws Exception {
-		Jwt jwt = Jwt.withTokenValue("token")
-				.header("alg", "none")
-				.claim("scope", "message:read")
-				.build();
-		when(jwtDecoder.decode(anyString())).thenReturn(jwt);
 		mockMvc.perform(post("/message")
-				.content("Hello message")
-				.header("Authorization", "Bearer " + jwt.getTokenValue()))
+				.with(jwt(jwt -> jwt.claim("scope", "message:read")))
+				.content("Hello message"))
 				.andExpect(status().isForbidden());
 	}
 
 	@Test
 	public void messageCanBeCreatedWithScopeMessageWriteAuthority()
 			throws Exception {
-		Jwt jwt = Jwt.withTokenValue("token")
-				.header("alg", "none")
-				.claim("scope", "message:write")
-				.build();
-		when(jwtDecoder.decode(anyString())).thenReturn(jwt);
 		mockMvc.perform(post("/message")
-				.content("Hello message")
-				.header("Authorization", "Bearer " + jwt.getTokenValue()))
+				.with(jwt(jwt -> jwt.claim("scope", "message:write")))
+				.content("Hello message"))
+				.andExpect(status().isOk())
+				.andExpect(content().string(is("Message was created. Content: Hello message")));
+
+		mockMvc.perform(post("/message")
+				.with(jwt().authorities(new SimpleGrantedAuthority(("SCOPE_message:write"))))
+				.content("Hello message"))
 				.andExpect(status().isOk())
 				.andExpect(content().string(is("Message was created. Content: Hello message")));
 	}

--- a/test/src/main/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessors.java
+++ b/test/src/main/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessors.java
@@ -1043,6 +1043,7 @@ public final class SecurityMockMvcRequestPostProcessors {
 
 		@Override
 		public MockHttpServletRequest postProcessRequest(MockHttpServletRequest request) {
+			WebTestUtils.setCsrfRequestMatcher(request, r -> false);
 			JwtAuthenticationToken token = new JwtAuthenticationToken(this.jwt, this.authorities);
 			return new AuthenticationRequestPostProcessor(token).postProcessRequest(request);
 		}

--- a/test/src/main/java/org/springframework/security/test/web/support/WebTestUtils.java
+++ b/test/src/main/java/org/springframework/security/test/web/support/WebTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.security.web.context.SecurityContextRepository;
 import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.csrf.CsrfTokenRepository;
 import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.WebApplicationContextUtils;
@@ -111,6 +112,21 @@ public abstract class WebTestUtils {
 		CsrfFilter filter = findFilter(request, CsrfFilter.class);
 		if (filter != null) {
 			ReflectionTestUtils.setField(filter, "tokenRepository", repository);
+		}
+	}
+
+	/**
+	 * Sets the {@link RequestMatcher} for the specified {@link HttpServletRequest}.
+	 *
+	 * @param request the {@link RequestMatcher} to obtain the
+	 * {@link RequestMatcher}
+	 * @param requestMatcher the {@link RequestMatcher} to set
+	 */
+	public static void setCsrfRequestMatcher(HttpServletRequest request,
+			RequestMatcher requestMatcher) {
+		CsrfFilter filter = findFilter(request, CsrfFilter.class);
+		if (filter != null) {
+			filter.setRequireCsrfProtectionMatcher(requestMatcher);
 		}
 	}
 


### PR DESCRIPTION
Fixes: gh-7170

Changes the JwtRequestPostProcessor to remove the check for a CSRF token in the request.

If there is a more elegant way to change the RequestMatcher of the request CsrfFilter, please let me know.