### PR TITLE
XML Exposes Only Single AuthenticationEventPublisher Bean

### DIFF
--- a/config/src/main/java/org/springframework/security/config/authentication/AuthenticationManagerBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/authentication/AuthenticationManagerBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.parsing.BeanComponentDefinition;
 import org.springframework.beans.factory.parsing.CompositeComponentDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
-import org.springframework.beans.factory.support.GenericBeanDefinition;
 import org.springframework.beans.factory.support.ManagedList;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.beans.factory.xml.BeanDefinitionParser;
@@ -58,7 +57,7 @@ public class AuthenticationManagerBeanDefinitionParser implements BeanDefinition
 
 	private static final String ATT_ERASE_CREDENTIALS = "erase-credentials";
 
-	private static final String AUTHENTICATION_EVENT_PUBLISHER_BEAN_NAME = "authenticationEventPublisher";
+	private static final String AUTHENTICATION_EVENT_PUBLISHER_BEAN_NAME = "defaultAuthenticationEventPublisher";
 
 	@Override
 	public BeanDefinition parse(Element element, ParserContext pc) {
@@ -92,9 +91,8 @@ public class AuthenticationManagerBeanDefinitionParser implements BeanDefinition
 
 		if (!pc.getRegistry().containsBeanDefinition(AUTHENTICATION_EVENT_PUBLISHER_BEAN_NAME)) {
 			// Add the default event publisher to the context
-			GenericBeanDefinition publisher = new GenericBeanDefinition();
-			publisher.setBeanClass(DefaultAuthenticationEventPublisher.class);
-			pc.getRegistry().registerBeanDefinition(AUTHENTICATION_EVENT_PUBLISHER_BEAN_NAME, publisher);
+			BeanDefinition publisher = new RootBeanDefinition(DefaultAuthenticationEventPublisher.class);
+			pc.registerBeanComponent(new BeanComponentDefinition(publisher, AUTHENTICATION_EVENT_PUBLISHER_BEAN_NAME));
 		}
 
 		providerManagerBldr.addPropertyReference("authenticationEventPublisher",

--- a/config/src/test/java/org/springframework/security/config/authentication/AuthenticationManagerBeanDefinitionParserTests.java
+++ b/config/src/test/java/org/springframework/security/config/authentication/AuthenticationManagerBeanDefinitionParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,9 +69,6 @@ public class AuthenticationManagerBeanDefinitionParserTests {
 	@Rule
 	public final SpringTestRule spring = new SpringTestRule();
 
-	@Autowired
-	MockMvc mockMvc;
-
 	@Test
 	// SEC-1225
 	public void providersAreRegisteredAsTopLevelBeans() {
@@ -118,6 +115,9 @@ public class AuthenticationManagerBeanDefinitionParserTests {
 		ProviderManager pm = (ProviderManager) appContext.getBeansOfType(ProviderManager.class).values().toArray()[0];
 		assertThat(pm.isEraseCredentialsAfterAuthentication()).isFalse();
 	}
+
+	@Autowired
+	MockMvc mockMvc;
 
 	@Test
 	public void passwordEncoderBeanUsed() throws Exception {


### PR DESCRIPTION
The DefaultAuthenticationEventPublisher is now an inner bean of the ProviderManager.
I would advise to avoid publishing multiple copies of generated inner beans to the global scope, rather either publish a singleton once or generate inner beans which are not visible to others

Note: I haven't pushed any test (yet), and also could not run unit tests in local IDE. Probably some bot here will run anti regression tests.

For the tests, I have taken a look at AuthenticationManagerBuilderTests.

Here are some ideas:

- Test that no more AuthenticationEventPublisher beans are in the Spring context
Before implementing the change: executing the Builder resulted in both a bean of type ProviderManager and a bean of type AuthenticationEventPublisher to be visible in Spring scope. After implementation only ProviderManager should be visible.
Enhancement: it is adivsable that AuthenticationManagerBuilder creates one and only one bean for segregation purposes (not tested)

- Test that authentication events are correctly propagated
This is actually an integration test. I must make sure that my change is consistent. DefaultAuthenticationEventPublisher has optional dependency over ApplicationEventPublisher. Need to make sure that on a bootstrapped setup, upon an authentication attempt, the correct event is published to the Context. 