### PR TITLE
Introduce LogoutSuccessEvent

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/LogoutConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/LogoutConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.security.web.authentication.logout.CookieClearingLogo
 import org.springframework.security.web.authentication.logout.DelegatingLogoutSuccessHandler;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.security.web.authentication.logout.LogoutSuccessEventPublishingLogoutHandler;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
@@ -60,6 +61,7 @@ import org.springframework.util.Assert;
  * No shared objects are used.
  *
  * @author Rob Winch
+ * @author Onur Kagan Ozcan
  * @since 3.2
  * @see RememberMeConfigurer
  */
@@ -85,8 +87,9 @@ public final class LogoutConfigurer<H extends HttpSecurityBuilder<H>> extends
 	}
 
 	/**
-	 * Adds a {@link LogoutHandler}. The {@link SecurityContextLogoutHandler} is added as
-	 * the last {@link LogoutHandler} by default.
+	 * Adds a {@link LogoutHandler}.
+	 * {@link SecurityContextLogoutHandler} and {@link LogoutSuccessEventPublishingLogoutHandler} are added as
+	 * last {@link LogoutHandler} instances by default.
 	 *
 	 * @param logoutHandler the {@link LogoutHandler} to add
 	 * @return the {@link LogoutConfigurer} for further customization
@@ -329,6 +332,7 @@ public final class LogoutConfigurer<H extends HttpSecurityBuilder<H>> extends
 	 */
 	private LogoutFilter createLogoutFilter(H http) throws Exception {
 		logoutHandlers.add(contextLogoutHandler);
+		logoutHandlers.add(postProcess(new LogoutSuccessEventPublishingLogoutHandler()));
 		LogoutHandler[] handlers = logoutHandlers
 				.toArray(new LogoutHandler[0]);
 		LogoutFilter result = new LogoutFilter(getLogoutSuccessHandler(), handlers);

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.security.core.session.SessionRegistryImpl;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.security.web.authentication.session.ChangeSessionIdAuthenticationStrategy;
 import org.springframework.security.web.authentication.session.CompositeSessionAuthenticationStrategy;
 import org.springframework.security.web.authentication.session.ConcurrentSessionControlAuthenticationStrategy;
@@ -54,6 +55,7 @@ import org.springframework.security.web.session.SessionManagementFilter;
 import org.springframework.security.web.session.SimpleRedirectInvalidSessionStrategy;
 import org.springframework.security.web.session.SimpleRedirectSessionInformationExpiredStrategy;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 
 /**
  * Allows configuring session management.
@@ -88,6 +90,7 @@ import org.springframework.util.Assert;
  * </ul>
  *
  * @author Rob Winch
+ * @author Onur Kagan Ozcan
  * @since 3.2
  * @see SessionManagementFilter
  * @see ConcurrentSessionFilter
@@ -505,21 +508,30 @@ public final class SessionManagementConfigurer<H extends HttpSecurityBuilder<H>>
 
 		http.addFilter(sessionManagementFilter);
 		if (isConcurrentSessionControlEnabled()) {
-			ConcurrentSessionFilter concurrentSessionFilter = createConccurencyFilter(http);
+			ConcurrentSessionFilter concurrentSessionFilter = createConcurrencyFilter(http);
 
 			concurrentSessionFilter = postProcess(concurrentSessionFilter);
 			http.addFilter(concurrentSessionFilter);
 		}
 	}
 
-	private ConcurrentSessionFilter createConccurencyFilter(H http) {
+	private ConcurrentSessionFilter createConcurrencyFilter(H http) {
 		SessionInformationExpiredStrategy expireStrategy = getExpiredSessionStrategy();
 		SessionRegistry sessionRegistry = getSessionRegistry(http);
+		ConcurrentSessionFilter concurrentSessionFilter;
 		if (expireStrategy == null) {
-			return new ConcurrentSessionFilter(sessionRegistry);
+			concurrentSessionFilter = new ConcurrentSessionFilter(sessionRegistry);
+		} else {
+			concurrentSessionFilter = new ConcurrentSessionFilter(sessionRegistry, expireStrategy);
 		}
-
-		return new ConcurrentSessionFilter(sessionRegistry, expireStrategy);
+		LogoutConfigurer<H> logoutConfigurer = http.getConfigurer(LogoutConfigurer.class);
+		if (logoutConfigurer != null) {
+			List<LogoutHandler> logoutHandlers = logoutConfigurer.getLogoutHandlers();
+			if (!CollectionUtils.isEmpty(logoutHandlers)) {
+				concurrentSessionFilter.setLogoutHandlers(logoutHandlers);
+			}
+		}
+		return concurrentSessionFilter;
 	}
 
 	/**

--- a/config/src/main/java/org/springframework/security/config/http/LogoutBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/http/LogoutBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2012 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.xml.BeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.security.web.authentication.logout.CookieClearingLogoutHandler;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.security.web.authentication.logout.LogoutSuccessEventPublishingLogoutHandler;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.util.StringUtils;
 import org.w3c.dom.Element;
@@ -32,6 +33,7 @@ import org.w3c.dom.Element;
 /**
  * @author Luke Taylor
  * @author Ben Alex
+ * @author Onur Kagan Ozcan
  */
 class LogoutBeanDefinitionParser implements BeanDefinitionParser {
 	static final String ATT_LOGOUT_SUCCESS_URL = "logout-success-url";
@@ -119,6 +121,8 @@ class LogoutBeanDefinitionParser implements BeanDefinitionParser {
 			cookieDeleter.getConstructorArgumentValues().addGenericArgumentValue(names);
 			logoutHandlers.add(cookieDeleter);
 		}
+
+		logoutHandlers.add(new RootBeanDefinition(LogoutSuccessEventPublishingLogoutHandler.class));
 
 		builder.addConstructorArgValue(logoutHandlers);
 

--- a/core/src/main/java/org/springframework/security/authentication/event/LogoutSuccessEvent.java
+++ b/core/src/main/java/org/springframework/security/authentication/event/LogoutSuccessEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authentication.event;
+
+import org.springframework.security.core.Authentication;
+
+/**
+ * Application event which indicates successful logout
+ *
+ * @author Onur Kagan Ozcan
+ * @since 5.2.0
+ */
+public class LogoutSuccessEvent extends AbstractAuthenticationEvent {
+
+	public LogoutSuccessEvent(Authentication authentication) {
+		super(authentication);
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/logout/LogoutSuccessEventPublishingLogoutHandler.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/logout/LogoutSuccessEventPublishingLogoutHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication.logout;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.security.authentication.event.LogoutSuccessEvent;
+import org.springframework.security.core.Authentication;
+
+/**
+ * A logout handler which publishes {@link LogoutSuccessEvent}
+ *
+ * @author Onur Kagan Ozcan
+ * @since 5.2.0
+ */
+public final class LogoutSuccessEventPublishingLogoutHandler implements LogoutHandler, ApplicationEventPublisherAware {
+
+	private ApplicationEventPublisher eventPublisher;
+
+	@Override
+	public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+		if (eventPublisher == null) {
+			return;
+		}
+		if (authentication == null) {
+			return;
+		}
+		eventPublisher.publishEvent(new LogoutSuccessEvent(authentication));
+	}
+
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+		this.eventPublisher = applicationEventPublisher;
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/session/ConcurrentSessionFilter.java
+++ b/web/src/main/java/org/springframework/security/web/session/ConcurrentSessionFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.security.web.session;
 
 import java.io.IOException;
 
+import java.util.List;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
@@ -61,6 +62,7 @@ import org.springframework.web.filter.GenericFilterBean;
  * @author Ben Alex
  * @author Eddú Meléndez
  * @author Marten Deinum
+ * @author Onur Kagan Ozcan
  */
 public class ConcurrentSessionFilter extends GenericFilterBean {
 
@@ -170,6 +172,16 @@ public class ConcurrentSessionFilter extends GenericFilterBean {
 	}
 
 	public void setLogoutHandlers(LogoutHandler[] handlers) {
+		this.handlers = new CompositeLogoutHandler(handlers);
+	}
+
+	/**
+	 * Set list of {@link LogoutHandler}
+	 *
+	 * @param handlers list of {@link LogoutHandler}
+	 * @since 5.2.0
+	 */
+	public void setLogoutHandlers(List<LogoutHandler> handlers) {
 		this.handlers = new CompositeLogoutHandler(handlers);
 	}
 

--- a/web/src/test/java/org/springframework/security/web/authentication/logout/LogoutSuccessEventPublishingLogoutHandlerTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/logout/LogoutSuccessEventPublishingLogoutHandlerTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication.logout;
+
+import org.junit.Test;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.event.LogoutSuccessEvent;
+import org.springframework.security.core.Authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Onur Kagan Ozcan
+ */
+public class LogoutSuccessEventPublishingLogoutHandlerTests {
+
+	@Test
+	public void shouldPublishEvent() {
+		LogoutSuccessEventPublishingLogoutHandler handler = new LogoutSuccessEventPublishingLogoutHandler();
+		LogoutAwareEventPublisher eventPublisher = new LogoutAwareEventPublisher();
+		handler.setApplicationEventPublisher(eventPublisher);
+
+		handler.logout(new MockHttpServletRequest(), new MockHttpServletResponse(), mock(Authentication.class));
+
+		assertThat(eventPublisher.flag).isTrue();
+	}
+
+	@Test
+	public void shouldNotPublishEventWhenAuthenticationIsNull() {
+		LogoutSuccessEventPublishingLogoutHandler handler = new LogoutSuccessEventPublishingLogoutHandler();
+		LogoutAwareEventPublisher eventPublisher = new LogoutAwareEventPublisher();
+		handler.setApplicationEventPublisher(eventPublisher);
+
+		handler.logout(new MockHttpServletRequest(), new MockHttpServletResponse(), null);
+
+		assertThat(eventPublisher.flag).isFalse();
+	}
+
+	private static class LogoutAwareEventPublisher implements ApplicationEventPublisher {
+
+		Boolean flag = false;
+
+		@Override
+		public void publishEvent(Object event) {
+			if (LogoutSuccessEvent.class.isAssignableFrom(event.getClass())) {
+				flag = true;
+			}
+		}
+	}
+}

--- a/web/src/test/java/org/springframework/security/web/concurrent/ConcurrentSessionFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/concurrent/ConcurrentSessionFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.security.web.concurrent;
 
 import java.util.Date;
+import java.util.List;
 
 import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
@@ -53,6 +54,7 @@ import static org.mockito.Mockito.when;
  *
  * @author Ben Alex
  * @author Luke Taylor
+ * @author Onur Kagan Ozcan
  */
 public class ConcurrentSessionFilterTests {
 
@@ -315,7 +317,7 @@ public class ConcurrentSessionFilterTests {
 	public void setLogoutHandlersWhenNullThenThrowsException() {
 		ConcurrentSessionFilter filter = new ConcurrentSessionFilter(new SessionRegistryImpl());
 
-		filter.setLogoutHandlers(null);
+		filter.setLogoutHandlers((List<LogoutHandler>) null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
LogoutSuccessEvent is a simple AbstractAuthenticationEvent implementation which indicates successful logout.

By default, LogoutConfigurer will add a new LogoutHandler called LogoutSuccessEventPublishingLogoutHandler to publish this event.

This PR will also fix ConcurrentSessionFilter's composite logoutHandler, now will get LogoutHandler instances from LogoutConfigurer for consistency.

Fixes gh-2900

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
