### PR TITLE
Use ConcurrentHashMap in InMemoryReactiveClientRegistrationRepository

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/InMemoryReactiveClientRegistrationRepository.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/InMemoryReactiveClientRegistrationRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,11 @@ package org.springframework.security.oauth2.client.registration;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.springframework.util.Assert;
-import org.springframework.util.ConcurrentReferenceHashMap;
 
 import reactor.core.publisher.Mono;
 
@@ -30,6 +30,7 @@ import reactor.core.publisher.Mono;
  * A Reactive {@link ClientRegistrationRepository} that stores {@link ClientRegistration}(s) in-memory.
  *
  * @author Rob Winch
+ * @author Ebert Toribio
  * @since 5.1
  * @see ClientRegistrationRepository
  * @see ClientRegistration
@@ -46,7 +47,7 @@ public final class InMemoryReactiveClientRegistrationRepository
 	 */
 	public InMemoryReactiveClientRegistrationRepository(ClientRegistration... registrations) {
 		Assert.notEmpty(registrations, "registrations cannot be empty");
-		this.clientIdToClientRegistration = new ConcurrentReferenceHashMap<>();
+		this.clientIdToClientRegistration = new ConcurrentHashMap<>();
 		for (ClientRegistration registration : registrations) {
 			Assert.notNull(registration, "registrations cannot contain null values");
 			this.clientIdToClientRegistration.put(registration.getRegistrationId(), registration);


### PR DESCRIPTION
Since InMemoryReactiveClientRegistrationRepository is intended to be persistent, it should instead use ConcurrentHashMap.

Fixes gh-7299

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
