### PR TITLE
Final redirect in OAuth2AuthorizationCodeGrantFilter needs to be configurable

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/DefaultOAuth2AuthorizationCodeGrantFinalRedirectStrategy.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/DefaultOAuth2AuthorizationCodeGrantFinalRedirectStrategy.java
@@ -1,0 +1,45 @@
+package org.springframework.security.oauth2.client.web;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponse;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.security.web.savedrequest.RequestCache;
+import org.springframework.security.web.savedrequest.SavedRequest;
+
+/**
+ * Default implementation of {@link OAuth2AuthorizationCodeGrantFinalRedirectStrategy}.
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 5.2
+ * @see OAuth2AuthorizationCodeGrantFilter
+ */
+public class DefaultOAuth2AuthorizationCodeGrantFinalRedirectStrategy implements OAuth2AuthorizationCodeGrantFinalRedirectStrategy {
+
+	private final RedirectStrategy redirectStrategy;
+	private final RequestCache requestCache;
+
+	public DefaultOAuth2AuthorizationCodeGrantFinalRedirectStrategy(RedirectStrategy redirectStrategy, RequestCache requestCache) {
+		this.redirectStrategy = redirectStrategy;
+		this.requestCache = requestCache;
+	}
+
+	@Override
+	public void sendRedirect(HttpServletRequest request, HttpServletResponse response,
+			OAuth2AuthorizationRequest authorizationRequest, OAuth2AuthorizationResponse authorizationResponse) throws IOException {
+
+		String redirectUrl = authorizationResponse.getRedirectUri();
+		SavedRequest savedRequest = this.requestCache.getRequest(request, response);
+		if (savedRequest != null) {
+			redirectUrl = savedRequest.getRedirectUrl();
+			this.requestCache.removeRequest(request, response);
+		}
+
+		this.redirectStrategy.sendRedirect(request, response, redirectUrl);
+	}
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/OAuth2AuthorizationCodeGrantFinalRedirectStrategy.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/OAuth2AuthorizationCodeGrantFinalRedirectStrategy.java
@@ -1,0 +1,23 @@
+package org.springframework.security.oauth2.client.web;
+
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponse;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Strategy interface to perform final redirect at the end of OAuth2 Authorization Code Grant Flow.
+ *
+ * @author Tadaya Tsuyukubo
+ * @since 5.2
+ * @see OAuth2AuthorizationCodeGrantFilter
+ */
+public interface OAuth2AuthorizationCodeGrantFinalRedirectStrategy {
+
+	void sendRedirect(HttpServletRequest request, HttpServletResponse response,
+			OAuth2AuthorizationRequest authorizationRequest,
+			OAuth2AuthorizationResponse authorizationResponse) throws IOException;
+
+}


### PR DESCRIPTION
Hi there,

Current implementation of `OAuth2AuthorizationCodeGrantFilter` is not flexible to change the final redirect url at the end of OAuth2 code grant flow.
The final redirect url is pretty much fixed to the where it received oauth2 authorization response(or only modifiable by `RequestCache`).

This makes it difficult to modify the final redirect uri based on `state` parameter, cookie, etc.
Thus, it would be nice that the `OAuth2AuthorizationCodeGrantFilter` takes a strategy that determines the final destination to redirect.

The PR code is a draft implementation. It has not updated the configuration part yet (`AuthorizationCodeGrantConfigurer`).

If we agree on the direction, then I'll update the review.

Thanks,
