### PR TITLE
Propagate additional parameters from exchange response

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/ClientCredentialsOAuth2AuthorizedClientProvider.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/ClientCredentialsOAuth2AuthorizedClientProvider.java
@@ -82,7 +82,8 @@ public final class ClientCredentialsOAuth2AuthorizedClientProvider implements OA
 		OAuth2AccessTokenResponse tokenResponse =
 				this.accessTokenResponseClient.getTokenResponse(clientCredentialsGrantRequest);
 
-		return new OAuth2AuthorizedClient(clientRegistration, context.getPrincipal().getName(), tokenResponse.getAccessToken());
+		return new OAuth2AuthorizedClient(clientRegistration, context.getPrincipal().getName(), tokenResponse.getAccessToken(),
+				null, tokenResponse.getAdditionalParameters());
 	}
 
 	private boolean hasTokenExpired(AbstractOAuth2Token token) {

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/ClientCredentialsReactiveOAuth2AuthorizedClientProvider.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/ClientCredentialsReactiveOAuth2AuthorizedClientProvider.java
@@ -78,7 +78,8 @@ public final class ClientCredentialsReactiveOAuth2AuthorizedClientProvider imple
 		return Mono.just(new OAuth2ClientCredentialsGrantRequest(clientRegistration))
 				.flatMap(this.accessTokenResponseClient::getTokenResponse)
 				.map(tokenResponse -> new OAuth2AuthorizedClient(
-						clientRegistration, context.getPrincipal().getName(), tokenResponse.getAccessToken()));
+						clientRegistration, context.getPrincipal().getName(), tokenResponse.getAccessToken(),
+						null, tokenResponse.getAdditionalParameters()));
 	}
 
 	private boolean hasTokenExpired(AbstractOAuth2Token token) {

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/OAuth2AuthorizedClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/OAuth2AuthorizedClient.java
@@ -23,6 +23,8 @@ import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.util.Assert;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * A representation of an OAuth 2.0 &quot;Authorized Client&quot;.
@@ -46,6 +48,7 @@ public class OAuth2AuthorizedClient implements Serializable {
 	private final String principalName;
 	private final OAuth2AccessToken accessToken;
 	private final OAuth2RefreshToken refreshToken;
+	private final Map<String, Object> additionalParameters;
 
 	/**
 	 * Constructs an {@code OAuth2AuthorizedClient} using the provided parameters.
@@ -55,7 +58,7 @@ public class OAuth2AuthorizedClient implements Serializable {
 	 * @param accessToken the access token credential granted
 	 */
 	public OAuth2AuthorizedClient(ClientRegistration clientRegistration, String principalName, OAuth2AccessToken accessToken) {
-		this(clientRegistration, principalName, accessToken, null);
+		this(clientRegistration, principalName, accessToken, null, Collections.emptyMap());
 	}
 
 	/**
@@ -65,16 +68,20 @@ public class OAuth2AuthorizedClient implements Serializable {
 	 * @param principalName the name of the End-User {@code Principal} (Resource Owner)
 	 * @param accessToken the access token credential granted
 	 * @param refreshToken the refresh token credential granted
+	 * @param additionalParameters the additional parameters granted
 	 */
 	public OAuth2AuthorizedClient(ClientRegistration clientRegistration, String principalName,
-									OAuth2AccessToken accessToken, @Nullable OAuth2RefreshToken refreshToken) {
+									OAuth2AccessToken accessToken, @Nullable OAuth2RefreshToken refreshToken,
+									Map<String, Object> additionalParameters) {
 		Assert.notNull(clientRegistration, "clientRegistration cannot be null");
 		Assert.hasText(principalName, "principalName cannot be empty");
 		Assert.notNull(accessToken, "accessToken cannot be null");
+		Assert.notNull(accessToken, "additionalParameters cannot be null");
 		this.clientRegistration = clientRegistration;
 		this.principalName = principalName;
 		this.accessToken = accessToken;
 		this.refreshToken = refreshToken;
+		this.additionalParameters = additionalParameters;
 	}
 
 	/**
@@ -112,5 +119,15 @@ public class OAuth2AuthorizedClient implements Serializable {
 	 */
 	public @Nullable OAuth2RefreshToken getRefreshToken() {
 		return this.refreshToken;
+	}
+
+	/**
+	 * Returns the additional parameters granted.
+	 *
+	 * @since 5.2
+	 * @return the additional parameters
+	 */
+	public Map<String, Object> getAdditionalParameters() {
+		return this.additionalParameters;
 	}
 }

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/RefreshTokenOAuth2AuthorizedClientProvider.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/RefreshTokenOAuth2AuthorizedClientProvider.java
@@ -90,7 +90,8 @@ public final class RefreshTokenOAuth2AuthorizedClientProvider implements OAuth2A
 				this.accessTokenResponseClient.getTokenResponse(refreshTokenGrantRequest);
 
 		return new OAuth2AuthorizedClient(context.getAuthorizedClient().getClientRegistration(),
-				context.getPrincipal().getName(), tokenResponse.getAccessToken(), tokenResponse.getRefreshToken());
+				context.getPrincipal().getName(), tokenResponse.getAccessToken(), tokenResponse.getRefreshToken(),
+				tokenResponse.getAdditionalParameters());
 	}
 
 	private boolean hasTokenExpired(AbstractOAuth2Token token) {

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/RefreshTokenReactiveOAuth2AuthorizedClientProvider.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/RefreshTokenReactiveOAuth2AuthorizedClientProvider.java
@@ -89,7 +89,7 @@ public final class RefreshTokenReactiveOAuth2AuthorizedClientProvider implements
 		return Mono.just(refreshTokenGrantRequest)
 				.flatMap(this.accessTokenResponseClient::getTokenResponse)
 				.map(tokenResponse -> new OAuth2AuthorizedClient(clientRegistration, context.getPrincipal().getName(),
-						tokenResponse.getAccessToken(), tokenResponse.getRefreshToken()));
+						tokenResponse.getAccessToken(), tokenResponse.getRefreshToken(), tokenResponse.getAdditionalParameters()));
 	}
 
 	private boolean hasTokenExpired(AbstractOAuth2Token token) {

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/authentication/OAuth2AuthorizationCodeAuthenticationProvider.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/authentication/OAuth2AuthorizationCodeAuthenticationProvider.java
@@ -73,7 +73,8 @@ public class OAuth2AuthorizationCodeAuthenticationProvider implements Authentica
 				authorizationCodeAuthentication.getClientRegistration(),
 				authorizationCodeAuthentication.getAuthorizationExchange(),
 				accessTokenResponse.getAccessToken(),
-				accessTokenResponse.getRefreshToken());
+				accessTokenResponse.getRefreshToken(),
+				accessTokenResponse.getAdditionalParameters());
 		authenticationResult.setDetails(authorizationCodeAuthentication.getDetails());
 
 		return authenticationResult;

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/OAuth2AuthorizationCodeGrantFilter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/OAuth2AuthorizationCodeGrantFilter.java
@@ -202,7 +202,8 @@ public class OAuth2AuthorizationCodeGrantFilter extends OncePerRequestFilter {
 			authenticationResult.getClientRegistration(),
 			principalName,
 			authenticationResult.getAccessToken(),
-			authenticationResult.getRefreshToken());
+			authenticationResult.getRefreshToken(),
+			authenticationResult.getAdditionalParameters());
 
 		this.authorizedClientRepository.saveAuthorizedClient(authorizedClient, currentAuthentication, request, response);
 

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/OAuth2LoginAuthenticationFilter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/OAuth2LoginAuthenticationFilter.java
@@ -43,6 +43,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Collections;
 
 /**
  * An implementation of an {@link AbstractAuthenticationProcessingFilter} for OAuth 2.0 Login.
@@ -196,7 +197,8 @@ public class OAuth2LoginAuthenticationFilter extends AbstractAuthenticationProce
 			authenticationResult.getClientRegistration(),
 			oauth2Authentication.getName(),
 			authenticationResult.getAccessToken(),
-			authenticationResult.getRefreshToken());
+			authenticationResult.getRefreshToken(),
+			Collections.emptyMap());
 
 		this.authorizedClientRepository.saveAuthorizedClient(authorizedClient, oauth2Authentication, request, response);
 

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/reactive/function/client/OAuth2AuthorizedClientResolver.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/reactive/function/client/OAuth2AuthorizedClientResolver.java
@@ -142,7 +142,7 @@ class OAuth2AuthorizedClientResolver {
 
 	private Mono<OAuth2AuthorizedClient> clientCredentialsResponse(ClientRegistration clientRegistration, Authentication authentication, ServerWebExchange exchange, OAuth2AccessTokenResponse tokenResponse) {
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(
-				clientRegistration, authentication.getName(), tokenResponse.getAccessToken());
+				clientRegistration, authentication.getName(), tokenResponse.getAccessToken(), null, tokenResponse.getAdditionalParameters());
 		return this.authorizedClientRepository.saveAuthorizedClient(authorizedClient, authentication, exchange)
 				.thenReturn(authorizedClient);
 	}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/reactive/result/method/annotation/OAuth2AuthorizedClientResolver.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/reactive/result/method/annotation/OAuth2AuthorizedClientResolver.java
@@ -143,7 +143,7 @@ class OAuth2AuthorizedClientResolver {
 
 	private Mono<OAuth2AuthorizedClient> clientCredentialsResponse(ClientRegistration clientRegistration, Authentication authentication, ServerWebExchange exchange, OAuth2AccessTokenResponse tokenResponse) {
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(
-				clientRegistration, authentication.getName(), tokenResponse.getAccessToken());
+				clientRegistration, authentication.getName(), tokenResponse.getAccessToken(), null, tokenResponse.getAdditionalParameters());
 		return this.authorizedClientRepository.saveAuthorizedClient(authorizedClient, authentication, exchange)
 				.thenReturn(authorizedClient);
 	}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/server/OAuth2AuthorizationCodeGrantWebFilter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/server/OAuth2AuthorizationCodeGrantWebFilter.java
@@ -155,7 +155,8 @@ public class OAuth2AuthorizationCodeGrantWebFilter implements WebFilter {
 				authenticationResult.getClientRegistration(),
 				authenticationResult.getName(),
 				authenticationResult.getAccessToken(),
-				authenticationResult.getRefreshToken());
+				authenticationResult.getRefreshToken(),
+				authenticationResult.getAdditionalParameters());
 		return this.authenticationSuccessHandler
 					.onAuthenticationSuccess(webFilterExchange, authentication)
 					.then(ReactiveSecurityContextHolder.getContext()

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/server/authentication/OAuth2LoginAuthenticationWebFilter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/server/authentication/OAuth2LoginAuthenticationWebFilter.java
@@ -26,6 +26,8 @@ import org.springframework.security.web.server.authentication.AuthenticationWebF
 import org.springframework.util.Assert;
 import reactor.core.publisher.Mono;
 
+import java.util.Collections;
+
 /**
  * A specialized {@link AuthenticationWebFilter} that converts from an {@link OAuth2LoginAuthenticationToken} to an
  * {@link OAuth2AuthenticationToken} and saves the {@link OAuth2AuthorizedClient}
@@ -59,7 +61,8 @@ public class OAuth2LoginAuthenticationWebFilter extends AuthenticationWebFilter 
 				authenticationResult.getClientRegistration(),
 				authenticationResult.getName(),
 				authenticationResult.getAccessToken(),
-				authenticationResult.getRefreshToken());
+				authenticationResult.getRefreshToken(),
+				Collections.emptyMap());
 		OAuth2AuthenticationToken result =  new OAuth2AuthenticationToken(
 				authenticationResult.getPrincipal(),
 				authenticationResult.getAuthorities(),

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/OAuth2AuthorizedClientProviderBuilderTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/OAuth2AuthorizedClientProviderBuilderTests.java
@@ -34,6 +34,7 @@ import org.springframework.web.client.RestOperations;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -96,7 +97,8 @@ public class OAuth2AuthorizedClientProviderBuilderTests {
 				TestClientRegistrations.clientRegistration().build(),
 				this.principal.getName(),
 				expiredAccessToken(),
-				TestOAuth2RefreshTokens.refreshToken());
+				TestOAuth2RefreshTokens.refreshToken(),
+				Collections.emptyMap());
 
 		OAuth2AuthorizationContext authorizationContext =
 				OAuth2AuthorizationContext.withAuthorizedClient(authorizedClient)
@@ -151,7 +153,8 @@ public class OAuth2AuthorizedClientProviderBuilderTests {
 				clientRegistration,
 				this.principal.getName(),
 				expiredAccessToken(),
-				TestOAuth2RefreshTokens.refreshToken());
+				TestOAuth2RefreshTokens.refreshToken(),
+				Collections.emptyMap());
 
 		OAuth2AuthorizationContext refreshTokenContext =
 				OAuth2AuthorizationContext.withAuthorizedClient(authorizedClient)

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/ReactiveOAuth2AuthorizedClientProviderBuilderTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/ReactiveOAuth2AuthorizedClientProviderBuilderTests.java
@@ -34,6 +34,7 @@ import reactor.core.publisher.Mono;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -103,7 +104,8 @@ public class ReactiveOAuth2AuthorizedClientProviderBuilderTests {
 				this.clientRegistrationBuilder.build(),
 				this.principal.getName(),
 				expiredAccessToken(),
-				TestOAuth2RefreshTokens.refreshToken());
+				TestOAuth2RefreshTokens.refreshToken(),
+				Collections.emptyMap());
 
 		OAuth2AuthorizationContext authorizationContext =
 				OAuth2AuthorizationContext.withAuthorizedClient(authorizedClient)
@@ -180,7 +182,8 @@ public class ReactiveOAuth2AuthorizedClientProviderBuilderTests {
 				this.clientRegistrationBuilder.build(),
 				this.principal.getName(),
 				expiredAccessToken(),
-				TestOAuth2RefreshTokens.refreshToken());
+				TestOAuth2RefreshTokens.refreshToken(),
+				Collections.emptyMap());
 
 		OAuth2AuthorizationContext refreshTokenContext =
 				OAuth2AuthorizationContext.withAuthorizedClient(authorizedClient)

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/RefreshTokenOAuth2AuthorizedClientProviderTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/RefreshTokenOAuth2AuthorizedClientProviderTests.java
@@ -33,6 +33,7 @@ import org.springframework.security.oauth2.core.endpoint.TestOAuth2AccessTokenRe
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -63,7 +64,7 @@ public class RefreshTokenOAuth2AuthorizedClientProviderTests {
 		OAuth2AccessToken expiredAccessToken = new OAuth2AccessToken(
 				OAuth2AccessToken.TokenType.BEARER, "access-token-1234", issuedAt, expiresAt);
 		this.authorizedClient = new OAuth2AuthorizedClient(this.clientRegistration, this.principal.getName(),
-				expiredAccessToken, TestOAuth2RefreshTokens.refreshToken());
+				expiredAccessToken, TestOAuth2RefreshTokens.refreshToken(), Collections.emptyMap());
 	}
 
 	@Test
@@ -125,7 +126,8 @@ public class RefreshTokenOAuth2AuthorizedClientProviderTests {
 	@Test
 	public void authorizeWhenAuthorizedAndAccessTokenNotExpiredThenNotReauthorize() {
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.clientRegistration,
-				this.principal.getName(), TestOAuth2AccessTokens.noScopes(), this.authorizedClient.getRefreshToken());
+				this.principal.getName(), TestOAuth2AccessTokens.noScopes(), this.authorizedClient.getRefreshToken(),
+				Collections.emptyMap());
 
 		OAuth2AuthorizationContext authorizationContext =
 				OAuth2AuthorizationContext.withAuthorizedClient(authorizedClient)

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/RefreshTokenReactiveOAuth2AuthorizedClientProviderTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/RefreshTokenReactiveOAuth2AuthorizedClientProviderTests.java
@@ -34,6 +34,7 @@ import reactor.core.publisher.Mono;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -65,7 +66,7 @@ public class RefreshTokenReactiveOAuth2AuthorizedClientProviderTests {
 		OAuth2AccessToken expiredAccessToken = new OAuth2AccessToken(
 				OAuth2AccessToken.TokenType.BEARER, "access-token-1234", issuedAt, expiresAt);
 		this.authorizedClient = new OAuth2AuthorizedClient(this.clientRegistration, this.principal.getName(),
-				expiredAccessToken, TestOAuth2RefreshTokens.refreshToken());
+				expiredAccessToken, TestOAuth2RefreshTokens.refreshToken(), Collections.emptyMap());
 	}
 
 	@Test
@@ -127,7 +128,8 @@ public class RefreshTokenReactiveOAuth2AuthorizedClientProviderTests {
 	@Test
 	public void authorizeWhenAuthorizedAndAccessTokenNotExpiredThenNotReauthorize() {
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.clientRegistration,
-				this.principal.getName(), TestOAuth2AccessTokens.noScopes(), this.authorizedClient.getRefreshToken());
+				this.principal.getName(), TestOAuth2AccessTokens.noScopes(), this.authorizedClient.getRefreshToken(),
+				Collections.emptyMap());
 
 		OAuth2AuthorizationContext authorizationContext =
 				OAuth2AuthorizationContext.withAuthorizedClient(authorizedClient)

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/authentication/OAuth2AuthorizationCodeAuthenticationProviderTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/authentication/OAuth2AuthorizationCodeAuthenticationProviderTests.java
@@ -17,6 +17,7 @@ package org.springframework.security.oauth2.client.authentication;
 
 import java.util.Collections;
 
+import org.assertj.core.util.Maps;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,6 +33,7 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResp
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -113,7 +115,10 @@ public class OAuth2AuthorizationCodeAuthenticationProviderTests {
 
 	@Test
 	public void authenticateWhenAuthorizationSuccessResponseThenExchangedForAccessToken() {
-		OAuth2AccessTokenResponse accessTokenResponse = accessTokenResponse().refreshToken("refresh").build();
+		OAuth2AccessTokenResponse accessTokenResponse = accessTokenResponse()
+				.refreshToken("refresh")
+				.additionalParameters(Maps.newHashMap("foo", "FOO"))
+				.build();
 		when(this.accessTokenResponseClient.getTokenResponse(any())).thenReturn(accessTokenResponse);
 
 		OAuth2AuthorizationExchange authorizationExchange = new OAuth2AuthorizationExchange(
@@ -131,5 +136,6 @@ public class OAuth2AuthorizationCodeAuthenticationProviderTests {
 		assertThat(authenticationResult.getAuthorizationExchange()).isEqualTo(authorizationExchange);
 		assertThat(authenticationResult.getAccessToken()).isEqualTo(accessTokenResponse.getAccessToken());
 		assertThat(authenticationResult.getRefreshToken()).isEqualTo(accessTokenResponse.getRefreshToken());
+		assertThat(authenticationResult.getAdditionalParameters()).containsExactly(entry("foo", "FOO"));
 	}
 }

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/DefaultOAuth2AuthorizedClientManagerTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/DefaultOAuth2AuthorizedClientManagerTests.java
@@ -32,6 +32,7 @@ import org.springframework.security.oauth2.core.TestOAuth2AccessTokens;
 import org.springframework.security.oauth2.core.TestOAuth2RefreshTokens;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 
+import java.util.Collections;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -70,7 +71,8 @@ public class DefaultOAuth2AuthorizedClientManagerTests {
 		this.clientRegistration = TestClientRegistrations.clientRegistration().build();
 		this.principal = new TestingAuthenticationToken("principal", "password");
 		this.authorizedClient = new OAuth2AuthorizedClient(this.clientRegistration, this.principal.getName(),
-				TestOAuth2AccessTokens.scopes("read", "write"), TestOAuth2RefreshTokens.refreshToken());
+				TestOAuth2AccessTokens.scopes("read", "write"), TestOAuth2RefreshTokens.refreshToken(),
+				Collections.emptyMap());
 		this.request = new MockHttpServletRequest();
 		this.response = new MockHttpServletResponse();
 		this.authorizationContextCaptor = ArgumentCaptor.forClass(OAuth2AuthorizationContext.class);
@@ -178,7 +180,7 @@ public class DefaultOAuth2AuthorizedClientManagerTests {
 
 		OAuth2AuthorizedClient reauthorizedClient = new OAuth2AuthorizedClient(
 				this.clientRegistration, this.principal.getName(),
-				TestOAuth2AccessTokens.noScopes(), TestOAuth2RefreshTokens.refreshToken());
+				TestOAuth2AccessTokens.noScopes(), TestOAuth2RefreshTokens.refreshToken(), Collections.emptyMap());
 
 		when(this.authorizedClientProvider.authorize(any(OAuth2AuthorizationContext.class))).thenReturn(reauthorizedClient);
 
@@ -224,7 +226,7 @@ public class DefaultOAuth2AuthorizedClientManagerTests {
 	public void reauthorizeWhenSupportedProviderThenReauthorized() {
 		OAuth2AuthorizedClient reauthorizedClient = new OAuth2AuthorizedClient(
 				this.clientRegistration, this.principal.getName(),
-				TestOAuth2AccessTokens.noScopes(), TestOAuth2RefreshTokens.refreshToken());
+				TestOAuth2AccessTokens.noScopes(), TestOAuth2RefreshTokens.refreshToken(), Collections.emptyMap());
 
 		when(this.authorizedClientProvider.authorize(any(OAuth2AuthorizationContext.class))).thenReturn(reauthorizedClient);
 
@@ -250,7 +252,7 @@ public class DefaultOAuth2AuthorizedClientManagerTests {
 	public void reauthorizeWhenRequestScopeParameterThenMappedToContext() {
 		OAuth2AuthorizedClient reauthorizedClient = new OAuth2AuthorizedClient(
 				this.clientRegistration, this.principal.getName(),
-				TestOAuth2AccessTokens.noScopes(), TestOAuth2RefreshTokens.refreshToken());
+				TestOAuth2AccessTokens.noScopes(), TestOAuth2RefreshTokens.refreshToken(), Collections.emptyMap());
 
 		when(this.authorizedClientProvider.authorize(any(OAuth2AuthorizationContext.class))).thenReturn(reauthorizedClient);
 

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/OAuth2AuthorizeRequestTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/OAuth2AuthorizeRequestTests.java
@@ -26,6 +26,8 @@ import org.springframework.security.oauth2.client.registration.TestClientRegistr
 import org.springframework.security.oauth2.core.TestOAuth2AccessTokens;
 import org.springframework.security.oauth2.core.TestOAuth2RefreshTokens;
 
+import java.util.Collections;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -39,7 +41,7 @@ public class OAuth2AuthorizeRequestTests {
 	private Authentication principal = new TestingAuthenticationToken("principal", "password");
 	private OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(
 			this.clientRegistration, this.principal.getName(),
-			TestOAuth2AccessTokens.scopes("read", "write"), TestOAuth2RefreshTokens.refreshToken());
+			TestOAuth2AccessTokens.scopes("read", "write"), TestOAuth2RefreshTokens.refreshToken(), Collections.emptyMap());
 	private MockHttpServletRequest servletRequest = new MockHttpServletRequest();
 	private MockHttpServletResponse servletResponse = new MockHttpServletResponse();
 

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServerOAuth2AuthorizedClientExchangeFilterFunctionTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServerOAuth2AuthorizedClientExchangeFilterFunctionTests.java
@@ -220,7 +220,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				issuedAt,
 				accessTokenExpiresAt);
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(registration,
-				"principalName", accessToken, null);
+				"principalName", accessToken, null, Collections.emptyMap());
 
 		TestingAuthenticationToken authentication = new TestingAuthenticationToken("test", "this");
 
@@ -251,7 +251,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 		ClientRegistration registration = TestClientRegistrations.clientCredentials().build();
 
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(registration,
-				"principalName", this.accessToken, null);
+				"principalName", this.accessToken, null, Collections.emptyMap());
 		ClientRequest request = ClientRequest.create(GET, URI.create("https://example.com"))
 				.attributes(oauth2AuthorizedClient(authorizedClient))
 				.build();
@@ -289,7 +289,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				accessTokenExpiresAt);
 		OAuth2RefreshToken refreshToken = new OAuth2RefreshToken("refresh-token", issuedAt);
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.registration,
-				"principalName", this.accessToken, refreshToken);
+				"principalName", this.accessToken, refreshToken, Collections.emptyMap());
 
 		ClientRequest request = ClientRequest.create(GET, URI.create("https://example.com"))
 				.attributes(oauth2AuthorizedClient(authorizedClient))
@@ -336,7 +336,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 
 		OAuth2RefreshToken refreshToken = new OAuth2RefreshToken("refresh-token", issuedAt);
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.registration,
-				"principalName", this.accessToken, refreshToken);
+				"principalName", this.accessToken, refreshToken, Collections.emptyMap());
 		ClientRequest request = ClientRequest.create(GET, URI.create("https://example.com"))
 				.attributes(oauth2AuthorizedClient(authorizedClient))
 				.build();
@@ -384,7 +384,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 	public void filterWhenNotExpiredThenShouldRefreshFalse() {
 		OAuth2RefreshToken refreshToken = new OAuth2RefreshToken("refresh-token", this.accessToken.getIssuedAt());
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.registration,
-				"principalName", this.accessToken, refreshToken);
+				"principalName", this.accessToken, refreshToken, Collections.emptyMap());
 		ClientRequest request = ClientRequest.create(GET, URI.create("https://example.com"))
 				.attributes(oauth2AuthorizedClient(authorizedClient))
 				.build();
@@ -407,7 +407,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 	public void filterWhenClientRegistrationIdThenAuthorizedClientResolved() {
 		OAuth2RefreshToken refreshToken = new OAuth2RefreshToken("refresh-token", this.accessToken.getIssuedAt());
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.registration,
-				"principalName", this.accessToken, refreshToken);
+				"principalName", this.accessToken, refreshToken, Collections.emptyMap());
 		when(this.authorizedClientRepository.loadAuthorizedClient(any(), any(), any())).thenReturn(Mono.just(authorizedClient));
 		ClientRequest request = ClientRequest.create(GET, URI.create("https://example.com"))
 				.attributes(clientRegistrationId(this.registration.getRegistrationId()))
@@ -432,7 +432,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 		this.function.setDefaultClientRegistrationId(this.registration.getRegistrationId());
 		OAuth2RefreshToken refreshToken = new OAuth2RefreshToken("refresh-token", this.accessToken.getIssuedAt());
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.registration,
-				"principalName", this.accessToken, refreshToken);
+				"principalName", this.accessToken, refreshToken, Collections.emptyMap());
 		when(this.authorizedClientRepository.loadAuthorizedClient(any(), any(), any())).thenReturn(Mono.just(authorizedClient));
 		ClientRequest request = ClientRequest.create(GET, URI.create("https://example.com"))
 				.build();
@@ -457,7 +457,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 
 		OAuth2RefreshToken refreshToken = new OAuth2RefreshToken("refresh-token", this.accessToken.getIssuedAt());
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.registration,
-				"principalName", this.accessToken, refreshToken);
+				"principalName", this.accessToken, refreshToken, Collections.emptyMap());
 		when(this.authorizedClientRepository.loadAuthorizedClient(any(), any(), any())).thenReturn(Mono.just(authorizedClient));
 		ClientRequest request = ClientRequest.create(GET, URI.create("https://example.com"))
 				.build();
@@ -505,7 +505,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 	public void filterWhenClientRegistrationIdAndServerWebExchangeFromContextThenServerWebExchangeFromContext() {
 		OAuth2RefreshToken refreshToken = new OAuth2RefreshToken("refresh-token", this.accessToken.getIssuedAt());
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.registration,
-				"principalName", this.accessToken, refreshToken);
+				"principalName", this.accessToken, refreshToken, Collections.emptyMap());
 		when(this.authorizedClientRepository.loadAuthorizedClient(any(), any(), any())).thenReturn(Mono.just(authorizedClient));
 		ClientRequest request = ClientRequest.create(GET, URI.create("https://example.com"))
 				.attributes(clientRegistrationId(this.registration.getRegistrationId()))

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServletOAuth2AuthorizedClientExchangeFilterFunctionITests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServletOAuth2AuthorizedClientExchangeFilterFunctionITests.java
@@ -49,6 +49,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -185,7 +186,7 @@ public class ServletOAuth2AuthorizedClientExchangeFilterFunctionITests {
 				"expired-access-token", issuedAt, expiresAt, new HashSet<>(Arrays.asList("read", "write")));
 		OAuth2RefreshToken refreshToken = TestOAuth2RefreshTokens.refreshToken();
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(
-				clientRegistration, this.authentication.getName(), accessToken, refreshToken);
+				clientRegistration, this.authentication.getName(), accessToken, refreshToken, Collections.emptyMap());
 		doReturn(authorizedClient).when(this.authorizedClientRepository).loadAuthorizedClient(
 				eq(clientRegistration.getRegistrationId()), eq(this.authentication), eq(this.request));
 

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServletOAuth2AuthorizedClientExchangeFilterFunctionTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServletOAuth2AuthorizedClientExchangeFilterFunctionTests.java
@@ -77,6 +77,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -279,7 +280,7 @@ public class ServletOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				accessTokenExpiresAt);
 		OAuth2RefreshToken refreshToken = new OAuth2RefreshToken("refresh-token", issuedAt);
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.registration,
-				"principalName", this.accessToken, refreshToken);
+				"principalName", this.accessToken, refreshToken, Collections.emptyMap());
 
 		ClientRequest request = ClientRequest.create(GET, URI.create("https://example.com"))
 				.attributes(oauth2AuthorizedClient(authorizedClient))
@@ -337,7 +338,7 @@ public class ServletOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				accessTokenExpiresAt);
 		OAuth2RefreshToken refreshToken = new OAuth2RefreshToken("refresh-token", issuedAt);
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.registration,
-				"principalName", this.accessToken, refreshToken);
+				"principalName", this.accessToken, refreshToken, Collections.emptyMap());
 
 		ClientRequest request = ClientRequest.create(GET, URI.create("https://example.com"))
 				.attributes(oauth2AuthorizedClient(authorizedClient))
@@ -369,7 +370,7 @@ public class ServletOAuth2AuthorizedClientExchangeFilterFunctionTests {
 	public void filterWhenClientCredentialsTokenNotExpiredThenUseCurrentToken() {
 		this.registration = TestClientRegistrations.clientCredentials().build();
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.registration,
-				"principalName", this.accessToken, null);
+				"principalName", this.accessToken, null, Collections.emptyMap());
 
 		ClientRequest request = ClientRequest.create(GET, URI.create("https://example.com"))
 				.attributes(oauth2AuthorizedClient(authorizedClient))
@@ -411,7 +412,7 @@ public class ServletOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				accessTokenExpiresAt);
 
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.registration,
-				"principalName", this.accessToken, null);
+				"principalName", this.accessToken, null, Collections.emptyMap());
 
 		ClientRequest request = ClientRequest.create(GET, URI.create("https://example.com"))
 				.attributes(oauth2AuthorizedClient(authorizedClient))
@@ -451,7 +452,7 @@ public class ServletOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				this.accessToken.getTokenValue(), issuedAt, accessTokenExpiresAt);
 		OAuth2RefreshToken refreshToken = new OAuth2RefreshToken("refresh-token", issuedAt);
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.registration,
-				"principalName", this.accessToken, refreshToken);
+				"principalName", this.accessToken, refreshToken, Collections.emptyMap());
 
 		ClientRequest request = ClientRequest.create(GET, URI.create("https://example.com"))
 				.attributes(oauth2AuthorizedClient(authorizedClient))
@@ -501,7 +502,7 @@ public class ServletOAuth2AuthorizedClientExchangeFilterFunctionTests {
 	public void filterWhenNotExpiredThenShouldRefreshFalse() {
 		OAuth2RefreshToken refreshToken = new OAuth2RefreshToken("refresh-token", this.accessToken.getIssuedAt());
 		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.registration,
-				"principalName", this.accessToken, refreshToken);
+				"principalName", this.accessToken, refreshToken, Collections.emptyMap());
 
 		ClientRequest request = ClientRequest.create(GET, URI.create("https://example.com"))
 				.attributes(oauth2AuthorizedClient(authorizedClient))

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/server/DefaultServerOAuth2AuthorizedClientManagerTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/server/DefaultServerOAuth2AuthorizedClientManagerTests.java
@@ -80,7 +80,7 @@ public class DefaultServerOAuth2AuthorizedClientManagerTests {
 		this.clientRegistration = TestClientRegistrations.clientRegistration().build();
 		this.principal = new TestingAuthenticationToken("principal", "password");
 		this.authorizedClient = new OAuth2AuthorizedClient(this.clientRegistration, this.principal.getName(),
-				TestOAuth2AccessTokens.scopes("read", "write"), TestOAuth2RefreshTokens.refreshToken());
+				TestOAuth2AccessTokens.scopes("read", "write"), TestOAuth2RefreshTokens.refreshToken(), Collections.emptyMap());
 		this.serverWebExchange = MockServerWebExchange.builder(MockServerHttpRequest.get("/")).build();
 		this.authorizationContextCaptor = ArgumentCaptor.forClass(OAuth2AuthorizationContext.class);
 	}
@@ -188,7 +188,7 @@ public class DefaultServerOAuth2AuthorizedClientManagerTests {
 
 		OAuth2AuthorizedClient reauthorizedClient = new OAuth2AuthorizedClient(
 				this.clientRegistration, this.principal.getName(),
-				TestOAuth2AccessTokens.noScopes(), TestOAuth2RefreshTokens.refreshToken());
+				TestOAuth2AccessTokens.noScopes(), TestOAuth2RefreshTokens.refreshToken(), Collections.emptyMap());
 
 		when(this.authorizedClientProvider.authorize(any(OAuth2AuthorizationContext.class))).thenReturn(Mono.just(reauthorizedClient));
 
@@ -234,7 +234,7 @@ public class DefaultServerOAuth2AuthorizedClientManagerTests {
 	public void reauthorizeWhenSupportedProviderThenReauthorized() {
 		OAuth2AuthorizedClient reauthorizedClient = new OAuth2AuthorizedClient(
 				this.clientRegistration, this.principal.getName(),
-				TestOAuth2AccessTokens.noScopes(), TestOAuth2RefreshTokens.refreshToken());
+				TestOAuth2AccessTokens.noScopes(), TestOAuth2RefreshTokens.refreshToken(), Collections.emptyMap());
 
 		when(this.authorizedClientProvider.authorize(any(OAuth2AuthorizationContext.class))).thenReturn(Mono.just(reauthorizedClient));
 
@@ -260,7 +260,7 @@ public class DefaultServerOAuth2AuthorizedClientManagerTests {
 	public void reauthorizeWhenRequestScopeParameterThenMappedToContext() {
 		OAuth2AuthorizedClient reauthorizedClient = new OAuth2AuthorizedClient(
 				this.clientRegistration, this.principal.getName(),
-				TestOAuth2AccessTokens.noScopes(), TestOAuth2RefreshTokens.refreshToken());
+				TestOAuth2AccessTokens.noScopes(), TestOAuth2RefreshTokens.refreshToken(), Collections.emptyMap());
 
 		when(this.authorizedClientProvider.authorize(any(OAuth2AuthorizationContext.class))).thenReturn(Mono.just(reauthorizedClient));
 

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/server/ServerOAuth2AuthorizeRequestTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/server/ServerOAuth2AuthorizeRequestTests.java
@@ -26,6 +26,8 @@ import org.springframework.security.oauth2.client.registration.TestClientRegistr
 import org.springframework.security.oauth2.core.TestOAuth2AccessTokens;
 import org.springframework.security.oauth2.core.TestOAuth2RefreshTokens;
 
+import java.util.Collections;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -39,7 +41,7 @@ public class ServerOAuth2AuthorizeRequestTests {
 	private Authentication principal = new TestingAuthenticationToken("principal", "password");
 	private OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(
 			this.clientRegistration, this.principal.getName(),
-			TestOAuth2AccessTokens.scopes("read", "write"), TestOAuth2RefreshTokens.refreshToken());
+			TestOAuth2AccessTokens.scopes("read", "write"), TestOAuth2RefreshTokens.refreshToken(), Collections.emptyMap());
 	private MockServerWebExchange serverWebExchange = MockServerWebExchange.builder(MockServerHttpRequest.get("/")).build();
 
 	@Test


### PR DESCRIPTION
This is about OAuth2 Authorization Code Grant flow.

Currently, when constructing `OAuth2AuthorizationCodeAuthenticationToken` from exchange response, `additionalParameters` are not passed to the token in `OAuth2AuthorizationCodeAuthenticationProvider`. Consequently, when saving the authorized client with `OAuth2AuthorizedClientRepository#saveAuthorizedClient`, `additionalParameters` are not available.

This prevents persisting additional parameters when storing access-token and refresh-token.

This PR propagates `additionalParameters` to `OAuth2AuthorizationCodeAuthenticationToken` and  `OAuth2AuthorizedClient`.
So that, they can be used in later part - `OAuth2AuthorizedClientRepository#saveAuthorizedClient`.
