### PR TITLE
Remove OAuth2AuthorizationRequest when a distributed session is used

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/server/WebSessionOAuth2ServerAuthorizationRequestRepository.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/server/WebSessionOAuth2ServerAuthorizationRequestRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,6 +85,8 @@ public final class WebSessionOAuth2ServerAuthorizationRequestRepository
 				OAuth2AuthorizationRequest removedValue = stateToAuthzRequest.remove(state);
 				if (stateToAuthzRequest.isEmpty()) {
 					sessionAttrs.remove(this.sessionAttributeName);
+				} else if (removedValue != null) {
+					sessionAttrs.put(this.sessionAttributeName, stateToAuthzRequest);
 				}
 				if (removedValue == null) {
 					sink.complete();


### PR DESCRIPTION
Dirties the WebSession by putting the amended AUTHORIZATION_REQUEST map into
the WebSession even it was already in the map. This causes common SessionRepository
implementations like Redis to persist the updated attribute.

Fixes gh-7327

Author: Andreas Kluth <mail@andreaskluth.net>