### PR TITLE
Dispose default Scheduler

### DIFF
--- a/core/src/test/java/org/springframework/security/authentication/ReactiveUserDetailsServiceAuthenticationManagerTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/ReactiveUserDetailsServiceAuthenticationManagerTests.java
@@ -33,6 +33,8 @@ import org.springframework.security.core.userdetails.ReactiveUserDetailsService;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
 /**
@@ -136,4 +138,33 @@ public class ReactiveUserDetailsServiceAuthenticationManagerTests {
 			.expectError(BadCredentialsException.class)
 			.verify();
 	}
+
+	@Test
+	public void destroyWhenDefaultSchedulerThenShouldDispose() {
+		assertThat(manager.scheduler.isDisposed()).isFalse();
+		manager.destroy();
+		assertThat(manager.scheduler.isDisposed())
+				.as("default Scheduler should be disposed")
+				.isTrue();
+	}
+
+	@Test
+	public void destroyWhenCustomSchedulerThenShouldNotDispose() {
+		manager.setScheduler(Schedulers.parallel());
+		manager.destroy();
+		assertThat(manager.scheduler.isDisposed())
+				.as("custom Scheduler should not be disposed")
+				.isFalse();
+	}
+
+	@Test
+	public void setSchedulerWhenSetCustomSchedulerThenDisposeDefault() {
+		Scheduler defaultScheduler = manager.scheduler;
+		assertThat(defaultScheduler.isDisposed()).isFalse();
+		manager.setScheduler(Schedulers.parallel());
+		assertThat(defaultScheduler.isDisposed())
+				.as("default Scheduler should be disposed")
+				.isTrue();
+	}
+
 }


### PR DESCRIPTION
AbstractUserDetailsReactiveAuthenticationManager creates parallel `Scheduler` with `daemon=false` `Thread`s. It is recommended to dispose such Schedulers to be able exit the VM

Fixes gh-7492
