### PR TITLE
fix webflux samples documentation path

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/reactive/webflux.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/reactive/webflux.adoc
@@ -4,9 +4,9 @@
 Spring Security's WebFlux support relies on a `WebFilter` and works the same for Spring WebFlux and Spring WebFlux.Fn.
 You can find a few sample applications that demonstrate the code below:
 
-* Hello WebFlux {gh-samples-url}/javaconfig/hellowebflux[hellowebflux]
-* Hello WebFlux.Fn {gh-samples-url}/javaconfig/hellowebfluxfn[hellowebfluxfn]
-* Hello WebFlux Method {gh-samples-url}/javaconfig/hellowebflux-method[hellowebflux-method]
+* Hello WebFlux {gh-samples-url}/boot/hellowebflux[hellowebflux]
+* Hello WebFlux.Fn {gh-samples-url}/boot/hellowebfluxfn[hellowebfluxfn]
+* Hello WebFlux Method {gh-samples-url}/boot/hellowebflux-method[hellowebflux-method]
 
 
 == Minimal WebFlux Security Configuration


### PR DESCRIPTION
The documentation of webflux integration sample projects was pointing to the `javaconfig` folder instead of `boot` sample folder.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
