### PR TITLE
Add support for multiple JWK Set URLs

### DIFF
--- a/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
@@ -1833,6 +1833,17 @@ public class ServerHttpSecurity {
 				return this;
 			}
 
+			/**
+			 * Configures a {@link ReactiveJwtDecoder} using
+			 * <a target="_blank" href="https://tools.ietf.org/html/rfc7517">JSON Web Key (JWK)</a> URLs
+			 * @param jwkSetUris URLs to use.
+			 * @return the {@code JwtSpec} for additional configuration
+			 */
+			public JwtSpec jwkSetUris(List<String> jwkSetUris) {
+				this.jwtDecoder = new NimbusReactiveJwtDecoder(jwkSetUris);
+				return this;
+			}
+
 			public OAuth2ResourceServerSpec and() {
 				return OAuth2ResourceServerSpec.this;
 			}


### PR DESCRIPTION
This is required when using Spring Boot application as a Resource Server
together with Keycloak, where each realm has it's own JWK Set.