### PR TITLE
Make saveAuthorizedClient save the authorized client

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/DefaultReactiveOAuth2AuthorizedClientManager.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/DefaultReactiveOAuth2AuthorizedClientManager.java
@@ -105,10 +105,8 @@ public final class DefaultReactiveOAuth2AuthorizedClientManager implements React
 	private Mono<OAuth2AuthorizedClient> saveAuthorizedClient(OAuth2AuthorizedClient authorizedClient, Authentication principal, ServerWebExchange serverWebExchange) {
 		return Mono.justOrEmpty(serverWebExchange)
 				.switchIfEmpty(Mono.defer(() -> currentServerWebExchange()))
-				.map(exchange -> {
-					this.authorizedClientRepository.saveAuthorizedClient(authorizedClient, principal, exchange);
-					return authorizedClient;
-				})
+				.flatMap(exchange -> this.authorizedClientRepository.saveAuthorizedClient(authorizedClient, principal, exchange)
+						.thenReturn(authorizedClient))
 				.defaultIfEmpty(authorizedClient);
 	}
 

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/DefaultReactiveOAuth2AuthorizedClientManagerTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/DefaultReactiveOAuth2AuthorizedClientManagerTests.java
@@ -36,6 +36,7 @@ import org.springframework.security.oauth2.core.TestOAuth2RefreshTokens;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
+import reactor.test.publisher.PublisherProbe;
 import reactor.util.context.Context;
 
 import java.util.Collections;
@@ -65,6 +66,8 @@ public class DefaultReactiveOAuth2AuthorizedClientManagerTests {
 	private Context context;
 	private ArgumentCaptor<OAuth2AuthorizationContext> authorizationContextCaptor;
 
+	private PublisherProbe<Void> saveAuthorizedClientProbe;
+
 	@SuppressWarnings("unchecked")
 	@Before
 	public void setup() {
@@ -74,8 +77,9 @@ public class DefaultReactiveOAuth2AuthorizedClientManagerTests {
 		this.authorizedClientRepository = mock(ServerOAuth2AuthorizedClientRepository.class);
 		when(this.authorizedClientRepository.loadAuthorizedClient(
 				anyString(), any(Authentication.class), any(ServerWebExchange.class))).thenReturn(Mono.empty());
+		this.saveAuthorizedClientProbe = PublisherProbe.empty();
 		when(this.authorizedClientRepository.saveAuthorizedClient(
-				any(OAuth2AuthorizedClient.class), any(Authentication.class), any(ServerWebExchange.class))).thenReturn(Mono.empty());
+				any(OAuth2AuthorizedClient.class), any(Authentication.class), any(ServerWebExchange.class))).thenReturn(saveAuthorizedClientProbe.mono());
 		this.authorizedClientProvider = mock(ReactiveOAuth2AuthorizedClientProvider.class);
 		when(this.authorizedClientProvider.authorize(any(OAuth2AuthorizationContext.class))).thenReturn(Mono.empty());
 		this.contextAttributesMapper = mock(Function.class);
@@ -187,6 +191,8 @@ public class DefaultReactiveOAuth2AuthorizedClientManagerTests {
 		assertThat(authorizedClient).isSameAs(this.authorizedClient);
 		verify(this.authorizedClientRepository).saveAuthorizedClient(
 				eq(this.authorizedClient), eq(this.principal), eq(this.serverWebExchange));
+
+		saveAuthorizedClientProbe.assertWasSubscribed();
 	}
 
 	@Test
@@ -245,6 +251,7 @@ public class DefaultReactiveOAuth2AuthorizedClientManagerTests {
 		assertThat(authorizedClient).isSameAs(reauthorizedClient);
 		verify(this.authorizedClientRepository).saveAuthorizedClient(
 				eq(reauthorizedClient), eq(this.principal), eq(this.serverWebExchange));
+		saveAuthorizedClientProbe.assertWasSubscribed();
 	}
 
 	@Test
@@ -337,6 +344,7 @@ public class DefaultReactiveOAuth2AuthorizedClientManagerTests {
 		assertThat(authorizedClient).isSameAs(reauthorizedClient);
 		verify(this.authorizedClientRepository).saveAuthorizedClient(
 				eq(reauthorizedClient), eq(this.principal), eq(this.serverWebExchange));
+		saveAuthorizedClientProbe.assertWasSubscribed();
 	}
 
 	@Test

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServerOAuth2AuthorizedClientExchangeFilterFunctionTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServerOAuth2AuthorizedClientExchangeFilterFunctionTests.java
@@ -140,6 +140,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				this.clientRegistrationRepository, this.authorizedClientRepository);
 		this.authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider);
 		this.function = new ServerOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager);
+		when(this.authorizedClientRepository.saveAuthorizedClient(any(), any(), any())).thenReturn(Mono.empty());
 	}
 
 	@Test


### PR DESCRIPTION
Make `DefaultReactiveOAuth2AuthorizedClientManager.saveAuthorizedClient` actually save the authorized client

Previously, `saveAuthorizedClient` never actually saved the authorized client, because it ignored the `Mono<Void>` returned from `authorizedClientRepository.saveAuthorizedClient`.

Now, it does not ignore the `Mono<Void>` returned from `authorizedClientRepository.saveAuthorizedClient`, and includes it in the stream, and therefore it will properly save the authorized client.

Added logic to unit test to verify the `Mono<Void>` returned from `authorizedClientRepository.saveAuthorizedClient` is subscribed.

Fixes gh-7546

I have signed the CLA