### PR TITLE
Adds UserCache to the DaoAuthenticationprovider through AuthenticationConfiguration

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeUserDetailsBeanManagerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeUserDetailsBeanManagerConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ class InitializeUserDetailsBeanManagerConfigurer
 		}
 
 		/**
-		 * @return
+		 * @return a bean of the requested class if there's just a single registered component, null otherwise.
 		 */
 		private <T> T getBeanOrNull(Class<T> type) {
 			String[] userDetailsBeanNames = InitializeUserDetailsBeanManagerConfigurer.this.context


### PR DESCRIPTION
When the AuthenticationConfiguration sets the UserDetailsBeanConfigurer it creates a DaoAuthenticationProvider without the capabilities of setting an ApplicationContext registered UserCache bean.

Fixes gh-7556

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
