### PR TITLE
Fix typo 'is' -> 'if' in javadoc

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ExceptionHandlingConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ExceptionHandlingConfigurer.java
@@ -135,7 +135,7 @@ public final class ExceptionHandlingConfigurer<H extends HttpSecurityBuilder<H>>
 	 * then
 	 * {@link #defaultAuthenticationEntryPointFor(AuthenticationEntryPoint, RequestMatcher)}
 	 * will be used. The first {@link AuthenticationEntryPoint} will be used as the
-	 * default is no matches were found.
+	 * default if no matches were found.
 	 * </p>
 	 *
 	 * <p>


### PR DESCRIPTION
Just a typo fix in javadoc for `authenticationEntryPoint` method. Nothing fancy here.