### PR TITLE
Align javadoc of continueFilterChainOnUnsuccessfulAuthentication with actual behaviour

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/preauth/AbstractPreAuthenticatedProcessingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/preauth/AbstractPreAuthenticatedProcessingFilter.java
@@ -267,10 +267,10 @@ public abstract class AbstractPreAuthenticatedProcessingFilter extends GenericFi
 	}
 
 	/**
-	 * If set to {@code true}, any {@code AuthenticationException} raised by the
+	 * If set to {@code true} (the default), any {@code AuthenticationException} raised by the
 	 * {@code AuthenticationManager} will be swallowed, and the request will be allowed to
-	 * proceed, potentially using alternative authentication mechanisms. If {@code false}
-	 * (the default), authentication failure will result in an immediate exception.
+	 * proceed, potentially using alternative authentication mechanisms. If {@code false},
+	 * authentication failure will result in an immediate exception.
 	 *
 	 * @param shouldContinue set to {@code true} to allow the request to proceed after a
 	 * failed authentication.


### PR DESCRIPTION

closes gh-3760

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
