### PR TITLE
Make save and load authorized clients work without exchange

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/DefaultReactiveOAuth2AuthorizedClientManager.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/DefaultReactiveOAuth2AuthorizedClientManager.java
@@ -34,6 +34,7 @@ import reactor.core.publisher.Mono;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -99,13 +100,19 @@ public final class DefaultReactiveOAuth2AuthorizedClientManager implements React
 	private Mono<OAuth2AuthorizedClient> loadAuthorizedClient(String clientRegistrationId, Authentication principal, ServerWebExchange serverWebExchange) {
 		return Mono.justOrEmpty(serverWebExchange)
 				.switchIfEmpty(Mono.defer(() -> currentServerWebExchange()))
-				.flatMap(exchange -> this.authorizedClientRepository.loadAuthorizedClient(clientRegistrationId, principal, exchange));
+				.map(Optional::of)
+				.defaultIfEmpty(Optional.empty())
+				.flatMap(exchange -> this.authorizedClientRepository.loadAuthorizedClient(
+						clientRegistrationId, principal, exchange.orElse(null)));
 	}
 
 	private Mono<OAuth2AuthorizedClient> saveAuthorizedClient(OAuth2AuthorizedClient authorizedClient, Authentication principal, ServerWebExchange serverWebExchange) {
 		return Mono.justOrEmpty(serverWebExchange)
 				.switchIfEmpty(Mono.defer(() -> currentServerWebExchange()))
-				.flatMap(exchange -> this.authorizedClientRepository.saveAuthorizedClient(authorizedClient, principal, exchange)
+				.map(Optional::of)
+				.defaultIfEmpty(Optional.empty())
+				.flatMap(exchange -> this.authorizedClientRepository.saveAuthorizedClient(
+						authorizedClient, principal, exchange.orElse(null))
 						.thenReturn(authorizedClient))
 				.defaultIfEmpty(authorizedClient);
 	}


### PR DESCRIPTION
Previously saveAuthorizedClient  and loadAuthorizedClient would not save nor load the authorized client when no current serverWebExchange was available. In case of the UnAuthenticatedServerOAuth2AuthorizedClientRepository it is however nescessary for the save and load call to also happen without and exchange.

I'm not entirely certain about the impact of the behavior change I introduced in the test `authorizeWhenNotAuthorizedAndSupportedProviderAndExchangeUnavailableThenAuthorizedButNotSaved` -> `authorizeWhenNotAuthorizedAndSupportedProviderAndExchangeUnavailableThenAuthorizedAndSaved`

Please verify

Fixes #7544 

I have signed the CLA