### PR TITLE
Restore Removed Throws Clauses

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/AbstractConfiguredSecurityBuilder.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/AbstractConfiguredSecurityBuilder.java
@@ -343,7 +343,7 @@ public abstract class AbstractConfiguredSecurityBuilder<O, B extends SecurityBui
 	 * method. Subclasses may override this method to hook into the lifecycle without
 	 * using a {@link SecurityConfigurer}.
 	 */
-	protected void beforeInit() {
+	protected void beforeInit() throws Exception {
 	}
 
 	/**

--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/builders/AuthenticationManagerBuilder.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/builders/AuthenticationManagerBuilder.java
@@ -228,7 +228,7 @@ public class AuthenticationManagerBuilder
 	}
 
 	@Override
-	protected ProviderManager performBuild() {
+	protected ProviderManager performBuild() throws Exception {
 		if (!isConfigured()) {
 			logger.debug("No authenticationProviders and no parentAuthenticationManager defined. Returning null.");
 			return null;

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurerAdapter.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurerAdapter.java
@@ -331,7 +331,7 @@ public abstract class WebSecurityConfigurerAdapter implements
 	 * Override this method to configure {@link WebSecurity}. For example, if you wish to
 	 * ignore certain requests.
 	 */
-	public void configure(WebSecurity web) {
+	public void configure(WebSecurity web) throws Exception {
 	}
 
 	/**

--- a/core/src/main/java/org/springframework/security/authentication/dao/AbstractUserDetailsAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/dao/AbstractUserDetailsAuthenticationProvider.java
@@ -228,7 +228,7 @@ public abstract class AbstractUserDetailsAuthenticationProvider implements
 		return result;
 	}
 
-	protected void doAfterPropertiesSet() {
+	protected void doAfterPropertiesSet() throws Exception {
 	}
 
 	public UserCache getUserCache() {

--- a/core/src/main/java/org/springframework/security/authentication/jaas/JaasAuthenticationCallbackHandler.java
+++ b/core/src/main/java/org/springframework/security/authentication/jaas/JaasAuthenticationCallbackHandler.java
@@ -16,9 +16,11 @@
 
 package org.springframework.security.authentication.jaas;
 
-import org.springframework.security.core.Authentication;
-
+import java.io.IOException;
 import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+
+import org.springframework.security.core.Authentication;
 
 /**
  * The JaasAuthenticationCallbackHandler is similar to the
@@ -58,5 +60,6 @@ public interface JaasAuthenticationCallbackHandler {
 	 * @param auth The Authentication object currently being authenticated.
 	 *
 	 */
-	void handle(Callback callback, Authentication auth);
+	void handle(Callback callback, Authentication auth) throws IOException,
+			UnsupportedCallbackException;
 }

--- a/remoting/src/main/java/org/springframework/security/remoting/httpinvoker/AuthenticationSimpleHttpInvokerRequestExecutor.java
+++ b/remoting/src/main/java/org/springframework/security/remoting/httpinvoker/AuthenticationSimpleHttpInvokerRequestExecutor.java
@@ -58,7 +58,8 @@ public class AuthenticationSimpleHttpInvokerRequestExecutor extends
 	 * @param contentLength the length of the content to send
 	 *
 	 */
-	protected void doPrepareConnection(HttpURLConnection con, int contentLength) {
+	protected void doPrepareConnection(HttpURLConnection con, int contentLength)
+			throws IOException {
 	}
 
 	/**

--- a/web/src/main/java/org/springframework/security/web/access/channel/ChannelEntryPoint.java
+++ b/web/src/main/java/org/springframework/security/web/access/channel/ChannelEntryPoint.java
@@ -17,7 +17,7 @@
 package org.springframework.security.web.access.channel;
 
 import java.io.IOException;
-
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -47,5 +47,5 @@ public interface ChannelEntryPoint {
 	 *
 	 */
 	void commence(HttpServletRequest request, HttpServletResponse response)
-			throws IOException;
+			throws IOException, ServletException;
 }

--- a/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.java
@@ -280,7 +280,8 @@ public abstract class AbstractAuthenticationProcessingFilter extends GenericFilt
 	 * @throws AuthenticationException if authentication fails.
 	 */
 	public abstract Authentication attemptAuthentication(HttpServletRequest request,
-			HttpServletResponse response) throws AuthenticationException, IOException;
+			HttpServletResponse response) throws AuthenticationException, IOException,
+			ServletException;
 
 	/**
 	 * Default behaviour for successful authentication.

--- a/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationTargetUrlRequestHandler.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationTargetUrlRequestHandler.java
@@ -16,12 +16,13 @@
 package org.springframework.security.web.authentication;
 
 import java.io.IOException;
-
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.DefaultRedirectStrategy;
 import org.springframework.security.web.RedirectStrategy;
@@ -78,7 +79,7 @@ public abstract class AbstractAuthenticationTargetUrlRequestHandler {
 	 * The redirect will not be performed if the response has already been committed.
 	 */
 	protected void handle(HttpServletRequest request, HttpServletResponse response,
-			Authentication authentication) throws IOException {
+			Authentication authentication) throws IOException, ServletException {
 		String targetUrl = determineTargetUrl(request, response, authentication);
 
 		if (response.isCommitted()) {

--- a/web/src/main/java/org/springframework/security/web/authentication/LoginUrlAuthenticationEntryPoint.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/LoginUrlAuthenticationEntryPoint.java
@@ -211,7 +211,8 @@ public class LoginUrlAuthenticationEntryPoint implements AuthenticationEntryPoin
 	 * Builds a URL to redirect the supplied request to HTTPS. Used to redirect the
 	 * current request to HTTPS, before doing a forward to the login page.
 	 */
-	protected String buildHttpsRedirectUrlForRequest(HttpServletRequest request) {
+	protected String buildHttpsRedirectUrlForRequest(HttpServletRequest request)
+			throws IOException, ServletException {
 
 		int serverPort = portResolver.getServerPort(request);
 		Integer httpsPort = portMapper.lookupHttpsPort(serverPort);

--- a/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilter.java
@@ -244,11 +244,11 @@ public class BasicAuthenticationFilter extends OncePerRequestFilter {
 	}
 
 	protected void onSuccessfulAuthentication(HttpServletRequest request,
-			HttpServletResponse response, Authentication authResult) {
+			HttpServletResponse response, Authentication authResult) throws IOException {
 	}
 
 	protected void onUnsuccessfulAuthentication(HttpServletRequest request,
-			HttpServletResponse response, AuthenticationException failed) {
+			HttpServletResponse response, AuthenticationException failed) throws IOException {
 	}
 
 	protected AuthenticationEntryPoint getAuthenticationEntryPoint() {

--- a/web/src/main/java/org/springframework/security/web/session/InvalidSessionStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/session/InvalidSessionStrategy.java
@@ -15,9 +15,10 @@
  */
 package org.springframework.security.web.session;
 
+import java.io.IOException;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 
 /**
  * Determines the behaviour of the {@code SessionManagementFilter} when an invalid session
@@ -28,6 +29,6 @@ import java.io.IOException;
 public interface InvalidSessionStrategy {
 
 	void onInvalidSessionDetected(HttpServletRequest request, HttpServletResponse response)
-			throws IOException;
+			throws IOException, ServletException;
 
 }

--- a/web/src/main/java/org/springframework/security/web/session/SessionInformationExpiredStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/session/SessionInformationExpiredStrategy.java
@@ -16,6 +16,7 @@
 package org.springframework.security.web.session;
 
 import java.io.IOException;
+import javax.servlet.ServletException;
 
 /**
  * Determines the behaviour of the {@code ConcurrentSessionFilter} when an expired session
@@ -28,5 +29,5 @@ import java.io.IOException;
 public interface SessionInformationExpiredStrategy {
 
 	void onExpiredSessionDetected(SessionInformationExpiredEvent event)
-			throws IOException;
+			throws IOException, ServletException;
 }


### PR DESCRIPTION
In a recent clean-up, certain exceptions were removed from various
throws clauses.

This PR re-introduces throws clauses that are important for one of the
following reasons:

1. It's a method on a public interface
2. It's a method clearly designed for inheritance, for example, a
method stub, an abstract method, or indicated as such in the docs.

Fixes gh-7541

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
