### PR TITLE
Back compatibility support for object_id_identity

### DIFF
--- a/acl/src/test/java/org/springframework/security/acls/jdbc/AclClassIdUtilsTest.java
+++ b/acl/src/test/java/org/springframework/security/acls/jdbc/AclClassIdUtilsTest.java
@@ -24,6 +24,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.convert.ConversionService;
 
 import java.io.Serializable;
+import java.math.BigInteger;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.UUID;
@@ -40,6 +41,7 @@ public class AclClassIdUtilsTest {
 
 	private static final Long DEFAULT_IDENTIFIER = 999L;
 	private static final String DEFAULT_IDENTIFIER_AS_STRING = DEFAULT_IDENTIFIER.toString();
+	private static final BigInteger DEFAULT_IDENTIFIER_AS_BIGINT = BigInteger.valueOf( DEFAULT_IDENTIFIER );
 
 	@Mock
 	private ResultSet resultSet;
@@ -69,6 +71,15 @@ public class AclClassIdUtilsTest {
 
 		// when
 		Serializable newIdentifier = aclClassIdUtils.identifierFrom(DEFAULT_IDENTIFIER_AS_STRING, resultSet);
+
+		// then
+		assertThat(newIdentifier).isEqualTo(DEFAULT_IDENTIFIER);
+	}
+
+	@Test
+	public void shouldReturnLongIfIdentifierIsBigInteger() throws SQLException {
+		// when
+		Serializable newIdentifier = aclClassIdUtils.identifierFrom(DEFAULT_IDENTIFIER_AS_BIGINT, resultSet);
 
 		// then
 		assertThat(newIdentifier).isEqualTo(DEFAULT_IDENTIFIER);


### PR DESCRIPTION
Back compatibility is broken in case of data models where the object_id_identity is of type `BIGINT`. In order to add support for this type, the `AclClassIdUtils` class is modified to support the conversion of the BigInteger type to Long.

https://github.com/spring-projects/spring-security/issues/7621
