### PR TITLE
Remove  unnecessary and inefficiency code

### DIFF
--- a/core/src/main/java/org/springframework/security/access/expression/SecurityExpressionRoot.java
+++ b/core/src/main/java/org/springframework/security/access/expression/SecurityExpressionRoot.java
@@ -158,7 +158,6 @@ public abstract class SecurityExpressionRoot implements SecurityExpressionOperat
 
 	private Set<String> getAuthoritySet() {
 		if (roles == null) {
-			roles = new HashSet<>();
 			Collection<? extends GrantedAuthority> userAuthorities = authentication
 					.getAuthorities();
 

--- a/core/src/main/java/org/springframework/security/access/expression/SecurityExpressionRoot.java
+++ b/core/src/main/java/org/springframework/security/access/expression/SecurityExpressionRoot.java
@@ -17,7 +17,6 @@ package org.springframework.security.access.expression;
 
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.springframework.security.access.PermissionEvaluator;


### PR DESCRIPTION
Code:

        private Set<String> getAuthoritySet() {
		if (roles == null) {
			roles = new HashSet<>();
			Collection<? extends GrantedAuthority> userAuthorities = authentication
					.getAuthorities();

			if (roleHierarchy != null) {
				userAuthorities = roleHierarchy
						.getReachableGrantedAuthorities(userAuthorities);
			}

			roles = AuthorityUtils.authorityListToSet(userAuthorities);
		}

		return roles;
	}

The "roles = new HashSet<>();" is  unnecessary and inefficiency.
Hope it can be modified.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
