### PR TITLE
Fix typo in log message in GlobalMethodSecurityBeanDefinitionParser.java.

### DIFF
--- a/config/src/main/java/org/springframework/security/config/method/GlobalMethodSecurityBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/method/GlobalMethodSecurityBeanDefinitionParser.java
@@ -208,7 +208,7 @@ public class GlobalMethodSecurityBeanDefinitionParser implements BeanDefinitionP
 					pc.registerBeanComponent(new BeanComponentDefinition(
 							expressionHandler, expressionHandlerRef));
 					logger.info("Expressions were enabled for method security but no SecurityExpressionHandler was configured. "
-							+ "All hasPermision() expressions will evaluate to false.");
+							+ "All hasPermission() expressions will evaluate to false.");
 				}
 
 				BeanDefinitionBuilder expressionPreAdviceBldr = BeanDefinitionBuilder


### PR DESCRIPTION
Fix a simple typo in a log message. See issue https://github.com/spring-projects/spring-security/issues/7658