### PR TITLE
Deserialize details field in UsernamePasswordAuthenticationToken

### DIFF
--- a/core/src/main/java/org/springframework/security/jackson2/UsernamePasswordAuthenticationTokenDeserializer.java
+++ b/core/src/main/java/org/springframework/security/jackson2/UsernamePasswordAuthenticationTokenDeserializer.java
@@ -87,7 +87,8 @@ class UsernamePasswordAuthenticationTokenDeserializer extends JsonDeserializer<U
 		if (detailsNode.isNull() || detailsNode.isMissingNode()) {
 			token.setDetails(null);
 		} else {
-			token.setDetails(detailsNode);
+			Object details = mapper.readValue(detailsNode.toString(), new TypeReference<Object>() {});
+			token.setDetails(details);
 		}
 		return token;
 	}

--- a/core/src/test/java/org/springframework/security/jackson2/UsernamePasswordAuthenticationTokenMixinTests.java
+++ b/core/src/test/java/org/springframework/security/jackson2/UsernamePasswordAuthenticationTokenMixinTests.java
@@ -168,7 +168,7 @@ public class UsernamePasswordAuthenticationTokenMixinTests extends AbstractMixin
 		assertThat(((User) token.getPrincipal()).getAuthorities()).isNotNull().hasSize(1).contains(new SimpleGrantedAuthority("ROLE_USER"));
 		assertThat(token.isAuthenticated()).isEqualTo(true);
 		assertThat(token.getAuthorities()).hasSize(1).contains(new SimpleGrantedAuthority("ROLE_USER"));
-		assertThat(token.getDetails()).isExactlyInstanceOf(String.class);
+		assertThat(token.getDetails()).isExactlyInstanceOf(String.class).isEqualTo("details");
 	}
 
 	@Test

--- a/core/src/test/java/org/springframework/security/jackson2/UsernamePasswordAuthenticationTokenMixinTests.java
+++ b/core/src/test/java/org/springframework/security/jackson2/UsernamePasswordAuthenticationTokenMixinTests.java
@@ -65,6 +65,10 @@ public class UsernamePasswordAuthenticationTokenMixinTests extends AbstractMixin
 	// @formatter:on
 
 	// @formatter:off
+	private static final String AUTHENTICATED_STRINGDETAILS_JSON = AUTHENTICATED_JSON.replace("\"details\": null, ", "\"details\": \"details\", ");
+	// @formatter:on
+
+	// @formatter:off
 	private static final String AUTHENTICATED_NON_USER_PRINCIPAL_JSON = AUTHENTICATED_JSON
 		.replace(UserDeserializerTests.USER_JSON, NON_USER_PRINCIPAL_JSON)
 		.replaceAll(UserDeserializerTests.USER_PASSWORD, "null")
@@ -153,6 +157,18 @@ public class UsernamePasswordAuthenticationTokenMixinTests extends AbstractMixin
 			.readValue(AUTHENTICATED_NON_USER_PRINCIPAL_JSON, UsernamePasswordAuthenticationToken.class);
 		assertThat(token).isNotNull();
 		assertThat(token.getPrincipal()).isNotNull().isInstanceOf(NonUserPrincipal.class);
+	}
+
+	@Test
+	public void deserializeAuthenticatedUsernamePasswordAuthenticationTokenWithDetailsTest() throws IOException {
+		UsernamePasswordAuthenticationToken token = mapper
+				.readValue(AUTHENTICATED_STRINGDETAILS_JSON, UsernamePasswordAuthenticationToken.class);
+		assertThat(token).isNotNull();
+		assertThat(token.getPrincipal()).isNotNull().isInstanceOf(User.class);
+		assertThat(((User) token.getPrincipal()).getAuthorities()).isNotNull().hasSize(1).contains(new SimpleGrantedAuthority("ROLE_USER"));
+		assertThat(token.isAuthenticated()).isEqualTo(true);
+		assertThat(token.getAuthorities()).hasSize(1).contains(new SimpleGrantedAuthority("ROLE_USER"));
+		assertThat(token.getDetails()).isExactlyInstanceOf(String.class);
 	}
 
 	@Test


### PR DESCRIPTION
Before this commit, the details field was set to a JsonNode, but now it is deserialized correctly.

Fixes gh-7482

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
