### PR TITLE
Fix InitializeAuthenticationProviderBeanManagerConfigurer Javadoc

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeAuthenticationProviderBeanManagerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeAuthenticationProviderBeanManagerConfigurer.java
@@ -19,13 +19,11 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 /**
- * Lazily initializes the global authentication with a {@link UserDetailsService} if it is
- * not yet configured and there is only a single Bean of that type. Optionally, if a
- * {@link PasswordEncoder} is defined will wire this up too.
+ * Lazily initializes the global authentication with an {@link AuthenticationProvider} if it is
+ * not yet configured and there is only a single Bean of that type.
  *
  * @author Rob Winch
  * @since 4.1

--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeAuthenticationProviderBeanManagerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeAuthenticationProviderBeanManagerConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 /**
  * Lazily initializes the global authentication with an {@link AuthenticationProvider} if it is
@@ -47,10 +46,10 @@ class InitializeAuthenticationProviderBeanManagerConfigurer
 
 	@Override
 	public void init(AuthenticationManagerBuilder auth) throws Exception {
-		auth.apply(new InitializeUserDetailsManagerConfigurer());
+		auth.apply(new InitializeAuthenticationProviderManagerConfigurer());
 	}
 
-	class InitializeUserDetailsManagerConfigurer
+	class InitializeAuthenticationProviderManagerConfigurer
 			extends GlobalAuthenticationConfigurerAdapter {
 		@Override
 		public void configure(AuthenticationManagerBuilder auth) {
@@ -68,17 +67,17 @@ class InitializeAuthenticationProviderBeanManagerConfigurer
 		}
 
 		/**
-		 * @return
+		 * @return a bean of the requested class if there's just a single registered component, null otherwise.
 		 */
 		private <T> T getBeanOrNull(Class<T> type) {
-			String[] userDetailsBeanNames = InitializeAuthenticationProviderBeanManagerConfigurer.this.context
+			String[] beanNames = InitializeAuthenticationProviderBeanManagerConfigurer.this.context
 					.getBeanNamesForType(type);
-			if (userDetailsBeanNames.length != 1) {
+			if (beanNames.length != 1) {
 				return null;
 			}
 
 			return InitializeAuthenticationProviderBeanManagerConfigurer.this.context
-					.getBean(userDetailsBeanNames[0], type);
+					.getBean(beanNames[0], type);
 		}
 	}
 }

--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeUserDetailsBeanManagerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeUserDetailsBeanManagerConfigurer.java
@@ -85,14 +85,14 @@ class InitializeUserDetailsBeanManagerConfigurer
 		 * @return a bean of the requested class if there's just a single registered component, null otherwise.
 		 */
 		private <T> T getBeanOrNull(Class<T> type) {
-			String[] userDetailsBeanNames = InitializeUserDetailsBeanManagerConfigurer.this.context
+			String[] beanNames = InitializeUserDetailsBeanManagerConfigurer.this.context
 					.getBeanNamesForType(type);
-			if (userDetailsBeanNames.length != 1) {
+			if (beanNames.length != 1) {
 				return null;
 			}
 
 			return InitializeUserDetailsBeanManagerConfigurer.this.context
-					.getBean(userDetailsBeanNames[0], type);
+					.getBean(beanNames[0], type);
 		}
 	}
 }


### PR DESCRIPTION
Currently the javadoc of class `InitializeAuthenticationProviderBeanManagerConfigurer` is copy-pasted from `InitializeUserDetailsBeanManagerConfigurer`. This PR just fixes the Javadoc and removes an unnecessary import.

This also fixes copy-pasted class and variable names in `InitializeAuthenticationProviderBeanManagerConfigurer` class and also fixes variable name in `InitializeUserDetailsBeanManagerConfigurer`: `userDetailsBeanNames` -> `beanNames` as the names returned for bean type that depends on method parameter and they are not always `UserDetailsService` type (the method `getBeanOrNull` is called several times with different 'type' argument actually).