### PR TITLE
Update @MessageMapping to match input/output cardinality

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/rsocket/RSocketMessageHandlerITests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/rsocket/RSocketMessageHandlerITests.java
@@ -186,19 +186,6 @@ public class RSocketMessageHandlerITests {
 	}
 
 	@Test
-	public void retrieveFluxWhenDataStringAndPublicThenGranted() throws Exception {
-		String data = "a";
-		List<String> hi = this.requester.route("retrieve-flux")
-				.data(data)
-				.retrieveFlux(String.class)
-				.collectList()
-				.block();
-
-		assertThat(hi).contains("hello a");
-		assertThat(this.controller.payloads).containsOnly(data);
-	}
-
-	@Test
 	public void sendWhenSecureThenDenied() throws Exception {
 		String data = "hi";
 		this.requester.route("secure.send")
@@ -287,7 +274,7 @@ public class RSocketMessageHandlerITests {
 		}
 
 		@MessageMapping({"secure.send", "send"})
-		Mono<Void> send(Flux<String> payload) {
+		Mono<Void> send(Mono<String> payload) {
 			return payload
 					.doOnNext(this::add)
 					.then(Mono.fromRunnable(() -> {


### PR DESCRIPTION
This commit fixes the tests failures when using spring version `5.2.2.BUILD-SNAPSHOT`.

This [Spring Framework issue](https://github.com/spring-projects/spring-framework/issues/23999), 
> refines each @MessageMapping to match only the RSocket interaction type it fits based on the input and output cardinality of the handler method.

After the commit that fixes the above issue, the test `retrieveFluxWhenDataStringAndPublicThenGranted ` is invalid because the destination `"retrieve-flux"` does not support `REQUEST_STREAM`, and only support `REQUEST_CHANNEL`, since the input cardinality is 2. 

Additionally, the destination `"send"` was not being used in the test `sendWhenPublicThenGranted` because it the provided input of cardinality 1 did not match the expect `Flux` input of cardinality 2.