### PR TITLE
Correctly configure authorization requests repository for OAuth2 login

### DIFF
--- a/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
@@ -1084,7 +1084,9 @@ public class ServerHttpSecurity {
 
 		private ServerAuthenticationConverter getAuthenticationConverter(ReactiveClientRegistrationRepository clientRegistrationRepository) {
 			if (this.authenticationConverter == null) {
-				this.authenticationConverter = new ServerOAuth2AuthorizationCodeAuthenticationTokenConverter(clientRegistrationRepository);
+				ServerOAuth2AuthorizationCodeAuthenticationTokenConverter authenticationConverter = new ServerOAuth2AuthorizationCodeAuthenticationTokenConverter(clientRegistrationRepository);
+				authenticationConverter.setAuthorizationRequestRepository(getAuthorizationRequestRepository());
+				this.authenticationConverter = authenticationConverter;
 			}
 			return this.authenticationConverter;
 		}


### PR DESCRIPTION
To use custom `ServerAuthorizationRequestRepository` both `OAuth2AuthorizationRequestRedirectWebFilter` and `OAuth2LoginAuthenticationWebFilter` should use the same repo provided in the configuration. Currently the former filter is correctly configured, but the latter always uses default, WebSession based repository. So authorization code created before redirect to authorization endpoint will never be found to complete OAuth2 login when custom `ServerAuthorizationRequestRepository` is used.

This change also makes OAuth2Client and OAuth2Login authentication converters consistent.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
