### PR TITLE
fix: make Saml2Authentication serializable

### DIFF
--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/OpenSamlAuthenticationProvider.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/OpenSamlAuthenticationProvider.java
@@ -178,7 +178,7 @@ public final class OpenSamlAuthenticationProvider implements AuthenticationProvi
 			Assertion assertion = validateSaml2Response(token, token.getRecipientUri(), samlResponse);
 			String username = getUsername(token, assertion);
 			return new Saml2Authentication(
-					() -> username, token.getSaml2Response(),
+					new SimpleSaml2AuthenticatedPrincipal(username), token.getSaml2Response(),
 					this.authoritiesMapper.mapAuthorities(getAssertionAuthorities(assertion))
 			);
 		} catch (Saml2AuthenticationException e) {

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/Saml2AuthenticatedPrincipal.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/Saml2AuthenticatedPrincipal.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.provider.service.authentication;
+
+import org.springframework.security.core.AuthenticatedPrincipal;
+
+/**
+ * Saml2 representation of an {@link AuthenticatedPrincipal}.
+ *
+ * @author Clement Stoquart
+ * @since 5.3
+ */
+public interface Saml2AuthenticatedPrincipal extends AuthenticatedPrincipal {
+}

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/SimpleSaml2AuthenticatedPrincipal.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/SimpleSaml2AuthenticatedPrincipal.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.provider.service.authentication;
+
+import java.io.Serializable;
+
+/**
+ * Default implementation of a {@link Saml2AuthenticatedPrincipal}.
+ *
+ * @author Clement Stoquart
+ * @since 5.3
+ */
+class SimpleSaml2AuthenticatedPrincipal implements Saml2AuthenticatedPrincipal, Serializable {
+
+	private final String name;
+
+	SimpleSaml2AuthenticatedPrincipal(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public String getName() {
+		return this.name;
+	}
+}

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/SimpleSaml2AuthenticatedPrincipalTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/SimpleSaml2AuthenticatedPrincipalTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.provider.service.authentication;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SimpleSaml2AuthenticatedPrincipalTests {
+
+	@Test
+	public void createSimpleSaml2AuthenticatedPrincipal() {
+		SimpleSaml2AuthenticatedPrincipal principal = new SimpleSaml2AuthenticatedPrincipal("user");
+
+		Assert.assertEquals("user", principal.getName());
+	}
+}


### PR DESCRIPTION
Fix https://github.com/spring-projects/spring-security/issues/7681