### PR TITLE
Don't cache requests with `Accept: text/event-stream` by default.

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurer.java
@@ -162,6 +162,7 @@ public final class RequestCacheConfigurer<H extends HttpSecurityBuilder<H>> exte
 		matchers.add(notMatchingMediaType(http, MediaType.APPLICATION_JSON));
 		matchers.add(notXRequestedWith);
 		matchers.add(notMatchingMediaType(http, MediaType.MULTIPART_FORM_DATA));
+		matchers.add(notMatchingMediaType(http, MediaType.TEXT_EVENT_STREAM));
 
 		return new AndRequestMatcher(matchers);
 	}

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurerTests.java
@@ -183,6 +183,21 @@ public class RequestCacheConfigurerTests {
 
 		//  This is desirable since XHR requests are typically not invoked directly from the browser and we don't want the browser to replay them
 	}
+	@Test
+	public void getWhenBookmarkedRequestIsTextEventStreamThenPostAuthenticationRedirectsToRoot() throws Exception {
+		this.spring.register(RequestCacheDefaultsConfig.class, DefaultSecurityConfig.class).autowire();
+
+		MockHttpSession session = (MockHttpSession)
+				this.mvc.perform(get("/messages")
+						.header(HttpHeaders.ACCEPT, MediaType.TEXT_EVENT_STREAM))
+						.andExpect(redirectedUrl("http://localhost/login"))
+						.andReturn().getRequest().getSession();
+
+		this.mvc.perform(formLogin(session))
+				.andExpect(redirectedUrl("/")); // ignores text/event-stream
+
+		//  This is desirable since event-stream requests are typically not invoked directly from the browser and we don't want the browser to replay them
+	}
 
 	@Test
 	public void getWhenBookmarkedRequestIsAllMediaTypeThenPostAuthenticationRemembers() throws Exception {


### PR DESCRIPTION
The eventstream requests is typically not directly invoked by the browser.
And even more unfortunately the browser api for `Eventsource` doesn't allow the set additional headers as `X-Requested-With: XMLHttpRequest`..

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
