### PR TITLE
Simplify customizing OAuth2AuthorizationRequest

### DIFF
--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthorizationRequestMixinTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthorizationRequestMixinTests.java
@@ -27,6 +27,7 @@ import org.springframework.security.oauth2.core.endpoint.TestOAuth2Authorization
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -70,8 +71,8 @@ public class OAuth2AuthorizationRequestMixinTests {
 				this.authorizationRequestBuilder
 						.scopes(null)
 						.state(null)
-						.additionalParameters(null)
-						.attributes(null)
+						.additionalParameters(Collections.emptyMap())
+						.attributes(Collections.emptyMap())
 						.build();
 		String expectedJson = asJson(authorizationRequest);
 		String json = this.mapper.writeValueAsString(authorizationRequest);
@@ -118,8 +119,8 @@ public class OAuth2AuthorizationRequestMixinTests {
 				this.authorizationRequestBuilder
 						.scopes(null)
 						.state(null)
-						.additionalParameters(null)
-						.attributes(null)
+						.additionalParameters(Collections.emptyMap())
+						.attributes(Collections.emptyMap())
 						.build();
 		String json = asJson(expectedAuthorizationRequest);
 		OAuth2AuthorizationRequest authorizationRequest = this.mapper.readValue(json, OAuth2AuthorizationRequest.class);

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/OAuth2AuthorizationRequestTests.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/OAuth2AuthorizationRequestTests.java
@@ -18,13 +18,16 @@ package org.springframework.security.oauth2.core.endpoint;
 import org.junit.Test;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for {@link OAuth2AuthorizationRequest}.
@@ -126,7 +129,7 @@ public class OAuth2AuthorizationRequestTests {
 					.redirectUri(REDIRECT_URI)
 					.scopes(SCOPES)
 					.state(STATE)
-					.additionalParameters(null)
+					.additionalParameters((Map) null)
 					.build())
 				.doesNotThrowAnyException();
 	}
@@ -216,6 +219,19 @@ public class OAuth2AuthorizationRequestTests {
 				.scopes(SCOPES)
 				.state(STATE)
 				.authorizationRequestUri(AUTHORIZATION_URI)
+				.build();
+		assertThat(authorizationRequest.getAuthorizationRequestUri()).isEqualTo(AUTHORIZATION_URI);
+	}
+
+	@Test
+	public void buildWhenAuthorizationRequestUriFunctionSetThenOverridesDefault() {
+		OAuth2AuthorizationRequest authorizationRequest = OAuth2AuthorizationRequest.authorizationCode()
+				.authorizationUri(AUTHORIZATION_URI)
+				.clientId(CLIENT_ID)
+				.redirectUri(REDIRECT_URI)
+				.scopes(SCOPES)
+				.state(STATE)
+				.authorizationRequestUri(uriBuilder -> URI.create(AUTHORIZATION_URI))
 				.build();
 		assertThat(authorizationRequest.getAuthorizationRequestUri()).isEqualTo(AUTHORIZATION_URI);
 	}


### PR DESCRIPTION
The `OAuth2AuthorizationRequestResolver` provides the ability to customize the Authorization Request using a [delegation-based strategy](https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#customizing-the-authorization-request).

Although this strategy could fulfill most (if not all) use cases, it does require some extra configuration that may not be as convenient compared to directly _"hooking"_ into the `OAuth2AuthorizationRequest.Builder` for customizations.

This PR addresses this by introducing a `Consumer<OAuth2AuthorizationRequest.Builder>` in `DefaultOAuth2AuthorizationRequestResolver`.

Fixes gh-7696

Related #7714 
