### PR TITLE
Resolve JavaType only once for whitelisted class

### DIFF
--- a/core/src/main/java/org/springframework/security/jackson2/SecurityJackson2Modules.java
+++ b/core/src/main/java/org/springframework/security/jackson2/SecurityJackson2Modules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -225,7 +225,7 @@ public final class SecurityJackson2Modules {
 			JavaType result = delegate.typeFromId(context, id);
 			String className = result.getRawClass().getName();
 			if (isWhitelisted(className)) {
-				return delegate.typeFromId(context, id);
+				return result;
 			}
 			boolean isExplicitMixin = config.findMixInClassFor(result.getRawClass()) != null;
 			if (isExplicitMixin) {


### PR DESCRIPTION
### Summary

The Jackson 2 `JavaType` is unnecessarily resolved twice when a class is whitelisted. This should be the most likely case. The delegate doing this may be a `ClassNameIdResolver` whose operations seem rather complex, so it would be a good idea to avoid a call.

### Actual Behavior

JavaTypes are resolved twice for a whitelisted class.

### Expected Behavior

JavaTypes are resolved only once for a whitelisted class.