### PR TITLE
Set secure on cookie when logging out

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/logout/CookieClearingLogoutHandler.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/logout/CookieClearingLogoutHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/springframework/security/web/authentication/logout/CookieClearingLogoutHandler.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/logout/CookieClearingLogoutHandler.java
@@ -32,6 +32,7 @@ import org.springframework.util.Assert;
  * - A given list of Cookies
  *
  * @author Luke Taylor
+ * @author Onur Kagan Ozcan
  * @since 3.1
  */
 public final class CookieClearingLogoutHandler implements LogoutHandler {
@@ -46,6 +47,7 @@ public final class CookieClearingLogoutHandler implements LogoutHandler {
 				String cookiePath = request.getContextPath() + "/";
 				cookie.setPath(cookiePath);
 				cookie.setMaxAge(0);
+				cookie.setSecure(request.isSecure());
 				return cookie;
 			};
 			cookieList.add(f);

--- a/web/src/test/java/org/springframework/security/web/authentication/logout/CookieClearingLogoutHandlerTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/logout/CookieClearingLogoutHandlerTests.java
@@ -75,6 +75,18 @@ public class CookieClearingLogoutHandlerTests {
 	}
 
 	@Test
+	public void configuredCookieIsNotSecure() {
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setSecure(false);
+		request.setContextPath("/app");
+		CookieClearingLogoutHandler handler = new CookieClearingLogoutHandler("my_cookie");
+		handler.logout(request, response, mock(Authentication.class));
+		assertThat(response.getCookies()).hasSize(1);
+		assertThat(response.getCookies()[0].getSecure()).isFalse();
+	}
+
+	@Test
 	public void passedInCookiesAreCleared() {
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		MockHttpServletRequest request = new MockHttpServletRequest();

--- a/web/src/test/java/org/springframework/security/web/authentication/logout/CookieClearingLogoutHandlerTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/logout/CookieClearingLogoutHandlerTests.java
@@ -27,6 +27,7 @@ import org.springframework.security.core.Authentication;
 
 /**
  * @author Luke Taylor
+ * @author Onur Kagan Ozcan
  */
 public class CookieClearingLogoutHandlerTests {
 
@@ -59,6 +60,18 @@ public class CookieClearingLogoutHandlerTests {
 			assertThat(c.getPath()).isEqualTo("/app/");
 			assertThat(c.getMaxAge()).isZero();
 		}
+	}
+
+	@Test
+	public void configuredCookieIsSecure() {
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setSecure(true);
+		request.setContextPath("/app");
+		CookieClearingLogoutHandler handler = new CookieClearingLogoutHandler("my_cookie");
+		handler.logout(request, response, mock(Authentication.class));
+		assertThat(response.getCookies()).hasSize(1);
+		assertThat(response.getCookies()[0].getSecure()).isTrue();
 	}
 
 	@Test

--- a/web/src/test/java/org/springframework/security/web/authentication/logout/CookieClearingLogoutHandlerTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/logout/CookieClearingLogoutHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
It is better to mark cookie secure flag with request.isSecure() to ensure cookie identity is same

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
