### PR TITLE
Fix return type of method AbstractConfiguredSecurityBuilder.objectPostProcessor()

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/AbstractConfiguredSecurityBuilder.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/AbstractConfiguredSecurityBuilder.java
@@ -286,10 +286,10 @@ public abstract class AbstractConfiguredSecurityBuilder<O, B extends SecurityBui
 	 * @return the {@link SecurityBuilder} for further customizations
 	 */
 	@SuppressWarnings("unchecked")
-	public O objectPostProcessor(ObjectPostProcessor<Object> objectPostProcessor) {
+	public B objectPostProcessor(ObjectPostProcessor<Object> objectPostProcessor) {
 		Assert.notNull(objectPostProcessor, "objectPostProcessor cannot be null");
 		this.objectPostProcessor = objectPostProcessor;
-		return (O) this;
+		return (B) this;
 	}
 
 	/**


### PR DESCRIPTION
The return type of the method AbstractConfiguredSecurityBuilder.objectPostProcessor() is wrong.
As mentioned in the Javadoc, the method returns the SecurityBuilder for further customizations.

```
/**
 * @param <O> The object that this builder returns
 * @param <B> The type of this builder (that is returned by the base class)
 */
public abstract class AbstractConfiguredSecurityBuilder<O, B extends SecurityBuilder<O>>
		extends AbstractSecurityBuilder<O> {
}
```
