### PR TITLE
Fix unchecked assignment and possible NPE

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/reactive/oauth2/resource-server.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/reactive/oauth2/resource-server.adoc
@@ -454,10 +454,11 @@ static class GrantedAuthoritiesExtractor
         implements Converter<Jwt, Collection<GrantedAuthority>> {
 
     public Collection<GrantedAuthority> convert(Jwt jwt) {
-        Collection<String> authorities = (Collection<String>)
-                jwt.getClaims().get("mycustomclaim");
+        Collection<?> authorities = (Collection<?>)
+	        jwt.getClaims().getOrDefault("mycustomclaim", Collections.emptyList());
 
         return authorities.stream()
+	        .map(Object::toString)
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
     }

--- a/docs/manual/src/docs/asciidoc/_includes/reactive/oauth2/resource-server.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/reactive/oauth2/resource-server.adoc
@@ -455,10 +455,10 @@ static class GrantedAuthoritiesExtractor
 
     public Collection<GrantedAuthority> convert(Jwt jwt) {
         Collection<?> authorities = (Collection<?>)
-	        jwt.getClaims().getOrDefault("mycustomclaim", Collections.emptyList());
+                jwt.getClaims().getOrDefault("mycustomclaim", Collections.emptyList());
 
         return authorities.stream()
-	        .map(Object::toString)
+                .map(Object::toString)
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
     }

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/oauth2/oauth2-resourceserver.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/oauth2/oauth2-resourceserver.adoc
@@ -473,10 +473,11 @@ static class GrantedAuthoritiesExtractor
         implements Converter<Jwt, Collection<GrantedAuthority>> {
 
     public Collection<GrantedAuthority> convert(Jwt jwt) {
-        Collection<String> authorities = (Collection<String>)
-                jwt.getClaims().get("mycustomclaim");
+        Collection<?> authorities = (Collection<?>)
+	        jwt.getClaims().getOrDefault("authorities", Collections.emptyList());
 
         return authorities.stream()
+	        .map(Object::toString)
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
     }

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/oauth2/oauth2-resourceserver.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/oauth2/oauth2-resourceserver.adoc
@@ -474,7 +474,7 @@ static class GrantedAuthoritiesExtractor
 
     public Collection<GrantedAuthority> convert(Jwt jwt) {
         Collection<?> authorities = (Collection<?>)
-	        jwt.getClaims().getOrDefault("authorities", Collections.emptyList());
+	        jwt.getClaims().getOrDefault("mycustomclaim", Collections.emptyList());
 
         return authorities.stream()
 	        .map(Object::toString)

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/oauth2/oauth2-resourceserver.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/oauth2/oauth2-resourceserver.adoc
@@ -474,10 +474,10 @@ static class GrantedAuthoritiesExtractor
 
     public Collection<GrantedAuthority> convert(Jwt jwt) {
         Collection<?> authorities = (Collection<?>)
-	        jwt.getClaims().getOrDefault("mycustomclaim", Collections.emptyList());
+                jwt.getClaims().getOrDefault("mycustomclaim", Collections.emptyList());
 
         return authorities.stream()
-	        .map(Object::toString)
+                .map(Object::toString)
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
The unchecked exception if fixed by casting to `Collection<?>` instead of `Collection<String>` and casting each item with `Object::toString` prior the `SimpleGrantedAuthority` instantiation.

The possible NPE is fixed by returning `Collections.emptyList()` if the custom claim is missing in the JWT.