### PR TITLE
Fixed desc of PasswordEncoder

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/servlet/architecture/core-services.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/architecture/core-services.adoc
@@ -78,7 +78,7 @@ Configuring the provider is quite simple:
 ----
 
 The `PasswordEncoder` is optional.
-A `PasswordEncoder` provides encoding and decoding of passwords presented in the `UserDetails` object that is returned from the configured `UserDetailsService`.
+A `PasswordEncoder` provides encoding and matching of encoded passwords presented in the `UserDetails` object that is returned from the configured `UserDetailsService`.
 This will be discussed in more detail <<core-services-password-encoding,below>>.
 
 


### PR DESCRIPTION
It does not offer decoding passwords. Only encoding and matching encoded passwords

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
