### PR TITLE
Always attempt to use PCKE for OAuth 2 auth code flows

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2ClientConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2ClientConfigurerTests.java
@@ -138,7 +138,9 @@ public class OAuth2ClientConfigurerTests {
 		assertThat(mvcResult.getResponse().getRedirectedUrl()).matches("https://provider.com/oauth2/authorize\\?" +
 				"response_type=code&client_id=client-1&" +
 				"scope=user&state=.{15,}&" +
-				"redirect_uri=http://localhost/client-1");
+				"redirect_uri=http://localhost/client-1&" +
+				"code_challenge_method=S256&" +
+				"code_challenge=([a-zA-Z0-9\\-\\.\\_\\~]){43}");
 	}
 
 	@Test
@@ -151,7 +153,9 @@ public class OAuth2ClientConfigurerTests {
 		assertThat(mvcResult.getResponse().getRedirectedUrl()).matches("https://provider.com/oauth2/authorize\\?" +
 				"response_type=code&client_id=client-1&" +
 				"scope=user&state=.{15,}&" +
-				"redirect_uri=http://localhost/client-1");
+				"redirect_uri=http://localhost/client-1&" +
+				"code_challenge_method=S256&" +
+				"code_challenge=([a-zA-Z0-9\\-\\.\\_\\~]){43}");
 	}
 
 	@Test
@@ -203,7 +207,9 @@ public class OAuth2ClientConfigurerTests {
 		assertThat(mvcResult.getResponse().getRedirectedUrl()).matches("https://provider.com/oauth2/authorize\\?" +
 				"response_type=code&client_id=client-1&" +
 				"scope=user&state=.{15,}&" +
-				"redirect_uri=http://localhost/client-1");
+				"redirect_uri=http://localhost/client-1&" +
+				"code_challenge_method=S256&" +
+				"code_challenge=([a-zA-Z0-9\\-\\.\\_\\~]){43}");
 
 		verify(requestCache).saveRequest(any(HttpServletRequest.class), any(HttpServletResponse.class));
 	}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/DefaultOAuth2AuthorizationRequestResolver.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/DefaultOAuth2AuthorizationRequestResolver.java
@@ -20,7 +20,6 @@ import org.springframework.security.crypto.keygen.StringKeyGenerator;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
-import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
@@ -130,9 +129,7 @@ public final class DefaultOAuth2AuthorizationRequestResolver implements OAuth2Au
 				// 		REQUIRED. OpenID Connect requests MUST contain the "openid" scope value.
 				addNonceParameters(attributes, additionalParameters);
 			}
-			if (ClientAuthenticationMethod.NONE.equals(clientRegistration.getClientAuthenticationMethod())) {
-				addPkceParameters(attributes, additionalParameters);
-			}
+			addPkceParameters(attributes, additionalParameters);
 			builder.additionalParameters(additionalParameters);
 		} else if (AuthorizationGrantType.IMPLICIT.equals(clientRegistration.getAuthorizationGrantType())) {
 			builder = OAuth2AuthorizationRequest.implicit();

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/server/DefaultServerOAuth2AuthorizationRequestResolver.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/server/DefaultServerOAuth2AuthorizationRequestResolver.java
@@ -23,7 +23,6 @@ import org.springframework.security.crypto.keygen.StringKeyGenerator;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
-import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
@@ -144,9 +143,7 @@ public class DefaultServerOAuth2AuthorizationRequestResolver
 				// 		REQUIRED. OpenID Connect requests MUST contain the "openid" scope value.
 				addNonceParameters(attributes, additionalParameters);
 			}
-			if (ClientAuthenticationMethod.NONE.equals(clientRegistration.getClientAuthenticationMethod())) {
-				addPkceParameters(attributes, additionalParameters);
-			}
+			addPkceParameters(attributes, additionalParameters);
 			builder.additionalParameters(additionalParameters);
 		} else if (AuthorizationGrantType.IMPLICIT.equals(clientRegistration.getAuthorizationGrantType())) {
 			builder = OAuth2AuthorizationRequest.implicit();

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/DefaultOAuth2AuthorizationRequestResolverTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/DefaultOAuth2AuthorizationRequestResolverTests.java
@@ -123,12 +123,15 @@ public class DefaultOAuth2AuthorizationRequestResolverTests {
 		assertThat(authorizationRequest.getState()).isNotNull();
 		assertThat(authorizationRequest.getAdditionalParameters()).doesNotContainKey(OAuth2ParameterNames.REGISTRATION_ID);
 		assertThat(authorizationRequest.getAttributes())
-				.containsExactly(entry(OAuth2ParameterNames.REGISTRATION_ID, clientRegistration.getRegistrationId()));
+				.containsOnlyKeys(OAuth2ParameterNames.REGISTRATION_ID, PkceParameterNames.CODE_VERIFIER)
+				.containsEntry(OAuth2ParameterNames.REGISTRATION_ID, clientRegistration.getRegistrationId());
 		assertThat(authorizationRequest.getAuthorizationRequestUri())
 				.matches("https://example.com/login/oauth/authorize\\?" +
 						"response_type=code&client_id=client-id&" +
 						"scope=read:user&state=.{15,}&" +
-						"redirect_uri=http://localhost/login/oauth2/code/registration-id");
+						"redirect_uri=http://localhost/login/oauth2/code/registration-id&" +
+						"code_challenge_method=S256&" +
+						"code_challenge=([a-zA-Z0-9\\-\\.\\_\\~]){43}");
 	}
 
 	@Test
@@ -141,7 +144,8 @@ public class DefaultOAuth2AuthorizationRequestResolverTests {
 		OAuth2AuthorizationRequest authorizationRequest = this.resolver.resolve(request, clientRegistration.getRegistrationId());
 		assertThat(authorizationRequest).isNotNull();
 		assertThat(authorizationRequest.getAttributes())
-				.containsExactly(entry(OAuth2ParameterNames.REGISTRATION_ID, clientRegistration.getRegistrationId()));
+				.containsOnlyKeys(OAuth2ParameterNames.REGISTRATION_ID, PkceParameterNames.CODE_VERIFIER)
+				.containsEntry(OAuth2ParameterNames.REGISTRATION_ID, clientRegistration.getRegistrationId());
 	}
 
 	@Test
@@ -263,7 +267,9 @@ public class DefaultOAuth2AuthorizationRequestResolverTests {
 				.matches("https://example.com/login/oauth/authorize\\?" +
 						"response_type=code&client_id=client-id&" +
 						"scope=read:user&state=.{15,}&" +
-						"redirect_uri=http://localhost/login/oauth2/code/registration-id");
+						"redirect_uri=http://localhost/login/oauth2/code/registration-id&" +
+						"code_challenge_method=S256&" +
+						"code_challenge=([a-zA-Z0-9\\-\\.\\_\\~]){43}");
 	}
 
 	@Test
@@ -281,7 +287,9 @@ public class DefaultOAuth2AuthorizationRequestResolverTests {
 				.matches("https://example.com/login/oauth/authorize\\?" +
 						"response_type=code&client_id=client-id&" +
 						"scope=read:user&state=.{15,}&" +
-						"redirect_uri=https://example.com/login/oauth2/code/registration-id");
+						"redirect_uri=https://example.com/login/oauth2/code/registration-id&" +
+						"code_challenge_method=S256&" +
+						"code_challenge=([a-zA-Z0-9\\-\\.\\_\\~]){43}");
 	}
 
 	@Test
@@ -296,7 +304,9 @@ public class DefaultOAuth2AuthorizationRequestResolverTests {
 				.matches("https://example.com/login/oauth/authorize\\?" +
 						"response_type=code&client_id=client-id&" +
 						"scope=read:user&state=.{15,}&" +
-						"redirect_uri=http://localhost/authorize/oauth2/code/registration-id");
+						"redirect_uri=http://localhost/authorize/oauth2/code/registration-id&" +
+						"code_challenge_method=S256&" +
+						"code_challenge=([a-zA-Z0-9\\-\\.\\_\\~]){43}");
 	}
 
 	@Test
@@ -311,7 +321,9 @@ public class DefaultOAuth2AuthorizationRequestResolverTests {
 				.matches("https://example.com/login/oauth/authorize\\?" +
 						"response_type=code&client_id=client-id-2&" +
 						"scope=read:user&state=.{15,}&" +
-						"redirect_uri=http://localhost/login/oauth2/code/registration-id-2");
+						"redirect_uri=http://localhost/login/oauth2/code/registration-id-2&" +
+						"code_challenge_method=S256&" +
+						"code_challenge=([a-zA-Z0-9\\-\\.\\_\\~]){43}");
 	}
 
 	@Test
@@ -327,7 +339,9 @@ public class DefaultOAuth2AuthorizationRequestResolverTests {
 				.matches("https://example.com/login/oauth/authorize\\?" +
 						"response_type=code&client_id=client-id&" +
 						"scope=read:user&state=.{15,}&" +
-						"redirect_uri=http://localhost/authorize/oauth2/code/registration-id");
+						"redirect_uri=http://localhost/authorize/oauth2/code/registration-id&" +
+						"code_challenge_method=S256&" +
+						"code_challenge=([a-zA-Z0-9\\-\\.\\_\\~]){43}");
 	}
 
 	@Test
@@ -343,7 +357,9 @@ public class DefaultOAuth2AuthorizationRequestResolverTests {
 				.matches("https://example.com/login/oauth/authorize\\?" +
 						"response_type=code&client_id=client-id-2&" +
 						"scope=read:user&state=.{15,}&" +
-						"redirect_uri=http://localhost/login/oauth2/code/registration-id-2");
+						"redirect_uri=http://localhost/login/oauth2/code/registration-id-2&" +
+						"code_challenge_method=S256&" +
+						"code_challenge=([a-zA-Z0-9\\-\\.\\_\\~]){43}");
 	}
 
 	@Test
@@ -411,7 +427,9 @@ public class DefaultOAuth2AuthorizationRequestResolverTests {
 						"response_type=code&client_id=client-id&" +
 						"scope=openid&state=.{15,}&" +
 						"redirect_uri=http://localhost/login/oauth2/code/oidc-registration-id&" +
-						"nonce=([a-zA-Z0-9\\-\\.\\_\\~]){43}");
+						"code_challenge_method=S256&" +
+						"nonce=([a-zA-Z0-9\\-\\.\\_\\~]){43}&" +
+						"code_challenge=([a-zA-Z0-9\\-\\.\\_\\~]){43}");
 	}
 
 	private static ClientRegistration.Builder fineRedirectUriTemplateClientRegistration() {

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/OAuth2AuthorizationRequestRedirectFilterTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/OAuth2AuthorizationRequestRedirectFilterTests.java
@@ -154,7 +154,9 @@ public class OAuth2AuthorizationRequestRedirectFilterTests {
 		assertThat(response.getRedirectedUrl()).matches("https://example.com/login/oauth/authorize\\?" +
 				"response_type=code&client_id=client-id&" +
 				"scope=read:user&state=.{15,}&" +
-				"redirect_uri=http://localhost/login/oauth2/code/registration-id");
+				"redirect_uri=http://localhost/login/oauth2/code/registration-id&" +
+				"code_challenge_method=S256&" +
+				"code_challenge=([a-zA-Z0-9\\-\\.\\_\\~]){43}");
 	}
 
 	@Test
@@ -234,7 +236,9 @@ public class OAuth2AuthorizationRequestRedirectFilterTests {
 		assertThat(response.getRedirectedUrl()).matches("https://example.com/login/oauth/authorize\\?" +
 				"response_type=code&client_id=client-id&" +
 				"scope=read:user&state=.{15,}&" +
-				"redirect_uri=http://localhost/login/oauth2/code/registration-id");
+				"redirect_uri=http://localhost/login/oauth2/code/registration-id&" +
+				"code_challenge_method=S256&" +
+				"code_challenge=([a-zA-Z0-9\\-\\.\\_\\~]){43}");
 	}
 
 	@Test
@@ -255,7 +259,9 @@ public class OAuth2AuthorizationRequestRedirectFilterTests {
 		assertThat(response.getRedirectedUrl()).matches("https://example.com/login/oauth/authorize\\?" +
 				"response_type=code&client_id=client-id&" +
 				"scope=read:user&state=.{15,}&" +
-				"redirect_uri=http://localhost/authorize/oauth2/code/registration-id");
+				"redirect_uri=http://localhost/authorize/oauth2/code/registration-id&" +
+				"code_challenge_method=S256&" +
+				"code_challenge=([a-zA-Z0-9\\-\\.\\_\\~]){43}");
 		verify(this.requestCache).saveRequest(any(HttpServletRequest.class), any(HttpServletResponse.class));
 	}
 
@@ -359,6 +365,8 @@ public class OAuth2AuthorizationRequestRedirectFilterTests {
 				"response_type=code&client_id=client-id&" +
 				"scope=read:user&state=.{15,}&" +
 				"redirect_uri=http://localhost/login/oauth2/code/registration-id&" +
+				"code_challenge_method=S256&" +
+				"code_challenge=([a-zA-Z0-9\\-\\.\\_\\~]){43}&" +
 				"login_hint=user@provider\\.com");
 	}
 }

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/server/DefaultServerOAuth2AuthorizationRequestResolverTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/server/DefaultServerOAuth2AuthorizationRequestResolverTests.java
@@ -84,7 +84,9 @@ public class DefaultServerOAuth2AuthorizationRequestResolverTests {
 		assertThat(request.getAuthorizationRequestUri()).matches("https://example.com/login/oauth/authorize\\?" +
 				"response_type=code&client_id=client-id&" +
 				"scope=read:user&state=.*?&" +
-				"redirect_uri=/login/oauth2/code/registration-id");
+				"redirect_uri=/login/oauth2/code/registration-id&" +
+				"code_challenge_method=S256&" +
+				"code_challenge=([a-zA-Z0-9\\-\\.\\_\\~]){43}");
 	}
 
 	@Test
@@ -98,7 +100,9 @@ public class DefaultServerOAuth2AuthorizationRequestResolverTests {
 		assertThat(request.getAuthorizationRequestUri()).matches("https://example.com/login/oauth/authorize\\?" +
 				"response_type=code&client_id=client-id&" +
 				"scope=read:user&state=.*?&" +
-				"redirect_uri=/login/oauth2/code/registration-id");
+				"redirect_uri=/login/oauth2/code/registration-id&" +
+				"code_challenge_method=S256&" +
+				"code_challenge=([a-zA-Z0-9\\-\\.\\_\\~]){43}");
 	}
 
 	@Test
@@ -136,7 +140,9 @@ public class DefaultServerOAuth2AuthorizationRequestResolverTests {
 				"response_type=code&client_id=client-id&" +
 				"scope=openid&state=.*?&" +
 				"redirect_uri=/login/oauth2/code/registration-id&" +
-				"nonce=([a-zA-Z0-9\\-\\.\\_\\~]){43}");
+				"code_challenge_method=S256&" +
+				"nonce=([a-zA-Z0-9\\-\\.\\_\\~]){43}&" +
+				"code_challenge=([a-zA-Z0-9\\-\\.\\_\\~]){43}");
 	}
 
 	private OAuth2AuthorizationRequest resolve(String path) {


### PR DESCRIPTION
The "OAuth 2.0 Security Best Current Practice" (draft)
https://tools.ietf.org/html/draft-ietf-oauth-security-topics-13#section-3.1.1

> Clients utilizing the authorization grant type MUST use PKCE
> [RFC7636] in order to (with the help of the authorization server)
> detect and prevent attempts to inject (replay) authorization codes
> into the authorization response.

*NOTE:* this change should be backward compatible with IdPs who do not yet support PKCE (as the related parameters should be ignored)