### PR TITLE
Restore setPreEstablishedRedirectUri() for behind-proxy deployments for OAuth2LoginAuthenticationFilter

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2LoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2LoginConfigurer.java
@@ -353,6 +353,7 @@ public final class OAuth2LoginConfigurer<B extends HttpSecurityBuilder<B>> exten
 	 */
 	public class RedirectionEndpointConfig {
 		private String authorizationResponseBaseUri;
+		private String preEstablishedRedirectUri;
 
 		private RedirectionEndpointConfig() {
 		}
@@ -366,6 +367,17 @@ public final class OAuth2LoginConfigurer<B extends HttpSecurityBuilder<B>> exten
 		public RedirectionEndpointConfig baseUri(String authorizationResponseBaseUri) {
 			Assert.hasText(authorizationResponseBaseUri, "authorizationResponseBaseUri cannot be empty");
 			this.authorizationResponseBaseUri = authorizationResponseBaseUri;
+			return this;
+		}
+
+		/**
+		 * The redirect URI that has been pre-established with the server. If present, the redirect URI will be omitted from
+		 * the user authorization request because the server doesn't need to know it.
+		 *
+		 * @param preEstablishedRedirectUri The redirect URI that has been pre-established with the server.
+		 */
+		public RedirectionEndpointConfig preEstablishedRedirectUri(String preEstablishedRedirectUri) {
+			this.preEstablishedRedirectUri = preEstablishedRedirectUri;
 			return this;
 		}
 
@@ -475,10 +487,12 @@ public final class OAuth2LoginConfigurer<B extends HttpSecurityBuilder<B>> exten
 	@Override
 	public void init(B http) throws Exception {
 		OAuth2LoginAuthenticationFilter authenticationFilter =
-			new OAuth2LoginAuthenticationFilter(
-				OAuth2ClientConfigurerUtils.getClientRegistrationRepository(this.getBuilder()),
-				OAuth2ClientConfigurerUtils.getAuthorizedClientRepository(this.getBuilder()),
-				this.loginProcessingUrl);
+				new OAuth2LoginAuthenticationFilter(
+						OAuth2ClientConfigurerUtils.getClientRegistrationRepository(this.getBuilder()),
+						OAuth2ClientConfigurerUtils.getAuthorizedClientRepository(this.getBuilder()),
+						this.loginProcessingUrl,
+						this.redirectionEndpointConfig.preEstablishedRedirectUri
+				);
 		this.setAuthenticationFilter(authenticationFilter);
 		super.loginProcessingUrl(this.loginProcessingUrl);
 


### PR DESCRIPTION
When app deployed behind proxy there aren't actual scheme, host, port used in OAuth2LoginAuthenticationFilter#attemptAuthentication() in
`UriComponentsBuilder.fromHttpUrl(UrlUtils.buildFullRequestUrl(request))`

Consequently it generates non-actual url which fails in `OAuth2AuthorizationExchangeValidator.validate()`.

It was possible to [set redirect url](https://github.com/spring-projects/spring-security-oauth/blob/master/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/client/token/grant/redirect/AbstractRedirectResourceDetails.java#L77) in `org.springframework.security.oauth:spring-security-oauth2:2.3.5.RELEASE` with `AbstractRedirectResourceDetails#setPreEstablishedRedirectUri()`.

I want to set actual uri explicitly.

Stacktrace
```
янв 11 21:43:14 selectel.nkonev.name blog[26382]: org.springframework.security.oauth2.core.OAuth2AuthenticationException: [invalid_redirect_uri_parameter] 
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.security.oauth2.client.authentication.OAuth2LoginAuthenticationProvider.authenticate(OAuth2LoginAuthenticationProvider.java:110) ~[spring-security-oauth2-client-5.2.1.RELEASE.jar!/:5.2.1.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.security.authentication.ProviderManager.authenticate(ProviderManager.java:175) ~[spring-security-core-5.2.1.RELEASE.jar!/:5.2.1.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter.attemptAuthentication(OAuth2LoginAuthenticationFilter.java:185) ~[spring-security-oauth2-client-5.2.1.RELEASE.jar!/:5.2.1.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.doFilter(AbstractAuthenticationProcessingFilter.java:212) ~[spring-security-web-5.2.1.RELEASE.jar!/:5.2.1.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334) ~[spring-security-web-5.2.1.RELEASE.jar!/:5.2.1.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter.doFilterInternal(OAuth2AuthorizationRequestRedirectFilter.java:160) ~[spring-security-oauth2-client-5.2.1.RELEASE.jar!/:5.2.1.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.2.2.RELEASE.jar!/:5.2.2.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334) ~[spring-security-web-5.2.1.RELEASE.jar!/:5.2.1.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.security.web.authentication.logout.LogoutFilter.doFilter(LogoutFilter.java:116) ~[spring-security-web-5.2.1.RELEASE.jar!/:5.2.1.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334) ~[spring-security-web-5.2.1.RELEASE.jar!/:5.2.1.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.security.web.csrf.CsrfFilter.doFilterInternal(CsrfFilter.java:117) ~[spring-security-web-5.2.1.RELEASE.jar!/:5.2.1.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.2.2.RELEASE.jar!/:5.2.2.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334) ~[spring-security-web-5.2.1.RELEASE.jar!/:5.2.1.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.security.web.header.HeaderWriterFilter.doHeadersAfter(HeaderWriterFilter.java:92) ~[spring-security-web-5.2.1.RELEASE.jar!/:5.2.1.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.security.web.header.HeaderWriterFilter.doFilterInternal(HeaderWriterFilter.java:77) ~[spring-security-web-5.2.1.RELEASE.jar!/:5.2.1.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.2.2.RELEASE.jar!/:5.2.2.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334) ~[spring-security-web-5.2.1.RELEASE.jar!/:5.2.1.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.security.web.context.SecurityContextPersistenceFilter.doFilter(SecurityContextPersistenceFilter.java:105) ~[spring-security-web-5.2.1.RELEASE.jar!/:5.2.1.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334) ~[spring-security-web-5.2.1.RELEASE.jar!/:5.2.1.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter.doFilterInternal(WebAsyncManagerIntegrationFilter.java:56) ~[spring-security-web-5.2.1.RELEASE.jar!/:5.2.1.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.2.2.RELEASE.jar!/:5.2.2.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334) ~[spring-security-web-5.2.1.RELEASE.jar!/:5.2.1.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.security.web.FilterChainProxy.doFilterInternal(FilterChainProxy.java:215) ~[spring-security-web-5.2.1.RELEASE.jar!/:5.2.1.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.security.web.FilterChainProxy.doFilter(FilterChainProxy.java:178) ~[spring-security-web-5.2.1.RELEASE.jar!/:5.2.1.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:358) ~[spring-web-5.2.2.RELEASE.jar!/:5.2.2.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:271) ~[spring-web-5.2.2.RELEASE.jar!/:5.2.2.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100) ~[spring-web-5.2.2.RELEASE.jar!/:5.2.2.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.2.2.RELEASE.jar!/:5.2.2.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93) ~[spring-web-5.2.2.RELEASE.jar!/:5.2.2.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.2.2.RELEASE.jar!/:5.2.2.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.session.web.http.SessionRepositoryFilter.doFilterInternal(SessionRepositoryFilter.java:141) ~[spring-session-core-2.2.0.RELEASE.jar!/:2.2.0.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.session.web.http.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:82) ~[spring-session-core-2.2.0.RELEASE.jar!/:2.2.0.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.boot.actuate.metrics.web.servlet.WebMvcMetricsFilter.doFilterInternal(WebMvcMetricsFilter.java:108) ~[spring-boot-actuator-2.2.2.RELEASE.jar!/:2.2.2.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.2.2.RELEASE.jar!/:5.2.2.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201) ~[spring-web-5.2.2.RELEASE.jar!/:5.2.2.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.2.2.RELEASE.jar!/:5.2.2.RELEASE]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at com.github.nkonev.blog.services.RendertronFilter.doFilter(RendertronFilter.java:138) ~[classes!/:na]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:202) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:526) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:139) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:367) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:860) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.tomcat.util.net.Nio2Endpoint$SocketProcessor.doRun(Nio2Endpoint.java:1682) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.tomcat.util.net.AbstractEndpoint.processSocket(AbstractEndpoint.java:1105) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.tomcat.util.net.Nio2Endpoint$Nio2SocketWrapper$2.completed(Nio2Endpoint.java:596) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.tomcat.util.net.Nio2Endpoint$Nio2SocketWrapper$2.completed(Nio2Endpoint.java:574) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at java.base/sun.nio.ch.Invoker.invokeUnchecked(Unknown Source) ~[na:na]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at java.base/sun.nio.ch.Invoker$2.run(Unknown Source) ~[na:na]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at java.base/sun.nio.ch.AsynchronousChannelGroupImpl$1.run(Unknown Source) ~[na:na]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[na:na]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[na:na]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61) ~[tomcat-embed-core-9.0.29.jar!/:9.0.29]
янв 11 21:43:14 selectel.nkonev.name blog[26382]:         at java.base/java.lang.Thread.run(Unknown Source) ~[na:na]
янв 11 21:43:14 selectel.nkonev.name blog[26382]: 
янв 11 21:43:14 selectel.nkonev.name blog[26382]: 2020-01-11 18:43:14.333 DEBUG 1 --- [io2-8098-exec-9] .s.o.c.w.OAuth2LoginAuthenticationFilter : Updated SecurityContextHolder to contain null Authentication
янв 11 21:43:14 selectel.nkonev.name blog[26382]: 2020-01-11 18:43:14.333 DEBUG 1 --- [io2-8098-exec-9] .s.o.c.w.OAuth2LoginAuthenticationFilter : Delegating to authentication failure handler com.github.nkonev.blog.security.OauthExceptionHandler@5190010f

```