### PR TITLE
Make OAuth2AccessToken converters public

### DIFF
--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/http/converter/OAuth2AccessTokenResponseConverter.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/http/converter/OAuth2AccessTokenResponseConverter.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.core.http.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.util.StringUtils;
+
+import java.util.*;
+
+/**
+ * A {@link Converter} that converts the provided
+ * OAuth 2.0 Access Token Response parameters to an {@link OAuth2AccessTokenResponse}.
+ *
+ * @author Joe Grandja
+ * @author Nikita Konev
+ * @since 5.3
+ */
+public final class OAuth2AccessTokenResponseConverter implements Converter<Map<String, String>, OAuth2AccessTokenResponse> {
+	private static final Set<String> TOKEN_RESPONSE_PARAMETER_NAMES = new HashSet<>(Arrays.asList(
+			OAuth2ParameterNames.ACCESS_TOKEN,
+			OAuth2ParameterNames.EXPIRES_IN,
+			OAuth2ParameterNames.REFRESH_TOKEN,
+			OAuth2ParameterNames.SCOPE,
+			OAuth2ParameterNames.TOKEN_TYPE
+	));
+
+	@Override
+	public OAuth2AccessTokenResponse convert(Map<String, String> tokenResponseParameters) {
+		String accessToken = tokenResponseParameters.get(OAuth2ParameterNames.ACCESS_TOKEN);
+
+		OAuth2AccessToken.TokenType accessTokenType = null;
+		if (OAuth2AccessToken.TokenType.BEARER.getValue().equalsIgnoreCase(
+				tokenResponseParameters.get(OAuth2ParameterNames.TOKEN_TYPE))) {
+			accessTokenType = OAuth2AccessToken.TokenType.BEARER;
+		}
+
+		long expiresIn = 0;
+		if (tokenResponseParameters.containsKey(OAuth2ParameterNames.EXPIRES_IN)) {
+			try {
+				expiresIn = Long.parseLong(tokenResponseParameters.get(OAuth2ParameterNames.EXPIRES_IN));
+			} catch (NumberFormatException ex) {
+			}
+		}
+
+		Set<String> scopes = Collections.emptySet();
+		if (tokenResponseParameters.containsKey(OAuth2ParameterNames.SCOPE)) {
+			String scope = tokenResponseParameters.get(OAuth2ParameterNames.SCOPE);
+			scopes = new HashSet<>(Arrays.asList(StringUtils.delimitedListToStringArray(scope, " ")));
+		}
+
+		String refreshToken = tokenResponseParameters.get(OAuth2ParameterNames.REFRESH_TOKEN);
+
+		Map<String, Object> additionalParameters = new LinkedHashMap<>();
+		for (Map.Entry<String, String> entry : tokenResponseParameters.entrySet()) {
+			if (!TOKEN_RESPONSE_PARAMETER_NAMES.contains(entry.getKey())) {
+				additionalParameters.put(entry.getKey(), entry.getValue());
+			}
+		}
+
+		return OAuth2AccessTokenResponse.withToken(accessToken)
+				.tokenType(accessTokenType)
+				.expiresIn(expiresIn)
+				.scopes(scopes)
+				.refreshToken(refreshToken)
+				.additionalParameters(additionalParameters)
+				.build();
+	}
+}

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/http/converter/OAuth2AccessTokenResponseParametersConverter.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/http/converter/OAuth2AccessTokenResponseParametersConverter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.core.http.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A {@link Converter} that converts the provided {@link OAuth2AccessTokenResponse}
+ * to a {@code Map} representation of the OAuth 2.0 Access Token Response parameters.
+ *
+ * @author Joe Grandja
+ * @author Nikita Konev
+ * @since 5.3
+ */
+public final class OAuth2AccessTokenResponseParametersConverter implements Converter<OAuth2AccessTokenResponse, Map<String, String>> {
+
+	@Override
+	public Map<String, String> convert(OAuth2AccessTokenResponse tokenResponse) {
+		Map<String, String> parameters = new HashMap<>();
+
+		long expiresIn = -1;
+		if (tokenResponse.getAccessToken().getExpiresAt() != null) {
+			expiresIn = ChronoUnit.SECONDS.between(Instant.now(), tokenResponse.getAccessToken().getExpiresAt());
+		}
+
+		parameters.put(OAuth2ParameterNames.ACCESS_TOKEN, tokenResponse.getAccessToken().getTokenValue());
+		parameters.put(OAuth2ParameterNames.TOKEN_TYPE, tokenResponse.getAccessToken().getTokenType().getValue());
+		parameters.put(OAuth2ParameterNames.EXPIRES_IN, String.valueOf(expiresIn));
+		if (!CollectionUtils.isEmpty(tokenResponse.getAccessToken().getScopes())) {
+			parameters.put(OAuth2ParameterNames.SCOPE,
+					StringUtils.collectionToDelimitedString(tokenResponse.getAccessToken().getScopes(), " "));
+		}
+		if (tokenResponse.getRefreshToken() != null) {
+			parameters.put(OAuth2ParameterNames.REFRESH_TOKEN, tokenResponse.getRefreshToken().getTokenValue());
+		}
+		if (!CollectionUtils.isEmpty(tokenResponse.getAdditionalParameters())) {
+			for (Map.Entry<String, Object> entry : tokenResponse.getAdditionalParameters().entrySet()) {
+				parameters.put(entry.getKey(), entry.getValue().toString());
+			}
+		}
+
+		return parameters;
+	}
+}

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/http/converter/OAuth2AccessTokenResponseConverterTest.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/http/converter/OAuth2AccessTokenResponseConverterTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.core.http.converter;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Tests for {@link OAuth2AccessTokenResponseConverter}.
+ *
+ * @author Nikita Konev
+ */
+public class OAuth2AccessTokenResponseConverterTest {
+
+	private OAuth2AccessTokenResponseConverter messageConverter;
+
+	@Before
+	public void setup() {
+		this.messageConverter = new OAuth2AccessTokenResponseConverter();
+	}
+
+
+	@Test
+	public void shouldConvertFull() {
+		Map<String, String> map = new HashMap<>();
+		map.put("access_token", "access-token-1234");
+		map.put("token_type", "bearer");
+		map.put("expires_in", "3600");
+		map.put("scope", "read write");
+		map.put("refresh_token", "refresh-token-1234");
+		map.put("custom_parameter_1", "custom-value-1");
+		map.put("custom_parameter_2", "custom-value-2");
+		OAuth2AccessTokenResponse converted = messageConverter.convert(map);
+		OAuth2AccessToken accessToken = converted.getAccessToken();
+		Assert.assertNotNull(accessToken);
+		Assert.assertEquals("access-token-1234", accessToken.getTokenValue());
+		Assert.assertEquals(OAuth2AccessToken.TokenType.BEARER, accessToken.getTokenType());
+		Set<String> scopes = accessToken.getScopes();
+		Assert.assertNotNull(scopes);
+		Assert.assertEquals(2, scopes.size());
+		Assert.assertTrue(scopes.contains("read"));
+		Assert.assertTrue(scopes.contains("write"));
+		Assert.assertEquals(3600, Duration.between(accessToken.getIssuedAt(), accessToken.getExpiresAt()).getSeconds());
+
+		OAuth2RefreshToken refreshToken = converted.getRefreshToken();
+		Assert.assertNotNull(refreshToken);
+		Assert.assertEquals("refresh-token-1234", refreshToken.getTokenValue());
+
+		Map<String, Object> additionalParameters = converted.getAdditionalParameters();
+		Assert.assertNotNull(additionalParameters);
+		Assert.assertEquals(2, additionalParameters.size());
+		Assert.assertEquals("custom-value-1", additionalParameters.get("custom_parameter_1"));
+		Assert.assertEquals("custom-value-2", additionalParameters.get("custom_parameter_2"));
+	}
+
+	@Test
+	public void shouldConvertMinimal() {
+		Map<String, String> map = new HashMap<>();
+		map.put("access_token", "access-token-1234");
+		map.put("token_type", "bearer");
+		OAuth2AccessTokenResponse converted = messageConverter.convert(map);
+		OAuth2AccessToken accessToken = converted.getAccessToken();
+		Assert.assertNotNull(accessToken);
+		Assert.assertEquals("access-token-1234", accessToken.getTokenValue());
+		Assert.assertEquals(OAuth2AccessToken.TokenType.BEARER, accessToken.getTokenType());
+		Set<String> scopes = accessToken.getScopes();
+		Assert.assertNotNull(scopes);
+		Assert.assertEquals(0, scopes.size());
+
+		Assert.assertEquals(1, Duration.between(accessToken.getIssuedAt(), accessToken.getExpiresAt()).getSeconds());
+
+		OAuth2RefreshToken refreshToken = converted.getRefreshToken();
+		Assert.assertNull(refreshToken);
+
+		Map<String, Object> additionalParameters = converted.getAdditionalParameters();
+		Assert.assertNotNull(additionalParameters);
+		Assert.assertEquals(0, additionalParameters.size());
+	}
+
+	@Test
+	public void shouldConvertWithUnsupportedExpiresIn() {
+		Map<String, String> map = new HashMap<>();
+		map.put("access_token", "access-token-1234");
+		map.put("token_type", "bearer");
+		map.put("expires_in", "2100-01-01-abc");
+		OAuth2AccessTokenResponse converted = messageConverter.convert(map);
+		OAuth2AccessToken accessToken = converted.getAccessToken();
+		Assert.assertNotNull(accessToken);
+		Assert.assertEquals("access-token-1234", accessToken.getTokenValue());
+		Assert.assertEquals(OAuth2AccessToken.TokenType.BEARER, accessToken.getTokenType());
+		Set<String> scopes = accessToken.getScopes();
+		Assert.assertNotNull(scopes);
+		Assert.assertEquals(0, scopes.size());
+
+		Assert.assertEquals(1, Duration.between(accessToken.getIssuedAt(), accessToken.getExpiresAt()).getSeconds());
+
+		OAuth2RefreshToken refreshToken = converted.getRefreshToken();
+		Assert.assertNull(refreshToken);
+
+		Map<String, Object> additionalParameters = converted.getAdditionalParameters();
+		Assert.assertNotNull(additionalParameters);
+		Assert.assertEquals(0, additionalParameters.size());
+	}
+}

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/http/converter/OAuth2AccessTokenResponseParametersConverterTest.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/http/converter/OAuth2AccessTokenResponseParametersConverterTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.core.http.converter;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link OAuth2AccessTokenResponseParametersConverter}.
+ *
+ * @author Nikita Konev
+ */
+public class OAuth2AccessTokenResponseParametersConverterTest {
+
+	private OAuth2AccessTokenResponseParametersConverter messageConverter;
+
+	@Before
+	public void setup() {
+		this.messageConverter = new OAuth2AccessTokenResponseParametersConverter();
+	}
+
+
+	@Test
+	public void convertFull() {
+		Map<String, Object> additionalParameters = new HashMap<>();
+		additionalParameters.put("custom_parameter_1", "custom-value-1");
+		additionalParameters.put("custom_parameter_2", "custom-value-2");
+
+		Set<String> scopes = new HashSet<>();
+		scopes.add("read");
+		scopes.add("write");
+
+		OAuth2AccessTokenResponse build = OAuth2AccessTokenResponse
+				.withToken("access-token-value-1234")
+				.expiresIn(3699)
+				.additionalParameters(additionalParameters)
+				.refreshToken("refresh-token-value-1234")
+				.scopes(scopes)
+				.tokenType(OAuth2AccessToken.TokenType.BEARER)
+				.build();
+		Map<String, String> result = messageConverter.convert(build);
+		Assert.assertEquals(7, result.size());
+
+		Assert.assertEquals("access-token-value-1234", result.get("access_token"));
+		Assert.assertEquals("refresh-token-value-1234", result.get("refresh_token"));
+		Assert.assertEquals("read write", result.get("scope"));
+		Assert.assertEquals("Bearer", result.get("token_type"));
+		Assert.assertNotNull(result.get("expires_in"));
+		Assert.assertEquals("custom-value-1", result.get("custom_parameter_1"));
+		Assert.assertEquals("custom-value-2", result.get("custom_parameter_2"));
+	}
+
+	@Test
+	public void convertMinimal() {
+		OAuth2AccessTokenResponse build = OAuth2AccessTokenResponse
+				.withToken("access-token-value-1234")
+				.tokenType(OAuth2AccessToken.TokenType.BEARER)
+				.build();
+		Map<String, String> result = messageConverter.convert(build);
+		Assert.assertEquals(3, result.size());
+
+		Assert.assertEquals("access-token-value-1234", result.get("access_token"));
+		Assert.assertEquals("Bearer", result.get("token_type"));
+		Assert.assertNotNull(result.get("expires_in"));
+	}
+}


### PR DESCRIPTION
I want to use Spring Security with vk.com OAuth2 provider, but it doesn't respond tokenType json field in `token-uri: https://oauth.vk.com/access_token`. [Here](https://vk.com/dev/auth_sites) is documentation. If it displayed in Russian, you can switch language at bottom right corner. 
![Снимок экрана_2020-01-13_01-23-55](https://user-images.githubusercontent.com/3160384/72226561-76f60f00-35a3-11ea-877b-57e84173f8cc.png)

Just check chapter 4, it contains response example
```json
{"access_token":"533bacf01e11f55b536a565b57531ac114461ae8736d6506a3", "expires_in":43200, "user_id":66748} 
```
It doesn't contains `token_type` field.
So currently I get following exception. 
```
2020-01-13 00:52:09.599 DEBUG 375934 --- [io2-8070-exec-8] .s.o.c.w.OAuth2LoginAuthenticationFilter : Authentication request failed: org.springframework.security.oauth2.core.OAuth2AuthenticationException: [invalid_token_response] An error occurred while attempting to retrieve the OAuth 2.0 Access Token Response: Error while extracting response for type [class org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse] and content type [application/json;charset=utf-8]; nested exception is org.springframework.http.converter.HttpMessageNotReadableException: An error occurred reading the OAuth 2.0 Access Token Response: tokenType cannot be null; nested exception is java.lang.IllegalArgumentException: tokenType cannot be null

org.springframework.security.oauth2.core.OAuth2AuthenticationException: [invalid_token_response] An error occurred while attempting to retrieve the OAuth 2.0 Access Token Response: Error while extracting response for type [class org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse] and content type [application/json;charset=utf-8]; nested exception is org.springframework.http.converter.HttpMessageNotReadableException: An error occurred reading the OAuth 2.0 Access Token Response: tokenType cannot be null; nested exception is java.lang.IllegalArgumentException: tokenType cannot be null
	at org.springframework.security.oauth2.client.authentication.OAuth2LoginAuthenticationProvider.authenticate(OAuth2LoginAuthenticationProvider.java:110) ~[spring-security-oauth2-client-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.security.authentication.ProviderManager.authenticate(ProviderManager.java:175) ~[spring-security-core-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter.attemptAuthentication(OAuth2LoginAuthenticationFilter.java:185) ~[spring-security-oauth2-client-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.doFilter(AbstractAuthenticationProcessingFilter.java:212) ~[spring-security-web-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334) ~[spring-security-web-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter.doFilterInternal(OAuth2AuthorizationRequestRedirectFilter.java:160) ~[spring-security-oauth2-client-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.2.2.RELEASE.jar:5.2.2.RELEASE]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334) ~[spring-security-web-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.security.web.authentication.logout.LogoutFilter.doFilter(LogoutFilter.java:116) ~[spring-security-web-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334) ~[spring-security-web-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.security.web.csrf.CsrfFilter.doFilterInternal(CsrfFilter.java:117) ~[spring-security-web-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.2.2.RELEASE.jar:5.2.2.RELEASE]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334) ~[spring-security-web-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.security.web.header.HeaderWriterFilter.doHeadersAfter(HeaderWriterFilter.java:92) ~[spring-security-web-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.security.web.header.HeaderWriterFilter.doFilterInternal(HeaderWriterFilter.java:77) ~[spring-security-web-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.2.2.RELEASE.jar:5.2.2.RELEASE]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334) ~[spring-security-web-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.security.web.context.SecurityContextPersistenceFilter.doFilter(SecurityContextPersistenceFilter.java:105) ~[spring-security-web-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334) ~[spring-security-web-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter.doFilterInternal(WebAsyncManagerIntegrationFilter.java:56) ~[spring-security-web-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.2.2.RELEASE.jar:5.2.2.RELEASE]
	at org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:334) ~[spring-security-web-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.security.web.FilterChainProxy.doFilterInternal(FilterChainProxy.java:215) ~[spring-security-web-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.security.web.FilterChainProxy.doFilter(FilterChainProxy.java:178) ~[spring-security-web-5.2.1.RELEASE.jar:5.2.1.RELEASE]
	at org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:358) ~[spring-web-5.2.2.RELEASE.jar:5.2.2.RELEASE]
	at org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:271) ~[spring-web-5.2.2.RELEASE.jar:5.2.2.RELEASE]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100) ~[spring-web-5.2.2.RELEASE.jar:5.2.2.RELEASE]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.2.2.RELEASE.jar:5.2.2.RELEASE]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93) ~[spring-web-5.2.2.RELEASE.jar:5.2.2.RELEASE]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.2.2.RELEASE.jar:5.2.2.RELEASE]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.springframework.session.web.http.SessionRepositoryFilter.doFilterInternal(SessionRepositoryFilter.java:141) ~[spring-session-core-2.2.0.RELEASE.jar:2.2.0.RELEASE]
	at org.springframework.session.web.http.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:82) ~[spring-session-core-2.2.0.RELEASE.jar:2.2.0.RELEASE]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.springframework.boot.actuate.metrics.web.servlet.WebMvcMetricsFilter.doFilterInternal(WebMvcMetricsFilter.java:108) ~[spring-boot-actuator-2.2.2.RELEASE.jar:2.2.2.RELEASE]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.2.2.RELEASE.jar:5.2.2.RELEASE]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201) ~[spring-web-5.2.2.RELEASE.jar:5.2.2.RELEASE]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.2.2.RELEASE.jar:5.2.2.RELEASE]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:202) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:526) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:139) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:367) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:860) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.tomcat.util.net.Nio2Endpoint$SocketProcessor.doRun(Nio2Endpoint.java:1682) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.tomcat.util.net.AbstractEndpoint.processSocket(AbstractEndpoint.java:1105) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.tomcat.util.net.Nio2Endpoint$Nio2SocketWrapper$2.completed(Nio2Endpoint.java:596) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at org.apache.tomcat.util.net.Nio2Endpoint$Nio2SocketWrapper$2.completed(Nio2Endpoint.java:574) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at java.base/sun.nio.ch.Invoker.invokeUnchecked(Invoker.java:127) ~[na:na]
	at java.base/sun.nio.ch.Invoker$2.run(Invoker.java:219) ~[na:na]
	at java.base/sun.nio.ch.AsynchronousChannelGroupImpl$1.run(AsynchronousChannelGroupImpl.java:112) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[na:na]
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61) ~[tomcat-embed-core-9.0.29.jar:9.0.29]
	at java.base/java.lang.Thread.run(Thread.java:830) ~[na:na]

```

It was working in org.springframework.security.oauth:spring-security-oauth2:2.3.5.RELEASE.

I think it is ok to give opportunity to configure default **non-null** tokenType to be able to use Spring Security with more non-typical OAuth2 providers like vk.com.

![Снимок экрана_2020-01-13_01-08-32](https://user-images.githubusercontent.com/3160384/72226372-6e043e00-35a1-11ea-8c50-3a62ecfb0c54.png)

Here is my config
```yml
spring.security:
    oauth2:
      client:
        registration:
          vkcom:
            client-id: your-app-client-id-vk
            client-secret: your-app-client-secret-vk
            authorization-grant-type: authorization_code
            redirect-uri: "{baseUrl}/api/login/oauth2/code/{registrationId}"
            client-authentication-method: post
          facebook:
            client-name: "facebook" # use in BlogOAuth2UserService
            client-id: your-app-client-id-fb
            client-secret: your-app-client-secret-fb
            redirect-uri: "{baseUrl}/api/login/oauth2/code/{registrationId}"
        provider:
          vkcom:
            authorization-uri: https://oauth.vk.com/authorize
            token-uri: https://oauth.vk.com/access_token
            user-info-uri: https://api.vk.com/method/users.get?v=5.92
            user-info-authentication-method: form
            user-name-attribute: response
          facebook:
            user-info-uri: "https://graph.facebook.com/me?fields=id,name,picture"
```