### PR TITLE
Updated Nimbus-Jose-JWT from 6.0.2 to 7.9 as a fix for CVE-2019-17195

### DIFF
--- a/dep-updates.txt
+++ b/dep-updates.txt
@@ -215,7 +215,7 @@ Gradle release-candidate updates:
 The following dependencies have later release versions:
  - com.fasterxml.jackson.core:jackson-databind [2.9.8 -> 2.10.0.pr1]
      http://github.com/FasterXML/jackson
- - com.nimbusds:nimbus-jose-jwt [6.0.2 -> 7.7]
+ - com.nimbusds:nimbus-jose-jwt [7.9 -> 8.4]
      https://bitbucket.org/connect2id/nimbus-jose-jwt
  - com.squareup.okhttp3:mockwebserver [3.12.2 -> 4.0.1]
      https://github.com/square/okhttp
@@ -1774,7 +1774,7 @@ The following dependencies are using the latest release version:
  - javax.xml.bind:jaxb-api:2.4.0-b180830.0359
 
 The following dependencies have later release versions:
- - com.nimbusds:nimbus-jose-jwt [6.0.2 -> 7.7]
+ - com.nimbusds:nimbus-jose-jwt [7.9 -> 8.4]
      https://bitbucket.org/connect2id/nimbus-jose-jwt
  - com.sun.xml.bind:jaxb-impl [2.3.0.1 -> 2.4.0-b180830.0438]
      http://jaxb.java.net

--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -54,7 +54,7 @@ dependencyManagement {
 		dependency 'com.google.guava:guava:20.0'
 		dependency 'com.google.inject:guice:3.0'
 		dependency 'com.nimbusds:lang-tag:1.4.3'
-		dependency 'com.nimbusds:nimbus-jose-jwt:6.0.2'
+		dependency 'com.nimbusds:nimbus-jose-jwt:7.9'
 		dependency 'com.nimbusds:oauth2-oidc-sdk:6.0'
 		dependency 'com.squareup.okhttp3:okhttp:3.12.2'
 		dependency 'com.squareup.okio:okio:1.13.0'


### PR DESCRIPTION
As per the issue https://github.com/spring-projects/spring-security/issues/7792,  spring-security-oauth2-jose:jar:5.1.7 brings in com.nimbusds:nimbus-jose-jwt:jar:6.0.2, which has the vulnerability [CVE-2019-17195](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-17195).

So, updated com.nimbusds:nimbus-jose-jwt:jar to 7.9 which fixes this. 