### PR TITLE
Improve Bearer Token Error Handling

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
@@ -94,6 +94,7 @@ import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
 import org.springframework.security.oauth2.jose.TestKeys;
+import org.springframework.security.oauth2.jwt.BadJwtException;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtException;
@@ -256,7 +257,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 		this.mvc.perform(get("/").with(bearerToken(token)))
 				.andExpect(status().isUnauthorized())
-				.andExpect(invalidTokenHeader("An error occurred while attempting to decode the Jwt: Malformed Jwk set"));
+				.andExpect(header().string("WWW-Authenticate", "Bearer"));
 	}
 
 	@Test
@@ -269,7 +270,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 		this.mvc.perform(get("/").with(bearerToken(token)))
 				.andExpect(status().isUnauthorized())
-				.andExpect(invalidTokenHeader("Invalid token"));
+				.andExpect(header().string("WWW-Authenticate", "Bearer"));
 	}
 
 	@Test
@@ -1099,7 +1100,7 @@ public class OAuth2ResourceServerConfigurerTests {
 		this.spring.register(CustomAuthenticationEventPublisher.class).autowire();
 
 		when(bean(JwtDecoder.class).decode(anyString()))
-				.thenThrow(new JwtException("problem"));
+				.thenThrow(new BadJwtException("problem"));
 
 		this.mvc.perform(get("/").with(bearerToken("token")));
 

--- a/core/src/main/java/org/springframework/security/authentication/DefaultAuthenticationEventPublisher.java
+++ b/core/src/main/java/org/springframework/security/authentication/DefaultAuthenticationEventPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,6 +92,9 @@ public class DefaultAuthenticationEventPublisher implements AuthenticationEventP
 		addMapping(
 				"org.springframework.security.authentication.cas.ProxyUntrustedException",
 				AuthenticationFailureProxyUntrustedEvent.class);
+		addMapping(
+				"org.springframework.security.oauth2.server.resource.InvalidBearerTokenException",
+				AuthenticationFailureBadCredentialsEvent.class);
 	}
 
 	public void publishAuthenticationSuccess(Authentication authentication) {

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/BadJwtException.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/BadJwtException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.jwt;
+
+/**
+ * An exception similar to {@link org.springframework.security.authentication.BadCredentialsException}
+ * that indicates a {@link Jwt} that is invalid in some way.
+ *
+ * @author Josh Cummings
+ * @since 5.3
+ */
+public class BadJwtException extends JwtException {
+	public BadJwtException(String message) {
+		super(message);
+	}
+
+	public BadJwtException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtValidationException.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtValidationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.springframework.util.Assert;
  * @author Josh Cummings
  * @since 5.1
  */
-public class JwtValidationException extends JwtException {
+public class JwtValidationException extends BadJwtException {
 	private final Collection<OAuth2Error> errors;
 
 	/**

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import javax.crypto.SecretKey;
 
+import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.RemoteKeySourceException;
 import com.nimbusds.jose.jwk.source.JWKSource;
@@ -120,7 +121,7 @@ public final class NimbusJwtDecoder implements JwtDecoder {
 	public Jwt decode(String token) throws JwtException {
 		JWT jwt = parse(token);
 		if (jwt instanceof PlainJWT) {
-			throw new JwtException("Unsupported algorithm of " + jwt.getHeader().getAlgorithm());
+			throw new BadJwtException("Unsupported algorithm of " + jwt.getHeader().getAlgorithm());
 		}
 		Jwt createdJwt = createJwt(token, jwt);
 		return validateJwt(createdJwt);
@@ -130,7 +131,7 @@ public final class NimbusJwtDecoder implements JwtDecoder {
 		try {
 			return JWTParser.parse(token);
 		} catch (Exception ex) {
-			throw new JwtException(String.format(DECODING_ERROR_MESSAGE_TEMPLATE, ex.getMessage()), ex);
+			throw new BadJwtException(String.format(DECODING_ERROR_MESSAGE_TEMPLATE, ex.getMessage()), ex);
 		}
 	}
 
@@ -152,11 +153,13 @@ public final class NimbusJwtDecoder implements JwtDecoder {
 			} else {
 				throw new JwtException(String.format(DECODING_ERROR_MESSAGE_TEMPLATE, ex.getMessage()), ex);
 			}
+		} catch (JOSEException ex) {
+			throw new JwtException(String.format(DECODING_ERROR_MESSAGE_TEMPLATE, ex.getMessage()), ex);
 		} catch (Exception ex) {
 			if (ex.getCause() instanceof ParseException) {
-				throw new JwtException(String.format(DECODING_ERROR_MESSAGE_TEMPLATE, "Malformed payload"));
+				throw new BadJwtException(String.format(DECODING_ERROR_MESSAGE_TEMPLATE, "Malformed payload"));
 			} else {
-				throw new JwtException(String.format(DECODING_ERROR_MESSAGE_TEMPLATE, ex.getMessage()), ex);
+				throw new BadJwtException(String.format(DECODING_ERROR_MESSAGE_TEMPLATE, ex.getMessage()), ex);
 			}
 		}
 	}

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/SingleKeyJWSKeySelector.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/SingleKeyJWSKeySelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ final class SingleKeyJWSKeySelector<C extends SecurityContext> implements JWSKey
 	@Override
 	public List<? extends Key> selectJWSKeys(JWSHeader header, C context) {
 		if (!this.expectedJwsAlgorithm.equals(header.getAlgorithm())) {
-			throw new IllegalArgumentException("Unsupported algorithm of " + header.getAlgorithm());
+			throw new BadJwtException("Unsupported algorithm of " + header.getAlgorithm());
 		}
 		return this.keySet;
 	}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationProvider.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationProvider.java
@@ -20,9 +20,11 @@ import java.util.Collection;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.BadJwtException;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtException;
@@ -80,8 +82,10 @@ public final class JwtAuthenticationProvider implements AuthenticationProvider {
 		Jwt jwt;
 		try {
 			jwt = this.jwtDecoder.decode(bearer.getToken());
-		} catch (JwtException failed) {
+		} catch (BadJwtException failed) {
 			throw new InvalidBearerTokenException(failed.getMessage(), failed);
+		} catch (JwtException failed) {
+			throw new AuthenticationServiceException(failed.getMessage(), failed);
 		}
 
 		AbstractAuthenticationToken token = this.jwtAuthenticationConverter.convert(jwt);

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtReactiveAuthenticationManager.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtReactiveAuthenticationManager.java
@@ -20,9 +20,11 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.ReactiveAuthenticationManager;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.jwt.BadJwtException;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
@@ -71,7 +73,11 @@ public final class JwtReactiveAuthenticationManager implements ReactiveAuthentic
 		this.jwtAuthenticationConverter = jwtAuthenticationConverter;
 	}
 
-	private OAuth2AuthenticationException onError(JwtException e) {
-		return new InvalidBearerTokenException(e.getMessage(), e);
+	private AuthenticationException onError(JwtException e) {
+		if (e instanceof BadJwtException) {
+			return new InvalidBearerTokenException(e.getMessage(), e);
+		} else {
+			return new AuthenticationServiceException(e.getMessage(), e);
+		}
 	}
 }

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/DefaultAuthenticationEventPublisherBearerTokenTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/DefaultAuthenticationEventPublisherBearerTokenTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.resource;
+
+import org.junit.Test;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
+import org.springframework.security.authentication.event.AuthenticationFailureBadCredentialsEvent;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.oauth2.jwt.TestJwts.jwt;
+
+/**
+ * Tests for {@link DefaultAuthenticationEventPublisher}'s bearer token use cases
+ *
+ * {@see DefaultAuthenticationEventPublisher}
+ */
+public class DefaultAuthenticationEventPublisherBearerTokenTests {
+	DefaultAuthenticationEventPublisher publisher;
+
+	@Test
+	public void publishAuthenticationFailureWhenInvalidBearerTokenExceptionThenMaps() {
+		ApplicationEventPublisher appPublisher = mock(ApplicationEventPublisher.class);
+		Authentication authentication = new JwtAuthenticationToken(jwt().build());
+		Exception cause = new Exception();
+		this.publisher = new DefaultAuthenticationEventPublisher(appPublisher);
+		this.publisher.publishAuthenticationFailure(new InvalidBearerTokenException("invalid"), authentication);
+		this.publisher.publishAuthenticationFailure(new InvalidBearerTokenException("invalid", cause), authentication);
+		verify(appPublisher, times(2)).publishEvent(
+				isA(AuthenticationFailureBadCredentialsEvent.class));
+	}
+}


### PR DESCRIPTION
This PR improves how Resource Server handles Bearer Token errors. 

Specifically:

* It adds `InvalidBearerTokenException` to `DefaultAuthenticationEventPublisher`.
* It differentiates between JWT processing errors that are token-related vs configuration or service-related.

These are in the same PR because Resource Server cannot currently determine whether or not a JWT processing error is really an invalid token, and I'd like to address that before registering that exception with `DefaultAuthenticationEventPublisher`.