### PR TITLE
Remove redundant branches from SessionManagementConfigurer

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
@@ -557,17 +557,13 @@ public final class SessionManagementConfigurer<H extends HttpSecurityBuilder<H>>
 		if (this.invalidSessionStrategy != null) {
 			return this.invalidSessionStrategy;
 		}
-		if (this.invalidSessionUrl != null) {
-			this.invalidSessionStrategy = new SimpleRedirectInvalidSessionStrategy(
-					this.invalidSessionUrl);
-		}
+		
 		if (this.invalidSessionUrl == null) {
 			return null;
 		}
-		if (this.invalidSessionStrategy == null) {
-			this.invalidSessionStrategy = new SimpleRedirectInvalidSessionStrategy(
+		
+		this.invalidSessionStrategy = new SimpleRedirectInvalidSessionStrategy(
 					this.invalidSessionUrl);
-		}
 		return this.invalidSessionStrategy;
 	}
 
@@ -580,10 +576,8 @@ public final class SessionManagementConfigurer<H extends HttpSecurityBuilder<H>>
 			return null;
 		}
 
-		if (this.expiredSessionStrategy == null) {
-			this.expiredSessionStrategy = new SimpleRedirectSessionInformationExpiredStrategy(
-					this.expiredUrl);
-		}
+		this.expiredSessionStrategy = new SimpleRedirectSessionInformationExpiredStrategy(
+				this.expiredUrl);
 		return this.expiredSessionStrategy;
 	}
 
@@ -596,10 +590,8 @@ public final class SessionManagementConfigurer<H extends HttpSecurityBuilder<H>>
 			return null;
 		}
 
-		if (this.sessionAuthenticationFailureHandler == null) {
-			this.sessionAuthenticationFailureHandler = new SimpleUrlAuthenticationFailureHandler(
-					this.sessionAuthenticationErrorUrl);
-		}
+		this.sessionAuthenticationFailureHandler = new SimpleUrlAuthenticationFailureHandler(
+				this.sessionAuthenticationErrorUrl);
 		return this.sessionAuthenticationFailureHandler;
 	}
 


### PR DESCRIPTION
I've complained about the style in which these are written before, but this was a prime example of how it over-complicates the control flow, leading to (in this case thankfully not dangerous) errors.

Making use of `else` and `&&` would simplify this, and other configuration code, even further.
For this case something like this would be best, but I've had changes like this rejected before.
```
if (this.invalidSessionStrategy == null && this.invalidSessionUrl != null) {
    this.invalidSessionStrategy = new SimpleRedirectInvalidSessionStrategy(
            this.invalidSessionUrl);
}
return this.invalidSessionStrategy;
```

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
