### PR TITLE
Prevent double-escaping of authorize URL parameters

### DIFF
--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/OAuth2AuthorizationRequest.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/OAuth2AuthorizationRequest.java
@@ -23,8 +23,10 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
 
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -375,21 +377,21 @@ public final class OAuth2AuthorizationRequest implements Serializable {
 
 		private String buildAuthorizationRequestUri() {
 			MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
-			parameters.set(OAuth2ParameterNames.RESPONSE_TYPE, percentEncode(this.responseType.getValue()));
-			parameters.set(OAuth2ParameterNames.CLIENT_ID, percentEncode(this.clientId));
+			parameters.set(OAuth2ParameterNames.RESPONSE_TYPE, encodeQueryParam(this.responseType.getValue()));
+			parameters.set(OAuth2ParameterNames.CLIENT_ID, encodeQueryParam(this.clientId));
 			if (!CollectionUtils.isEmpty(this.scopes)) {
 				parameters.set(OAuth2ParameterNames.SCOPE,
-						percentEncode(StringUtils.collectionToDelimitedString(this.scopes, " ")));
+						encodeQueryParam(StringUtils.collectionToDelimitedString(this.scopes, " ")));
 			}
 			if (this.state != null) {
-				parameters.set(OAuth2ParameterNames.STATE, percentEncode(this.state));
+				parameters.set(OAuth2ParameterNames.STATE, encodeQueryParam(this.state));
 			}
 			if (this.redirectUri != null) {
-				parameters.set(OAuth2ParameterNames.REDIRECT_URI, percentEncode(this.redirectUri));
+				parameters.set(OAuth2ParameterNames.REDIRECT_URI, encodeQueryParam(this.redirectUri));
 			}
 			if (!CollectionUtils.isEmpty(this.additionalParameters)) {
 				this.additionalParameters.forEach((k, v) ->
-						parameters.set(percentEncode(k), percentEncode(v.toString())));
+						parameters.set(encodeQueryParam(k), encodeQueryParam(v.toString())));
 			}
 
 			return UriComponentsBuilder.fromHttpUrl(this.authorizationUri)
@@ -399,14 +401,8 @@ public final class OAuth2AuthorizationRequest implements Serializable {
 		}
 
 		// Encode query parameter value according to RFC 3986
-		private static String percentEncode(String value) {
-			return UriComponentsBuilder
-					.fromPath("")
-					.queryParam("t", value)
-					.build()
-					.encode()
-					.toUriString()
-					.substring(3);
+		private static String encodeQueryParam(String value) {
+			return UriUtils.encodeQueryParam(value, StandardCharsets.UTF_8);
 		}
 
 		private LinkedHashSet<String> toLinkedHashSet(String... scope) {

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/OAuth2AuthorizationRequestTests.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/OAuth2AuthorizationRequestTests.java
@@ -307,4 +307,19 @@ public class OAuth2AuthorizationRequestTests {
 						"response_type=code&client_id=client-id&state=state&" +
 						"redirect_uri=https://example.com/authorize/oauth2/code/registration-id");
 	}
+
+	@Test
+	public void buildWhenAuthorizationUriIncludesEscapedQueryParameterThenAuthorizationRequestUrlIncludesIt() {
+		OAuth2AuthorizationRequest authorizationRequest =
+				TestOAuth2AuthorizationRequests.request()
+						.authorizationUri(AUTHORIZATION_URI +
+								"?claims=%7B%22userinfo%22%3A%7B%22email_verified%22%3A%7B%22essential%22%3Atrue%7D%7D%7D").build();
+
+		assertThat(authorizationRequest.getAuthorizationRequestUri()).isNotNull();
+		assertThat(authorizationRequest.getAuthorizationRequestUri())
+				.isEqualTo("https://provider.com/oauth2/authorize?" +
+						"claims=%7B%22userinfo%22%3A%7B%22email_verified%22%3A%7B%22essential%22%3Atrue%7D%7D%7D&" +
+						"response_type=code&client_id=client-id&state=state&" +
+						"redirect_uri=https://example.com/authorize/oauth2/code/registration-id");
+	}
 }

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/OAuth2AuthorizationRequestTests.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/OAuth2AuthorizationRequestTests.java
@@ -322,4 +322,23 @@ public class OAuth2AuthorizationRequestTests {
 						"response_type=code&client_id=client-id&state=state&" +
 						"redirect_uri=https://example.com/authorize/oauth2/code/registration-id");
 	}
+
+	@Test
+	public void buildWhenNonAsciiAdditionalParametersThenProperlyEncoded() {
+		Map<String, Object> additionalParameters = new HashMap<>();
+		additionalParameters.put("item amount", "19.95€");
+		additionalParameters.put("item name", "HÅMÖ");
+		additionalParameters.put("âge", "4½");
+		OAuth2AuthorizationRequest authorizationRequest =
+				TestOAuth2AuthorizationRequests.request()
+						.additionalParameters(additionalParameters)
+						.build();
+
+		assertThat(authorizationRequest.getAuthorizationRequestUri()).isNotNull();
+		assertThat(authorizationRequest.getAuthorizationRequestUri())
+				.isEqualTo("https://example.com/login/oauth/authorize?" +
+						"response_type=code&client_id=client-id&state=state&" +
+						"redirect_uri=https://example.com/authorize/oauth2/code/registration-id&" +
+						"item%20amount=19.95%E2%82%AC&%C3%A2ge=4%C2%BD&item%20name=H%C3%85M%C3%96");
+	}
 }


### PR DESCRIPTION
If the authorization URL in the OAuth2 provider configuration contained query parameters with percent escaped characters, these characters were escaped a second time – damaging the URL. This commit fixes it.

It is relevant to support the OIDC claims parameter (see https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter).

Fixes gh-7871

**Implementation notes**

As `UriComponentsBuilder` cannot fully decode query parameters (no implementation for undoing the percent escaping), the approach is to assemble already escaped components. Before adding query parameters to the authorization URL, they must therefore be properly escaped.

The method for percent escaping uses separate `UriComponentsBuilder` instances. That's not straight-forward but the only way to access the method `HierarchicalUriComponents.encodeUriComponent`. It ensures that the minimal necessary escaping according to RFC 3986 is applied.

An alternative would be to use `java.net.URLEncoder.encode`. Contrary to its name, this method applies *HTML form encoding*, which is similar but far more aggressive, i.e. it escapes additional characters such as `/`, `:` etc.
