### PR TITLE
BCryptPasswordEncoder handle null rawPassword

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoder.java
@@ -123,7 +123,6 @@ public class BCryptPasswordEncoder implements PasswordEncoder {
 			logger.warn("Empty raw password");
 			return false;
 		}
-
 		return BCrypt.checkpw(rawPassword.toString(), encodedPassword);
 	}
 

--- a/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoder.java
@@ -123,6 +123,7 @@ public class BCryptPasswordEncoder implements PasswordEncoder {
 			logger.warn("Empty raw password");
 			return false;
 		}
+
 		return BCrypt.checkpw(rawPassword.toString(), encodedPassword);
 	}
 

--- a/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoder.java
@@ -119,6 +119,11 @@ public class BCryptPasswordEncoder implements PasswordEncoder {
 			return false;
 		}
 
+		if(rawPassword.toString() == null || rawPassword.toString.length() == 0){
+			logger.warn("Empty raw password");
+			return false;
+		}
+
 		return BCrypt.checkpw(rawPassword.toString(), encodedPassword);
 	}
 

--- a/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2011 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Detecting the NullPointerException of rawPassword

I believe that the method of BCryptPasswordEncoder's matches() should have       a way to detect whether the rawPassword is null.Because Spring Security will delete the password of authentication stored in the SecurityContext after I log in, so my other authenticate request will get a NullPointerException from BCryptPasswordEncoder's matches().There should have a way to detect the NullPointerException of rawPassword

