### PR TITLE
Instantiate exceptions lazily

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
@@ -121,7 +121,7 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 		return this.issuerConverter.convert(exchange)
 				.flatMap(issuer ->
 					this.issuerAuthenticationManagerResolver.resolve(issuer).switchIfEmpty(
-							Mono.error(new InvalidBearerTokenException("Invalid issuer " + issuer)))
+							Mono.error(() -> new InvalidBearerTokenException("Invalid issuer " + issuer)))
 				);
 	}
 
@@ -142,7 +142,7 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 			try {
 				String issuer = JWTParser.parse(token.getToken()).getJWTClaimsSet().getIssuer();
 				return Mono.justOrEmpty(issuer).switchIfEmpty(
-						Mono.error(new InvalidBearerTokenException("Missing issuer")));
+						Mono.error(() -> new InvalidBearerTokenException("Missing issuer")));
 			} catch (Exception e) {
 				return Mono.error(new InvalidBearerTokenException(e.getMessage()));
 			}


### PR DESCRIPTION
Add lazy Exception instantiation and reduce amount of
reactor operators to reduce allocations

Fixes gh-7995

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
