### PR TITLE
Allow to configure principal name for Resource Server auth

### DIFF
--- a/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
@@ -1794,8 +1794,8 @@ public class ServerHttpSecurity {
 		public class JwtSpec {
 			private ReactiveAuthenticationManager authenticationManager;
 			private ReactiveJwtDecoder jwtDecoder;
-			private Converter<Jwt, ? extends Mono<? extends AbstractAuthenticationToken>> jwtAuthenticationConverter
-					= new ReactiveJwtAuthenticationConverterAdapter(new JwtAuthenticationConverter());
+			private Converter<Jwt, ? extends Mono<? extends AbstractAuthenticationToken>> jwtAuthenticationConverter;
+			private String principalNameClaim;
 
 			/**
 			 * Configures the {@link ReactiveAuthenticationManager} to use
@@ -1855,6 +1855,16 @@ public class ServerHttpSecurity {
 				return this;
 			}
 
+			/**
+			 * Name of a JWT claim to use as a principal name
+			 * @param principalNameClaim name of a JWT claim
+			 * @return the {@code JwtSpec} for additional configuration
+			 */
+			public JwtSpec principalNameClaim(String principalNameClaim) {
+				this.principalNameClaim = principalNameClaim;
+				return this;
+			}
+
 			public OAuth2ResourceServerSpec and() {
 				return OAuth2ResourceServerSpec.this;
 			}
@@ -1877,6 +1887,12 @@ public class ServerHttpSecurity {
 
 			protected Converter<Jwt, ? extends Mono<? extends AbstractAuthenticationToken>>
 					getJwtAuthenticationConverter() {
+
+				if (this.jwtAuthenticationConverter == null) {
+					JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+					converter.setPrincipalNameClaim(this.principalNameClaim);
+					this.jwtAuthenticationConverter = new ReactiveJwtAuthenticationConverterAdapter(converter);
+				}
 
 				return this.jwtAuthenticationConverter;
 			}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationConverter.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationConverter.java
@@ -33,10 +33,16 @@ public class JwtAuthenticationConverter implements Converter<Jwt, AbstractAuthen
 	private Converter<Jwt, Collection<GrantedAuthority>> jwtGrantedAuthoritiesConverter
 			= new JwtGrantedAuthoritiesConverter();
 
+	private String principalNameClaim;
+
 	@Override
 	public final AbstractAuthenticationToken convert(Jwt jwt) {
 		Collection<GrantedAuthority> authorities = extractAuthorities(jwt);
-		return new JwtAuthenticationToken(jwt, authorities);
+		if (this.principalNameClaim != null && jwt.containsClaim(this.principalNameClaim)) {
+			return new JwtAuthenticationToken(jwt, authorities, jwt.getClaimAsString(this.principalNameClaim));
+		} else {
+			return new JwtAuthenticationToken(jwt, authorities);
+		}
 	}
 
 	/**
@@ -64,5 +70,9 @@ public class JwtAuthenticationConverter implements Converter<Jwt, AbstractAuthen
 	public void setJwtGrantedAuthoritiesConverter(Converter<Jwt, Collection<GrantedAuthority>> jwtGrantedAuthoritiesConverter) {
 		Assert.notNull(jwtGrantedAuthoritiesConverter, "jwtGrantedAuthoritiesConverter cannot be null");
 		this.jwtGrantedAuthoritiesConverter = jwtGrantedAuthoritiesConverter;
+	}
+
+	public void setPrincipalNameClaim(String principalNameClaim) {
+		this.principalNameClaim = principalNameClaim;
 	}
 }

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationConverterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationConverterTests.java
@@ -73,4 +73,22 @@ public class JwtAuthenticationConverterTests {
 		assertThat(authorities).containsExactly(
 				new SimpleGrantedAuthority("blah"));
 	}
+
+	@Test
+	public void convertWithConfiguredPrincipalClaimName() {
+		Jwt jwt = jwt().claim("username", "test-user").build();
+		this.jwtAuthenticationConverter.setPrincipalNameClaim("username");
+		AbstractAuthenticationToken authentication = this.jwtAuthenticationConverter.convert(jwt);
+
+		assertThat(authentication.getName()).isEqualTo("test-user");
+	}
+
+	@Test
+	public void convertWithConfiguredPrincipalClaimNameWithMissingClaim() {
+		Jwt jwt = jwt().claim("username", "test-user").build();
+		this.jwtAuthenticationConverter.setPrincipalNameClaim("given_name");
+		AbstractAuthenticationToken authentication = this.jwtAuthenticationConverter.convert(jwt);
+
+		assertThat(authentication.getName()).isEqualTo(jwt.getSubject());
+	}
 }


### PR DESCRIPTION
Add new configuration property `.jwt().principalNameClaim("claim-name")` to configure `JwtAuthenticationConverter` to use value of that claim as a token name, so `authentication.getName()` can contain any value from the token.

If claim name is not provided or JWT token doesn't contain it, default of 'sub' claim will be used to keep changes backward compatible.

Currently the only way to have different name for `JwtAuthenticationToken` authentication object is to override the whole `jwtAuthenticationConverter` and implement a custom converter. However extracting a different principal name seems to be a common requirement, so I think this option can be useful. 

I was thinking to introduce new `JwtAuthenticationConverterSpec` class to chain it more logically, like `jwt().jwtAuthenticationConverter().principalNameClaim("...")` but that is potenitally not backward compatible (requires an extra `.and()` to back to `JwtSpec` level). 

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
