### PR TITLE
Fixes gh-4001 : CSRF token BREACH Attack

### DIFF
--- a/config/src/test/java/org/springframework/security/config/http/CsrfConfigTests.java
+++ b/config/src/test/java/org/springframework/security/config/http/CsrfConfigTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -640,7 +640,7 @@ public class CsrfConfigTests {
 			MockHttpServletRequest request = result.getRequest();
 			CsrfToken token = WebTestUtils.getCsrfTokenRepository(request).loadToken(request);
 			assertThat(token).isNotNull();
-			assertThat(token.getToken()).isEqualTo(this.token.apply(result));
+			assertThat(token.matches(this.token.apply(result))).isTrue();
 		}
 	}
 

--- a/docs/manual/src/docs/asciidoc/_includes/about/exploits/csrf.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/about/exploits/csrf.adoc
@@ -411,3 +411,10 @@ Overriding the HTTP method occurs in a filter.
 That filter must be placed before Spring Security's support.
 Note that overriding only happens on a `post`, so this is actually unlikely to cause any real problems.
 However, it is still best practice to ensure it is placed before Spring Security's filters.
+
+
+[[csrf-considerations-breach-mitigation]]
+==== BREACH Security Exploit Mitigation
+In order to protect our application from BREACH attacks https://en.wikipedia.org/wiki/BREACH consider to use `XorCsrfToken` implementation instead of `DefaultCsrfToken`.
+`XorCsrfToken` implementation provides protection from BREACH by always returning random string for the token value.
+this will make it harder to guess the actual length of each response payload when using HTTP compression.

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/exploits/csrf.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/exploits/csrf.adoc
@@ -414,3 +414,62 @@ We have <<csrf-considerations-multipart-body,already discussed>> the trade-offs 
 
 In Spring's Servlet support, overriding the HTTP method is done using https://docs.spring.io/spring-framework/docs/5.2.x/javadoc-api/org/springframework/web/filter/reactive/HiddenHttpMethodFilter.html[HiddenHttpMethodFilter].
 More information can be found in https://docs.spring.io/spring/docs/5.2.x/spring-framework-reference/web.html#mvc-rest-method-conversion[HTTP Method Conversion] section of the reference documentation.
+
+[[servlet-csrf-considerations-breach-mitigation]]
+=== BREACH Security Exploit Mitigation
+We have <<csrf-considerations-breach-mitigation,already discussed>> usage on `XorCsrfToken` implementation.
+
+In Spring's Servlet support, https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/web/csrf/CookieCsrfTokenRepository.html[CookieCsrfTokenRepository] and https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/web/csrf/HttpSessionCsrfTokenRepository.html[HttpSessionCsrfTokenRepository] use https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/web/csrf/DefaultCsrfToken.html[DefaultCsrfToken] instance type as return type for method `generateToken(HttpServletRequest request)` and `loadToken(HttpServletRequest request)`.
+
+In order to override the default implementation in both classes `setGenerateToken(GenerateTokenProvider<? extends CsrfToken> generateTokenProvider)` is introduced.
+We could set the https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/web/csrf/GenerateTokenProvider.html[GenerateTokenProvider] from provided static method https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/web/csrf/XorCsrfToken.html[XorCsrfToken.createGenerateTokenProvider()] as per below:
+
+.setGenerateToken from provided static method
+====
+[source,java]
+----
+CookieCsrfTokenRepository cookieCsrfTokenRepository = new CookieCsrfTokenRepository();
+cookieCsrfTokenRepository.setGenerateToken(XorCsrfToken.createGenerateTokenProvider())
+----
+====
+
+or we could set by defining our own implementation
+
+.setGenerateToken own implementation
+====
+[source,java]
+----
+CookieCsrfTokenRepository cookieCsrfTokenRepository = new CookieCsrfTokenRepository();
+cookieCsrfTokenRepository.setGenerateToken((headerName, parameterName, value) -> new XorCsrfToken(headerName, parameterName, value))
+----
+====
+
+Note that `GenerateTokenProvider` is a `FunctionalInterface` that accepts three parameters `(headerName, parameterName, value)`,
+`headerName` and `parameterName` values are derived/assigned from `CookieCsrfTokenRepository` / `HttpSessionCsrfTokenRepository` fields,
+`value` is a string token value generated/loaded from `CookieCsrfTokenRepository` / `HttpSessionCsrfTokenRepository`.
+
+We could customize `headerName` and `parameterName` in a couple of ways:
+
+.setGenerateToken hard coded
+====
+[source,java]
+----
+CookieCsrfTokenRepository cookieCsrfTokenRepository = new CookieCsrfTokenRepository();
+cookieCsrfTokenRepository.setGenerateToken((headerName, parameterName, value) -> new XorCsrfToken("customHeader", "customParameter", value));
+----
+====
+
+.setGenerateToken from our own configuration instance
+====
+[source,java]
+----
+ExampleConfig exampleConfig = new ExampleConfig();
+
+CookieCsrfTokenRepository cookieCsrfTokenRepository = new CookieCsrfTokenRepository();
+cookieCsrfTokenRepository.setGenerateToken((headerName, parameterName, value) -> new XorCsrfToken(exampleConfig.getHeaderName(), exampleConfig.getParameterName(), value))
+----
+====
+
+This means in the future `headerName` and `parameterName` will be maintained outside of `CookieCsrfTokenRepository` / `HttpSessionCsrfTokenRepository` classes,
+so `setHeaderName(String headerName)` and `setParameterName(String parameterName)` are deprecated and might be removed in the future version.
+

--- a/messaging/src/main/java/org/springframework/security/messaging/web/csrf/CsrfChannelInterceptor.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/web/csrf/CsrfChannelInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public final class CsrfChannelInterceptor extends ChannelInterceptorAdapter {
 		String actualTokenValue = SimpMessageHeaderAccessor.wrap(message)
 				.getFirstNativeHeader(expectedToken.getHeaderName());
 
-		boolean csrfCheckPassed = expectedToken.getToken().equals(actualTokenValue);
+		boolean csrfCheckPassed = expectedToken.matches(actualTokenValue);
 		if (csrfCheckPassed) {
 			return message;
 		}

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestBuildersFormLoginTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestBuildersFormLoginTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,8 +44,7 @@ public class SecurityMockMvcRequestBuildersFormLoginTests {
 		assertThat(request.getParameter("username")).isEqualTo("user");
 		assertThat(request.getParameter("password")).isEqualTo("password");
 		assertThat(request.getMethod()).isEqualTo("POST");
-		assertThat(request.getParameter(token.getParameterName()))
-				.isEqualTo(token.getToken());
+		assertThat(token.matches(request.getParameter(token.getParameterName()))).isTrue();
 		assertThat(request.getRequestURI()).isEqualTo("/login");
 		assertThat(request.getParameter("_csrf")).isNotNull();
 	}
@@ -61,8 +60,7 @@ public class SecurityMockMvcRequestBuildersFormLoginTests {
 		assertThat(request.getParameter("username")).isEqualTo("admin");
 		assertThat(request.getParameter("password")).isEqualTo("secret");
 		assertThat(request.getMethod()).isEqualTo("POST");
-		assertThat(request.getParameter(token.getParameterName()))
-				.isEqualTo(token.getToken());
+		assertThat(token.matches(request.getParameter(token.getParameterName()))).isTrue();
 		assertThat(request.getRequestURI()).isEqualTo("/login");
 	}
 
@@ -77,8 +75,7 @@ public class SecurityMockMvcRequestBuildersFormLoginTests {
 		assertThat(request.getParameter("username")).isEqualTo("admin");
 		assertThat(request.getParameter("password")).isEqualTo("secret");
 		assertThat(request.getMethod()).isEqualTo("POST");
-		assertThat(request.getParameter(token.getParameterName()))
-				.isEqualTo(token.getToken());
+		assertThat(token.matches(request.getParameter(token.getParameterName()))).isTrue();
 		assertThat(request.getRequestURI()).isEqualTo("/uri-login/val1/val2");
 	}
 

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestBuildersFormLogoutTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestBuildersFormLogoutTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2014 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,8 +40,7 @@ public class SecurityMockMvcRequestBuildersFormLogoutTests {
 		CsrfToken token = (CsrfToken) request.getAttribute(CsrfRequestPostProcessor.TestCsrfTokenRepository.TOKEN_ATTR_NAME);
 
 		assertThat(request.getMethod()).isEqualTo("POST");
-		assertThat(request.getParameter(token.getParameterName())).isEqualTo(
-				token.getToken());
+		assertThat(token.matches(request.getParameter(token.getParameterName()))).isTrue();
 		assertThat(request.getRequestURI()).isEqualTo("/logout");
 	}
 
@@ -53,8 +52,7 @@ public class SecurityMockMvcRequestBuildersFormLogoutTests {
 		CsrfToken token = (CsrfToken) request.getAttribute(CsrfRequestPostProcessor.TestCsrfTokenRepository.TOKEN_ATTR_NAME);
 
 		assertThat(request.getMethod()).isEqualTo("POST");
-		assertThat(request.getParameter(token.getParameterName())).isEqualTo(
-				token.getToken());
+		assertThat(token.matches(request.getParameter(token.getParameterName()))).isTrue();
 		assertThat(request.getRequestURI()).isEqualTo("/admin/logout");
 	}
 
@@ -66,8 +64,7 @@ public class SecurityMockMvcRequestBuildersFormLogoutTests {
 		CsrfToken token = (CsrfToken) request.getAttribute(CsrfRequestPostProcessor.TestCsrfTokenRepository.TOKEN_ATTR_NAME);
 
 		assertThat(request.getMethod()).isEqualTo("POST");
-		assertThat(request.getParameter(token.getParameterName())).isEqualTo(
-				token.getToken());
+		assertThat(token.matches(request.getParameter(token.getParameterName()))).isTrue();
 		assertThat(request.getRequestURI()).isEqualTo("/uri-logout/val1/val2");
 	}
 

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,7 +122,7 @@ public final class CsrfFilter extends OncePerRequestFilter {
 		if (actualToken == null) {
 			actualToken = request.getParameter(csrfToken.getParameterName());
 		}
-		if (!csrfToken.getToken().equals(actualToken)) {
+		if (!csrfToken.matches(actualToken)) {
 			if (this.logger.isDebugEnabled()) {
 				this.logger.debug("Invalid CSRF token found for "
 						+ UrlUtils.buildFullRequestUrl(request));

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfToken.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.io.Serializable;
  * Provides the information about an expected CSRF token.
  *
  * @see DefaultCsrfToken
+ * @see XorCsrfToken
  *
  * @author Rob Winch
  * @since 3.2
@@ -49,4 +50,14 @@ public interface CsrfToken extends Serializable {
 	 */
 	String getToken();
 
+	/**
+	 * Compare if this token matches with another token.
+	 *
+	 * @param token to be matched
+	 * @return true if this instance token matches the token, otherwise false.
+	 * @since 5.4
+	 */
+	default boolean matches(String token) {
+		return getToken().equals(token);
+	}
 }

--- a/web/src/main/java/org/springframework/security/web/csrf/GenerateTokenProvider.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/GenerateTokenProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.web.csrf;
+
+/**
+ * Functional interface to provide CSRF token generation logic
+ *
+ * @author Ruby Hartono
+ *
+ * @param <T> the type of the returned CsrfToken
+ * @since 5.4
+ */
+@FunctionalInterface
+public interface GenerateTokenProvider<T extends CsrfToken> {
+
+	/**
+	 * Generate CsrfToken from parameters
+	 *
+	 * @param headerName    header name
+	 * @param parameterName parameter name
+	 * @param value         token value
+	 * @return CsrfToken generated from parameters
+	 */
+	T generateToken(String headerName, String parameterName, String value);
+}

--- a/web/src/main/java/org/springframework/security/web/csrf/LazyCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/LazyCsrfTokenRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2016 the original author or authors.
+ * Copyright 2012-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,6 +126,12 @@ public final class LazyCsrfTokenRepository implements CsrfTokenRepository {
 		public String getToken() {
 			saveTokenIfNecessary();
 			return this.delegate.getToken();
+		}
+
+		@Override
+		public boolean matches(String token) {
+			saveTokenIfNecessary();
+			return this.delegate.matches(token);
 		}
 
 		@Override

--- a/web/src/main/java/org/springframework/security/web/csrf/XorCsrfToken.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/XorCsrfToken.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.web.csrf;
+
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+import org.springframework.security.crypto.codec.Utf8;
+import org.springframework.util.Assert;
+
+/**
+ * A CSRF token that is used to protect against CSRF attacks.<br/>
+ * <br/>
+ * This token provide protection from BREACH exploit by always returning a Base64Url encoded
+ * random string (XOR-ed token value with salt) {@link #getToken()}. In order to check if an
+ * instance token matches with the string value use
+ * {@link #matches(String)}
+ *
+ * @author Ruby Hartono
+ * @since 5.4
+ */
+@SuppressWarnings("serial")
+public final class XorCsrfToken implements CsrfToken {
+
+	/**
+	 * Convenient method to provide generate token
+	 *
+	 * @return GenerateTokenProvider that generate XorCsrfToken with
+	 *         {@link java.security.SecureRandom} empty constructor
+	 * @see CookieCsrfTokenRepository
+	 * @see HttpSessionCsrfTokenRepository
+	 */
+	public static GenerateTokenProvider<XorCsrfToken> createGenerateTokenProvider() {
+		return (headerName, parameterName, value) -> new XorCsrfToken(headerName, parameterName, value);
+	}
+
+	/**
+	 * Convenient method to provide generate token
+	 *
+	 * @param secureRandom instance to be set for the XorCsrfToken
+	 * @return GenerateTokenProvider that that generate XorCsrfToken with
+	 *         {@link java.security.SecureRandom} from parameter
+	 * @see CookieCsrfTokenRepository
+	 * @see HttpSessionCsrfTokenRepository
+	 */
+	public static GenerateTokenProvider<XorCsrfToken> createGenerateTokenProvider(SecureRandom secureRandom) {
+		return (headerName, parameterName, value) -> new XorCsrfToken(headerName, parameterName, value, secureRandom);
+	}
+
+	private final byte[] tokenBytes;
+
+	private final String parameterName;
+
+	private final String headerName;
+
+	private final SecureRandom secureRandom;
+
+	/**
+	 * Creates a new instance
+	 *
+	 * @param headerName    the HTTP header name to use
+	 * @param parameterName the HTTP parameter name to use
+	 * @param token         the value of the token (i.e. expected value of the HTTP
+	 *                      parameter of parametername).
+	 */
+	public XorCsrfToken(String headerName, String parameterName, String token) {
+		this(headerName, parameterName, token, new SecureRandom());
+	}
+
+	/**
+	 * Creates a new instance
+	 *
+	 * @param headerName    the HTTP header name to use
+	 * @param parameterName the HTTP parameter name to use
+	 * @param token         the value of the token (i.e. expected value of the HTTP
+	 *                      parameter of parametername).
+	 * @param secureRandom  secure random instance to be used for random salt
+	 */
+	public XorCsrfToken(String headerName, String parameterName, String token, SecureRandom secureRandom) {
+		Assert.hasLength(headerName, "headerName cannot be null or empty");
+		Assert.hasLength(parameterName, "parameterName cannot be null or empty");
+		Assert.hasLength(token, "token cannot be null or empty");
+		this.headerName = headerName;
+		this.parameterName = parameterName;
+		this.tokenBytes = Utf8.encode(token);
+		this.secureRandom = secureRandom;
+	}
+
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see org.springframework.security.web.csrf.CsrfToken#getHeaderName()
+	 */
+	public String getHeaderName() {
+		return this.headerName;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see org.springframework.security.web.csrf.CsrfToken#getParameterName()
+	 */
+	public String getParameterName() {
+		return this.parameterName;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see org.springframework.security.web.csrf.CsrfToken#getToken()
+	 */
+	public String getToken() {
+		byte[] randomBytes = new byte[this.tokenBytes.length];
+		this.secureRandom.nextBytes(randomBytes);
+
+		byte[] xoredCsrf = xorCsrf(randomBytes, this.tokenBytes);
+
+		byte[] combinedBytes = new byte[randomBytes.length + xoredCsrf.length];
+		System.arraycopy(randomBytes, 0, combinedBytes, 0, randomBytes.length);
+		System.arraycopy(xoredCsrf, 0, combinedBytes, randomBytes.length, xoredCsrf.length);
+
+		// returning randomBytes + XOR csrf token
+		return Base64.getUrlEncoder().encodeToString(combinedBytes);
+	}
+
+	public String getTokenValue() {
+		return Utf8.decode(this.tokenBytes);
+	}
+
+
+	private static byte[] xorCsrf(byte[] randomBytes, byte[] csrfBytes) {
+		byte[] xoredCsrf = new byte[csrfBytes.length];
+		System.arraycopy(csrfBytes, 0, xoredCsrf, 0, csrfBytes.length);
+		for (byte b : randomBytes) {
+			for (int i = 0; i < xoredCsrf.length; i++) {
+				xoredCsrf[i] ^= b;
+			}
+		}
+
+		return xoredCsrf;
+	}
+
+	@Override
+	public boolean matches(String token) {
+		byte[] paramToken = null;
+
+		try {
+			paramToken = Base64.getUrlDecoder().decode(token);
+		} catch (Exception ex) {
+			return false;
+		}
+
+		int tokenSize = this.tokenBytes.length;
+
+		if (paramToken.length == tokenSize) {
+			return MessageDigest.isEqual(this.tokenBytes, paramToken);
+		} else if (paramToken.length < tokenSize) {
+			return false;
+		}
+
+		// extract token and random bytes
+		int paramXorTokenOffset = paramToken.length - tokenSize;
+		byte[] paramXoredToken = new byte[tokenSize];
+		byte[] paramRandomBytes = new byte[paramXorTokenOffset];
+
+		System.arraycopy(paramToken, 0, paramRandomBytes, 0, paramXorTokenOffset);
+		System.arraycopy(paramToken, paramXorTokenOffset, paramXoredToken, 0, paramXoredToken.length);
+
+		byte[] paramActualCsrfToken = xorCsrf(paramRandomBytes, paramXoredToken);
+
+		// comparing this token with the actual csrf token from param
+		return MessageDigest.isEqual(this.tokenBytes, paramActualCsrfToken);
+	}
+}

--- a/web/src/test/java/org/springframework/security/web/csrf/CsrfAuthenticationStrategyTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CsrfAuthenticationStrategyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ public class CsrfAuthenticationStrategyTests {
 		// SEC-2404, SEC-2832
 		CsrfToken tokenInRequest = (CsrfToken) this.request
 				.getAttribute(CsrfToken.class.getName());
-		assertThat(tokenInRequest.getToken()).isSameAs(this.generatedToken.getToken());
+		assertThat(tokenInRequest.matches(this.generatedToken.getToken())).isTrue();
 		assertThat(tokenInRequest.getHeaderName())
 				.isSameAs(this.generatedToken.getHeaderName());
 		assertThat(tokenInRequest.getParameterName())

--- a/web/src/test/java/org/springframework/security/web/csrf/CsrfFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CsrfFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -439,7 +439,7 @@ public class CsrfFilterTests {
 			assertThat(this.actual.getHeaderName()).isEqualTo(expected.getHeaderName());
 			assertThat(this.actual.getParameterName())
 					.isEqualTo(expected.getParameterName());
-			assertThat(this.actual.getToken()).isEqualTo(expected.getToken());
+			assertThat(this.actual.matches(expected.getToken())).isTrue();
 			return this;
 		}
 	}

--- a/web/src/test/java/org/springframework/security/web/csrf/DefaultCsrfTokenTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/DefaultCsrfTokenTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package org.springframework.security.web.csrf;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
@@ -54,5 +56,31 @@ public class DefaultCsrfTokenTests {
 	@Test(expected = IllegalArgumentException.class)
 	public void constructorEmptyTokenValue() {
 		new DefaultCsrfToken(headerName, parameterName, "");
+	}
+
+	@Test
+	public void matchesTokenValue() {
+		String tokenStr = "123456";
+		DefaultCsrfToken token = new DefaultCsrfToken(headerName, parameterName, tokenStr);
+		String csrfToken = token.getToken();
+		String csrfToken2 = token.getToken();
+
+		assertThat(token.getToken()).isEqualTo(csrfToken);
+		assertThat(token.getToken()).isEqualTo(csrfToken2);
+		assertThat(csrfToken).isEqualTo(csrfToken2);
+		assertThat(token.matches(csrfToken)).isTrue();
+		assertThat(token.matches(csrfToken2)).isTrue();
+	}
+
+	@Test
+	public void notMatchesTokenValue() {
+		DefaultCsrfToken token1 = new DefaultCsrfToken(headerName, parameterName, "token1");
+		DefaultCsrfToken token2 = new DefaultCsrfToken(headerName, parameterName, "token2");
+		String csrfToken1 = token1.getToken();
+		String csrfToken2 = token2.getToken();
+
+		assertThat(csrfToken1).isNotEqualTo(csrfToken2);
+		assertThat(token1.matches(csrfToken2)).isFalse();
+		assertThat(token2.matches(csrfToken1)).isFalse();
 	}
 }

--- a/web/src/test/java/org/springframework/security/web/csrf/XorCsrfTokenTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/XorCsrfTokenTests.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.web.csrf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
+
+/**
+ * @author Ruby Hartono
+ *
+ */
+public class XorCsrfTokenTests {
+	private final String headerName = "headerName";
+	private final String parameterName = "parameterName";
+	private final String tokenValue = "tokenValue";
+
+	@Test(expected = IllegalArgumentException.class)
+	public void constructorNullHeaderName() {
+		new XorCsrfToken(null, parameterName, tokenValue);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void constructorEmptyHeaderName() {
+		new XorCsrfToken("", parameterName, tokenValue);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void constructorNullParameterName() {
+		new XorCsrfToken(headerName, null, tokenValue);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void constructorEmptyParameterName() {
+		new XorCsrfToken(headerName, "", tokenValue);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void constructorNullTokenValue() {
+		new XorCsrfToken(headerName, parameterName, null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void constructorEmptyTokenValue() {
+		new XorCsrfToken(headerName, parameterName, "");
+	}
+
+	@Test
+	public void matchesTokenValue() {
+		String tokenStr = "123456";
+		XorCsrfToken token = new XorCsrfToken(headerName, parameterName, tokenStr);
+		String randomCsrfToken = token.getToken();
+		String randomCsrfToken2 = token.getToken();
+
+		assertThat(token.getToken()).isNotEqualTo(randomCsrfToken);
+		assertThat(token.getToken()).isNotEqualTo(randomCsrfToken2);
+		assertThat(randomCsrfToken).isNotEqualTo(randomCsrfToken2);
+		assertThat(token.matches(randomCsrfToken)).isTrue();
+		assertThat(token.matches(randomCsrfToken2)).isTrue();
+	}
+
+	@Test
+	public void notMatchesTokenValue() {
+		XorCsrfToken token1 = new XorCsrfToken(headerName, parameterName, "token1");
+		XorCsrfToken token2 = new XorCsrfToken(headerName, parameterName, "token2");
+		String randomCsrfToken1 = token1.getToken();
+		String randomCsrfToken2 = token2.getToken();
+
+		assertThat(randomCsrfToken1).isNotEqualTo(randomCsrfToken2);
+		assertThat(token1.matches(randomCsrfToken2)).isFalse();
+		assertThat(token2.matches(randomCsrfToken1)).isFalse();
+	}
+
+	@Test
+	public void createGenerateTokenProviderShouldReturnInstanceWithSameBehaviorAsConstructorCreation() {
+		XorCsrfToken token1 = new XorCsrfToken(headerName, parameterName, "token1");
+		XorCsrfToken tokenFromProvider = XorCsrfToken.createGenerateTokenProvider().generateToken(headerName,
+				parameterName, "token1");
+		String randomCsrfToken1 = token1.getToken();
+		String randomCsrfToken2 = tokenFromProvider.getToken();
+
+		assertThat(randomCsrfToken1).isNotEqualTo(randomCsrfToken2);
+		assertThat(token1.matches(randomCsrfToken1)).isTrue();
+		assertThat(token1.matches(randomCsrfToken2)).isTrue();
+		assertThat(tokenFromProvider.matches(randomCsrfToken1)).isTrue();
+		assertThat(tokenFromProvider.matches(randomCsrfToken2)).isTrue();
+	}
+}

--- a/web/src/test/java/org/springframework/security/web/jackson2/DefaultCsrfTokenMixinTests.java
+++ b/web/src/test/java/org/springframework/security/web/jackson2/DefaultCsrfTokenMixinTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import org.json.JSONException;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
-
 import org.springframework.security.web.csrf.DefaultCsrfToken;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,7 +55,7 @@ public class DefaultCsrfTokenMixinTests extends AbstractMixinTests {
 		assertThat(token).isNotNull();
 		assertThat(token.getHeaderName()).isEqualTo("csrf-header");
 		assertThat(token.getParameterName()).isEqualTo("_csrf");
-		assertThat(token.getToken()).isEqualTo("1");
+		assertThat(token.matches("1")).isTrue();
 	}
 
 	@Test(expected = JsonMappingException.class)

--- a/web/src/test/java/org/springframework/security/web/servlet/support/csrf/CsrfRequestDataValueProcessorTests.java
+++ b/web/src/test/java/org/springframework/security/web/servlet/support/csrf/CsrfRequestDataValueProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,6 @@ package org.springframework.security.web.servlet.support.csrf;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -39,7 +36,6 @@ public class CsrfRequestDataValueProcessorTests {
 	private CsrfRequestDataValueProcessor processor;
 
 	private CsrfToken token;
-	private Map<String, String> expected = new HashMap<>();
 
 	@Before
 	public void setup() {
@@ -48,8 +44,6 @@ public class CsrfRequestDataValueProcessorTests {
 
 		token = new DefaultCsrfToken("1", "a", "b");
 		request.setAttribute(CsrfToken.class.getName(), token);
-
-		expected.put(token.getParameterName(), token.getToken());
 	}
 
 	@Test
@@ -73,7 +67,7 @@ public class CsrfRequestDataValueProcessorTests {
 
 	@Test
 	public void getExtraHiddenFieldsHasCsrfTokenNoMethodSet() {
-		assertThat(processor.getExtraHiddenFields(request)).isEqualTo(expected);
+		assertThat(token.matches(processor.getExtraHiddenFields(request).getOrDefault(token.getParameterName(), null))).isTrue();
 	}
 
 	@Test
@@ -91,13 +85,13 @@ public class CsrfRequestDataValueProcessorTests {
 	@Test
 	public void getExtraHiddenFieldsHasCsrfToken_POST() {
 		processor.processAction(request, "action", "POST");
-		assertThat(processor.getExtraHiddenFields(request)).isEqualTo(expected);
+		assertThat(token.matches(processor.getExtraHiddenFields(request).getOrDefault(token.getParameterName(), null))).isTrue();
 	}
 
 	@Test
 	public void getExtraHiddenFieldsHasCsrfToken_post() {
 		processor.processAction(request, "action", "post");
-		assertThat(processor.getExtraHiddenFields(request)).isEqualTo(expected);
+		assertThat(token.matches(processor.getExtraHiddenFields(request).getOrDefault(token.getParameterName(), null))).isTrue();
 	}
 
 	@Test
@@ -129,10 +123,8 @@ public class CsrfRequestDataValueProcessorTests {
 	public void createGetExtraHiddenFieldsHasCsrfToken() {
 		CsrfToken token = new DefaultCsrfToken("1", "a", "b");
 		request.setAttribute(CsrfToken.class.getName(), token);
-		Map<String, String> expected = new HashMap<>();
-		expected.put(token.getParameterName(), token.getToken());
 
 		RequestDataValueProcessor processor = new CsrfRequestDataValueProcessor();
-		assertThat(processor.getExtraHiddenFields(request)).isEqualTo(expected);
+		assertThat(token.matches(processor.getExtraHiddenFields(request).getOrDefault(token.getParameterName(), null))).isTrue();
 	}
 }


### PR DESCRIPTION
Fixes gh-4001

Apply Base64 encoding at `getToken` string as well