### PR TITLE
Fix typo 'properites' -> 'properties' in documentation

### DIFF
--- a/cas/src/main/java/org/springframework/security/cas/web/authentication/ServiceAuthenticationDetailsSource.java
+++ b/cas/src/main/java/org/springframework/security/cas/web/authentication/ServiceAuthenticationDetailsSource.java
@@ -47,7 +47,7 @@ public class ServiceAuthenticationDetailsSource implements
 	// ===================================================================================================
 
 	/**
-	 * Creates an implementation that uses the specified ServiceProperites and the default
+	 * Creates an implementation that uses the specified ServiceProperties and the default
 	 * CAS artifactParameterName.
 	 *
 	 * @param serviceProperties The ServiceProperties to use to construct the serviceUrl.

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/AbstractAuthenticationFilterConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/AbstractAuthenticationFilterConfigurer.java
@@ -172,7 +172,7 @@ public abstract class AbstractAuthenticationFilterConfigurer<B extends HttpSecur
 
 	/**
 	 * Specifies the {@link AuthenticationSuccessHandler} to be used. The default is
-	 * {@link SavedRequestAwareAuthenticationSuccessHandler} with no additional properites
+	 * {@link SavedRequestAwareAuthenticationSuccessHandler} with no additional properties
 	 * set.
 	 *
 	 * @param successHandler the {@link AuthenticationSuccessHandler}.

--- a/core/src/main/java/org/springframework/security/authentication/jaas/JaasAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/jaas/JaasAuthenticationProvider.java
@@ -129,7 +129,7 @@ import org.springframework.util.Assert;
  *  &lt;/property&gt;
  * </pre>
  *
- * A configuration note: The JaasAuthenticationProvider uses the security properites
+ * A configuration note: The JaasAuthenticationProvider uses the security properties
  * "login.config.url.X" to configure jaas. If you would like to customize the way Jaas
  * gets configured, create a subclass of this and override the
  * {@link #configureJaas(Resource)} method.

--- a/test/src/main/java/org/springframework/security/test/context/support/WithMockUserSecurityContextFactory.java
+++ b/test/src/main/java/org/springframework/security/test/context/support/WithMockUserSecurityContextFactory.java
@@ -43,7 +43,7 @@ final class WithMockUserSecurityContextFactory implements
 				.username() : withUser.value();
 		if (username == null) {
 			throw new IllegalArgumentException(withUser
-					+ " cannot have null username on both username and value properites");
+					+ " cannot have null username on both username and value properties");
 		}
 
 		List<GrantedAuthority> grantedAuthorities = new ArrayList<>();


### PR DESCRIPTION
This fixes #8095 

@pivotal-issuemaster this is an obvious fix
