### PR TITLE
Fix exception from empty basic auth header token

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationConverter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationConverter.java
@@ -87,6 +87,10 @@ public class BasicAuthenticationConverter implements AuthenticationConverter {
 			return null;
 		}
 
+		if (header.equalsIgnoreCase(AUTHENTICATION_SCHEME_BASIC)) {
+			throw new BadCredentialsException("Empty basic authentication token");
+		}
+
 		byte[] base64Token = header.substring(6).getBytes(StandardCharsets.UTF_8);
 		byte[] decoded;
 		try {

--- a/web/src/test/java/org/springframework/security/web/authentication/www/BasicAuthenticationConverterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/www/BasicAuthenticationConverterTests.java
@@ -111,4 +111,12 @@ public class BasicAuthenticationConverterTests {
 		assertThat(authentication.getName()).isEqualTo("rod");
 		assertThat(authentication.getCredentials()).isEqualTo("");
 	}
+
+	@Test(expected = BadCredentialsException.class)
+	public void requestWhenEmptyBasicAuthorizationHeaderTokenThenError() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Basic ");
+		converter.convert(request);
+	}
+
 }

--- a/web/src/test/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilterTests.java
@@ -424,4 +424,20 @@ public class BasicAuthenticationFilterTests {
 		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
 	}
 
+	@Test
+	public void requestWhenEmptyBasicAuthorizationHeaderTokenThenUnauthorized() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Basic ");
+		request.setServletPath("/some_file.html");
+		request.setSession(new MockHttpSession());
+		final MockHttpServletResponse response = new MockHttpServletResponse();
+
+		FilterChain chain = mock(FilterChain.class);
+		filter.doFilter(request, response, chain);
+		verify(chain, never()).doFilter(any(ServletRequest.class),
+				any(ServletResponse.class));
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+		assertThat(response.getStatus()).isEqualTo(401);
+	}
+
 }


### PR DESCRIPTION
fixes spring-projectsgh-7976

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
