### PR TITLE
Fix typo in Javadoc of HttpSecurity#csrf()

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
@@ -1471,7 +1471,7 @@ public final class HttpSecurity extends
 	 * }
 	 * </pre>
 	 *
-	 * @return the {@link ServletApiConfigurer} for further customizations
+	 * @return the {@link CsrfConfigurer} for further customizations
 	 * @throws Exception
 	 */
 	public CsrfConfigurer<HttpSecurity> csrf() throws Exception {


### PR DESCRIPTION
`HttpSecurity#csrf()` returns a `CsrfConfigurer`, while the Javadoc states that it returns the `ServletApiConfigurer`. This was probably copied from the method above.
