### PR TITLE
Allow port=0 for LDAP Servers

### DIFF
--- a/config/src/integration-test/java/org/springframework/security/config/ldap/LdapProviderBeanDefinitionParserTests.java
+++ b/config/src/integration-test/java/org/springframework/security/config/ldap/LdapProviderBeanDefinitionParserTests.java
@@ -16,8 +16,11 @@
 
 package org.springframework.security.config.ldap;
 
+import java.text.MessageFormat;
+
 import org.junit.After;
 import org.junit.Test;
+
 import org.springframework.context.ApplicationContextException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -28,8 +31,6 @@ import org.springframework.security.config.util.InMemoryXmlApplicationContext;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.ldap.userdetails.InetOrgPersonContextMapper;
-
-import java.text.MessageFormat;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,7 +47,7 @@ public class LdapProviderBeanDefinitionParserTests {
 
 	@Test
 	public void simpleProviderAuthenticatesCorrectly() {
-		appCtx = new InMemoryXmlApplicationContext("<ldap-server ldif='classpath:test-server.ldif'/>"
+		appCtx = new InMemoryXmlApplicationContext("<ldap-server ldif='classpath:test-server.ldif' port='0'/>"
 				+ "<authentication-manager>"
 				+ "  <ldap-authentication-provider group-search-filter='member={0}' />"
 				+ "</authentication-manager>"
@@ -60,7 +61,7 @@ public class LdapProviderBeanDefinitionParserTests {
 
 	@Test
 	public void multipleProvidersAreSupported() {
-		appCtx = new InMemoryXmlApplicationContext("<ldap-server ldif='classpath:test-server.ldif'/>"
+		appCtx = new InMemoryXmlApplicationContext("<ldap-server ldif='classpath:test-server.ldif' port='0'/>"
 				+ "<authentication-manager>"
 				+ "  <ldap-authentication-provider group-search-filter='member={0}' />"
 				+ "  <ldap-authentication-provider group-search-filter='uniqueMember={0}' />"
@@ -84,7 +85,7 @@ public class LdapProviderBeanDefinitionParserTests {
 
 	@Test
 	public void supportsPasswordComparisonAuthentication() {
-		appCtx = new InMemoryXmlApplicationContext("<ldap-server ldif='classpath:test-server.ldif'/>"
+		appCtx = new InMemoryXmlApplicationContext("<ldap-server ldif='classpath:test-server.ldif' port='0'/>"
 				+ "<authentication-manager>"
 				+ "  <ldap-authentication-provider user-dn-pattern='uid={0},ou=people'>"
 				+ "    <password-compare />"
@@ -100,7 +101,7 @@ public class LdapProviderBeanDefinitionParserTests {
 
 	@Test
 	public void supportsPasswordComparisonAuthenticationWithPasswordEncoder() {
-		appCtx = new InMemoryXmlApplicationContext("<ldap-server ldif='classpath:test-server.ldif'/>"
+		appCtx = new InMemoryXmlApplicationContext("<ldap-server ldif='classpath:test-server.ldif' port='0'/>"
 				+ "<authentication-manager>"
 				+ "  <ldap-authentication-provider user-dn-pattern='uid={0},ou=people'>"
 				+ "    <password-compare password-attribute='uid'>"
@@ -120,7 +121,7 @@ public class LdapProviderBeanDefinitionParserTests {
 	// SEC-2472
 	@Test
 	public void supportsCryptoPasswordEncoder() {
-		appCtx = new InMemoryXmlApplicationContext("<ldap-server ldif='classpath:test-server.ldif'/>"
+		appCtx = new InMemoryXmlApplicationContext("<ldap-server ldif='classpath:test-server.ldif' port='0'/>"
 				+ "<authentication-manager>"
 				+ "  <ldap-authentication-provider user-dn-pattern='uid={0},ou=people'>"
 				+ "    <password-compare>"
@@ -139,7 +140,7 @@ public class LdapProviderBeanDefinitionParserTests {
 
 	@Test
 	public void inetOrgContextMapperIsSupported() {
-		appCtx = new InMemoryXmlApplicationContext("<ldap-server url='ldap://127.0.0.1:343/dc=springframework,dc=org'/>"
+		appCtx = new InMemoryXmlApplicationContext("<ldap-server url='ldap://127.0.0.1:343/dc=springframework,dc=org' port='0'/>"
 				+ "<authentication-manager>"
 				+ "  <ldap-authentication-provider user-details-class='inetOrgPerson' />"
 				+ "</authentication-manager>"

--- a/config/src/integration-test/java/org/springframework/security/config/ldap/LdapServerBeanDefinitionParserTests.java
+++ b/config/src/integration-test/java/org/springframework/security/config/ldap/LdapServerBeanDefinitionParserTests.java
@@ -15,19 +15,20 @@
  */
 package org.springframework.security.config.ldap;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.io.IOException;
 import java.net.ServerSocket;
 
 import org.junit.After;
 import org.junit.Test;
+
 import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.security.config.BeanIds;
 import org.springframework.security.config.util.InMemoryXmlApplicationContext;
 import org.springframework.security.ldap.DefaultSpringSecurityContextSource;
 import org.springframework.security.ldap.server.ApacheDSContainer;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Luke Taylor
@@ -47,7 +48,7 @@ public class LdapServerBeanDefinitionParserTests {
 	@Test
 	public void embeddedServerCreationContainsExpectedContextSourceAndData() {
 		appCtx = new InMemoryXmlApplicationContext(
-				"<ldap-server ldif='classpath:test-server.ldif'/>");
+				"<ldap-server ldif='classpath:test-server.ldif' port='0'/>");
 
 		DefaultSpringSecurityContextSource contextSource = (DefaultSpringSecurityContextSource) appCtx
 				.getBean(BeanIds.CONTEXT_SOURCE);
@@ -82,7 +83,7 @@ public class LdapServerBeanDefinitionParserTests {
 	@Test
 	public void loadingSpecificLdifFileIsSuccessful() {
 		appCtx = new InMemoryXmlApplicationContext(
-				"<ldap-server ldif='classpath*:test-server2.xldif' root='dc=monkeymachine,dc=co,dc=uk' />");
+				"<ldap-server ldif='classpath*:test-server2.xldif' root='dc=monkeymachine,dc=co,dc=uk' port='0'/>");
 		DefaultSpringSecurityContextSource contextSource = (DefaultSpringSecurityContextSource) appCtx
 				.getBean(BeanIds.CONTEXT_SOURCE);
 

--- a/config/src/main/java/org/springframework/security/config/SecurityNamespaceHandler.java
+++ b/config/src/main/java/org/springframework/security/config/SecurityNamespaceHandler.java
@@ -20,6 +20,9 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
 import org.springframework.beans.factory.xml.BeanDefinitionDecorator;
@@ -45,8 +48,6 @@ import org.springframework.security.config.oauth2.client.ClientRegistrationsBean
 import org.springframework.security.config.websocket.WebSocketMessageBrokerSecurityBeanDefinitionParser;
 import org.springframework.security.core.SpringSecurityCoreVersion;
 import org.springframework.util.ClassUtils;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
 
 /**
  * Parses elements from the "security" namespace
@@ -87,7 +88,7 @@ public final class SecurityNamespaceHandler implements NamespaceHandler {
 		if (!namespaceMatchesVersion(element)) {
 			pc.getReaderContext()
 					.fatal("You cannot use a spring-security-2.0.xsd or spring-security-3.0.xsd or spring-security-3.1.xsd schema or spring-security-3.2.xsd schema or spring-security-4.0.xsd schema "
-							+ "with Spring Security 5.3. Please update your schema declarations to the 5.3 schema.",
+							+ "with Spring Security 5.4. Please update your schema declarations to the 5.4 schema.",
 							element);
 		}
 		String name = pc.getDelegate().getLocalName(element);
@@ -223,7 +224,7 @@ public final class SecurityNamespaceHandler implements NamespaceHandler {
 	private boolean matchesVersionInternal(Element element) {
 		String schemaLocation = element.getAttributeNS(
 				"http://www.w3.org/2001/XMLSchema-instance", "schemaLocation");
-		return schemaLocation.matches("(?m).*spring-security-5\\.3.*.xsd.*")
+		return schemaLocation.matches("(?m).*spring-security-5\\.4.*.xsd.*")
 				|| schemaLocation.matches("(?m).*spring-security.xsd.*")
 				|| !schemaLocation.matches("(?m).*spring-security.*");
 	}

--- a/config/src/main/resources/META-INF/spring.schemas
+++ b/config/src/main/resources/META-INF/spring.schemas
@@ -1,4 +1,5 @@
-http\://www.springframework.org/schema/security/spring-security.xsd=org/springframework/security/config/spring-security-5.3.xsd
+http\://www.springframework.org/schema/security/spring-security.xsd=org/springframework/security/config/spring-security-5.4.xsd
+http\://www.springframework.org/schema/security/spring-security-5.4.xsd=org/springframework/security/config/spring-security-5.4.xsd
 http\://www.springframework.org/schema/security/spring-security-5.3.xsd=org/springframework/security/config/spring-security-5.3.xsd
 http\://www.springframework.org/schema/security/spring-security-5.2.xsd=org/springframework/security/config/spring-security-5.2.xsd
 http\://www.springframework.org/schema/security/spring-security-5.1.xsd=org/springframework/security/config/spring-security-5.1.xsd
@@ -14,7 +15,8 @@ http\://www.springframework.org/schema/security/spring-security-2.0.xsd=org/spri
 http\://www.springframework.org/schema/security/spring-security-2.0.1.xsd=org/springframework/security/config/spring-security-2.0.1.xsd
 http\://www.springframework.org/schema/security/spring-security-2.0.2.xsd=org/springframework/security/config/spring-security-2.0.2.xsd
 http\://www.springframework.org/schema/security/spring-security-2.0.4.xsd=org/springframework/security/config/spring-security-2.0.4.xsd
-https\://www.springframework.org/schema/security/spring-security.xsd=org/springframework/security/config/spring-security-5.3.xsd
+https\://www.springframework.org/schema/security/spring-security.xsd=org/springframework/security/config/spring-security-5.4.xsd
+https\://www.springframework.org/schema/security/spring-security-5.4.xsd=org/springframework/security/config/spring-security-5.4.xsd
 https\://www.springframework.org/schema/security/spring-security-5.3.xsd=org/springframework/security/config/spring-security-5.3.xsd
 https\://www.springframework.org/schema/security/spring-security-5.2.xsd=org/springframework/security/config/spring-security-5.2.xsd
 https\://www.springframework.org/schema/security/spring-security-5.1.xsd=org/springframework/security/config/spring-security-5.1.xsd

--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.4.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.4.rnc
@@ -1,0 +1,1095 @@
+namespace a = "https://relaxng.org/ns/compatibility/annotations/1.0"
+datatypes xsd = "http://www.w3.org/2001/XMLSchema-datatypes"
+
+default namespace = "http://www.springframework.org/schema/security"
+
+start = http | ldap-server | authentication-provider | ldap-authentication-provider | any-user-service | ldap-server | ldap-authentication-provider
+
+hash =
+	## Defines the hashing algorithm used on user passwords. Bcrypt is recommended.
+	attribute hash {"bcrypt"}
+base64 =
+	## Whether a string should be base64 encoded
+	attribute base64 {xsd:boolean}
+request-matcher =
+	## Defines the strategy use for matching incoming requests. Currently the options are 'mvc' (for Spring MVC matcher), 'ant' (for ant path patterns), 'regex' for regular expressions and 'ciRegex' for case-insensitive regular expressions.
+	attribute request-matcher {"mvc" | "ant" | "regex" | "ciRegex"}
+port =
+	## Specifies an IP port number. Used to configure an embedded LDAP server, for example.
+	attribute port { xsd:nonNegativeInteger }
+url =
+	## Specifies a URL.
+	attribute url { xsd:token }
+id =
+	## A bean identifier, used for referring to the bean elsewhere in the context.
+	attribute id {xsd:token}
+name =
+	## A bean identifier, used for referring to the bean elsewhere in the context.
+	attribute name {xsd:token}
+ref =
+	## Defines a reference to a Spring bean Id.
+	attribute ref {xsd:token}
+
+cache-ref =
+	## Defines a reference to a cache for use with a UserDetailsService.
+	attribute cache-ref {xsd:token}
+
+user-service-ref =
+	## A reference to a user-service (or UserDetailsService bean) Id
+	attribute user-service-ref {xsd:token}
+
+authentication-manager-ref =
+	## A reference to an AuthenticationManager bean
+	attribute authentication-manager-ref {xsd:token}
+
+data-source-ref =
+	## A reference to a DataSource bean
+	attribute data-source-ref {xsd:token}
+
+
+
+debug =
+	## Enables Spring Security debugging infrastructure. This will provide human-readable (multi-line) debugging information to monitor requests coming into the security filters. This may include sensitive information, such as request parameters or headers, and should only be used in a development environment.
+	element debug {empty}
+
+password-encoder =
+	## element which defines a password encoding strategy. Used by an authentication provider to convert submitted passwords to hashed versions, for example.
+	element password-encoder {password-encoder.attlist}
+password-encoder.attlist &=
+	ref | (hash)
+
+role-prefix =
+	## A non-empty string prefix that will be added to role strings loaded from persistent storage (e.g. "ROLE_"). Use the value "none" for no prefix in cases where the default is non-empty.
+	attribute role-prefix {xsd:token}
+
+use-expressions =
+	## Enables the use of expressions in the 'access' attributes in <intercept-url> elements rather than the traditional list of configuration attributes. Defaults to 'true'. If enabled, each attribute should contain a single boolean expression. If the expression evaluates to 'true', access will be granted.
+	attribute use-expressions {xsd:boolean}
+
+ldap-server =
+	## Defines an LDAP server location or starts an embedded server. The url indicates the location of a remote server. If no url is given, an embedded server will be started, listening on the supplied port number. The port is optional and defaults to 33389. A Spring LDAP ContextSource bean will be registered for the server with the id supplied.
+	element ldap-server {ldap-server.attlist}
+ldap-server.attlist &= id?
+ldap-server.attlist &= (url | port)?
+ldap-server.attlist &=
+	## Username (DN) of the "manager" user identity which will be used to authenticate to a (non-embedded) LDAP server. If omitted, anonymous access will be used.
+	attribute manager-dn {xsd:string}?
+ldap-server.attlist &=
+	## The password for the manager DN. This is required if the manager-dn is specified.
+	attribute manager-password {xsd:string}?
+ldap-server.attlist &=
+	## Explicitly specifies an ldif file resource to load into an embedded LDAP server. The default is classpath*:*.ldiff
+	attribute ldif { xsd:string }?
+ldap-server.attlist &=
+	## Optional root suffix for the embedded LDAP server. Default is "dc=springframework,dc=org"
+	attribute root { xsd:string }?
+ldap-server.attlist &=
+	## Explicitly specifies which embedded ldap server should use. Values are 'apacheds' and 'unboundid'. By default, it will depends if the library is available in the classpath.
+	attribute mode { "apacheds" | "unboundid" }?
+
+ldap-server-ref-attribute =
+	## The optional server to use. If omitted, and a default LDAP server is registered (using <ldap-server> with no Id), that server will be used.
+	attribute server-ref {xsd:token}
+
+
+group-search-filter-attribute =
+	## Group search filter. Defaults to (uniqueMember={0}). The substituted parameter is the DN of the user.
+	attribute group-search-filter {xsd:token}
+group-search-base-attribute =
+	## Search base for group membership searches. Defaults to "" (searching from the root).
+	attribute group-search-base {xsd:token}
+user-search-filter-attribute =
+	## The LDAP filter used to search for users (optional). For example "(uid={0})". The substituted parameter is the user's login name.
+	attribute user-search-filter {xsd:token}
+user-search-base-attribute =
+	## Search base for user searches. Defaults to "". Only used with a 'user-search-filter'.
+	attribute user-search-base {xsd:token}
+group-role-attribute-attribute =
+	## The LDAP attribute name which contains the role name which will be used within Spring Security. Defaults to "cn".
+	attribute group-role-attribute {xsd:token}
+user-details-class-attribute =
+	## Allows the objectClass of the user entry to be specified. If set, the framework will attempt to load standard attributes for the defined class into the returned UserDetails object
+	attribute user-details-class {"person" | "inetOrgPerson"}
+user-context-mapper-attribute =
+	## Allows explicit customization of the loaded user object by specifying a UserDetailsContextMapper bean which will be called with the context information from the user's directory entry
+	attribute user-context-mapper-ref {xsd:token}
+
+
+ldap-user-service =
+	## This element configures a LdapUserDetailsService which is a combination of a FilterBasedLdapUserSearch and a DefaultLdapAuthoritiesPopulator.
+	element ldap-user-service {ldap-us.attlist}
+ldap-us.attlist &= id?
+ldap-us.attlist &=
+	ldap-server-ref-attribute?
+ldap-us.attlist &=
+	user-search-filter-attribute?
+ldap-us.attlist &=
+	user-search-base-attribute?
+ldap-us.attlist &=
+	group-search-filter-attribute?
+ldap-us.attlist &=
+	group-search-base-attribute?
+ldap-us.attlist &=
+	group-role-attribute-attribute?
+ldap-us.attlist &=
+	cache-ref?
+ldap-us.attlist &=
+	role-prefix?
+ldap-us.attlist &=
+	(user-details-class-attribute | user-context-mapper-attribute)?
+
+ldap-authentication-provider =
+	## Sets up an ldap authentication provider
+	element ldap-authentication-provider {ldap-ap.attlist, password-compare-element?}
+ldap-ap.attlist &=
+	ldap-server-ref-attribute?
+ldap-ap.attlist &=
+	user-search-base-attribute?
+ldap-ap.attlist &=
+	user-search-filter-attribute?
+ldap-ap.attlist &=
+	group-search-base-attribute?
+ldap-ap.attlist &=
+	group-search-filter-attribute?
+ldap-ap.attlist &=
+	group-role-attribute-attribute?
+ldap-ap.attlist &=
+	## A specific pattern used to build the user's DN, for example "uid={0},ou=people". The key "{0}" must be present and will be substituted with the username.
+	attribute user-dn-pattern {xsd:token}?
+ldap-ap.attlist &=
+	role-prefix?
+ldap-ap.attlist &=
+	(user-details-class-attribute | user-context-mapper-attribute)?
+
+password-compare-element =
+	## Specifies that an LDAP provider should use an LDAP compare operation of the user's password to authenticate the user
+	element password-compare {password-compare.attlist, password-encoder?}
+
+password-compare.attlist &=
+	## The attribute in the directory which contains the user password. Defaults to "userPassword".
+	attribute password-attribute {xsd:token}?
+password-compare.attlist &=
+	hash?
+
+intercept-methods =
+	## Can be used inside a bean definition to add a security interceptor to the bean and set up access configuration attributes for the bean's methods
+	element intercept-methods {intercept-methods.attlist, protect+}
+intercept-methods.attlist &=
+	## Optional AccessDecisionManager bean ID to be used by the created method security interceptor.
+	attribute access-decision-manager-ref {xsd:token}?
+
+
+protect =
+	## Defines a protected method and the access control configuration attributes that apply to it. We strongly advise you NOT to mix "protect" declarations with any services provided "global-method-security".
+	element protect {protect.attlist, empty}
+protect.attlist &=
+	## A method name
+	attribute method {xsd:token}
+protect.attlist &=
+	## Access configuration attributes list that applies to the method, e.g. "ROLE_A,ROLE_B".
+	attribute access {xsd:token}
+
+method-security-metadata-source =
+	## Creates a MethodSecurityMetadataSource instance
+	element method-security-metadata-source {msmds.attlist, protect+}
+msmds.attlist &= id?
+
+msmds.attlist &= use-expressions?
+
+global-method-security =
+	## Provides method security for all beans registered in the Spring application context. Specifically, beans will be scanned for matches with the ordered list of "protect-pointcut" sub-elements, Spring Security annotations and/or. Where there is a match, the beans will automatically be proxied and security authorization applied to the methods accordingly. If you use and enable all four sources of method security metadata (ie "protect-pointcut" declarations, expression annotations, @Secured and also JSR250 security annotations), the metadata sources will be queried in that order. In practical terms, this enables you to use XML to override method security metadata expressed in annotations. If using annotations, the order of precedence is EL-based (@PreAuthorize etc.), @Secured and finally JSR-250.
+	element global-method-security {global-method-security.attlist, (pre-post-annotation-handling | expression-handler)?, protect-pointcut*, after-invocation-provider*}
+global-method-security.attlist &=
+	## Specifies whether the use of Spring Security's pre and post invocation annotations (@PreFilter, @PreAuthorize, @PostFilter, @PostAuthorize) should be enabled for this application context. Defaults to "disabled".
+	attribute pre-post-annotations {"disabled" | "enabled" }?
+global-method-security.attlist &=
+	## Specifies whether the use of Spring Security's @Secured annotations should be enabled for this application context. Defaults to "disabled".
+	attribute secured-annotations {"disabled" | "enabled" }?
+global-method-security.attlist &=
+	## Specifies whether JSR-250 style attributes are to be used (for example "RolesAllowed"). This will require the javax.annotation.security classes on the classpath. Defaults to "disabled".
+	attribute jsr250-annotations {"disabled" | "enabled" }?
+global-method-security.attlist &=
+	## Optional AccessDecisionManager bean ID to override the default used for method security.
+	attribute access-decision-manager-ref {xsd:token}?
+global-method-security.attlist &=
+	## Optional RunAsmanager implementation which will be used by the configured MethodSecurityInterceptor
+	attribute run-as-manager-ref {xsd:token}?
+global-method-security.attlist &=
+	## Allows the advice "order" to be set for the method security interceptor.
+	attribute order {xsd:token}?
+global-method-security.attlist &=
+	## If true, class based proxying will be used instead of interface based proxying.
+	attribute proxy-target-class {xsd:boolean}?
+global-method-security.attlist &=
+	## Can be used to specify that AspectJ should be used instead of the default Spring AOP. If set, secured classes must be woven with the AnnotationSecurityAspect from the spring-security-aspects module.
+	attribute mode {"aspectj"}?
+global-method-security.attlist &=
+	## An external MethodSecurityMetadataSource instance can be supplied which will take priority over other sources (such as the default annotations).
+	attribute metadata-source-ref {xsd:token}?
+global-method-security.attlist &=
+	authentication-manager-ref?
+
+
+after-invocation-provider =
+	## Allows addition of extra AfterInvocationProvider beans which should be called by the MethodSecurityInterceptor created by global-method-security.
+	element after-invocation-provider {ref}
+
+pre-post-annotation-handling =
+	## Allows the default expression-based mechanism for handling Spring Security's pre and post invocation annotations (@PreFilter, @PreAuthorize, @PostFilter, @PostAuthorize) to be replace entirely. Only applies if these annotations are enabled.
+	element pre-post-annotation-handling {invocation-attribute-factory, pre-invocation-advice, post-invocation-advice}
+
+invocation-attribute-factory =
+	## Defines the PrePostInvocationAttributeFactory instance which is used to generate pre and post invocation metadata from the annotated methods.
+	element invocation-attribute-factory {ref}
+
+pre-invocation-advice =
+	## Customizes the PreInvocationAuthorizationAdviceVoter with the ref as the PreInvocationAuthorizationAdviceVoter for the <pre-post-annotation-handling> element.
+	element pre-invocation-advice {ref}
+
+post-invocation-advice =
+	## Customizes the PostInvocationAdviceProvider with the ref as the PostInvocationAuthorizationAdvice for the <pre-post-annotation-handling> element.
+	element post-invocation-advice {ref}
+
+
+expression-handler =
+	## Defines the SecurityExpressionHandler instance which will be used if expression-based access-control is enabled. A default implementation (with no ACL support) will be used if not supplied.
+	element expression-handler {ref}
+
+protect-pointcut =
+	## Defines a protected pointcut and the access control configuration attributes that apply to it. Every bean registered in the Spring application context that provides a method that matches the pointcut will receive security authorization.
+	element protect-pointcut {protect-pointcut.attlist, empty}
+protect-pointcut.attlist &=
+	## An AspectJ expression, including the 'execution' keyword. For example, 'execution(int com.foo.TargetObject.countLength(String))' (without the quotes).
+	attribute expression {xsd:string}
+protect-pointcut.attlist &=
+	## Access configuration attributes list that applies to all methods matching the pointcut, e.g. "ROLE_A,ROLE_B"
+	attribute access {xsd:token}
+
+websocket-message-broker =
+	## Allows securing a Message Broker. There are two modes. If no id is specified: ensures that any SimpAnnotationMethodMessageHandler has the AuthenticationPrincipalArgumentResolver registered as a custom argument resolver; ensures that the SecurityContextChannelInterceptor is automatically registered for the clientInboundChannel; and that a ChannelSecurityInterceptor is registered with the clientInboundChannel. If the id is specified, creates a ChannelSecurityInterceptor that can be manually registered with the clientInboundChannel.
+	element websocket-message-broker { websocket-message-broker.attrlist, (intercept-message* & expression-handler?) }
+
+websocket-message-broker.attrlist &=
+	## A bean identifier, used for referring to the bean elsewhere in the context. If specified, explicit configuration within clientInboundChannel is required. If not specified, ensures that any SimpAnnotationMethodMessageHandler has the AuthenticationPrincipalArgumentResolver registered as a custom argument resolver; ensures that the SecurityContextChannelInterceptor is automatically registered for the clientInboundChannel; and that a ChannelSecurityInterceptor is registered with the clientInboundChannel.
+	attribute id {xsd:token}?
+websocket-message-broker.attrlist &=
+	## Disables the requirement for CSRF token to be present in the Stomp headers (default false). Changing the default is useful if it is necessary to allow other origins to make SockJS connections.
+	attribute same-origin-disabled {xsd:boolean}?
+
+intercept-message =
+	## Creates an authorization rule for a websocket message.
+	element intercept-message {intercept-message.attrlist}
+
+intercept-message.attrlist &=
+	## The destination ant pattern which will be mapped to the access attribute. For example, /** matches any message with a destination, /admin/** matches any message that has a destination that starts with admin.
+	attribute pattern {xsd:token}?
+intercept-message.attrlist &=
+	## The access configuration attributes that apply for the configured message. For example, permitAll grants access to anyone, hasRole('ROLE_ADMIN') requires the user have the role 'ROLE_ADMIN'.
+	attribute access {xsd:token}?
+intercept-message.attrlist &=
+	## The type of message to match on. Valid values are defined in SimpMessageType (i.e. CONNECT, CONNECT_ACK, HEARTBEAT, MESSAGE, SUBSCRIBE, UNSUBSCRIBE, DISCONNECT, DISCONNECT_ACK, OTHER).
+	attribute type {"CONNECT" | "CONNECT_ACK" | "HEARTBEAT" | "MESSAGE" | "SUBSCRIBE"| "UNSUBSCRIBE" | "DISCONNECT" | "DISCONNECT_ACK" | "OTHER"}?
+
+http-firewall =
+	## Allows a custom instance of HttpFirewall to be injected into the FilterChainProxy created by the namespace.
+	element http-firewall {ref}
+
+http =
+	## Container element for HTTP security configuration. Multiple elements can now be defined, each with a specific pattern to which the enclosed security configuration applies. A pattern can also be configured to bypass Spring Security's filters completely by setting the "security" attribute to "none".
+	element http {http.attlist, (intercept-url* & access-denied-handler? & form-login? & oauth2-login? & oauth2-client? & oauth2-resource-server? & openid-login? & x509? & jee? & http-basic? & logout? & session-management & remember-me? & anonymous? & port-mappings & custom-filter* & request-cache? & expression-handler? & headers? & csrf? & cors?) }
+http.attlist &=
+	## The request URL pattern which will be mapped to the filter chain created by this <http> element. If omitted, the filter chain will match all requests.
+	attribute pattern {xsd:token}?
+http.attlist &=
+	## When set to 'none', requests matching the pattern attribute will be ignored by Spring Security. No security filters will be applied and no SecurityContext will be available. If set, the <http> element must be empty, with no children.
+	attribute security {"none"}?
+http.attlist &=
+	## Allows a RequestMatcher instance to be used, as an alternative to pattern-matching.
+	attribute request-matcher-ref { xsd:token }?
+http.attlist &=
+	## A legacy attribute which automatically registers a login form, BASIC authentication and a logout URL and logout services. If unspecified, defaults to "false". We'd recommend you avoid using this and instead explicitly configure the services you require.
+	attribute auto-config {xsd:boolean}?
+http.attlist &=
+	use-expressions?
+http.attlist &=
+	## Controls the eagerness with which an HTTP session is created by Spring Security classes. If not set, defaults to "ifRequired". If "stateless" is used, this implies that the application guarantees that it will not create a session. This differs from the use of "never" which means that Spring Security will not create a session, but will make use of one if the application does.
+	attribute create-session {"ifRequired" | "always" | "never" | "stateless"}?
+http.attlist &=
+	## A reference to a SecurityContextRepository bean. This can be used to customize how the SecurityContext is stored between requests.
+	attribute security-context-repository-ref {xsd:token}?
+http.attlist &=
+	request-matcher?
+http.attlist &=
+	## Provides versions of HttpServletRequest security methods such as isUserInRole() and getPrincipal() which are implemented by accessing the Spring SecurityContext. Defaults to "true".
+	attribute servlet-api-provision {xsd:boolean}?
+http.attlist &=
+	## If available, runs the request as the Subject acquired from the JaasAuthenticationToken. Defaults to "false".
+	attribute jaas-api-provision {xsd:boolean}?
+http.attlist &=
+	## Optional attribute specifying the ID of the AccessDecisionManager implementation which should be used for authorizing HTTP requests.
+	attribute access-decision-manager-ref {xsd:token}?
+http.attlist &=
+	## Optional attribute specifying the realm name that will be used for all authentication features that require a realm name (eg BASIC and Digest authentication). If unspecified, defaults to "Spring Security Application".
+	attribute realm {xsd:token}?
+http.attlist &=
+	## Allows a customized AuthenticationEntryPoint to be set on the ExceptionTranslationFilter.
+	attribute entry-point-ref {xsd:token}?
+http.attlist &=
+	## Corresponds to the observeOncePerRequest property of FilterSecurityInterceptor. Defaults to "true"
+	attribute once-per-request {xsd:boolean}?
+http.attlist &=
+	## Prevents the jsessionid parameter from being added to rendered URLs. Defaults to "true" (rewriting is disabled).
+	attribute disable-url-rewriting {xsd:boolean}?
+http.attlist &=
+	## Exposes the list of filters defined by this configuration under this bean name in the application context.
+	name?
+http.attlist &=
+	authentication-manager-ref?
+
+access-denied-handler =
+	## Defines the access-denied strategy that should be used. An access denied page can be defined or a reference to an AccessDeniedHandler instance.
+	element access-denied-handler {access-denied-handler.attlist, empty}
+access-denied-handler.attlist &= (ref | access-denied-handler-page)
+
+access-denied-handler-page =
+	## The access denied page that an authenticated user will be redirected to if they request a page which they don't have the authority to access.
+	attribute error-page {xsd:token}
+
+intercept-url =
+	## Specifies the access attributes and/or filter list for a particular set of URLs.
+	element intercept-url {intercept-url.attlist, empty}
+intercept-url.attlist &=
+	(pattern | request-matcher-ref)
+intercept-url.attlist &=
+	## The access configuration attributes that apply for the configured path.
+	attribute access {xsd:token}?
+intercept-url.attlist &=
+	## The HTTP Method for which the access configuration attributes should apply. If not specified, the attributes will apply to any method.
+	attribute method {"GET" | "DELETE" | "HEAD" | "OPTIONS" | "POST" | "PUT" | "PATCH" | "TRACE"}?
+
+intercept-url.attlist &=
+	## Used to specify that a URL must be accessed over http or https, or that there is no preference. The value should be "http", "https" or "any", respectively.
+	attribute requires-channel {xsd:token}?
+intercept-url.attlist &=
+	## The path to the servlet. This attribute is only applicable when 'request-matcher' is 'mvc'. In addition, the value is only required in the following 2 use cases: 1) There are 2 or more HttpServlet's registered in the ServletContext that have mappings starting with '/' and are different; 2) The pattern starts with the same value of a registered HttpServlet path, excluding the default (root) HttpServlet '/'.
+	attribute servlet-path {xsd:token}?
+
+logout =
+	## Incorporates a logout processing filter. Most web applications require a logout filter, although you may not require one if you write a controller to provider similar logic.
+	element logout {logout.attlist, empty}
+logout.attlist &=
+	## Specifies the URL that will cause a logout. Spring Security will initialize a filter that responds to this particular URL. Defaults to /logout if unspecified.
+	attribute logout-url {xsd:token}?
+logout.attlist &=
+	## Specifies the URL to display once the user has logged out. If not specified, defaults to <form-login-login-page>/?logout (i.e. /login?logout).
+	attribute logout-success-url {xsd:token}?
+logout.attlist &=
+	## Specifies whether a logout also causes HttpSession invalidation, which is generally desirable. If unspecified, defaults to true.
+	attribute invalidate-session {xsd:boolean}?
+logout.attlist &=
+	## A reference to a LogoutSuccessHandler implementation which will be used to determine the destination to which the user is taken after logging out.
+	attribute success-handler-ref {xsd:token}?
+logout.attlist &=
+	## A comma-separated list of the names of cookies which should be deleted when the user logs out
+	attribute delete-cookies {xsd:token}?
+
+request-cache =
+	## Allow the RequestCache used for saving requests during the login process to be set
+	element request-cache {ref}
+
+form-login =
+	## Sets up a form login configuration for authentication with a username and password
+	element form-login {form-login.attlist, empty}
+form-login.attlist &=
+	## The URL that the login form is posted to. If unspecified, it defaults to /login.
+	attribute login-processing-url {xsd:token}?
+form-login.attlist &=
+	## The name of the request parameter which contains the username. Defaults to 'username'.
+	attribute username-parameter {xsd:token}?
+form-login.attlist &=
+	## The name of the request parameter which contains the password. Defaults to 'password'.
+	attribute password-parameter {xsd:token}?
+form-login.attlist &=
+	## The URL that will be redirected to after successful authentication, if the user's previous action could not be resumed. This generally happens if the user visits a login page without having first requested a secured operation that triggers authentication. If unspecified, defaults to the root of the application.
+	attribute default-target-url {xsd:token}?
+form-login.attlist &=
+	## Whether the user should always be redirected to the default-target-url after login.
+	attribute always-use-default-target {xsd:boolean}?
+form-login.attlist &=
+	## The URL for the login page. If no login URL is specified, Spring Security will automatically create a login URL at GET /login and a corresponding filter to render that login URL when requested.
+	attribute login-page {xsd:token}?
+form-login.attlist &=
+	## The URL for the login failure page. If no login failure URL is specified, Spring Security will automatically create a failure login URL at /login?error and a corresponding filter to render that login failure URL when requested.
+	attribute authentication-failure-url {xsd:token}?
+form-login.attlist &=
+	## Reference to an AuthenticationSuccessHandler bean which should be used to handle a successful authentication request. Should not be used in combination with default-target-url (or always-use-default-target-url) as the implementation should always deal with navigation to the subsequent destination
+	attribute authentication-success-handler-ref {xsd:token}?
+form-login.attlist &=
+	## Reference to an AuthenticationFailureHandler bean which should be used to handle a failed authentication request. Should not be used in combination with authentication-failure-url as the implementation should always deal with navigation to the subsequent destination
+	attribute authentication-failure-handler-ref {xsd:token}?
+form-login.attlist &=
+	## Reference to an AuthenticationDetailsSource which will be used by the authentication filter
+	attribute authentication-details-source-ref {xsd:token}?
+form-login.attlist &=
+	## The URL for the ForwardAuthenticationFailureHandler
+	attribute authentication-failure-forward-url {xsd:token}?
+form-login.attlist &=
+	## The URL for the ForwardAuthenticationSuccessHandler
+	attribute authentication-success-forward-url {xsd:token}?
+
+oauth2-login =
+	## Configures authentication support using an OAuth 2.0 and/or OpenID Connect 1.0 Provider.
+	element oauth2-login {oauth2-login.attlist}
+oauth2-login.attlist &=
+	## Reference to the ClientRegistrationRepository
+	attribute client-registration-repository-ref {xsd:token}?
+oauth2-login.attlist &=
+	## Reference to the OAuth2AuthorizedClientRepository
+	attribute authorized-client-repository-ref {xsd:token}?
+oauth2-login.attlist &=
+	## Reference to the OAuth2AuthorizedClientService
+	attribute authorized-client-service-ref {xsd:token}?
+oauth2-login.attlist &=
+	## Reference to the AuthorizationRequestRepository
+	attribute authorization-request-repository-ref {xsd:token}?
+oauth2-login.attlist &=
+	## Reference to the OAuth2AuthorizationRequestResolver
+	attribute authorization-request-resolver-ref {xsd:token}?
+oauth2-login.attlist &=
+	## Reference to the OAuth2AccessTokenResponseClient
+	attribute access-token-response-client-ref {xsd:token}?
+oauth2-login.attlist &=
+	## Reference to the GrantedAuthoritiesMapper
+	attribute user-authorities-mapper-ref {xsd:token}?
+oauth2-login.attlist &=
+	## Reference to the OAuth2UserService
+	attribute user-service-ref {xsd:token}?
+oauth2-login.attlist &=
+	## Reference to the OpenID Connect OAuth2UserService
+	attribute oidc-user-service-ref {xsd:token}?
+oauth2-login.attlist &=
+	## The URI where the filter processes authentication requests
+	attribute login-processing-url {xsd:token}?
+oauth2-login.attlist &=
+	## The URI to send users to login
+	attribute login-page {xsd:token}?
+oauth2-login.attlist &=
+	## Reference to the AuthenticationSuccessHandler
+	attribute authentication-success-handler-ref {xsd:token}?
+oauth2-login.attlist &=
+	## Reference to the AuthenticationFailureHandler
+	attribute authentication-failure-handler-ref {xsd:token}?
+oauth2-login.attlist &=
+	## Reference to the JwtDecoderFactory used by OidcAuthorizationCodeAuthenticationProvider
+	attribute jwt-decoder-factory-ref {xsd:token}?
+
+oauth2-client =
+	## Configures OAuth 2.0 Client support.
+	element oauth2-client {oauth2-client.attlist, (authorization-code-grant?) }
+oauth2-client.attlist &=
+	## Reference to the ClientRegistrationRepository
+	attribute client-registration-repository-ref {xsd:token}?
+oauth2-client.attlist &=
+	## Reference to the OAuth2AuthorizedClientRepository
+	attribute authorized-client-repository-ref {xsd:token}?
+oauth2-client.attlist &=
+	## Reference to the OAuth2AuthorizedClientService
+	attribute authorized-client-service-ref {xsd:token}?
+
+authorization-code-grant =
+	## Configures OAuth 2.0 Authorization Code Grant.
+	element authorization-code-grant {authorization-code-grant.attlist, empty}
+authorization-code-grant.attlist &=
+	## Reference to the AuthorizationRequestRepository
+	attribute authorization-request-repository-ref {xsd:token}?
+authorization-code-grant.attlist &=
+	## Reference to the OAuth2AuthorizationRequestResolver
+	attribute authorization-request-resolver-ref {xsd:token}?
+authorization-code-grant.attlist &=
+	## Reference to the OAuth2AccessTokenResponseClient
+	attribute access-token-response-client-ref {xsd:token}?
+
+client-registrations =
+	## Container element for client(s) registered with an OAuth 2.0 or OpenID Connect 1.0 Provider.
+	element client-registrations {client-registration+, provider*}
+
+client-registration =
+	## Represents a client registered with an OAuth 2.0 or OpenID Connect 1.0 Provider.
+	element client-registration {client-registration.attlist}
+client-registration.attlist &=
+	## The ID that uniquely identifies the client registration.
+	attribute registration-id {xsd:token}
+client-registration.attlist &=
+	## The client identifier.
+	attribute client-id {xsd:token}
+client-registration.attlist &=
+	## The client secret.
+	attribute client-secret {xsd:token}?
+client-registration.attlist &=
+	## The method used to authenticate the client with the provider. The supported values are basic, post and none (public clients).
+	attribute client-authentication-method {"basic" | "post" | "none"}?
+client-registration.attlist &=
+	## The OAuth 2.0 Authorization Framework defines four Authorization Grant types. The supported values are authorization_code, client_credentials, password and implicit.
+	attribute authorization-grant-type {"authorization_code" | "client_credentials" | "password" | "implicit"}?
+client-registration.attlist &=
+	## The client’s registered redirect URI that the Authorization Server redirects the end-user’s user-agent to after the end-user has authenticated and authorized access to the client.
+	attribute redirect-uri {xsd:token}?
+client-registration.attlist &=
+	## A comma-separated list of scope(s) requested by the client during the Authorization Request flow, such as openid, email, or profile.
+	attribute scope {xsd:token}?
+client-registration.attlist &=
+	## A descriptive name used for the client. The name may be used in certain scenarios, such as when displaying the name of the client in the auto-generated login page.
+	attribute client-name {xsd:token}?
+client-registration.attlist &=
+	## A reference to the associated provider. May reference a 'provider' element or use one of the common providers (google, github, facebook, okta).
+	attribute provider-id {xsd:token}
+
+provider =
+	## The configuration information for an OAuth 2.0 or OpenID Connect 1.0 Provider.
+	element provider {provider.attlist}
+provider.attlist &=
+	## The ID that uniquely identifies the provider.
+	attribute provider-id {xsd:token}
+provider.attlist &=
+	## The Authorization Endpoint URI for the Authorization Server.
+	attribute authorization-uri {xsd:token}?
+provider.attlist &=
+	## The Token Endpoint URI for the Authorization Server.
+	attribute token-uri {xsd:token}?
+provider.attlist &=
+	## The UserInfo Endpoint URI used to access the claims/attributes of the authenticated end-user.
+	attribute user-info-uri {xsd:token}?
+provider.attlist &=
+	## The authentication method used when sending the access token to the UserInfo Endpoint. The supported values are header, form and query.
+	attribute user-info-authentication-method {"header" | "form" | "query"}?
+provider.attlist &=
+	## The name of the attribute returned in the UserInfo Response that references the Name or Identifier of the end-user.
+	attribute user-info-user-name-attribute {xsd:token}?
+provider.attlist &=
+	## The URI used to retrieve the JSON Web Key (JWK) Set from the Authorization Server, which contains the cryptographic key(s) used to verify the JSON Web Signature (JWS) of the ID Token and optionally the UserInfo Response.
+	attribute jwk-set-uri {xsd:token}?
+provider.attlist &=
+	## The URI used to discover the configuration information for an OAuth 2.0 or OpenID Connect 1.0 Provider.
+	attribute issuer-uri {xsd:token}?
+
+oauth2-resource-server =
+	## Configures authentication support as an OAuth 2.0 Resource Server.
+	element oauth2-resource-server {oauth2-resource-server.attlist, (jwt? & opaque-token?)}
+oauth2-resource-server.attlist &=
+	## Reference to an AuthenticationManagerResolver
+	attribute authentication-manager-resolver-ref {xsd:token}?
+oauth2-resource-server.attlist &=
+	## Reference to a BearerTokenResolver
+	attribute bearer-token-resolver-ref {xsd:token}?
+oauth2-resource-server.attlist &=
+	## Reference to a AuthenticationEntryPoint
+	attribute entry-point-ref {xsd:token}?
+
+jwt =
+    ## Configures JWT authentication
+    element jwt {jwt.attlist}
+jwt.attlist &=
+    ## The URI to use to collect the JWK Set for verifying JWTs
+    attribute jwk-set-uri {xsd:token}?
+jwt.attlist &=
+    ## Reference to a JwtDecoder
+    attribute decoder-ref {xsd:token}?
+jwt.attlist &=
+    ## Reference to a Converter<Jwt, AbstractAuthenticationToken>
+    attribute jwt-authentication-converter-ref {xsd:token}?
+
+opaque-token =
+    ## Configuration Opaque Token authentication
+    element opaque-token {opaque-token.attlist}
+opaque-token.attlist &=
+    ## The URI to use to introspect opaque token attributes
+    attribute introspection-uri {xsd:token}?
+opaque-token.attlist &=
+    ## The Client ID to use to authenticate the introspection request
+    attribute client-id {xsd:token}?
+opaque-token.attlist &=
+    ## The Client secret to use to authenticate the introspection request
+    attribute client-secret {xsd:token}?
+opaque-token.attlist &=
+    ## Reference to an OpaqueTokenIntrospector
+    attribute introspector-ref {xsd:token}?
+
+openid-login =
+	## Sets up form login for authentication with an Open ID identity
+	element openid-login {form-login.attlist, user-service-ref?, attribute-exchange*}
+
+attribute-exchange =
+	## Sets up an attribute exchange configuration to request specified attributes from the OpenID identity provider. When multiple elements are used, each must have an identifier-attribute attribute. Each configuration will be matched in turn against the supplied login identifier until a match is found.
+	element attribute-exchange {attribute-exchange.attlist, openid-attribute+}
+
+attribute-exchange.attlist &=
+	## A regular expression which will be compared against the claimed identity, when deciding which attribute-exchange configuration to use during authentication.
+	attribute identifier-match {xsd:token}?
+
+openid-attribute =
+	## Attributes used when making an OpenID AX Fetch Request
+	element openid-attribute {openid-attribute.attlist}
+
+openid-attribute.attlist &=
+	## Specifies the name of the attribute that you wish to get back. For example, email.
+	attribute name {xsd:token}
+openid-attribute.attlist &=
+	## Specifies the attribute type. For example, https://axschema.org/contact/email. See your OP's documentation for valid attribute types.
+	attribute type {xsd:token}
+openid-attribute.attlist &=
+	## Specifies if this attribute is required to the OP, but does not error out if the OP does not return the attribute. Default is false.
+	attribute required {xsd:boolean}?
+openid-attribute.attlist &=
+	## Specifies the number of attributes that you wish to get back. For example, return 3 emails. The default value is 1.
+	attribute count {xsd:int}?
+
+
+filter-chain-map =
+	## Used to explicitly configure a FilterChainProxy instance with a FilterChainMap
+	element filter-chain-map {filter-chain-map.attlist, filter-chain+}
+filter-chain-map.attlist &=
+	request-matcher?
+
+filter-chain =
+	## Used within to define a specific URL pattern and the list of filters which apply to the URLs matching that pattern. When multiple filter-chain elements are assembled in a list in order to configure a FilterChainProxy, the most specific patterns must be placed at the top of the list, with  most general ones at the bottom.
+	element filter-chain {filter-chain.attlist, empty}
+filter-chain.attlist &=
+	(pattern | request-matcher-ref)
+filter-chain.attlist &=
+	## A comma separated list of bean names that implement Filter that should be processed for this FilterChain. If the value is none, then no Filters will be used for this FilterChain.
+	attribute filters {xsd:token}
+
+pattern =
+	## The request URL pattern which will be mapped to the FilterChain.
+	attribute pattern {xsd:token}
+request-matcher-ref =
+	## Allows a RequestMatcher instance to be used, as an alternative to pattern-matching.
+	attribute request-matcher-ref {xsd:token}
+
+filter-security-metadata-source =
+	## Used to explicitly configure a FilterSecurityMetadataSource bean for use with a FilterSecurityInterceptor. Usually only needed if you are configuring a FilterChainProxy explicitly, rather than using the <http> element. The intercept-url elements used should only contain pattern, method and access attributes. Any others will result in a configuration error.
+	element filter-security-metadata-source {fsmds.attlist, intercept-url+}
+fsmds.attlist &=
+	use-expressions?
+fsmds.attlist &=
+	id?
+fsmds.attlist &=
+	request-matcher?
+
+http-basic =
+	## Adds support for basic authentication
+	element http-basic {http-basic.attlist, empty}
+
+http-basic.attlist &=
+	## Sets the AuthenticationEntryPoint which is used by the BasicAuthenticationFilter.
+	attribute entry-point-ref {xsd:token}?
+http-basic.attlist &=
+	## Reference to an AuthenticationDetailsSource which will be used by the authentication filter
+	attribute authentication-details-source-ref {xsd:token}?
+
+session-management =
+	## Session-management related functionality is implemented by the addition of a SessionManagementFilter to the filter stack.
+	element session-management {session-management.attlist, concurrency-control?}
+
+session-management.attlist &=
+	## Indicates how session fixation protection will be applied when a user authenticates. If set to "none", no protection will be applied. "newSession" will create a new empty session, with only Spring Security-related attributes migrated. "migrateSession" will create a new session and copy all session attributes to the new session. In Servlet 3.1 (Java EE 7) and newer containers, specifying "changeSessionId" will keep the existing session and use the container-supplied session fixation protection (HttpServletRequest#changeSessionId()). Defaults to "changeSessionId" in Servlet 3.1 and newer containers, "migrateSession" in older containers. Throws an exception if "changeSessionId" is used in older containers.
+	attribute session-fixation-protection {"none" | "newSession" | "migrateSession" | "changeSessionId" }?
+session-management.attlist &=
+	## The URL to which a user will be redirected if they submit an invalid session indentifier. Typically used to detect session timeouts.
+	attribute invalid-session-url {xsd:token}?
+session-management.attlist &=
+	## Allows injection of the InvalidSessionStrategy instance used by the SessionManagementFilter
+	attribute invalid-session-strategy-ref {xsd:token}?
+session-management.attlist &=
+	## Allows injection of the SessionAuthenticationStrategy instance used by the SessionManagementFilter
+	attribute session-authentication-strategy-ref {xsd:token}?
+session-management.attlist &=
+	## Defines the URL of the error page which should be shown when the SessionAuthenticationStrategy raises an exception. If not set, an unauthorized (401) error code will be returned to the client. Note that this attribute doesn't apply if the error occurs during a form-based login, where the URL for authentication failure will take precedence.
+	attribute session-authentication-error-url {xsd:token}?
+
+
+concurrency-control =
+	## Enables concurrent session control, limiting the number of authenticated sessions a user may have at the same time.
+	element concurrency-control {concurrency-control.attlist, empty}
+
+concurrency-control.attlist &=
+	## The maximum number of sessions a single authenticated user can have open at the same time. Defaults to "1". A negative value denotes unlimited sessions.
+	attribute max-sessions {xsd:integer}?
+concurrency-control.attlist &=
+	## The URL a user will be redirected to if they attempt to use a session which has been "expired" because they have logged in again.
+	attribute expired-url {xsd:token}?
+concurrency-control.attlist &=
+	## Allows injection of the SessionInformationExpiredStrategy instance used by the ConcurrentSessionFilter
+	attribute expired-session-strategy-ref {xsd:token}?
+concurrency-control.attlist &=
+	## Specifies that an unauthorized error should be reported when a user attempts to login when they already have the maximum configured sessions open. The default behaviour is to expire the original session. If the session-authentication-error-url attribute is set on the session-management URL, the user will be redirected to this URL.
+	attribute error-if-maximum-exceeded {xsd:boolean}?
+concurrency-control.attlist &=
+	## Allows you to define an alias for the SessionRegistry bean in order to access it in your own configuration.
+	attribute session-registry-alias {xsd:token}?
+concurrency-control.attlist &=
+	## Allows you to define an external SessionRegistry bean to be used by the concurrency control setup.
+	attribute session-registry-ref {xsd:token}?
+
+
+remember-me =
+	## Sets up remember-me authentication. If used with the "key" attribute (or no attributes) the cookie-only implementation will be used. Specifying "token-repository-ref" or "remember-me-data-source-ref" will use the more secure, persisten token approach.
+	element remember-me {remember-me.attlist}
+remember-me.attlist &=
+	## The "key" used to identify cookies from a specific token-based remember-me application. You should set this to a unique value for your application. If unset, it will default to a random value generated by SecureRandom.
+	attribute key {xsd:token}?
+
+remember-me.attlist &=
+	(token-repository-ref | remember-me-data-source-ref | remember-me-services-ref)
+
+remember-me.attlist &=
+	user-service-ref?
+
+remember-me.attlist &=
+	## Exports the internally defined RememberMeServices as a bean alias, allowing it to be used by other beans in the application context.
+	attribute services-alias {xsd:token}?
+
+remember-me.attlist &=
+	## Determines whether the "secure" flag will be set on the remember-me cookie. If set to true, the cookie will only be submitted over HTTPS (recommended). By default, secure cookies will be used if the request is made on a secure connection.
+	attribute use-secure-cookie {xsd:boolean}?
+
+remember-me.attlist &=
+	## The period (in seconds) for which the remember-me cookie should be valid.
+	attribute token-validity-seconds {xsd:string}?
+
+remember-me.attlist &=
+	## Reference to an AuthenticationSuccessHandler bean which should be used to handle a successful remember-me authentication.
+	attribute authentication-success-handler-ref {xsd:token}?
+remember-me.attlist &=
+	## The name of the request parameter which toggles remember-me authentication. Defaults to 'remember-me'.
+	attribute remember-me-parameter {xsd:token}?
+remember-me.attlist &=
+	## The name of cookie which store the token for remember-me authentication. Defaults to 'remember-me'.
+	attribute remember-me-cookie {xsd:token}?
+
+token-repository-ref =
+	## Reference to a PersistentTokenRepository bean for use with the persistent token remember-me implementation.
+	attribute token-repository-ref {xsd:token}
+remember-me-services-ref =
+	## Allows a custom implementation of RememberMeServices to be used. Note that this implementation should return RememberMeAuthenticationToken instances with the same "key" value as specified in the remember-me element. Alternatively it should register its own AuthenticationProvider. It should also implement the LogoutHandler interface, which will be invoked when a user logs out. Typically the remember-me cookie would be removed on logout.
+	attribute services-ref {xsd:token}?
+remember-me-data-source-ref =
+	## DataSource bean for the database that contains the token repository schema.
+	data-source-ref
+
+anonymous =
+	## Adds support for automatically granting all anonymous web requests a particular principal identity and a corresponding granted authority.
+	element anonymous {anonymous.attlist}
+anonymous.attlist &=
+	## The key shared between the provider and filter. This generally does not need to be set. If unset, it will default to a random value generated by SecureRandom.
+	attribute key {xsd:token}?
+anonymous.attlist &=
+	## The username that should be assigned to the anonymous request. This allows the principal to be identified, which may be important for logging and auditing. if unset, defaults to "anonymousUser".
+	attribute username {xsd:token}?
+anonymous.attlist &=
+	## The granted authority that should be assigned to the anonymous request. Commonly this is used to assign the anonymous request particular roles, which can subsequently be used in authorization decisions. If unset, defaults to "ROLE_ANONYMOUS".
+	attribute granted-authority {xsd:token}?
+anonymous.attlist &=
+	## With the default namespace setup, the anonymous "authentication" facility is automatically enabled. You can disable it using this property.
+	attribute enabled {xsd:boolean}?
+
+
+port-mappings =
+	## Defines the list of mappings between http and https ports for use in redirects
+	element port-mappings {port-mappings.attlist, port-mapping+}
+
+port-mappings.attlist &= empty
+
+port-mapping =
+	## Provides a method to map http ports to https ports when forcing a redirect.
+	element port-mapping {http-port, https-port}
+
+http-port =
+	## The http port to use.
+	attribute http {xsd:token}
+
+https-port =
+	## The https port to use.
+	attribute https {xsd:token}
+
+
+x509 =
+	## Adds support for X.509 client authentication.
+	element x509 {x509.attlist}
+x509.attlist &=
+	## The regular expression used to obtain the username from the certificate's subject. Defaults to matching on the common name using the pattern "CN=(.*?),".
+	attribute subject-principal-regex {xsd:token}?
+x509.attlist &=
+	## Explicitly specifies which user-service should be used to load user data for X.509 authenticated clients. If ommitted, the default user-service will be used.
+	user-service-ref?
+x509.attlist &=
+	## Reference to an AuthenticationDetailsSource which will be used by the authentication filter
+	attribute authentication-details-source-ref {xsd:token}?
+
+jee =
+	## Adds a J2eePreAuthenticatedProcessingFilter to the filter chain to provide integration with container authentication.
+	element jee {jee.attlist}
+jee.attlist &=
+	## A comma-separate list of roles to look for in the incoming HttpServletRequest.
+	attribute mappable-roles {xsd:token}
+jee.attlist &=
+	## Explicitly specifies which user-service should be used to load user data for container authenticated clients. If ommitted, the set of mappable-roles will be used to construct the authorities for the user.
+	user-service-ref?
+
+authentication-manager =
+	## Registers the AuthenticationManager instance and allows its list of AuthenticationProviders to be defined. Also allows you to define an alias to allow you to reference the AuthenticationManager in your own beans.
+	element authentication-manager {authman.attlist & authentication-provider* & ldap-authentication-provider*}
+authman.attlist &=
+	id?
+authman.attlist &=
+	## An alias you wish to use for the AuthenticationManager bean (not required it you are using a specific id)
+	attribute alias {xsd:token}?
+authman.attlist &=
+	## If set to true, the AuthenticationManger will attempt to clear any credentials data in the returned Authentication object, once the user has been authenticated.
+	attribute erase-credentials {xsd:boolean}?
+
+authentication-provider =
+	## Indicates that the contained user-service should be used as an authentication source.
+	element authentication-provider {ap.attlist & any-user-service & password-encoder?}
+ap.attlist &=
+	## Specifies a reference to a separately configured AuthenticationProvider instance which should be registered within the AuthenticationManager.
+	ref?
+ap.attlist &=
+	## Specifies a reference to a separately configured UserDetailsService from which to obtain authentication data.
+	user-service-ref?
+
+user-service =
+	## Creates an in-memory UserDetailsService from a properties file or a list of "user" child elements. Usernames are converted to lower-case internally to allow for case-insensitive lookups, so this should not be used if case-sensitivity is required.
+	element user-service {id? & (properties-file | (user*))}
+properties-file =
+	## The location of a Properties file where each line is in the format of username=password,grantedAuthority[,grantedAuthority][,enabled|disabled]
+	attribute properties {xsd:token}?
+
+user =
+	## Represents a user in the application.
+	element user {user.attlist, empty}
+user.attlist &=
+	## The username assigned to the user.
+	attribute name {xsd:token}
+user.attlist &=
+	## The password assigned to the user. This may be hashed if the corresponding authentication provider supports hashing (remember to set the "hash" attribute of the "user-service" element). This attribute be omitted in the case where the data will not be used for authentication, but only for accessing authorities. If omitted, the namespace will generate a random value, preventing its accidental use for authentication. Cannot be empty.
+	attribute password {xsd:string}?
+user.attlist &=
+	## One of more authorities granted to the user. Separate authorities with a comma (but no space). For example, "ROLE_USER,ROLE_ADMINISTRATOR"
+	attribute authorities {xsd:token}
+user.attlist &=
+	## Can be set to "true" to mark an account as locked and unusable.
+	attribute locked {xsd:boolean}?
+user.attlist &=
+	## Can be set to "true" to mark an account as disabled and unusable.
+	attribute disabled {xsd:boolean}?
+
+jdbc-user-service =
+	## Causes creation of a JDBC-based UserDetailsService.
+	element jdbc-user-service {id? & jdbc-user-service.attlist}
+jdbc-user-service.attlist &=
+	## The bean ID of the DataSource which provides the required tables.
+	attribute data-source-ref {xsd:token}
+jdbc-user-service.attlist &=
+	cache-ref?
+jdbc-user-service.attlist &=
+	## An SQL statement to query a username, password, and enabled status given a username. Default is "select username,password,enabled from users where username = ?"
+	attribute users-by-username-query {xsd:token}?
+jdbc-user-service.attlist &=
+	## An SQL statement to query for a user's granted authorities given a username. The default is "select username, authority from authorities where username = ?"
+	attribute authorities-by-username-query {xsd:token}?
+jdbc-user-service.attlist &=
+	## An SQL statement to query user's group authorities given a username. The default is "select g.id, g.group_name, ga.authority from groups g, group_members gm, group_authorities ga where gm.username = ? and g.id = ga.group_id and g.id = gm.group_id"
+	attribute group-authorities-by-username-query {xsd:token}?
+jdbc-user-service.attlist &=
+	role-prefix?
+
+csrf =
+## Element for configuration of the CsrfFilter for protection against CSRF. It also updates the default RequestCache to only replay "GET" requests.
+	element csrf {csrf-options.attlist}
+csrf-options.attlist &=
+	## Specifies if csrf protection should be disabled. Default false (i.e. CSRF protection is enabled).
+	attribute disabled {xsd:boolean}?
+csrf-options.attlist &=
+	## The RequestMatcher instance to be used to determine if CSRF should be applied. Default is any HTTP method except "GET", "TRACE", "HEAD", "OPTIONS"
+	attribute request-matcher-ref { xsd:token }?
+csrf-options.attlist &=
+	## The CsrfTokenRepository to use. The default is HttpSessionCsrfTokenRepository wrapped by LazyCsrfTokenRepository.
+	attribute token-repository-ref { xsd:token }?
+
+headers =
+## Element for configuration of the HeaderWritersFilter. Enables easy setting for the X-Frame-Options, X-XSS-Protection and X-Content-Type-Options headers.
+element headers { headers-options.attlist, (cache-control? & xss-protection? & hsts? & frame-options? & content-type-options? & hpkp? & content-security-policy? & referrer-policy? & feature-policy? & header*)}
+headers-options.attlist &=
+	## Specifies if the default headers should be disabled. Default false.
+	attribute defaults-disabled {xsd:token}?
+headers-options.attlist &=
+	## Specifies if headers should be disabled. Default false.
+	attribute disabled {xsd:token}?
+hsts =
+	## Adds support for HTTP Strict Transport Security (HSTS)
+	element hsts {hsts-options.attlist}
+hsts-options.attlist &=
+	## Specifies if HTTP Strict Transport Security (HSTS) should be disabled. Default false.
+	attribute disabled {xsd:boolean}?
+hsts-options.attlist &=
+	## Specifies if subdomains should be included. Default true.
+	attribute include-subdomains {xsd:boolean}?
+hsts-options.attlist &=
+	## Specifies the maximum amount of time the host should be considered a Known HSTS Host. Default one year.
+	attribute max-age-seconds {xsd:integer}?
+hsts-options.attlist &=
+	## The RequestMatcher instance to be used to determine if the header should be set. Default is if HttpServletRequest.isSecure() is true.
+	attribute request-matcher-ref { xsd:token }?
+hsts-options.attlist &=
+	## Specifies if preload should be included. Default false.
+	attribute preload {xsd:boolean}?
+
+cors =
+## Element for configuration of CorsFilter. If no CorsFilter or CorsConfigurationSource is specified a HandlerMappingIntrospector is used as the CorsConfigurationSource
+element cors { cors-options.attlist }
+cors-options.attlist &=
+	ref?
+cors-options.attlist &=
+	## Specifies a bean id that is a CorsConfigurationSource used to construct the CorsFilter to use
+	attribute configuration-source-ref {xsd:token}?
+
+hpkp =
+	## Adds support for HTTP Public Key Pinning (HPKP).
+	element hpkp {hpkp.pins,hpkp.attlist}
+hpkp.pins =
+	## The list with pins
+	element pins {hpkp.pin+}
+hpkp.pin =
+	## A pin is specified using the base64-encoded SPKI fingerprint as value and the cryptographic hash algorithm as attribute
+	element pin {
+		## The cryptographic hash algorithm
+		attribute algorithm { xsd:string }?,
+		text
+	}
+hpkp.attlist &=
+	## Specifies if HTTP Public Key Pinning (HPKP) should be disabled. Default false.
+	attribute disabled {xsd:boolean}?
+hpkp.attlist &=
+	## Specifies if subdomains should be included. Default false.
+	attribute include-subdomains {xsd:boolean}?
+hpkp.attlist &=
+	## Sets the value for the max-age directive of the Public-Key-Pins header. Default 60 days.
+	attribute max-age-seconds {xsd:integer}?
+hpkp.attlist &=
+	## Specifies if the browser should only report pin validation failures. Default true.
+	attribute report-only {xsd:boolean}?
+hpkp.attlist &=
+	## Specifies the URI to which the browser should report pin validation failures.
+	attribute report-uri {xsd:string}?
+
+content-security-policy =
+	## Adds support for Content Security Policy (CSP)
+	element content-security-policy {csp-options.attlist}
+csp-options.attlist &=
+	## The security policy directive(s) for the Content-Security-Policy header or if report-only is set to true, then the Content-Security-Policy-Report-Only header is used.
+	attribute policy-directives {xsd:token}?
+csp-options.attlist &=
+	## Set to true, to enable the Content-Security-Policy-Report-Only header for reporting policy violations only. Defaults to false.
+	attribute report-only {xsd:boolean}?
+
+referrer-policy =
+	## Adds support for Referrer Policy
+	element referrer-policy {referrer-options.attlist}
+referrer-options.attlist &=
+	## The policies for the Referrer-Policy header.
+	attribute policy {"no-referrer","no-referrer-when-downgrade","same-origin","origin","strict-origin","origin-when-cross-origin","strict-origin-when-cross-origin","unsafe-url"}?
+
+feature-policy =
+	## Adds support for Feature Policy
+	element feature-policy {feature-options.attlist}
+feature-options.attlist &=
+	## The security policy directive(s) for the Feature-Policy header.
+	attribute policy-directives {xsd:token}?
+
+cache-control =
+	## Adds Cache-Control no-cache, no-store, must-revalidate, Pragma no-cache, and Expires 0 for every request
+	element cache-control {cache-control.attlist}
+cache-control.attlist &=
+	## Specifies if Cache Control should be disabled. Default false.
+	attribute disabled {xsd:boolean}?
+
+frame-options =
+	## Enable basic clickjacking support for newer browsers (IE8+), will set the X-Frame-Options header.
+	element frame-options {frame-options.attlist,empty}
+frame-options.attlist &=
+	## If disabled, the X-Frame-Options header will not be included. Default false.
+	attribute disabled {xsd:boolean}?
+frame-options.attlist &=
+	## Specify the policy to use for the X-Frame-Options-Header.
+	attribute policy {"DENY","SAMEORIGIN","ALLOW-FROM"}?
+frame-options.attlist &=
+	## Specify the strategy to use when ALLOW-FROM is chosen.
+	attribute strategy {"static","whitelist","regexp"}?
+frame-options.attlist &=
+	## Specify a reference to the custom AllowFromStrategy to use when ALLOW-FROM is chosen.
+	ref?
+frame-options.attlist &=
+	## Specify a value to use for the chosen strategy.
+	attribute value {xsd:string}?
+frame-options.attlist &=
+	## Specify the request parameter to use for the origin when using a 'whitelist' or 'regexp' based strategy. Default is 'from'.
+	attribute from-parameter {xsd:string}?
+
+
+xss-protection =
+	## Enable basic XSS browser protection, supported by newer browsers (IE8+), will set the X-XSS-Protection header.
+	element xss-protection {xss-protection.attlist,empty}
+xss-protection.attlist &=
+	## disable the X-XSS-Protection header. Default is 'false' meaning it is enabled.
+	attribute disabled {xsd:boolean}?
+xss-protection.attlist &=
+	## specify that XSS Protection should be explicitly enabled or disabled. Default is 'true' meaning it is enabled.
+	attribute enabled {xsd:boolean}?
+xss-protection.attlist &=
+	## Add mode=block to the header or not, default is on.
+	attribute block {xsd:boolean}?
+
+content-type-options =
+	## Add a X-Content-Type-Options header to the resopnse. Value is always 'nosniff'.
+	element content-type-options {content-type-options.attlist, empty}
+content-type-options.attlist &=
+	## If disabled, the X-Content-Type-Options header will not be included. Default false.
+	attribute disabled {xsd:boolean}?
+
+header=
+	## Add additional headers to the response.
+	element header {header.attlist}
+header.attlist &=
+	## The name of the header to add.
+	attribute name {xsd:token}?
+header.attlist &=
+	## The value for the header.
+	attribute value {xsd:token}?
+header.attlist &=
+	## Reference to a custom HeaderWriter implementation.
+	ref?
+
+any-user-service = user-service | jdbc-user-service | ldap-user-service
+
+custom-filter =
+	## Used to indicate that a filter bean declaration should be incorporated into the security filter chain.
+	element custom-filter {custom-filter.attlist}
+
+custom-filter.attlist &=
+	ref
+
+custom-filter.attlist &=
+	(after | before | position)
+
+after =
+	## The filter immediately after which the custom-filter should be placed in the chain. This feature will only be needed by advanced users who wish to mix their own filters into the security filter chain and have some knowledge of the standard Spring Security filters. The filter names map to specific Spring Security implementation filters.
+	attribute after {named-security-filter}
+before =
+	## The filter immediately before which the custom-filter should be placed in the chain
+	attribute before {named-security-filter}
+position =
+	## The explicit position at which the custom-filter should be placed in the chain. Use if you are replacing a standard filter.
+	attribute position {named-security-filter}
+
+named-security-filter = "FIRST" | "CHANNEL_FILTER" | "SECURITY_CONTEXT_FILTER" | "CONCURRENT_SESSION_FILTER" | "WEB_ASYNC_MANAGER_FILTER" | "HEADERS_FILTER" | "CORS_FILTER" | "CSRF_FILTER" | "LOGOUT_FILTER" | "OAUTH2_AUTHORIZATION_REQUEST_FILTER" | "X509_FILTER" | "PRE_AUTH_FILTER" | "CAS_FILTER" | "OAUTH2_LOGIN_FILTER" | "FORM_LOGIN_FILTER" | "OPENID_FILTER" | "LOGIN_PAGE_FILTER" |"LOGOUT_PAGE_FILTER" | "DIGEST_AUTH_FILTER" | "BEARER_TOKEN_AUTH_FILTER" | "BASIC_AUTH_FILTER" | "REQUEST_CACHE_FILTER" | "SERVLET_API_SUPPORT_FILTER" | "JAAS_API_SUPPORT_FILTER" | "REMEMBER_ME_FILTER" | "ANONYMOUS_FILTER" | "OAUTH2_AUTHORIZATION_CODE_GRANT_FILTER" | "SESSION_MANAGEMENT_FILTER" | "EXCEPTION_TRANSLATION_FILTER" | "FILTER_SECURITY_INTERCEPTOR" | "SWITCH_USER_FILTER" | "LAST"

--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.4.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.4.xsd
@@ -1,0 +1,3177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:security="http://www.springframework.org/schema/security"
+           elementFormDefault="qualified"
+           targetNamespace="http://www.springframework.org/schema/security">
+  <xs:attributeGroup name="hash">
+      <xs:attribute name="hash" use="required">
+         <xs:annotation>
+            <xs:documentation>Defines the hashing algorithm used on user passwords. Bcrypt is recommended.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="bcrypt"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="base64">
+      <xs:attribute name="base64" use="required" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Whether a string should be base64 encoded
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="request-matcher">
+      <xs:attribute name="request-matcher" use="required">
+         <xs:annotation>
+            <xs:documentation>Defines the strategy use for matching incoming requests. Currently the options are 'mvc'
+                (for Spring MVC matcher), 'ant' (for ant path patterns), 'regex' for regular expressions
+                and 'ciRegex' for case-insensitive regular expressions.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="mvc"/>
+               <xs:enumeration value="ant"/>
+               <xs:enumeration value="regex"/>
+               <xs:enumeration value="ciRegex"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="port">
+      <xs:attribute name="port" use="required" type="xs:nonNegativeInteger">
+         <xs:annotation>
+            <xs:documentation>Specifies an IP port number. Used to configure an embedded LDAP server, for example.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="url">
+      <xs:attribute name="url" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Specifies a URL.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="id">
+      <xs:attribute name="id" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="name">
+      <xs:attribute name="name" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="ref">
+      <xs:attribute name="ref" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines a reference to a Spring bean Id.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="cache-ref">
+      <xs:attribute name="cache-ref" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines a reference to a cache for use with a UserDetailsService.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="user-service-ref">
+      <xs:attribute name="user-service-ref" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to a user-service (or UserDetailsService bean) Id
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="authentication-manager-ref">
+      <xs:attribute name="authentication-manager-ref" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to an AuthenticationManager bean
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="data-source-ref">
+      <xs:attribute name="data-source-ref" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to a DataSource bean
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="debug">
+      <xs:annotation>
+         <xs:documentation>Enables Spring Security debugging infrastructure. This will provide human-readable
+                (multi-line) debugging information to monitor requests coming into the security filters.
+                This may include sensitive information, such as request parameters or headers, and should
+                only be used in a development environment.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType/>
+   </xs:element>
+  
+  <xs:attributeGroup name="password-encoder.attlist">
+      <xs:attribute name="ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines a reference to a Spring bean Id.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="hash">
+         <xs:annotation>
+            <xs:documentation>Defines the hashing algorithm used on user passwords. Bcrypt is recommended.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="bcrypt"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="role-prefix">
+      <xs:attribute name="role-prefix" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A non-empty string prefix that will be added to role strings loaded from persistent
+                storage (e.g. "ROLE_"). Use the value "none" for no prefix in cases where the default is
+                non-empty.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="use-expressions">
+      <xs:attribute name="use-expressions" use="required" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Enables the use of expressions in the 'access' attributes in &lt;intercept-url&gt; elements
+                rather than the traditional list of configuration attributes. Defaults to 'true'. If
+                enabled, each attribute should contain a single boolean expression. If the expression
+                evaluates to 'true', access will be granted.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="ldap-server">
+      <xs:annotation>
+         <xs:documentation>Defines an LDAP server location or starts an embedded server. The url indicates the
+                location of a remote server. If no url is given, an embedded server will be started,
+                listening on the supplied port number. The port is optional and defaults to 33389. A
+                Spring LDAP ContextSource bean will be registered for the server with the id supplied.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:ldap-server.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="ldap-server.attlist">
+      <xs:attribute name="id" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Specifies a URL.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="port" type="xs:nonNegativeInteger">
+         <xs:annotation>
+            <xs:documentation>Specifies an IP port number. Used to configure an embedded LDAP server, for example.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="manager-dn" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>Username (DN) of the "manager" user identity which will be used to authenticate to a
+                (non-embedded) LDAP server. If omitted, anonymous access will be used.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="manager-password" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>The password for the manager DN. This is required if the manager-dn is specified.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ldif" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>Explicitly specifies an ldif file resource to load into an embedded LDAP server. The
+                default is classpath*:*.ldiff
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="root" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>Optional root suffix for the embedded LDAP server. Default is "dc=springframework,dc=org"
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="mode">
+         <xs:annotation>
+            <xs:documentation>Explicitly specifies which embedded ldap server should use. Values are 'apacheds' and
+                'unboundid'. By default, it will depends if the library is available in the classpath.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="apacheds"/>
+               <xs:enumeration value="unboundid"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="ldap-server-ref-attribute">
+      <xs:attribute name="server-ref" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The optional server to use. If omitted, and a default LDAP server is registered (using
+                &lt;ldap-server&gt; with no Id), that server will be used.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="group-search-filter-attribute">
+      <xs:attribute name="group-search-filter" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Group search filter. Defaults to (uniqueMember={0}). The substituted parameter is the DN
+                of the user.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="group-search-base-attribute">
+      <xs:attribute name="group-search-base" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Search base for group membership searches. Defaults to "" (searching from the root).
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="user-search-filter-attribute">
+      <xs:attribute name="user-search-filter" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The LDAP filter used to search for users (optional). For example "(uid={0})". The
+                substituted parameter is the user's login name.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="user-search-base-attribute">
+      <xs:attribute name="user-search-base" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Search base for user searches. Defaults to "". Only used with a 'user-search-filter'.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="group-role-attribute-attribute">
+      <xs:attribute name="group-role-attribute" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The LDAP attribute name which contains the role name which will be used within Spring
+                Security. Defaults to "cn".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="user-details-class-attribute">
+      <xs:attribute name="user-details-class" use="required">
+         <xs:annotation>
+            <xs:documentation>Allows the objectClass of the user entry to be specified. If set, the framework will
+                attempt to load standard attributes for the defined class into the returned UserDetails
+                object
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="person"/>
+               <xs:enumeration value="inetOrgPerson"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="user-context-mapper-attribute">
+      <xs:attribute name="user-context-mapper-ref" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows explicit customization of the loaded user object by specifying a
+                UserDetailsContextMapper bean which will be called with the context information from the
+                user's directory entry
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="ldap-user-service" substitutionGroup="security:any-user-service">
+      <xs:annotation>
+         <xs:documentation>This element configures a LdapUserDetailsService which is a combination of a
+                FilterBasedLdapUserSearch and a DefaultLdapAuthoritiesPopulator.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:ldap-us.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="ldap-us.attlist">
+      <xs:attribute name="id" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="server-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The optional server to use. If omitted, and a default LDAP server is registered (using
+                &lt;ldap-server&gt; with no Id), that server will be used.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-search-filter" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The LDAP filter used to search for users (optional). For example "(uid={0})". The
+                substituted parameter is the user's login name.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-search-base" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Search base for user searches. Defaults to "". Only used with a 'user-search-filter'.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="group-search-filter" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Group search filter. Defaults to (uniqueMember={0}). The substituted parameter is the DN
+                of the user.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="group-search-base" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Search base for group membership searches. Defaults to "" (searching from the root).
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="group-role-attribute" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The LDAP attribute name which contains the role name which will be used within Spring
+                Security. Defaults to "cn".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="cache-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines a reference to a cache for use with a UserDetailsService.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="role-prefix" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A non-empty string prefix that will be added to role strings loaded from persistent
+                storage (e.g. "ROLE_"). Use the value "none" for no prefix in cases where the default is
+                non-empty.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-details-class">
+         <xs:annotation>
+            <xs:documentation>Allows the objectClass of the user entry to be specified. If set, the framework will
+                attempt to load standard attributes for the defined class into the returned UserDetails
+                object
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="person"/>
+               <xs:enumeration value="inetOrgPerson"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="user-context-mapper-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows explicit customization of the loaded user object by specifying a
+                UserDetailsContextMapper bean which will be called with the context information from the
+                user's directory entry
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="ldap-ap.attlist">
+      <xs:attribute name="server-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The optional server to use. If omitted, and a default LDAP server is registered (using
+                &lt;ldap-server&gt; with no Id), that server will be used.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-search-base" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Search base for user searches. Defaults to "". Only used with a 'user-search-filter'.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-search-filter" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The LDAP filter used to search for users (optional). For example "(uid={0})". The
+                substituted parameter is the user's login name.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="group-search-base" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Search base for group membership searches. Defaults to "" (searching from the root).
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="group-search-filter" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Group search filter. Defaults to (uniqueMember={0}). The substituted parameter is the DN
+                of the user.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="group-role-attribute" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The LDAP attribute name which contains the role name which will be used within Spring
+                Security. Defaults to "cn".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-dn-pattern" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A specific pattern used to build the user's DN, for example "uid={0},ou=people". The key
+                "{0}" must be present and will be substituted with the username.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="role-prefix" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A non-empty string prefix that will be added to role strings loaded from persistent
+                storage (e.g. "ROLE_"). Use the value "none" for no prefix in cases where the default is
+                non-empty.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-details-class">
+         <xs:annotation>
+            <xs:documentation>Allows the objectClass of the user entry to be specified. If set, the framework will
+                attempt to load standard attributes for the defined class into the returned UserDetails
+                object
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="person"/>
+               <xs:enumeration value="inetOrgPerson"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="user-context-mapper-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows explicit customization of the loaded user object by specifying a
+                UserDetailsContextMapper bean which will be called with the context information from the
+                user's directory entry
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="password-compare.attlist">
+      <xs:attribute name="password-attribute" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The attribute in the directory which contains the user password. Defaults to
+                "userPassword".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="hash">
+         <xs:annotation>
+            <xs:documentation>Defines the hashing algorithm used on user passwords. Bcrypt is recommended.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="bcrypt"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="intercept-methods">
+      <xs:annotation>
+         <xs:documentation>Can be used inside a bean definition to add a security interceptor to the bean and set up
+                access configuration attributes for the bean's methods
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="protect">
+               <xs:annotation>
+                  <xs:documentation>Defines a protected method and the access control configuration attributes that apply to
+                it. We strongly advise you NOT to mix "protect" declarations with any services provided
+                "global-method-security".
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:protect.attlist"/>
+               </xs:complexType>
+            </xs:element>
+         </xs:sequence>
+         <xs:attributeGroup ref="security:intercept-methods.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="intercept-methods.attlist">
+      <xs:attribute name="access-decision-manager-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Optional AccessDecisionManager bean ID to be used by the created method security
+                interceptor.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="protect.attlist">
+      <xs:attribute name="method" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A method name
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="access" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Access configuration attributes list that applies to the method, e.g. "ROLE_A,ROLE_B".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="method-security-metadata-source">
+      <xs:annotation>
+         <xs:documentation>Creates a MethodSecurityMetadataSource instance
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="protect">
+               <xs:annotation>
+                  <xs:documentation>Defines a protected method and the access control configuration attributes that apply to
+                it. We strongly advise you NOT to mix "protect" declarations with any services provided
+                "global-method-security".
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:protect.attlist"/>
+               </xs:complexType>
+            </xs:element>
+         </xs:sequence>
+         <xs:attributeGroup ref="security:msmds.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="msmds.attlist">
+      <xs:attribute name="id" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="use-expressions" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Enables the use of expressions in the 'access' attributes in &lt;intercept-url&gt; elements
+                rather than the traditional list of configuration attributes. Defaults to 'true'. If
+                enabled, each attribute should contain a single boolean expression. If the expression
+                evaluates to 'true', access will be granted.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="global-method-security">
+      <xs:annotation>
+         <xs:documentation>Provides method security for all beans registered in the Spring application context.
+                Specifically, beans will be scanned for matches with the ordered list of
+                "protect-pointcut" sub-elements, Spring Security annotations and/or. Where there is a
+                match, the beans will automatically be proxied and security authorization applied to the
+                methods accordingly. If you use and enable all four sources of method security metadata
+                (ie "protect-pointcut" declarations, expression annotations, @Secured and also JSR250
+                security annotations), the metadata sources will be queried in that order. In practical
+                terms, this enables you to use XML to override method security metadata expressed in
+                annotations. If using annotations, the order of precedence is EL-based (@PreAuthorize
+                etc.), @Secured and finally JSR-250.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:choice minOccurs="0">
+               <xs:element name="pre-post-annotation-handling">
+                  <xs:annotation>
+                     <xs:documentation>Allows the default expression-based mechanism for handling Spring Security's pre and post
+                invocation annotations (@PreFilter, @PreAuthorize, @PostFilter, @PostAuthorize) to be
+                replace entirely. Only applies if these annotations are enabled.
+                </xs:documentation>
+                  </xs:annotation>
+                  <xs:complexType>
+                     <xs:sequence>
+                        <xs:element name="invocation-attribute-factory">
+                           <xs:annotation>
+                              <xs:documentation>Defines the PrePostInvocationAttributeFactory instance which is used to generate pre and
+                post invocation metadata from the annotated methods.
+                </xs:documentation>
+                           </xs:annotation>
+                           <xs:complexType>
+                              <xs:attributeGroup ref="security:ref"/>
+                           </xs:complexType>
+                        </xs:element>
+                        <xs:element name="pre-invocation-advice">
+                           <xs:annotation>
+                              <xs:documentation>Customizes the PreInvocationAuthorizationAdviceVoter with the ref as the
+                PreInvocationAuthorizationAdviceVoter for the &lt;pre-post-annotation-handling&gt; element.
+                </xs:documentation>
+                           </xs:annotation>
+                           <xs:complexType>
+                              <xs:attributeGroup ref="security:ref"/>
+                           </xs:complexType>
+                        </xs:element>
+                        <xs:element name="post-invocation-advice">
+                           <xs:annotation>
+                              <xs:documentation>Customizes the PostInvocationAdviceProvider with the ref as the
+                PostInvocationAuthorizationAdvice for the &lt;pre-post-annotation-handling&gt; element.
+                </xs:documentation>
+                           </xs:annotation>
+                           <xs:complexType>
+                              <xs:attributeGroup ref="security:ref"/>
+                           </xs:complexType>
+                        </xs:element>
+                     </xs:sequence>
+                  </xs:complexType>
+               </xs:element>
+               <xs:element name="expression-handler">
+                  <xs:annotation>
+                     <xs:documentation>Defines the SecurityExpressionHandler instance which will be used if expression-based
+                access-control is enabled. A default implementation (with no ACL support) will be used if
+                not supplied.
+                </xs:documentation>
+                  </xs:annotation>
+                  <xs:complexType>
+                     <xs:attributeGroup ref="security:ref"/>
+                  </xs:complexType>
+               </xs:element>
+            </xs:choice>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="protect-pointcut">
+               <xs:annotation>
+                  <xs:documentation>Defines a protected pointcut and the access control configuration attributes that apply to
+                it. Every bean registered in the Spring application context that provides a method that
+                matches the pointcut will receive security authorization.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:protect-pointcut.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="after-invocation-provider">
+               <xs:annotation>
+                  <xs:documentation>Allows addition of extra AfterInvocationProvider beans which should be called by the
+                MethodSecurityInterceptor created by global-method-security.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:ref"/>
+               </xs:complexType>
+            </xs:element>
+         </xs:sequence>
+         <xs:attributeGroup ref="security:global-method-security.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="global-method-security.attlist">
+      <xs:attribute name="pre-post-annotations">
+         <xs:annotation>
+            <xs:documentation>Specifies whether the use of Spring Security's pre and post invocation annotations
+                (@PreFilter, @PreAuthorize, @PostFilter, @PostAuthorize) should be enabled for this
+                application context. Defaults to "disabled".
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="disabled"/>
+               <xs:enumeration value="enabled"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="secured-annotations">
+         <xs:annotation>
+            <xs:documentation>Specifies whether the use of Spring Security's @Secured annotations should be enabled for
+                this application context. Defaults to "disabled".
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="disabled"/>
+               <xs:enumeration value="enabled"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="jsr250-annotations">
+         <xs:annotation>
+            <xs:documentation>Specifies whether JSR-250 style attributes are to be used (for example "RolesAllowed").
+                This will require the javax.annotation.security classes on the classpath. Defaults to
+                "disabled".
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="disabled"/>
+               <xs:enumeration value="enabled"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="access-decision-manager-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Optional AccessDecisionManager bean ID to override the default used for method security.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="run-as-manager-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Optional RunAsmanager implementation which will be used by the configured
+                MethodSecurityInterceptor
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="order" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows the advice "order" to be set for the method security interceptor.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="proxy-target-class" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>If true, class based proxying will be used instead of interface based proxying.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="mode">
+         <xs:annotation>
+            <xs:documentation>Can be used to specify that AspectJ should be used instead of the default Spring AOP. If
+                set, secured classes must be woven with the AnnotationSecurityAspect from the
+                spring-security-aspects module.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="aspectj"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="metadata-source-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>An external MethodSecurityMetadataSource instance can be supplied which will take priority
+                over other sources (such as the default annotations).
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-manager-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to an AuthenticationManager bean
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  
+  
+  
+  
+  
+  
+  <xs:attributeGroup name="protect-pointcut.attlist">
+      <xs:attribute name="expression" use="required" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>An AspectJ expression, including the 'execution' keyword. For example, 'execution(int
+                com.foo.TargetObject.countLength(String))' (without the quotes).
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="access" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Access configuration attributes list that applies to all methods matching the pointcut,
+                e.g. "ROLE_A,ROLE_B"
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="websocket-message-broker">
+      <xs:annotation>
+         <xs:documentation>Allows securing a Message Broker. There are two modes. If no id is specified: ensures that
+                any SimpAnnotationMethodMessageHandler has the AuthenticationPrincipalArgumentResolver
+                registered as a custom argument resolver; ensures that the
+                SecurityContextChannelInterceptor is automatically registered for the
+                clientInboundChannel; and that a ChannelSecurityInterceptor is registered with the
+                clientInboundChannel. If the id is specified, creates a ChannelSecurityInterceptor that
+                can be manually registered with the clientInboundChannel.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="security:intercept-message"/>
+            <xs:element name="expression-handler">
+               <xs:annotation>
+                  <xs:documentation>Defines the SecurityExpressionHandler instance which will be used if expression-based
+                access-control is enabled. A default implementation (with no ACL support) will be used if
+                not supplied.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:ref"/>
+               </xs:complexType>
+            </xs:element>
+         </xs:choice>
+         <xs:attributeGroup ref="security:websocket-message-broker.attrlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="websocket-message-broker.attrlist">
+      <xs:attribute name="id" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context. If specified,
+                explicit configuration within clientInboundChannel is required. If not specified, ensures
+                that any SimpAnnotationMethodMessageHandler has the
+                AuthenticationPrincipalArgumentResolver registered as a custom argument resolver; ensures
+                that the SecurityContextChannelInterceptor is automatically registered for the
+                clientInboundChannel; and that a ChannelSecurityInterceptor is registered with the
+                clientInboundChannel.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="same-origin-disabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Disables the requirement for CSRF token to be present in the Stomp headers (default
+                false). Changing the default is useful if it is necessary to allow other origins to make
+                SockJS connections.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="intercept-message">
+      <xs:annotation>
+         <xs:documentation>Creates an authorization rule for a websocket message.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:intercept-message.attrlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="intercept-message.attrlist">
+      <xs:attribute name="pattern" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The destination ant pattern which will be mapped to the access attribute. For example, /**
+                matches any message with a destination, /admin/** matches any message that has a
+                destination that starts with admin.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="access" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The access configuration attributes that apply for the configured message. For example,
+                permitAll grants access to anyone, hasRole('ROLE_ADMIN') requires the user have the role
+                'ROLE_ADMIN'.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="type">
+         <xs:annotation>
+            <xs:documentation>The type of message to match on. Valid values are defined in SimpMessageType (i.e.
+                CONNECT, CONNECT_ACK, HEARTBEAT, MESSAGE, SUBSCRIBE, UNSUBSCRIBE, DISCONNECT,
+                DISCONNECT_ACK, OTHER).
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="CONNECT"/>
+               <xs:enumeration value="CONNECT_ACK"/>
+               <xs:enumeration value="HEARTBEAT"/>
+               <xs:enumeration value="MESSAGE"/>
+               <xs:enumeration value="SUBSCRIBE"/>
+               <xs:enumeration value="UNSUBSCRIBE"/>
+               <xs:enumeration value="DISCONNECT"/>
+               <xs:enumeration value="DISCONNECT_ACK"/>
+               <xs:enumeration value="OTHER"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="http-firewall">
+      <xs:annotation>
+         <xs:documentation>Allows a custom instance of HttpFirewall to be injected into the FilterChainProxy created
+                by the namespace.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:ref"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:element name="http">
+      <xs:annotation>
+         <xs:documentation>Container element for HTTP security configuration. Multiple elements can now be defined,
+                each with a specific pattern to which the enclosed security configuration applies. A
+                pattern can also be configured to bypass Spring Security's filters completely by setting
+                the "security" attribute to "none".
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="intercept-url">
+               <xs:annotation>
+                  <xs:documentation>Specifies the access attributes and/or filter list for a particular set of URLs.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:intercept-url.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="access-denied-handler">
+               <xs:annotation>
+                  <xs:documentation>Defines the access-denied strategy that should be used. An access denied page can be
+                defined or a reference to an AccessDeniedHandler instance.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:access-denied-handler.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="form-login">
+               <xs:annotation>
+                  <xs:documentation>Sets up a form login configuration for authentication with a username and password
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:form-login.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element ref="security:oauth2-login"/>
+            <xs:element ref="security:oauth2-client"/>
+            <xs:element ref="security:oauth2-resource-server"/>
+            <xs:element name="openid-login">
+               <xs:annotation>
+                  <xs:documentation>Sets up form login for authentication with an Open ID identity
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:sequence>
+                     <xs:element minOccurs="0" maxOccurs="unbounded" ref="security:attribute-exchange"/>
+                  </xs:sequence>
+                  <xs:attributeGroup ref="security:form-login.attlist"/>
+                  <xs:attribute name="user-service-ref" type="xs:token">
+                     <xs:annotation>
+                        <xs:documentation>A reference to a user-service (or UserDetailsService bean) Id
+                </xs:documentation>
+                     </xs:annotation>
+                  </xs:attribute>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="x509">
+               <xs:annotation>
+                  <xs:documentation>Adds support for X.509 client authentication.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:x509.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element ref="security:jee"/>
+            <xs:element name="http-basic">
+               <xs:annotation>
+                  <xs:documentation>Adds support for basic authentication
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:http-basic.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="logout">
+               <xs:annotation>
+                  <xs:documentation>Incorporates a logout processing filter. Most web applications require a logout filter,
+                although you may not require one if you write a controller to provider similar logic.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:logout.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="session-management">
+               <xs:annotation>
+                  <xs:documentation>Session-management related functionality is implemented by the addition of a
+                SessionManagementFilter to the filter stack.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:sequence>
+                     <xs:element minOccurs="0" name="concurrency-control">
+                        <xs:annotation>
+                           <xs:documentation>Enables concurrent session control, limiting the number of authenticated sessions a user
+                may have at the same time.
+                </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                           <xs:attributeGroup ref="security:concurrency-control.attlist"/>
+                        </xs:complexType>
+                     </xs:element>
+                  </xs:sequence>
+                  <xs:attributeGroup ref="security:session-management.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="remember-me">
+               <xs:annotation>
+                  <xs:documentation>Sets up remember-me authentication. If used with the "key" attribute (or no attributes)
+                the cookie-only implementation will be used. Specifying "token-repository-ref" or
+                "remember-me-data-source-ref" will use the more secure, persisten token approach.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:remember-me.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="anonymous">
+               <xs:annotation>
+                  <xs:documentation>Adds support for automatically granting all anonymous web requests a particular principal
+                identity and a corresponding granted authority.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:anonymous.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="port-mappings">
+               <xs:annotation>
+                  <xs:documentation>Defines the list of mappings between http and https ports for use in redirects
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:sequence>
+                     <xs:element maxOccurs="unbounded" name="port-mapping">
+                        <xs:annotation>
+                           <xs:documentation>Provides a method to map http ports to https ports when forcing a redirect.
+                </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                           <xs:attributeGroup ref="security:http-port"/>
+                           <xs:attributeGroup ref="security:https-port"/>
+                        </xs:complexType>
+                     </xs:element>
+                  </xs:sequence>
+               </xs:complexType>
+            </xs:element>
+            <xs:element ref="security:custom-filter"/>
+            <xs:element ref="security:request-cache"/>
+            <xs:element name="expression-handler">
+               <xs:annotation>
+                  <xs:documentation>Defines the SecurityExpressionHandler instance which will be used if expression-based
+                access-control is enabled. A default implementation (with no ACL support) will be used if
+                not supplied.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:ref"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element ref="security:headers"/>
+            <xs:element ref="security:csrf"/>
+            <xs:element ref="security:cors"/>
+         </xs:choice>
+         <xs:attributeGroup ref="security:http.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="http.attlist">
+      <xs:attribute name="pattern" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The request URL pattern which will be mapped to the filter chain created by this &lt;http&gt;
+                element. If omitted, the filter chain will match all requests.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="security">
+         <xs:annotation>
+            <xs:documentation>When set to 'none', requests matching the pattern attribute will be ignored by Spring
+                Security. No security filters will be applied and no SecurityContext will be available. If
+                set, the &lt;http&gt; element must be empty, with no children.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="none"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="request-matcher-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows a RequestMatcher instance to be used, as an alternative to pattern-matching.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="auto-config" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>A legacy attribute which automatically registers a login form, BASIC authentication and a
+                logout URL and logout services. If unspecified, defaults to "false". We'd recommend you
+                avoid using this and instead explicitly configure the services you require.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="use-expressions" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Enables the use of expressions in the 'access' attributes in &lt;intercept-url&gt; elements
+                rather than the traditional list of configuration attributes. Defaults to 'true'. If
+                enabled, each attribute should contain a single boolean expression. If the expression
+                evaluates to 'true', access will be granted.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="create-session">
+         <xs:annotation>
+            <xs:documentation>Controls the eagerness with which an HTTP session is created by Spring Security classes.
+                If not set, defaults to "ifRequired". If "stateless" is used, this implies that the
+                application guarantees that it will not create a session. This differs from the use of
+                "never" which means that Spring Security will not create a session, but will make use of
+                one if the application does.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="ifRequired"/>
+               <xs:enumeration value="always"/>
+               <xs:enumeration value="never"/>
+               <xs:enumeration value="stateless"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="security-context-repository-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to a SecurityContextRepository bean. This can be used to customize how the
+                SecurityContext is stored between requests.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="request-matcher">
+         <xs:annotation>
+            <xs:documentation>Defines the strategy use for matching incoming requests. Currently the options are 'mvc'
+                (for Spring MVC matcher), 'ant' (for ant path patterns), 'regex' for regular expressions
+                and 'ciRegex' for case-insensitive regular expressions.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="mvc"/>
+               <xs:enumeration value="ant"/>
+               <xs:enumeration value="regex"/>
+               <xs:enumeration value="ciRegex"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="servlet-api-provision" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Provides versions of HttpServletRequest security methods such as isUserInRole() and
+                getPrincipal() which are implemented by accessing the Spring SecurityContext. Defaults to
+                "true".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="jaas-api-provision" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>If available, runs the request as the Subject acquired from the JaasAuthenticationToken.
+                Defaults to "false".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="access-decision-manager-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Optional attribute specifying the ID of the AccessDecisionManager implementation which
+                should be used for authorizing HTTP requests.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="realm" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Optional attribute specifying the realm name that will be used for all authentication
+                features that require a realm name (eg BASIC and Digest authentication). If unspecified,
+                defaults to "Spring Security Application".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="entry-point-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows a customized AuthenticationEntryPoint to be set on the ExceptionTranslationFilter.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="once-per-request" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Corresponds to the observeOncePerRequest property of FilterSecurityInterceptor. Defaults
+                to "true"
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="disable-url-rewriting" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Prevents the jsessionid parameter from being added to rendered URLs. Defaults to "true"
+                (rewriting is disabled).
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="name" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-manager-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to an AuthenticationManager bean
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="access-denied-handler.attlist">
+      <xs:attribute name="ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines a reference to a Spring bean Id.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="error-page" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The access denied page that an authenticated user will be redirected to if they request a
+                page which they don't have the authority to access.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="access-denied-handler-page">
+      <xs:attribute name="error-page" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The access denied page that an authenticated user will be redirected to if they request a
+                page which they don't have the authority to access.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="intercept-url.attlist">
+      <xs:attribute name="pattern" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The request URL pattern which will be mapped to the FilterChain.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="request-matcher-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows a RequestMatcher instance to be used, as an alternative to pattern-matching.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="access" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The access configuration attributes that apply for the configured path.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="method">
+         <xs:annotation>
+            <xs:documentation>The HTTP Method for which the access configuration attributes should apply. If not
+                specified, the attributes will apply to any method.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="GET"/>
+               <xs:enumeration value="DELETE"/>
+               <xs:enumeration value="HEAD"/>
+               <xs:enumeration value="OPTIONS"/>
+               <xs:enumeration value="POST"/>
+               <xs:enumeration value="PUT"/>
+               <xs:enumeration value="PATCH"/>
+               <xs:enumeration value="TRACE"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="requires-channel" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Used to specify that a URL must be accessed over http or https, or that there is no
+                preference. The value should be "http", "https" or "any", respectively.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="servlet-path" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The path to the servlet. This attribute is only applicable when 'request-matcher' is
+                'mvc'. In addition, the value is only required in the following 2 use cases: 1) There are
+                2 or more HttpServlet's registered in the ServletContext that have mappings starting with
+                '/' and are different; 2) The pattern starts with the same value of a registered
+                HttpServlet path, excluding the default (root) HttpServlet '/'.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="logout.attlist">
+      <xs:attribute name="logout-url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Specifies the URL that will cause a logout. Spring Security will initialize a filter that
+                responds to this particular URL. Defaults to /logout if unspecified.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="logout-success-url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Specifies the URL to display once the user has logged out. If not specified, defaults to
+                &lt;form-login-login-page&gt;/?logout (i.e. /login?logout).
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="invalidate-session" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies whether a logout also causes HttpSession invalidation, which is generally
+                desirable. If unspecified, defaults to true.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="success-handler-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to a LogoutSuccessHandler implementation which will be used to determine the
+                destination to which the user is taken after logging out.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="delete-cookies" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A comma-separated list of the names of cookies which should be deleted when the user logs
+                out
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="request-cache">
+      <xs:annotation>
+         <xs:documentation>Allow the RequestCache used for saving requests during the login process to be set
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:ref"/>
+      </xs:complexType>
+   </xs:element>
+  
+  <xs:attributeGroup name="form-login.attlist">
+      <xs:attribute name="login-processing-url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The URL that the login form is posted to. If unspecified, it defaults to /login.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="username-parameter" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The name of the request parameter which contains the username. Defaults to 'username'.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="password-parameter" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The name of the request parameter which contains the password. Defaults to 'password'.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="default-target-url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The URL that will be redirected to after successful authentication, if the user's previous
+                action could not be resumed. This generally happens if the user visits a login page
+                without having first requested a secured operation that triggers authentication. If
+                unspecified, defaults to the root of the application.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="always-use-default-target" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Whether the user should always be redirected to the default-target-url after login.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="login-page" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The URL for the login page. If no login URL is specified, Spring Security will
+                automatically create a login URL at GET /login and a corresponding filter to render that
+                login URL when requested.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-failure-url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The URL for the login failure page. If no login failure URL is specified, Spring Security
+                will automatically create a failure login URL at /login?error and a corresponding filter
+                to render that login failure URL when requested.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-success-handler-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationSuccessHandler bean which should be used to handle a
+                successful authentication request. Should not be used in combination with
+                default-target-url (or always-use-default-target-url) as the implementation should always
+                deal with navigation to the subsequent destination
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-failure-handler-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationFailureHandler bean which should be used to handle a failed
+                authentication request. Should not be used in combination with authentication-failure-url
+                as the implementation should always deal with navigation to the subsequent destination
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-details-source-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationDetailsSource which will be used by the authentication
+                filter
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-failure-forward-url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The URL for the ForwardAuthenticationFailureHandler
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-success-forward-url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The URL for the ForwardAuthenticationSuccessHandler
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="oauth2-login">
+      <xs:annotation>
+         <xs:documentation>Configures authentication support using an OAuth 2.0 and/or OpenID Connect 1.0 Provider.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:oauth2-login.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="oauth2-login.attlist">
+      <xs:attribute name="client-registration-repository-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to the ClientRegistrationRepository
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authorized-client-repository-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to the OAuth2AuthorizedClientRepository
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authorized-client-service-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to the OAuth2AuthorizedClientService
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authorization-request-repository-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to the AuthorizationRequestRepository
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authorization-request-resolver-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to the OAuth2AuthorizationRequestResolver
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="access-token-response-client-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to the OAuth2AccessTokenResponseClient
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-authorities-mapper-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to the GrantedAuthoritiesMapper
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-service-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to the OAuth2UserService
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="oidc-user-service-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to the OpenID Connect OAuth2UserService
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="login-processing-url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The URI where the filter processes authentication requests
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="login-page" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The URI to send users to login
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-success-handler-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to the AuthenticationSuccessHandler
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-failure-handler-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to the AuthenticationFailureHandler
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="jwt-decoder-factory-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to the JwtDecoderFactory used by OidcAuthorizationCodeAuthenticationProvider
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="oauth2-client">
+      <xs:annotation>
+         <xs:documentation>Configures OAuth 2.0 Client support.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element minOccurs="0" ref="security:authorization-code-grant"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="security:oauth2-client.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="oauth2-client.attlist">
+      <xs:attribute name="client-registration-repository-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to the ClientRegistrationRepository
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authorized-client-repository-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to the OAuth2AuthorizedClientRepository
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authorized-client-service-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to the OAuth2AuthorizedClientService
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="authorization-code-grant">
+      <xs:annotation>
+         <xs:documentation>Configures OAuth 2.0 Authorization Code Grant.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:authorization-code-grant.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="authorization-code-grant.attlist">
+      <xs:attribute name="authorization-request-repository-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to the AuthorizationRequestRepository
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authorization-request-resolver-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to the OAuth2AuthorizationRequestResolver
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="access-token-response-client-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to the OAuth2AccessTokenResponseClient
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="client-registrations">
+      <xs:annotation>
+         <xs:documentation>Container element for client(s) registered with an OAuth 2.0 or OpenID Connect 1.0
+                Provider.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="security:client-registration"/>
+            <xs:element minOccurs="0" maxOccurs="unbounded" ref="security:provider"/>
+         </xs:sequence>
+      </xs:complexType>
+   </xs:element>
+  <xs:element name="client-registration">
+      <xs:annotation>
+         <xs:documentation>Represents a client registered with an OAuth 2.0 or OpenID Connect 1.0 Provider.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:client-registration.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="client-registration.attlist">
+      <xs:attribute name="registration-id" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The ID that uniquely identifies the client registration.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="client-id" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The client identifier.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="client-secret" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The client secret.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="client-authentication-method">
+         <xs:annotation>
+            <xs:documentation>The method used to authenticate the client with the provider. The supported values are
+                basic, post and none (public clients).
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="basic"/>
+               <xs:enumeration value="post"/>
+               <xs:enumeration value="none"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="authorization-grant-type">
+         <xs:annotation>
+            <xs:documentation>The OAuth 2.0 Authorization Framework defines four Authorization Grant types. The
+                supported values are authorization_code, client_credentials, password and implicit.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="authorization_code"/>
+               <xs:enumeration value="client_credentials"/>
+               <xs:enumeration value="password"/>
+               <xs:enumeration value="implicit"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="redirect-uri" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The client’s registered redirect URI that the Authorization Server redirects the
+                end-user’s user-agent to after the end-user has authenticated and authorized access to the
+                client.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="scope" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A comma-separated list of scope(s) requested by the client during the Authorization
+                Request flow, such as openid, email, or profile.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="client-name" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A descriptive name used for the client. The name may be used in certain scenarios, such as
+                when displaying the name of the client in the auto-generated login page.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="provider-id" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to the associated provider. May reference a 'provider' element or use one of
+                the common providers (google, github, facebook, okta).
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="provider">
+      <xs:annotation>
+         <xs:documentation>The configuration information for an OAuth 2.0 or OpenID Connect 1.0 Provider.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:provider.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="provider.attlist">
+      <xs:attribute name="provider-id" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The ID that uniquely identifies the provider.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authorization-uri" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The Authorization Endpoint URI for the Authorization Server.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="token-uri" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The Token Endpoint URI for the Authorization Server.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-info-uri" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The UserInfo Endpoint URI used to access the claims/attributes of the authenticated
+                end-user.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-info-authentication-method">
+         <xs:annotation>
+            <xs:documentation>The authentication method used when sending the access token to the UserInfo Endpoint. The
+                supported values are header, form and query.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="header"/>
+               <xs:enumeration value="form"/>
+               <xs:enumeration value="query"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="user-info-user-name-attribute" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The name of the attribute returned in the UserInfo Response that references the Name or
+                Identifier of the end-user.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="jwk-set-uri" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The URI used to retrieve the JSON Web Key (JWK) Set from the Authorization Server, which
+                contains the cryptographic key(s) used to verify the JSON Web Signature (JWS) of the ID
+                Token and optionally the UserInfo Response.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="issuer-uri" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The URI used to discover the configuration information for an OAuth 2.0 or OpenID Connect
+                1.0 Provider.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="oauth2-resource-server">
+      <xs:annotation>
+         <xs:documentation>Configures authentication support as an OAuth 2.0 Resource Server.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="security:jwt"/>
+            <xs:element ref="security:opaque-token"/>
+         </xs:choice>
+         <xs:attributeGroup ref="security:oauth2-resource-server.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="oauth2-resource-server.attlist">
+      <xs:attribute name="authentication-manager-resolver-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationManagerResolver
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="bearer-token-resolver-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to a BearerTokenResolver
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="entry-point-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to a AuthenticationEntryPoint
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="jwt">
+      <xs:annotation>
+         <xs:documentation>Configures JWT authentication
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:jwt.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="jwt.attlist">
+      <xs:attribute name="jwk-set-uri" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The URI to use to collect the JWK Set for verifying JWTs
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="decoder-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to a JwtDecoder
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="jwt-authentication-converter-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to a Converter&lt;Jwt, AbstractAuthenticationToken&gt;
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="opaque-token">
+      <xs:annotation>
+         <xs:documentation>Configuration Opaque Token authentication
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:opaque-token.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="opaque-token.attlist">
+      <xs:attribute name="introspection-uri" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The URI to use to introspect opaque token attributes
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="client-id" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The Client ID to use to authenticate the introspection request
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="client-secret" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The Client secret to use to authenticate the introspection request
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="introspector-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an OpaqueTokenIntrospector
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:element name="attribute-exchange">
+      <xs:annotation>
+         <xs:documentation>Sets up an attribute exchange configuration to request specified attributes from the
+                OpenID identity provider. When multiple elements are used, each must have an
+                identifier-attribute attribute. Each configuration will be matched in turn against the
+                supplied login identifier until a match is found.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="security:openid-attribute"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="security:attribute-exchange.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="attribute-exchange.attlist">
+      <xs:attribute name="identifier-match" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A regular expression which will be compared against the claimed identity, when deciding
+                which attribute-exchange configuration to use during authentication.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="openid-attribute">
+      <xs:annotation>
+         <xs:documentation>Attributes used when making an OpenID AX Fetch Request
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:openid-attribute.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="openid-attribute.attlist">
+      <xs:attribute name="name" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Specifies the name of the attribute that you wish to get back. For example, email.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="type" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Specifies the attribute type. For example, https://axschema.org/contact/email. See your
+                OP's documentation for valid attribute types.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="required" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies if this attribute is required to the OP, but does not error out if the OP does
+                not return the attribute. Default is false.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="count" type="xs:int">
+         <xs:annotation>
+            <xs:documentation>Specifies the number of attributes that you wish to get back. For example, return 3
+                emails. The default value is 1.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="filter-chain-map">
+      <xs:annotation>
+         <xs:documentation>Used to explicitly configure a FilterChainProxy instance with a FilterChainMap
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="security:filter-chain"/>
+         </xs:sequence>
+         <xs:attributeGroup ref="security:filter-chain-map.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="filter-chain-map.attlist">
+      <xs:attribute name="request-matcher">
+         <xs:annotation>
+            <xs:documentation>Defines the strategy use for matching incoming requests. Currently the options are 'mvc'
+                (for Spring MVC matcher), 'ant' (for ant path patterns), 'regex' for regular expressions
+                and 'ciRegex' for case-insensitive regular expressions.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="mvc"/>
+               <xs:enumeration value="ant"/>
+               <xs:enumeration value="regex"/>
+               <xs:enumeration value="ciRegex"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="filter-chain">
+      <xs:annotation>
+         <xs:documentation>Used within to define a specific URL pattern and the list of filters which apply to the
+                URLs matching that pattern. When multiple filter-chain elements are assembled in a list in
+                order to configure a FilterChainProxy, the most specific patterns must be placed at the
+                top of the list, with most general ones at the bottom.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:filter-chain.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="filter-chain.attlist">
+      <xs:attribute name="pattern" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The request URL pattern which will be mapped to the FilterChain.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="request-matcher-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows a RequestMatcher instance to be used, as an alternative to pattern-matching.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="filters" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A comma separated list of bean names that implement Filter that should be processed for
+                this FilterChain. If the value is none, then no Filters will be used for this FilterChain.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="pattern">
+      <xs:attribute name="pattern" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The request URL pattern which will be mapped to the FilterChain.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="request-matcher-ref">
+      <xs:attribute name="request-matcher-ref" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows a RequestMatcher instance to be used, as an alternative to pattern-matching.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="filter-security-metadata-source">
+      <xs:annotation>
+         <xs:documentation>Used to explicitly configure a FilterSecurityMetadataSource bean for use with a
+                FilterSecurityInterceptor. Usually only needed if you are configuring a FilterChainProxy
+                explicitly, rather than using the &lt;http&gt; element. The intercept-url elements used should
+                only contain pattern, method and access attributes. Any others will result in a
+                configuration error.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" name="intercept-url">
+               <xs:annotation>
+                  <xs:documentation>Specifies the access attributes and/or filter list for a particular set of URLs.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:intercept-url.attlist"/>
+               </xs:complexType>
+            </xs:element>
+         </xs:sequence>
+         <xs:attributeGroup ref="security:fsmds.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="fsmds.attlist">
+      <xs:attribute name="use-expressions" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Enables the use of expressions in the 'access' attributes in &lt;intercept-url&gt; elements
+                rather than the traditional list of configuration attributes. Defaults to 'true'. If
+                enabled, each attribute should contain a single boolean expression. If the expression
+                evaluates to 'true', access will be granted.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="id" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="request-matcher">
+         <xs:annotation>
+            <xs:documentation>Defines the strategy use for matching incoming requests. Currently the options are 'mvc'
+                (for Spring MVC matcher), 'ant' (for ant path patterns), 'regex' for regular expressions
+                and 'ciRegex' for case-insensitive regular expressions.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="mvc"/>
+               <xs:enumeration value="ant"/>
+               <xs:enumeration value="regex"/>
+               <xs:enumeration value="ciRegex"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="http-basic.attlist">
+      <xs:attribute name="entry-point-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Sets the AuthenticationEntryPoint which is used by the BasicAuthenticationFilter.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-details-source-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationDetailsSource which will be used by the authentication
+                filter
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="session-management.attlist">
+      <xs:attribute name="session-fixation-protection">
+         <xs:annotation>
+            <xs:documentation>Indicates how session fixation protection will be applied when a user authenticates. If
+                set to "none", no protection will be applied. "newSession" will create a new empty
+                session, with only Spring Security-related attributes migrated. "migrateSession" will
+                create a new session and copy all session attributes to the new session. In Servlet 3.1
+                (Java EE 7) and newer containers, specifying "changeSessionId" will keep the existing
+                session and use the container-supplied session fixation protection
+                (HttpServletRequest#changeSessionId()). Defaults to "changeSessionId" in Servlet 3.1 and
+                newer containers, "migrateSession" in older containers. Throws an exception if
+                "changeSessionId" is used in older containers.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="none"/>
+               <xs:enumeration value="newSession"/>
+               <xs:enumeration value="migrateSession"/>
+               <xs:enumeration value="changeSessionId"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="invalid-session-url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The URL to which a user will be redirected if they submit an invalid session indentifier.
+                Typically used to detect session timeouts.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="invalid-session-strategy-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows injection of the InvalidSessionStrategy instance used by the
+                SessionManagementFilter
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="session-authentication-strategy-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows injection of the SessionAuthenticationStrategy instance used by the
+                SessionManagementFilter
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="session-authentication-error-url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines the URL of the error page which should be shown when the
+                SessionAuthenticationStrategy raises an exception. If not set, an unauthorized (401) error
+                code will be returned to the client. Note that this attribute doesn't apply if the error
+                occurs during a form-based login, where the URL for authentication failure will take
+                precedence.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="concurrency-control.attlist">
+      <xs:attribute name="max-sessions" type="xs:integer">
+         <xs:annotation>
+            <xs:documentation>The maximum number of sessions a single authenticated user can have open at the same time.
+                Defaults to "1". A negative value denotes unlimited sessions.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="expired-url" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The URL a user will be redirected to if they attempt to use a session which has been
+                "expired" because they have logged in again.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="expired-session-strategy-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows injection of the SessionInformationExpiredStrategy instance used by the
+                ConcurrentSessionFilter
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="error-if-maximum-exceeded" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies that an unauthorized error should be reported when a user attempts to login when
+                they already have the maximum configured sessions open. The default behaviour is to expire
+                the original session. If the session-authentication-error-url attribute is set on the
+                session-management URL, the user will be redirected to this URL.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="session-registry-alias" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows you to define an alias for the SessionRegistry bean in order to access it in your
+                own configuration.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="session-registry-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows you to define an external SessionRegistry bean to be used by the concurrency
+                control setup.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="remember-me.attlist">
+      <xs:attribute name="key" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The "key" used to identify cookies from a specific token-based remember-me application.
+                You should set this to a unique value for your application. If unset, it will default to a
+                random value generated by SecureRandom.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="token-repository-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to a PersistentTokenRepository bean for use with the persistent token
+                remember-me implementation.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="data-source-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to a DataSource bean
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attributeGroup ref="security:remember-me-services-ref"/>
+      <xs:attribute name="user-service-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to a user-service (or UserDetailsService bean) Id
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="services-alias" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Exports the internally defined RememberMeServices as a bean alias, allowing it to be used
+                by other beans in the application context.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="use-secure-cookie" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Determines whether the "secure" flag will be set on the remember-me cookie. If set to
+                true, the cookie will only be submitted over HTTPS (recommended). By default, secure
+                cookies will be used if the request is made on a secure connection.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="token-validity-seconds" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>The period (in seconds) for which the remember-me cookie should be valid.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-success-handler-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationSuccessHandler bean which should be used to handle a
+                successful remember-me authentication.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="remember-me-parameter" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The name of the request parameter which toggles remember-me authentication. Defaults to
+                'remember-me'.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="remember-me-cookie" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The name of cookie which store the token for remember-me authentication. Defaults to
+                'remember-me'.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="token-repository-ref">
+      <xs:attribute name="token-repository-ref" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to a PersistentTokenRepository bean for use with the persistent token
+                remember-me implementation.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="remember-me-services-ref">
+      <xs:attribute name="services-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Allows a custom implementation of RememberMeServices to be used. Note that this
+                implementation should return RememberMeAuthenticationToken instances with the same "key"
+                value as specified in the remember-me element. Alternatively it should register its own
+                AuthenticationProvider. It should also implement the LogoutHandler interface, which will
+                be invoked when a user logs out. Typically the remember-me cookie would be removed on
+                logout.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="remember-me-data-source-ref">
+      <xs:attributeGroup ref="security:data-source-ref"/>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="anonymous.attlist">
+      <xs:attribute name="key" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The key shared between the provider and filter. This generally does not need to be set. If
+                unset, it will default to a random value generated by SecureRandom.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="username" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The username that should be assigned to the anonymous request. This allows the principal
+                to be identified, which may be important for logging and auditing. if unset, defaults to
+                "anonymousUser".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="granted-authority" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The granted authority that should be assigned to the anonymous request. Commonly this is
+                used to assign the anonymous request particular roles, which can subsequently be used in
+                authorization decisions. If unset, defaults to "ROLE_ANONYMOUS".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="enabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>With the default namespace setup, the anonymous "authentication" facility is automatically
+                enabled. You can disable it using this property.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  
+  <xs:attributeGroup name="http-port">
+      <xs:attribute name="http" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The http port to use.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="https-port">
+      <xs:attribute name="https" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The https port to use.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="x509.attlist">
+      <xs:attribute name="subject-principal-regex" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The regular expression used to obtain the username from the certificate's subject.
+                Defaults to matching on the common name using the pattern "CN=(.*?),".
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-service-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to a user-service (or UserDetailsService bean) Id
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authentication-details-source-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationDetailsSource which will be used by the authentication
+                filter
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="jee">
+      <xs:annotation>
+         <xs:documentation>Adds a J2eePreAuthenticatedProcessingFilter to the filter chain to provide integration
+                with container authentication.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:jee.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="jee.attlist">
+      <xs:attribute name="mappable-roles" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A comma-separate list of roles to look for in the incoming HttpServletRequest.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-service-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to a user-service (or UserDetailsService bean) Id
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="authentication-manager">
+      <xs:annotation>
+         <xs:documentation>Registers the AuthenticationManager instance and allows its list of
+                AuthenticationProviders to be defined. Also allows you to define an alias to allow you to
+                reference the AuthenticationManager in your own beans.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="authentication-provider">
+               <xs:annotation>
+                  <xs:documentation>Indicates that the contained user-service should be used as an authentication source.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:choice minOccurs="0" maxOccurs="unbounded">
+                     <xs:element ref="security:any-user-service"/>
+                     <xs:element name="password-encoder">
+                        <xs:annotation>
+                           <xs:documentation>element which defines a password encoding strategy. Used by an authentication provider to
+                convert submitted passwords to hashed versions, for example.
+                </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                           <xs:attributeGroup ref="security:password-encoder.attlist"/>
+                        </xs:complexType>
+                     </xs:element>
+                  </xs:choice>
+                  <xs:attributeGroup ref="security:ap.attlist"/>
+               </xs:complexType>
+            </xs:element>
+            <xs:element name="ldap-authentication-provider">
+               <xs:annotation>
+                  <xs:documentation>Sets up an ldap authentication provider
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:sequence>
+                     <xs:element minOccurs="0" name="password-compare">
+                        <xs:annotation>
+                           <xs:documentation>Specifies that an LDAP provider should use an LDAP compare operation of the user's
+                password to authenticate the user
+                </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                           <xs:sequence>
+                              <xs:element minOccurs="0" name="password-encoder">
+                                 <xs:annotation>
+                                    <xs:documentation>element which defines a password encoding strategy. Used by an authentication provider to
+                convert submitted passwords to hashed versions, for example.
+                </xs:documentation>
+                                 </xs:annotation>
+                                 <xs:complexType>
+                                    <xs:attributeGroup ref="security:password-encoder.attlist"/>
+                                 </xs:complexType>
+                              </xs:element>
+                           </xs:sequence>
+                           <xs:attributeGroup ref="security:password-compare.attlist"/>
+                        </xs:complexType>
+                     </xs:element>
+                  </xs:sequence>
+                  <xs:attributeGroup ref="security:ldap-ap.attlist"/>
+               </xs:complexType>
+            </xs:element>
+         </xs:choice>
+         <xs:attributeGroup ref="security:authman.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="authman.attlist">
+      <xs:attribute name="id" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="alias" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>An alias you wish to use for the AuthenticationManager bean (not required it you are using
+                a specific id)
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="erase-credentials" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>If set to true, the AuthenticationManger will attempt to clear any credentials data in the
+                returned Authentication object, once the user has been authenticated.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="ap.attlist">
+      <xs:attribute name="ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines a reference to a Spring bean Id.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="user-service-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A reference to a user-service (or UserDetailsService bean) Id
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="user-service" substitutionGroup="security:any-user-service">
+      <xs:annotation>
+         <xs:documentation>Creates an in-memory UserDetailsService from a properties file or a list of "user" child
+                elements. Usernames are converted to lower-case internally to allow for case-insensitive
+                lookups, so this should not be used if case-sensitivity is required.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="user">
+               <xs:annotation>
+                  <xs:documentation>Represents a user in the application.
+                </xs:documentation>
+               </xs:annotation>
+               <xs:complexType>
+                  <xs:attributeGroup ref="security:user.attlist"/>
+               </xs:complexType>
+            </xs:element>
+         </xs:sequence>
+         <xs:attribute name="id" type="xs:token">
+            <xs:annotation>
+               <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context.
+                </xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attributeGroup ref="security:properties-file"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="properties-file">
+      <xs:attribute name="properties" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The location of a Properties file where each line is in the format of
+                username=password,grantedAuthority[,grantedAuthority][,enabled|disabled]
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  
+  <xs:attributeGroup name="user.attlist">
+      <xs:attribute name="name" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The username assigned to the user.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="password" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>The password assigned to the user. This may be hashed if the corresponding authentication
+                provider supports hashing (remember to set the "hash" attribute of the "user-service"
+                element). This attribute be omitted in the case where the data will not be used for
+                authentication, but only for accessing authorities. If omitted, the namespace will
+                generate a random value, preventing its accidental use for authentication. Cannot be
+                empty.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authorities" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>One of more authorities granted to the user. Separate authorities with a comma (but no
+                space). For example, "ROLE_USER,ROLE_ADMINISTRATOR"
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="locked" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Can be set to "true" to mark an account as locked and unusable.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="disabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Can be set to "true" to mark an account as disabled and unusable.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="jdbc-user-service" substitutionGroup="security:any-user-service">
+      <xs:annotation>
+         <xs:documentation>Causes creation of a JDBC-based UserDetailsService.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attribute name="id" type="xs:token">
+            <xs:annotation>
+               <xs:documentation>A bean identifier, used for referring to the bean elsewhere in the context.
+                </xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+         <xs:attributeGroup ref="security:jdbc-user-service.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="jdbc-user-service.attlist">
+      <xs:attribute name="data-source-ref" use="required" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The bean ID of the DataSource which provides the required tables.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="cache-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines a reference to a cache for use with a UserDetailsService.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="users-by-username-query" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>An SQL statement to query a username, password, and enabled status given a username.
+                Default is "select username,password,enabled from users where username = ?"
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authorities-by-username-query" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>An SQL statement to query for a user's granted authorities given a username. The default
+                is "select username, authority from authorities where username = ?"
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="group-authorities-by-username-query" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>An SQL statement to query user's group authorities given a username. The default is
+                "select g.id, g.group_name, ga.authority from groups g, group_members gm,
+                group_authorities ga where gm.username = ? and g.id = ga.group_id and g.id = gm.group_id"
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="role-prefix" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>A non-empty string prefix that will be added to role strings loaded from persistent
+                storage (e.g. "ROLE_"). Use the value "none" for no prefix in cases where the default is
+                non-empty.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="csrf">
+      <xs:annotation>
+         <xs:documentation>Element for configuration of the CsrfFilter for protection against CSRF. It also updates
+                the default RequestCache to only replay "GET" requests.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:csrf-options.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="csrf-options.attlist">
+      <xs:attribute name="disabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies if csrf protection should be disabled. Default false (i.e. CSRF protection is
+                enabled).
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="request-matcher-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The RequestMatcher instance to be used to determine if CSRF should be applied. Default is
+                any HTTP method except "GET", "TRACE", "HEAD", "OPTIONS"
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="token-repository-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The CsrfTokenRepository to use. The default is HttpSessionCsrfTokenRepository wrapped by
+                LazyCsrfTokenRepository.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="headers">
+      <xs:annotation>
+         <xs:documentation>Element for configuration of the HeaderWritersFilter. Enables easy setting for the
+                X-Frame-Options, X-XSS-Protection and X-Content-Type-Options headers.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="security:cache-control"/>
+            <xs:element ref="security:xss-protection"/>
+            <xs:element ref="security:hsts"/>
+            <xs:element ref="security:frame-options"/>
+            <xs:element ref="security:content-type-options"/>
+            <xs:element ref="security:hpkp"/>
+            <xs:element ref="security:content-security-policy"/>
+            <xs:element ref="security:referrer-policy"/>
+            <xs:element ref="security:feature-policy"/>
+            <xs:element ref="security:header"/>
+         </xs:choice>
+         <xs:attributeGroup ref="security:headers-options.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="headers-options.attlist">
+      <xs:attribute name="defaults-disabled" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Specifies if the default headers should be disabled. Default false.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="disabled" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Specifies if headers should be disabled. Default false.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="hsts">
+      <xs:annotation>
+         <xs:documentation>Adds support for HTTP Strict Transport Security (HSTS)
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:hsts-options.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="hsts-options.attlist">
+      <xs:attribute name="disabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies if HTTP Strict Transport Security (HSTS) should be disabled. Default false.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="include-subdomains" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies if subdomains should be included. Default true.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="max-age-seconds" type="xs:integer">
+         <xs:annotation>
+            <xs:documentation>Specifies the maximum amount of time the host should be considered a Known HSTS Host.
+                Default one year.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="request-matcher-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The RequestMatcher instance to be used to determine if the header should be set. Default
+                is if HttpServletRequest.isSecure() is true.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="preload" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies if preload should be included. Default false.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="cors">
+      <xs:annotation>
+         <xs:documentation>Element for configuration of CorsFilter. If no CorsFilter or CorsConfigurationSource is
+                specified a HandlerMappingIntrospector is used as the CorsConfigurationSource
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:cors-options.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="cors-options.attlist">
+      <xs:attribute name="ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines a reference to a Spring bean Id.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="configuration-source-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Specifies a bean id that is a CorsConfigurationSource used to construct the CorsFilter to
+                use
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="hpkp">
+      <xs:annotation>
+         <xs:documentation>Adds support for HTTP Public Key Pinning (HPKP).
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:complexContent>
+            <xs:extension base="security:hpkp.pins">
+               <xs:attributeGroup ref="security:hpkp.attlist"/>
+            </xs:extension>
+         </xs:complexContent>
+      </xs:complexType>
+   </xs:element>
+  <xs:complexType name="hpkp.pins">
+      <xs:sequence>
+         <xs:element ref="security:pins"/>
+      </xs:sequence>
+  </xs:complexType>
+  <xs:element name="pins">
+      <xs:annotation>
+         <xs:documentation>The list with pins
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="security:pin"/>
+         </xs:sequence>
+      </xs:complexType>
+   </xs:element>
+  <xs:element name="pin">
+      <xs:annotation>
+         <xs:documentation>A pin is specified using the base64-encoded SPKI fingerprint as value and the
+                cryptographic hash algorithm as attribute
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType mixed="true">
+         <xs:attribute name="algorithm" type="xs:string">
+            <xs:annotation>
+               <xs:documentation>The cryptographic hash algorithm
+                </xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="hpkp.attlist">
+      <xs:attribute name="disabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies if HTTP Public Key Pinning (HPKP) should be disabled. Default false.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="include-subdomains" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies if subdomains should be included. Default false.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="max-age-seconds" type="xs:integer">
+         <xs:annotation>
+            <xs:documentation>Sets the value for the max-age directive of the Public-Key-Pins header. Default 60 days.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="report-only" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies if the browser should only report pin validation failures. Default true.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="report-uri" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>Specifies the URI to which the browser should report pin validation failures.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="content-security-policy">
+      <xs:annotation>
+         <xs:documentation>Adds support for Content Security Policy (CSP)
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:csp-options.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="csp-options.attlist">
+      <xs:attribute name="policy-directives" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The security policy directive(s) for the Content-Security-Policy header or if report-only
+                is set to true, then the Content-Security-Policy-Report-Only header is used.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="report-only" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Set to true, to enable the Content-Security-Policy-Report-Only header for reporting policy
+                violations only. Defaults to false.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="referrer-policy">
+      <xs:annotation>
+         <xs:documentation>Adds support for Referrer Policy
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:referrer-options.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="referrer-options.attlist">
+      <xs:attribute name="policy">
+         <xs:annotation>
+            <xs:documentation>The policies for the Referrer-Policy header.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="no-referrer"/>
+               <xs:enumeration value="no-referrer-when-downgrade"/>
+               <xs:enumeration value="same-origin"/>
+               <xs:enumeration value="origin"/>
+               <xs:enumeration value="strict-origin"/>
+               <xs:enumeration value="origin-when-cross-origin"/>
+               <xs:enumeration value="strict-origin-when-cross-origin"/>
+               <xs:enumeration value="unsafe-url"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="feature-policy">
+      <xs:annotation>
+         <xs:documentation>Adds support for Feature Policy
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:feature-options.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="feature-options.attlist">
+      <xs:attribute name="policy-directives" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The security policy directive(s) for the Feature-Policy header.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="cache-control">
+      <xs:annotation>
+         <xs:documentation>Adds Cache-Control no-cache, no-store, must-revalidate, Pragma no-cache, and Expires 0 for
+                every request
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:cache-control.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="cache-control.attlist">
+      <xs:attribute name="disabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Specifies if Cache Control should be disabled. Default false.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="frame-options">
+      <xs:annotation>
+         <xs:documentation>Enable basic clickjacking support for newer browsers (IE8+), will set the X-Frame-Options
+                header.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:frame-options.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="frame-options.attlist">
+      <xs:attribute name="disabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>If disabled, the X-Frame-Options header will not be included. Default false.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="policy">
+         <xs:annotation>
+            <xs:documentation>Specify the policy to use for the X-Frame-Options-Header.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="DENY"/>
+               <xs:enumeration value="SAMEORIGIN"/>
+               <xs:enumeration value="ALLOW-FROM"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="strategy">
+         <xs:annotation>
+            <xs:documentation>Specify the strategy to use when ALLOW-FROM is chosen.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="static"/>
+               <xs:enumeration value="whitelist"/>
+               <xs:enumeration value="regexp"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines a reference to a Spring bean Id.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="value" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>Specify a value to use for the chosen strategy.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="from-parameter" type="xs:string">
+         <xs:annotation>
+            <xs:documentation>Specify the request parameter to use for the origin when using a 'whitelist' or 'regexp'
+                based strategy. Default is 'from'.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="xss-protection">
+      <xs:annotation>
+         <xs:documentation>Enable basic XSS browser protection, supported by newer browsers (IE8+), will set the
+                X-XSS-Protection header.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:xss-protection.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="xss-protection.attlist">
+      <xs:attribute name="disabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>disable the X-XSS-Protection header. Default is 'false' meaning it is enabled.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="enabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>specify that XSS Protection should be explicitly enabled or disabled. Default is 'true'
+                meaning it is enabled.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="block" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>Add mode=block to the header or not, default is on.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="content-type-options">
+      <xs:annotation>
+         <xs:documentation>Add a X-Content-Type-Options header to the resopnse. Value is always 'nosniff'.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:content-type-options.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="content-type-options.attlist">
+      <xs:attribute name="disabled" type="xs:boolean">
+         <xs:annotation>
+            <xs:documentation>If disabled, the X-Content-Type-Options header will not be included. Default false.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="header">
+      <xs:annotation>
+         <xs:documentation>Add additional headers to the response.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:header.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="header.attlist">
+      <xs:attribute name="name" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The name of the header to add.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="value" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The value for the header.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Defines a reference to a Spring bean Id.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="any-user-service" abstract="true"/>
+  <xs:element name="custom-filter">
+      <xs:annotation>
+         <xs:documentation>Used to indicate that a filter bean declaration should be incorporated into the security
+                filter chain.
+                </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:attributeGroup ref="security:custom-filter.attlist"/>
+      </xs:complexType>
+   </xs:element>
+  <xs:attributeGroup name="custom-filter.attlist">
+      <xs:attributeGroup ref="security:ref"/>
+      <xs:attribute name="after" type="security:named-security-filter">
+         <xs:annotation>
+            <xs:documentation>The filter immediately after which the custom-filter should be placed in the chain. This
+                feature will only be needed by advanced users who wish to mix their own filters into the
+                security filter chain and have some knowledge of the standard Spring Security filters. The
+                filter names map to specific Spring Security implementation filters.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="before" type="security:named-security-filter">
+         <xs:annotation>
+            <xs:documentation>The filter immediately before which the custom-filter should be placed in the chain
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="position" type="security:named-security-filter">
+         <xs:annotation>
+            <xs:documentation>The explicit position at which the custom-filter should be placed in the chain. Use if you
+                are replacing a standard filter.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="after">
+      <xs:attribute name="after" use="required" type="security:named-security-filter">
+         <xs:annotation>
+            <xs:documentation>The filter immediately after which the custom-filter should be placed in the chain. This
+                feature will only be needed by advanced users who wish to mix their own filters into the
+                security filter chain and have some knowledge of the standard Spring Security filters. The
+                filter names map to specific Spring Security implementation filters.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="before">
+      <xs:attribute name="before" use="required" type="security:named-security-filter">
+         <xs:annotation>
+            <xs:documentation>The filter immediately before which the custom-filter should be placed in the chain
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="position">
+      <xs:attribute name="position" use="required" type="security:named-security-filter">
+         <xs:annotation>
+            <xs:documentation>The explicit position at which the custom-filter should be placed in the chain. Use if you
+                are replacing a standard filter.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+  </xs:attributeGroup>
+  <xs:simpleType name="named-security-filter">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="FIRST"/>
+         <xs:enumeration value="CHANNEL_FILTER"/>
+         <xs:enumeration value="SECURITY_CONTEXT_FILTER"/>
+         <xs:enumeration value="CONCURRENT_SESSION_FILTER"/>
+         <xs:enumeration value="WEB_ASYNC_MANAGER_FILTER"/>
+         <xs:enumeration value="HEADERS_FILTER"/>
+         <xs:enumeration value="CORS_FILTER"/>
+         <xs:enumeration value="CSRF_FILTER"/>
+         <xs:enumeration value="LOGOUT_FILTER"/>
+         <xs:enumeration value="OAUTH2_AUTHORIZATION_REQUEST_FILTER"/>
+         <xs:enumeration value="X509_FILTER"/>
+         <xs:enumeration value="PRE_AUTH_FILTER"/>
+         <xs:enumeration value="CAS_FILTER"/>
+         <xs:enumeration value="OAUTH2_LOGIN_FILTER"/>
+         <xs:enumeration value="FORM_LOGIN_FILTER"/>
+         <xs:enumeration value="OPENID_FILTER"/>
+         <xs:enumeration value="LOGIN_PAGE_FILTER"/>
+         <xs:enumeration value="LOGOUT_PAGE_FILTER"/>
+         <xs:enumeration value="DIGEST_AUTH_FILTER"/>
+         <xs:enumeration value="BEARER_TOKEN_AUTH_FILTER"/>
+         <xs:enumeration value="BASIC_AUTH_FILTER"/>
+         <xs:enumeration value="REQUEST_CACHE_FILTER"/>
+         <xs:enumeration value="SERVLET_API_SUPPORT_FILTER"/>
+         <xs:enumeration value="JAAS_API_SUPPORT_FILTER"/>
+         <xs:enumeration value="REMEMBER_ME_FILTER"/>
+         <xs:enumeration value="ANONYMOUS_FILTER"/>
+         <xs:enumeration value="OAUTH2_AUTHORIZATION_CODE_GRANT_FILTER"/>
+         <xs:enumeration value="SESSION_MANAGEMENT_FILTER"/>
+         <xs:enumeration value="EXCEPTION_TRANSLATION_FILTER"/>
+         <xs:enumeration value="FILTER_SECURITY_INTERCEPTOR"/>
+         <xs:enumeration value="SWITCH_USER_FILTER"/>
+         <xs:enumeration value="LAST"/>
+      </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/config/src/test/java/org/springframework/security/config/doc/XsdDocumentedTests.java
+++ b/config/src/test/java/org/springframework/security/config/doc/XsdDocumentedTests.java
@@ -15,18 +15,25 @@
  */
 package org.springframework.security.config.doc;
 
-import org.apache.commons.lang.StringUtils;
-import org.junit.After;
-import org.junit.Test;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.security.config.http.SecurityFiltersAssertions;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.After;
+import org.junit.Test;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.security.config.http.SecurityFiltersAssertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -50,7 +57,7 @@ public class XsdDocumentedTests {
 	String referenceLocation = "../docs/manual/src/docs/asciidoc/_includes/servlet/appendix/namespace.adoc";
 
 	String schema31xDocumentLocation = "org/springframework/security/config/spring-security-3.1.xsd";
-	String schemaDocumentLocation = "org/springframework/security/config/spring-security-5.3.xsd";
+	String schemaDocumentLocation = "org/springframework/security/config/spring-security-5.4.xsd";
 
 	XmlSupport xml = new XmlSupport();
 
@@ -142,8 +149,8 @@ public class XsdDocumentedTests {
 
 		String[] schemas = resource.getFile().getParentFile().list((dir, name) -> name.endsWith(".xsd"));
 
-		assertThat(schemas.length).isEqualTo(15)
-			.withFailMessage("the count is equal to 15, if not then schemaDocument needs updating");
+		assertThat(schemas.length).isEqualTo(16)
+			.withFailMessage("the count is equal to 16, if not then schemaDocument needs updating");
 	}
 
 	/**

--- a/config/src/test/java/org/springframework/security/config/util/InMemoryXmlApplicationContext.java
+++ b/config/src/test/java/org/springframework/security/config/util/InMemoryXmlApplicationContext.java
@@ -41,7 +41,7 @@ public class InMemoryXmlApplicationContext extends AbstractXmlApplicationContext
 			+ "http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security-";
 	static final String BEANS_CLOSE = "</b:beans>\n";
 
-	static final String SPRING_SECURITY_VERSION = "5.3";
+	static final String SPRING_SECURITY_VERSION = "5.4";
 
 	Resource inMemoryXml;
 

--- a/itest/ldap/embedded-ldap-apacheds-default/src/integration-test/resources/applicationContext-security.xml
+++ b/itest/ldap/embedded-ldap-apacheds-default/src/integration-test/resources/applicationContext-security.xml
@@ -4,6 +4,6 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
-	<s:ldap-server ldif="classpath:users.ldif"/>
+	<s:ldap-server ldif="classpath:users.ldif" port="0"/>
 
 </beans>

--- a/itest/ldap/embedded-ldap-mode-apacheds/src/integration-test/resources/applicationContext-security.xml
+++ b/itest/ldap/embedded-ldap-mode-apacheds/src/integration-test/resources/applicationContext-security.xml
@@ -4,6 +4,6 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
-	<s:ldap-server mode="apacheds" ldif="classpath:users.ldif"/>
+	<s:ldap-server mode="apacheds" ldif="classpath:users.ldif" port="0"/>
 
 </beans>

--- a/itest/ldap/embedded-ldap-mode-unboundid/src/integration-test/resources/applicationContext-security.xml
+++ b/itest/ldap/embedded-ldap-mode-unboundid/src/integration-test/resources/applicationContext-security.xml
@@ -4,6 +4,6 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
-	<s:ldap-server mode="unboundid" ldif="classpath:users.ldif"/>
+	<s:ldap-server mode="unboundid" ldif="classpath:users.ldif" port="0"/>
 
 </beans>

--- a/itest/ldap/embedded-ldap-none/src/integration-test/resources/applicationContext-security.xml
+++ b/itest/ldap/embedded-ldap-none/src/integration-test/resources/applicationContext-security.xml
@@ -4,6 +4,6 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
-	<s:ldap-server ldif="classpath:users.ldif"/>
+	<s:ldap-server ldif="classpath:users.ldif" port="0"/>
 
 </beans>

--- a/itest/ldap/embedded-ldap-unboundid-default/src/integration-test/resources/applicationContext-security.xml
+++ b/itest/ldap/embedded-ldap-unboundid-default/src/integration-test/resources/applicationContext-security.xml
@@ -4,6 +4,6 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 	http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd">
 
-	<s:ldap-server ldif="classpath:users.ldif"/>
+	<s:ldap-server ldif="classpath:users.ldif" port="0"/>
 
 </beans>


### PR DESCRIPTION
Fixes gh-8138

Note that a change to the XSD was necessary in order to allow for 0 in `port`.

Also, note that I've left one test in each `LdapServerBeanDefinitionParserTests` and `LdapProviderBeanDefinitionParserTests` that don't use port=0 to demonstrate and test default usage.