### PR TITLE
Fixes gh-8187 : OAuth2 ClientRegistrations UserInfo endpoint NPE fix

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistrations.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistrations.java
@@ -146,9 +146,12 @@ public final class ClientRegistrations {
 			RequestEntity<Void> request = RequestEntity.get(uri).build();
 			Map<String, Object> configuration = rest.exchange(request, typeReference).getBody();
 			OIDCProviderMetadata metadata = parse(configuration, OIDCProviderMetadata::parse);
-			return withProviderConfiguration(metadata, issuer.toASCIIString())
-					.jwkSetUri(metadata.getJWKSetURI().toASCIIString())
-					.userInfoUri(metadata.getUserInfoEndpointURI().toASCIIString());
+			ClientRegistration.Builder builder = withProviderConfiguration(metadata, issuer.toASCIIString())
+					.jwkSetUri(metadata.getJWKSetURI().toASCIIString());
+			if (metadata.getUserInfoEndpointURI() != null) {
+				builder.userInfoUri(metadata.getUserInfoEndpointURI().toASCIIString());
+			}
+			return builder;
 		};
 	}
 

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/ClientRegistrationsTest.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/ClientRegistrationsTest.java
@@ -195,6 +195,14 @@ public class ClientRegistrationsTest {
 		assertThat(provider.getJwkSetUri()).isNull();
 	}
 
+	// gh-8187
+	@Test
+	public void issuerWhenResponseMissingUserInfoUriThenSuccess() throws Exception {
+		this.response.remove("userinfo_endpoint");
+		ClientRegistration registration = registration("").build();
+		assertThat(registration.getProviderDetails().getUserInfoEndpoint().getUri()).isNull();
+	}
+
 	@Test
 	public void issuerWhenContainsTrailingSlashThenSuccess() throws Exception {
 		assertThat(registration("")).isNotNull();


### PR DESCRIPTION
A null check was added to the code that caused the NPE. A unit test was added.

Fixes [gh-8187](https://github.com/spring-projects/spring-security/issues/8187).
