### PR TITLE
Fix issue #8309

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.java
@@ -161,7 +161,7 @@ public abstract class AbstractAuthenticationProcessingFilter extends GenericFilt
 
 	@Override
 	public void afterPropertiesSet() {
-		Assert.notNull(authenticationManager, "authenticationManager must be specified");
+		Assert.notNull(getAuthenticationManager(), "authenticationManager must be specified");
 	}
 
 	/**


### PR DESCRIPTION
Change `authenticationManager` to `getAuthenticationManager()` to prevent inappropriate assertion error. [gh-8309]

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
