### PR TITLE
BCryptPasswordEncoder rawPassword cannot be null

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoder.java
@@ -99,6 +99,10 @@ public class BCryptPasswordEncoder implements PasswordEncoder {
 	}
 
 	public String encode(CharSequence rawPassword) {
+		if (rawPassword == null) {
+			throw new IllegalArgumentException("rawPassword cannot be null");
+		}
+
 		String salt;
 		if (random != null) {
 			salt = BCrypt.gensalt(version.getVersion(), strength, random);
@@ -109,6 +113,10 @@ public class BCryptPasswordEncoder implements PasswordEncoder {
 	}
 
 	public boolean matches(CharSequence rawPassword, String encodedPassword) {
+		if (rawPassword == null) {
+			throw new IllegalArgumentException("rawPassword cannot be null");
+		}
+
 		if (encodedPassword == null || encodedPassword.length() == 0) {
 			logger.warn("Empty encoded password");
 			return false;

--- a/crypto/src/test/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoderTests.java
@@ -200,4 +200,16 @@ public class BCryptPasswordEncoderTests {
 		encoder.upgradeEncoding("not-a-bcrypt-password");
 	}
 
+	@Test(expected = IllegalArgumentException.class)
+	public void encodeNullRawPassword() {
+		BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+		encoder.encode(null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void matchNullRawPassword() {
+		BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+		encoder.matches(null, "does-not-matter");
+	}
+
 }


### PR DESCRIPTION
Issue #8317 - made BCryptPasswordEncoder#encode() and BCryptPasswordEncoder#matches() null-safe