### PR TITLE
Adding Map support to DefaultMethodSecurityExpressionHandler

### DIFF
--- a/core/src/test/java/org/springframework/security/access/expression/method/DefaultMethodSecurityExpressionHandlerTests.java
+++ b/core/src/test/java/org/springframework/security/access/expression/method/DefaultMethodSecurityExpressionHandlerTests.java
@@ -15,7 +15,9 @@
  */
 package org.springframework.security.access.expression.method;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -76,6 +78,72 @@ public class DefaultMethodSecurityExpressionHandlerTests {
 		expression.getValue(context, Boolean.class);
 
 		verify(trustResolver).isAnonymous(authentication);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void filterByKeyWhenUsingMapThenFiltersMap() {
+		final Map<String, String> map = new HashMap<>();
+		map.put("key1", "value1");
+		map.put("key2", "value2");
+		map.put("key3", "value3");
+
+		Expression expression = handler.getExpressionParser().parseExpression("filterObject.key eq 'key2'");
+
+		EvaluationContext context = handler.createEvaluationContext(authentication,
+				methodInvocation);
+
+		Object filtered = handler.filter(map, expression, context);
+
+		assertThat(filtered == map);
+		Map<String, String> result = ((Map<String, String>) filtered);
+		assertThat(result.size() == 1);
+		assertThat(result).containsKey("key2");
+		assertThat(result).containsValue("value2");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void filterByValueWhenUsingMapThenFiltersMap() {
+		final Map<String, String> map = new HashMap<>();
+		map.put("key1", "value1");
+		map.put("key2", "value2");
+		map.put("key3", "value3");
+
+		Expression expression = handler.getExpressionParser().parseExpression("filterObject.value eq 'value3'");
+
+		EvaluationContext context = handler.createEvaluationContext(authentication,
+				methodInvocation);
+
+		Object filtered = handler.filter(map, expression, context);
+
+		assertThat(filtered == map);
+		Map<String, String> result = ((Map<String, String>) filtered);
+		assertThat(result.size() == 1);
+		assertThat(result).containsKey("key3");
+		assertThat(result).containsValue("value3");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void filterByKeyAndValueWhenUsingMapThenFiltersMap() {
+		final Map<String, String> map = new HashMap<>();
+		map.put("key1", "value1");
+		map.put("key2", "value2");
+		map.put("key3", "value3");
+
+		Expression expression = handler.getExpressionParser().parseExpression("(filterObject.key eq 'key1') or (filterObject.value eq 'value2')");
+
+		EvaluationContext context = handler.createEvaluationContext(authentication,
+				methodInvocation);
+
+		Object filtered = handler.filter(map, expression, context);
+
+		assertThat(filtered == map);
+		Map<String, String> result = ((Map<String, String>) filtered);
+		assertThat(result.size() == 2);
+		assertThat(result).containsKeys("key1", "key2");
+		assertThat(result).containsValues("value1", "value2");
 	}
 
 	@Test

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/authorization/expression-based.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/authorization/expression-based.adoc
@@ -304,7 +304,7 @@ To access the return value from a method, use the built-in name `returnObject` i
 --
 
 ===== Filtering using @PreFilter and @PostFilter
-As you may already be aware, Spring Security supports filtering of collections and arrays and this can now be achieved using expressions.
+Spring Security supports filtering of collections, arrays, maps and streams using expressions.
 This is most commonly performed on the return value of a method.
 For example:
 
@@ -315,8 +315,10 @@ For example:
 public List<Contact> getAll();
 ----
 
-When using the `@PostFilter` annotation, Spring Security iterates through the returned collection and removes any elements for which the supplied expression is false.
+When using the `@PostFilter` annotation, Spring Security iterates through the returned collection or map and removes any elements for which the supplied expression is false.
+For an array, a new array instance will be returned containing filtered elements.
 The name `filterObject` refers to the current object in the collection.
+In case when a map is used it will refer to the current `Map.Entry` object which allows one to use `filterObject.key` or `filterObject.value` in the expresion.
 You can also filter before the method call, using `@PreFilter`, though this is a less common requirement.
 The syntax is just the same, but if there is more than one argument which is a collection type then you have to select one by name using the `filterTarget` property of this annotation.
 


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
This pull requests adds support for Maps to DefaultMethodSecurityExpressionHandler.

Notes:
- Not sure if `permissionCacheOptimizer.cachePermissionsFor` can be used with Maps.

