### PR TITLE
Add authorize() DSL method that accepts HttpMethod

### DIFF
--- a/config/src/main/kotlin/org/springframework/security/config/web/servlet/AbstractRequestMatcherDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/servlet/AbstractRequestMatcherDsl.kt
@@ -16,6 +16,7 @@
 
 package org.springframework.security.config.web.servlet
 
+import org.springframework.http.HttpMethod
 import org.springframework.security.web.util.matcher.AnyRequestMatcher
 import org.springframework.security.web.util.matcher.RequestMatcher
 
@@ -38,6 +39,7 @@ abstract class AbstractRequestMatcherDsl {
     protected data class PatternAuthorizationRule(val pattern: String,
                                                   val patternType: PatternType,
                                                   val servletPath: String? = null,
+                                                  val httpMethod: HttpMethod? = null,
                                                   override val rule: String) : AuthorizationRule(rule)
 
     protected abstract class AuthorizationRule(open val rule: String)

--- a/config/src/main/kotlin/org/springframework/security/config/web/servlet/AbstractRequestMatcherDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/servlet/AbstractRequestMatcherDsl.kt
@@ -37,7 +37,7 @@ abstract class AbstractRequestMatcherDsl {
 
     protected data class PatternAuthorizationRule(val pattern: String,
                                                   val patternType: PatternType,
-                                                  val servletPath: String?,
+                                                  val servletPath: String? = null,
                                                   override val rule: String) : AuthorizationRule(rule)
 
     protected abstract class AuthorizationRule(open val rule: String)

--- a/config/src/main/kotlin/org/springframework/security/config/web/servlet/AuthorizeRequestsDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/servlet/AuthorizeRequestsDsl.kt
@@ -35,6 +35,7 @@ class AuthorizeRequestsDsl : AbstractRequestMatcherDsl() {
     private val MVC_PRESENT = ClassUtils.isPresent(
             HANDLER_MAPPING_INTROSPECTOR,
             AuthorizeRequestsDsl::class.java.classLoader)
+    private val PATTERN_TYPE = if (MVC_PRESENT) PatternType.MVC else PatternType.ANT
 
     /**
      * Adds a request authorization rule.
@@ -64,11 +65,7 @@ class AuthorizeRequestsDsl : AbstractRequestMatcherDsl() {
      * (i.e. "hasAuthority('ROLE_USER') and hasAuthority('ROLE_SUPER')")
      */
     fun authorize(pattern: String, access: String = "authenticated") {
-        if (MVC_PRESENT) {
-            authorizationRules.add(PatternAuthorizationRule(pattern, PatternType.MVC, null, access))
-        } else {
-            authorizationRules.add(PatternAuthorizationRule(pattern, PatternType.ANT, null, access))
-        }
+        authorizationRules.add(PatternAuthorizationRule(pattern, PATTERN_TYPE, null, access))
     }
 
     /**
@@ -89,11 +86,7 @@ class AuthorizeRequestsDsl : AbstractRequestMatcherDsl() {
      * (i.e. "hasAuthority('ROLE_USER') and hasAuthority('ROLE_SUPER')")
      */
     fun authorize(pattern: String, servletPath: String, access: String = "authenticated") {
-        if (MVC_PRESENT) {
-            authorizationRules.add(PatternAuthorizationRule(pattern, PatternType.MVC, servletPath, access))
-        } else {
-            authorizationRules.add(PatternAuthorizationRule(pattern, PatternType.ANT, servletPath, access))
-        }
+        authorizationRules.add(PatternAuthorizationRule(pattern, PATTERN_TYPE, servletPath, access))
     }
 
     /**

--- a/config/src/main/kotlin/org/springframework/security/config/web/servlet/AuthorizeRequestsDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/servlet/AuthorizeRequestsDsl.kt
@@ -65,7 +65,9 @@ class AuthorizeRequestsDsl : AbstractRequestMatcherDsl() {
      * (i.e. "hasAuthority('ROLE_USER') and hasAuthority('ROLE_SUPER')")
      */
     fun authorize(pattern: String, access: String = "authenticated") {
-        authorizationRules.add(PatternAuthorizationRule(pattern, PATTERN_TYPE, null, access))
+        authorizationRules.add(PatternAuthorizationRule(pattern = pattern,
+                                                        patternType = PATTERN_TYPE,
+                                                        rule = access))
     }
 
     /**
@@ -86,7 +88,10 @@ class AuthorizeRequestsDsl : AbstractRequestMatcherDsl() {
      * (i.e. "hasAuthority('ROLE_USER') and hasAuthority('ROLE_SUPER')")
      */
     fun authorize(pattern: String, servletPath: String, access: String = "authenticated") {
-        authorizationRules.add(PatternAuthorizationRule(pattern, PATTERN_TYPE, servletPath, access))
+        authorizationRules.add(PatternAuthorizationRule(pattern = pattern,
+                                                        patternType = PATTERN_TYPE,
+                                                        servletPath = servletPath,
+                                                        rule = access))
     }
 
     /**

--- a/config/src/main/kotlin/org/springframework/security/config/web/servlet/RequiresChannelDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/servlet/RequiresChannelDsl.kt
@@ -72,7 +72,9 @@ class RequiresChannelDsl : AbstractRequestMatcherDsl() {
      * (i.e. "REQUIRES_SECURE_CHANNEL")
      */
     fun secure(pattern: String, attribute: String = "REQUIRES_SECURE_CHANNEL") {
-        channelSecurityRules.add(PatternAuthorizationRule(pattern, PATTERN_TYPE, null, attribute))
+        channelSecurityRules.add(PatternAuthorizationRule(pattern = pattern,
+                                                          patternType = PATTERN_TYPE,
+                                                          rule = attribute))
     }
 
     /**
@@ -93,7 +95,10 @@ class RequiresChannelDsl : AbstractRequestMatcherDsl() {
      * (i.e. "REQUIRES_SECURE_CHANNEL")
      */
     fun secure(pattern: String, servletPath: String, attribute: String = "REQUIRES_SECURE_CHANNEL") {
-        channelSecurityRules.add(PatternAuthorizationRule(pattern, PATTERN_TYPE, servletPath, attribute))
+        channelSecurityRules.add(PatternAuthorizationRule(pattern = pattern,
+                                                          patternType = PATTERN_TYPE,
+                                                          servletPath = servletPath,
+                                                          rule = attribute))
     }
 
     /**

--- a/config/src/main/kotlin/org/springframework/security/config/web/servlet/RequiresChannelDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/servlet/RequiresChannelDsl.kt
@@ -40,6 +40,7 @@ class RequiresChannelDsl : AbstractRequestMatcherDsl() {
     private val MVC_PRESENT = ClassUtils.isPresent(
             HANDLER_MAPPING_INTROSPECTOR,
             RequiresChannelDsl::class.java.classLoader)
+    private val PATTERN_TYPE = if (MVC_PRESENT) PatternType.MVC else PatternType.ANT
 
     var channelProcessors: List<ChannelProcessor>? = null
 
@@ -71,11 +72,7 @@ class RequiresChannelDsl : AbstractRequestMatcherDsl() {
      * (i.e. "REQUIRES_SECURE_CHANNEL")
      */
     fun secure(pattern: String, attribute: String = "REQUIRES_SECURE_CHANNEL") {
-        if (MVC_PRESENT) {
-            channelSecurityRules.add(PatternAuthorizationRule(pattern, PatternType.MVC, null, attribute))
-        } else {
-            channelSecurityRules.add(PatternAuthorizationRule(pattern, PatternType.ANT, null, attribute))
-        }
+        channelSecurityRules.add(PatternAuthorizationRule(pattern, PATTERN_TYPE, null, attribute))
     }
 
     /**
@@ -96,11 +93,7 @@ class RequiresChannelDsl : AbstractRequestMatcherDsl() {
      * (i.e. "REQUIRES_SECURE_CHANNEL")
      */
     fun secure(pattern: String, servletPath: String, attribute: String = "REQUIRES_SECURE_CHANNEL") {
-        if (MVC_PRESENT) {
-            channelSecurityRules.add(PatternAuthorizationRule(pattern, PatternType.MVC, servletPath, attribute))
-        } else {
-            channelSecurityRules.add(PatternAuthorizationRule(pattern, PatternType.ANT, servletPath, attribute))
-        }
+        channelSecurityRules.add(PatternAuthorizationRule(pattern, PATTERN_TYPE, servletPath, attribute))
     }
 
     /**


### PR DESCRIPTION
Attempted an implementation for #8307, which adds an implementation of `authorize()` for `AuthorizeRequestsDsl`, so that we can write code like this:

```kotlin
http {
    authorizeRequests {
        authorize(GET, "/path", permitAll)
        authorize(PUT, "/path", denyAll)
    }
}
```