### PR TITLE
Allow the ability to configure AuthoritiesMapper in Reactive OAuth2Login

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/reactive/oauth2/login.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/reactive/oauth2/login.adoc
@@ -160,3 +160,21 @@ SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
 	return http.build();
 }
 ----
+
+You may register a `GrantedAuthoritiesMapper` `@Bean` to have it automatically applied to the default configuration, as shown in the following example:
+
+[source,java]
+----
+@Bean
+public GrantedAuthoritiesMapper userAuthoritiesMapper() {
+    ...
+}
+
+@Bean
+SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
+	http
+		// ...
+		.oauth2Login(withDefaults());
+	return http.build();
+}
+----

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/authentication/OAuth2LoginReactiveAuthenticationManager.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/authentication/OAuth2LoginReactiveAuthenticationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,6 +93,18 @@ public class OAuth2LoginReactiveAuthenticationManager implements
 					.cast(OAuth2AuthorizationCodeAuthenticationToken.class)
 					.flatMap(this::onSuccess);
 		});
+	}
+
+	/**
+	 * Sets the {@link GrantedAuthoritiesMapper} used for mapping {@link OAuth2User#getAuthorities()}
+	 * to a new set of authorities which will be associated to the {@link OAuth2LoginAuthenticationToken}.
+	 *
+	 * @since 5.4
+	 * @param authoritiesMapper the {@link GrantedAuthoritiesMapper} used for mapping the user's authorities
+	 */
+	public final void setAuthoritiesMapper(GrantedAuthoritiesMapper authoritiesMapper) {
+		Assert.notNull(authoritiesMapper, "authoritiesMapper cannot be null");
+		this.authoritiesMapper = authoritiesMapper;
 	}
 
 	private Mono<OAuth2LoginAuthenticationToken> onSuccess(OAuth2AuthorizationCodeAuthenticationToken authentication) {

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/authentication/OidcAuthorizationCodeReactiveAuthenticationManager.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/authentication/OidcAuthorizationCodeReactiveAuthenticationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -154,6 +154,18 @@ public class OidcAuthorizationCodeReactiveAuthenticationManager implements
 	public final void setJwtDecoderFactory(ReactiveJwtDecoderFactory<ClientRegistration> jwtDecoderFactory) {
 		Assert.notNull(jwtDecoderFactory, "jwtDecoderFactory cannot be null");
 		this.jwtDecoderFactory = jwtDecoderFactory;
+	}
+
+	/**
+	 * Sets the {@link GrantedAuthoritiesMapper} used for mapping {@link OAuth2User#getAuthorities()}
+	 * to a new set of authorities which will be associated to the {@link OAuth2LoginAuthenticationToken}.
+	 *
+	 * @since 5.4
+	 * @param authoritiesMapper the {@link GrantedAuthoritiesMapper} used for mapping the user's authorities
+	 */
+	public final void setAuthoritiesMapper(GrantedAuthoritiesMapper authoritiesMapper) {
+		Assert.notNull(authoritiesMapper, "authoritiesMapper cannot be null");
+		this.authoritiesMapper = authoritiesMapper;
 	}
 
 	private Mono<OAuth2LoginAuthenticationToken> authenticationResult(OAuth2AuthorizationCodeAuthenticationToken authorizationCodeAuthentication, OAuth2AccessTokenResponse accessTokenResponse) {

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/authentication/OAuth2LoginReactiveAuthenticationManagerTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/authentication/OAuth2LoginReactiveAuthenticationManagerTests.java
@@ -20,10 +20,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
@@ -33,8 +36,11 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
 import org.springframework.security.oauth2.client.endpoint.ReactiveOAuth2AccessTokenResponseClient;
@@ -93,6 +99,12 @@ public class OAuth2LoginReactiveAuthenticationManagerTests {
 	public void constructorWhenNullUserServiceThenIllegalArgumentException() {
 		this.userService = null;
 		assertThatThrownBy(() -> new OAuth2LoginReactiveAuthenticationManager(this.accessTokenResponseClient, this.userService))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void setAuthoritiesMapperWhenAuthoritiesMapperIsNullThenThrowIllegalArgumentException() {
+		assertThatThrownBy(() -> this.manager.setAuthoritiesMapper(null))
 				.isInstanceOf(IllegalArgumentException.class);
 	}
 
@@ -176,6 +188,24 @@ public class OAuth2LoginReactiveAuthenticationManagerTests {
 
 		assertThat(userRequestArgCaptor.getValue().getAdditionalParameters())
 				.containsAllEntriesOf(accessTokenResponse.getAdditionalParameters());
+	}
+
+	@Test
+	public void authenticateWhenAuthoritiesMapperSetThenReturnMappedAuthorities() {
+		OAuth2AccessTokenResponse accessTokenResponse = OAuth2AccessTokenResponse.withToken("foo")
+				.tokenType(OAuth2AccessToken.TokenType.BEARER)
+				.build();
+		when(this.accessTokenResponseClient.getTokenResponse(any())).thenReturn(Mono.just(accessTokenResponse));
+		DefaultOAuth2User user = new DefaultOAuth2User(AuthorityUtils.createAuthorityList("ROLE_USER"), Collections.singletonMap("user", "rob"), "user");
+		when(this.userService.loadUser(any())).thenReturn(Mono.just(user));
+		List<GrantedAuthority> mappedAuthorities = AuthorityUtils.createAuthorityList("ROLE_OAUTH_USER");
+		GrantedAuthoritiesMapper authoritiesMapper = mock(GrantedAuthoritiesMapper.class);
+		when(authoritiesMapper.mapAuthorities(anyCollection())).thenAnswer((Answer<List<GrantedAuthority>>) invocation -> mappedAuthorities);
+		manager.setAuthoritiesMapper(authoritiesMapper);
+
+		OAuth2LoginAuthenticationToken result = (OAuth2LoginAuthenticationToken) this.manager.authenticate(loginToken()).block();
+
+		assertThat(result.getAuthorities()).isEqualTo(mappedAuthorities);
 	}
 
 	private OAuth2AuthorizationCodeAuthenticationToken loginToken() {


### PR DESCRIPTION
Allow the configuration of a custom GrantedAuthorityMapper for reactive OAuth2Login

- Add setter in OidcAuthorizationCodeReactiveAuthenticationManager
  and OAuth2LoginReactiveAuthenticationManager

- Use an available GrantedAuthorityMapper bean to configure the default ReactiveAuthenticationManager

Fixes [gh-8324](https://github.com/spring-projects/spring-security/issues/8324)