### PR TITLE
Add marker to make Kotlin DSL type safe

### DIFF
--- a/config/src/main/kotlin/org/springframework/security/config/web/server/AuthorizeExchangeDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/AuthorizeExchangeDsl.kt
@@ -34,6 +34,7 @@ import reactor.core.publisher.Mono
  * @author Eleftheria Stein
  * @since 5.4
  */
+@ServerSecurityMarker
 class AuthorizeExchangeDsl {
     private val authorizationRules = mutableListOf<ExchangeAuthorizationRule>()
 

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerAnonymousDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerAnonymousDsl.kt
@@ -32,6 +32,7 @@ import org.springframework.security.web.server.authentication.AnonymousAuthentic
  * @property authenticationFilter the [AnonymousAuthenticationWebFilter] used to populate
  * an anonymous user.
  */
+@ServerSecurityMarker
 class ServerAnonymousDsl {
     var key: String? = null
     var principal: Any? = null

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerCorsDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerCorsDsl.kt
@@ -26,6 +26,7 @@ import org.springframework.web.cors.reactive.CorsConfigurationSource
  * @since 5.4
  * @property configurationSource the [CorsConfigurationSource] to use.
  */
+@ServerSecurityMarker
 class ServerCorsDsl {
     var configurationSource: CorsConfigurationSource? = null
 

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerCsrfDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerCsrfDsl.kt
@@ -32,6 +32,7 @@ import org.springframework.security.web.server.util.matcher.ServerWebExchangeMat
  * @property requireCsrfProtectionMatcher the [ServerWebExchangeMatcher] used to determine when CSRF protection
  * is enabled.
  */
+@ServerSecurityMarker
 class ServerCsrfDsl {
     var accessDeniedHandler: ServerAccessDeniedHandler? = null
     var csrfTokenRepository: ServerCsrfTokenRepository? = null

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerExceptionHandlingDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerExceptionHandlingDsl.kt
@@ -30,6 +30,7 @@ import org.springframework.security.web.server.authorization.ServerAccessDeniedH
  * @property accessDeniedHandler the [ServerAccessDeniedHandler] to use when an
  * authenticated user does not hold a required authority
  */
+@ServerSecurityMarker
 class ServerExceptionHandlingDsl {
     var authenticationEntryPoint: ServerAuthenticationEntryPoint? = null
     var accessDeniedHandler: ServerAccessDeniedHandler? = null

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerFormLoginDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerFormLoginDsl.kt
@@ -50,6 +50,7 @@ import org.springframework.security.web.server.util.matcher.ServerWebExchangeMat
  * [ReactorContextWebFilter] must be configured to be able to load the value (they are not
  * implicitly linked).
  */
+@ServerSecurityMarker
 class ServerFormLoginDsl {
     var authenticationManager: ReactiveAuthenticationManager? = null
     var loginPage: String? = null

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerHeadersDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerHeadersDsl.kt
@@ -25,6 +25,7 @@ import org.springframework.security.web.server.header.*
  * @author Eleftheria Stein
  * @since 5.4
  */
+@ServerSecurityMarker
 class ServerHeadersDsl {
     private var contentTypeOptions: ((ServerHttpSecurity.HeaderSpec.ContentTypeOptionsSpec) -> Unit)? = null
     private var xssProtection: ((ServerHttpSecurity.HeaderSpec.XssProtectionSpec) -> Unit)? = null

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerHttpBasicDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerHttpBasicDsl.kt
@@ -38,6 +38,7 @@ import org.springframework.security.web.server.context.ServerSecurityContextRepo
  * @property authenticationEntryPoint the [ServerAuthenticationEntryPoint] to be
  * populated on [BasicAuthenticationFilter] in the event that authentication fails.
  */
+@ServerSecurityMarker
 class ServerHttpBasicDsl {
     var authenticationManager: ReactiveAuthenticationManager? = null
     var securityContextRepository: ServerSecurityContextRepository? = null

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerHttpSecurityDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerHttpSecurityDsl.kt
@@ -57,6 +57,7 @@ operator fun ServerHttpSecurity.invoke(httpConfiguration: ServerHttpSecurityDsl.
  * @since 5.4
  * @param init the configurations to apply to the provided [ServerHttpSecurity]
  */
+@ServerSecurityMarker
 class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val init: ServerHttpSecurityDsl.() -> Unit) {
 
     /**

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerHttpsRedirectDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerHttpsRedirectDsl.kt
@@ -28,6 +28,7 @@ import org.springframework.web.server.ServerWebExchange
  * @since 5.4
  * @property portMapper the [PortMapper] that specifies a custom HTTPS port to redirect to.
  */
+@ServerSecurityMarker
 class ServerHttpsRedirectDsl {
     var portMapper: PortMapper? = null
 

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerLogoutDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerLogoutDsl.kt
@@ -32,6 +32,7 @@ import org.springframework.security.web.server.util.matcher.ServerWebExchangeMat
  * @property logoutSuccessHandler the [ServerLogoutSuccessHandler] to use after logout has
  * occurred.
  */
+@ServerSecurityMarker
 class ServerLogoutDsl {
     var logoutHandler: ServerLogoutHandler? = null
     var logoutUrl: String? = null

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerOAuth2ClientDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerOAuth2ClientDsl.kt
@@ -38,6 +38,7 @@ import org.springframework.web.server.ServerWebExchange
  * @property authorizedClientRepository the repository for authorized client(s).
  * @property authorizationRequestRepository the repository to use for storing [OAuth2AuthorizationRequest]s.
  */
+@ServerSecurityMarker
 class ServerOAuth2ClientDsl {
     var authenticationManager: ReactiveAuthenticationManager? = null
     var authenticationConverter: ServerAuthenticationConverter? = null

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerOAuth2LoginDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerOAuth2LoginDsl.kt
@@ -52,6 +52,7 @@ import org.springframework.web.server.ServerWebExchange
  * @property authenticationMatcher the [ServerWebExchangeMatcher] used for determining if the request is an
  * authentication request.
  */
+@ServerSecurityMarker
 class ServerOAuth2LoginDsl {
     var authenticationManager: ReactiveAuthenticationManager? = null
     var securityContextRepository: ServerSecurityContextRepository? = null

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerOAuth2ResourceServerDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerOAuth2ResourceServerDsl.kt
@@ -37,6 +37,7 @@ import org.springframework.web.server.ServerWebExchange
  * Bearer Tokens.
  * @property authenticationManagerResolver the [ReactiveAuthenticationManagerResolver] to use.
  */
+@ServerSecurityMarker
 class ServerOAuth2ResourceServerDsl {
     var accessDeniedHandler: ServerAccessDeniedHandler? = null
     var authenticationEntryPoint: ServerAuthenticationEntryPoint? = null

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerRequestCacheDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerRequestCacheDsl.kt
@@ -25,6 +25,7 @@ import org.springframework.security.web.server.savedrequest.ServerRequestCache
  * @since 5.4
  * @property requestCache allows explicit configuration of the [ServerRequestCache] to be used.
  */
+@ServerSecurityMarker
 class ServerRequestCacheDsl {
     var requestCache: ServerRequestCache? = null
 

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerSecurityMarker.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerSecurityMarker.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.config.web.server
+
+/**
+ * Marker annotation indicating that the annotated class is part of the security DSL for server configuration.
+ *
+ * @author Loïc Labagnara
+ * @since 5.4
+ */
+@DslMarker
+annotation class ServerSecurityMarker

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerX509Dsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerX509Dsl.kt
@@ -29,6 +29,7 @@ import org.springframework.security.web.authentication.preauth.x509.X509Principa
  * @property authenticationManager the [ReactiveAuthenticationManager] used to determine if the provided
  * [Authentication] can be authenticated.
  */
+@ServerSecurityMarker
 class ServerX509Dsl {
     var principalExtractor: X509PrincipalExtractor? = null
     var authenticationManager: ReactiveAuthenticationManager? = null

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/headers/ServerCacheControlDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/headers/ServerCacheControlDsl.kt
@@ -17,6 +17,7 @@
 package org.springframework.security.config.web.server.headers
 
 import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.config.web.server.ServerSecurityMarker
 
 /**
  * A Kotlin DSL to configure the [ServerHttpSecurity] cache control headers using
@@ -25,6 +26,7 @@ import org.springframework.security.config.web.server.ServerHttpSecurity
  * @author Eleftheria Stein
  * @since 5.4
  */
+@ServerSecurityMarker
 class ServerCacheControlDsl {
     private var disabled = false
 

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/headers/ServerContentSecurityPolicyDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/headers/ServerContentSecurityPolicyDsl.kt
@@ -17,6 +17,7 @@
 package org.springframework.security.config.web.server.headers
 
 import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.config.web.server.ServerSecurityMarker
 
 /**
  * A Kotlin DSL to configure the [ServerHttpSecurity] Content-Security-Policy header using
@@ -25,6 +26,7 @@ import org.springframework.security.config.web.server.ServerHttpSecurity
  * @author Eleftheria Stein
  * @since 5.4
  */
+@ServerSecurityMarker
 class ServerContentSecurityPolicyDsl {
     var policyDirectives: String? = null
     var reportOnly: Boolean? = null

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/headers/ServerContentTypeOptionsDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/headers/ServerContentTypeOptionsDsl.kt
@@ -17,6 +17,7 @@
 package org.springframework.security.config.web.server.headers
 
 import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.config.web.server.ServerSecurityMarker
 
 /**
  * A Kotlin DSL to configure the [ServerHttpSecurity] the content type options header
@@ -25,6 +26,7 @@ import org.springframework.security.config.web.server.ServerHttpSecurity
  * @author Eleftheria Stein
  * @since 5.4
  */
+@ServerSecurityMarker
 class ServerContentTypeOptionsDsl {
     private var disabled = false
 

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/headers/ServerFrameOptionsDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/headers/ServerFrameOptionsDsl.kt
@@ -17,6 +17,7 @@
 package org.springframework.security.config.web.server.headers
 
 import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.config.web.server.ServerSecurityMarker
 import org.springframework.security.web.server.header.XFrameOptionsServerHttpHeadersWriter
 
 /**
@@ -27,6 +28,7 @@ import org.springframework.security.web.server.header.XFrameOptionsServerHttpHea
  * @since 5.4
  * @property mode the X-Frame-Options mode to set in the response header.
  */
+@ServerSecurityMarker
 class ServerFrameOptionsDsl {
     var mode: XFrameOptionsServerHttpHeadersWriter.Mode? = null
 

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/headers/ServerHttpStrictTransportSecurityDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/headers/ServerHttpStrictTransportSecurityDsl.kt
@@ -17,6 +17,7 @@
 package org.springframework.security.config.web.server.headers
 
 import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.config.web.server.ServerSecurityMarker
 import java.time.Duration
 
 /**
@@ -30,6 +31,7 @@ import java.time.Duration
  * @property includeSubdomains if true, subdomains should be considered HSTS Hosts too.
  * @property preload if true, preload will be included in HSTS Header.
  */
+@ServerSecurityMarker
 class ServerHttpStrictTransportSecurityDsl {
     var maxAge: Duration? = null
     var includeSubdomains: Boolean? = null

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/headers/ServerReferrerPolicyDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/headers/ServerReferrerPolicyDsl.kt
@@ -17,6 +17,7 @@
 package org.springframework.security.config.web.server.headers
 
 import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.config.web.server.ServerSecurityMarker
 import org.springframework.security.web.server.header.ReferrerPolicyServerHttpHeadersWriter
 
 /**
@@ -27,6 +28,7 @@ import org.springframework.security.web.server.header.ReferrerPolicyServerHttpHe
  * @since 5.4
  * @property policy the policy to be used in the response header.
  */
+@ServerSecurityMarker
 class ServerReferrerPolicyDsl {
     var policy: ReferrerPolicyServerHttpHeadersWriter.ReferrerPolicy? = null
 

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/headers/ServerXssProtectionDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/headers/ServerXssProtectionDsl.kt
@@ -17,6 +17,7 @@
 package org.springframework.security.config.web.server.headers
 
 import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.config.web.server.ServerSecurityMarker
 
 /**
  * A Kotlin DSL to configure the [ServerHttpSecurity] XSS protection header using
@@ -25,6 +26,7 @@ import org.springframework.security.config.web.server.ServerHttpSecurity
  * @author Eleftheria Stein
  * @since 5.4
  */
+@ServerSecurityMarker
 class ServerXssProtectionDsl {
     private var disabled = false
 

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/oauth2/resourceserver/ServerJwtDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/oauth2/resourceserver/ServerJwtDsl.kt
@@ -20,6 +20,7 @@ import org.springframework.core.convert.converter.Converter
 import org.springframework.security.authentication.AbstractAuthenticationToken
 import org.springframework.security.authentication.ReactiveAuthenticationManager
 import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.config.web.server.ServerSecurityMarker
 import org.springframework.security.core.Authentication
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder
@@ -40,6 +41,7 @@ import java.security.interfaces.RSAPublicKey
  * @property jwkSetUri configures a [ReactiveJwtDecoder] using a
  * <a target="_blank" href="https://tools.ietf.org/html/rfc7517">JSON Web Key (JWK)</a> URL
  */
+@ServerSecurityMarker
 class ServerJwtDsl {
     private var _jwtDecoder: ReactiveJwtDecoder? = null
     private var _publicKey: RSAPublicKey? = null

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/oauth2/resourceserver/ServerOpaqueTokenDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/oauth2/resourceserver/ServerOpaqueTokenDsl.kt
@@ -17,6 +17,7 @@
 package org.springframework.security.config.web.server.oauth2.resourceserver
 
 import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.config.web.server.ServerSecurityMarker
 import org.springframework.security.oauth2.server.resource.introspection.ReactiveOpaqueTokenIntrospector
 
 /**
@@ -27,6 +28,7 @@ import org.springframework.security.oauth2.server.resource.introspection.Reactiv
  * @property introspectionUri the URI of the Introspection endpoint.
  * @property introspector the [ReactiveOpaqueTokenIntrospector] to use.
  */
+@ServerSecurityMarker
 class ServerOpaqueTokenDsl {
     private var _introspectionUri: String? = null
     private var _introspector: ReactiveOpaqueTokenIntrospector? = null


### PR DESCRIPTION
Add marker on web server security configuration
to make Kotlin DSL type safe.

Issue gh-8366
