### PR TITLE
Throw exception if URL does not include context path when context relative

### DIFF
--- a/web/src/main/java/org/springframework/security/web/DefaultRedirectStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/DefaultRedirectStrategy.java
@@ -74,7 +74,7 @@ public class DefaultRedirectStrategy implements RedirectStrategy {
 		}
 
 		if (!url.contains(contextPath)) {
-			return "";
+			throw new IllegalArgumentException("The fully qualified URL does not include context path.");
 		}
 
 		// Calculate the relative URL from the fully qualified URL, minus the last

--- a/web/src/test/java/org/springframework/security/web/DefaultRedirectStrategyTests.java
+++ b/web/src/test/java/org/springframework/security/web/DefaultRedirectStrategyTests.java
@@ -57,8 +57,8 @@ public class DefaultRedirectStrategyTests {
 		assertThat(response.getRedirectedUrl()).isEqualTo("remainder");
 	}
 
-	@Test
-	public void contextRelativeShouldRedirectToRootIfURLDoesNotContainContextPath()
+	@Test(expected = IllegalArgumentException.class)
+	public void contextRelativeShouldThrowExceptionIfURLDoesNotContainContextPath()
 		throws Exception {
 		DefaultRedirectStrategy rds = new DefaultRedirectStrategy();
 		rds.setContextRelative(true);
@@ -68,7 +68,5 @@ public class DefaultRedirectStrategyTests {
 
 		rds.sendRedirect(request, response,
 			"https://redirectme.somewhere.else");
-
-		assertThat(response.getRedirectedUrl()).isEqualTo("");
 	}
 }


### PR DESCRIPTION
### Versions

* Spring 5.2.3
* Spring Security 5.2.1
* Tomcat 9.0.7.B

### Problem

https://github.com/spring-projects/spring-security/pull/4142
`DefaultRedirectStrategy` send redirect to `""` if redirect argument `url` not contains application context path.

But on Tomcat, it may not redirect to the context root as intended.
When `HttpServletResponse#sendRedirect("")`, Tomcat response with empty Location header.

If the request url is `/context-root/login` and response empty Location header:

| Browser | Redierct url | ? |
|---|---|---|
| Chrome | `/context-root/login` | NG |
| Firefox | `/context-root/login` | NG |
| IE 11 | `/context-root` | OK |

https://javaee.github.io/javaee-spec/javadocs/javax/servlet/http/HttpServletResponse.html#sendRedirect-java.lang.String-
> If the location is relative without a leading '/' the container interprets it as relative to the current request URI.
> If the location is relative with a leading '/' the container interprets it as relative to the servlet container root.

It seems to be the case in the latter case.

Note:
  On Weblogic, `""` is converted to the context path and set in the Location header.

### Solution

Change to send redirect to explicitly specifying the context path.

`HttpServletResponse#sendRedirect("")`
-> `HttpServletResponse#sendRedirect(contextPath)`