### PR TITLE
Fix mismatch between CONTRIBUTING.adoc and .editorconfig

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -66,7 +66,7 @@ Please carefully follow the whitespace and formatting conventions already presen
 . Aim to wrap code at 120 characters, but favor readability over wrapping
 . Preserve existing formatting; i.e. do not reformat code for its own sake
 . Search the codebase using git grep and other tools to discover common naming conventions, etc.
-. Latin-1 (ISO-8859-1) encoding for Java sources; use native2ascii to convert if necessary
+. UTF-8 encoding for Java sources and XML files
 
 Whitespace management tips
 


### PR DESCRIPTION
In CONTRIBUTING.adoc, we have:
>Latin-1 (ISO-8859-1) encoding for Java sources; use native2ascii to convert if necessary

In .editorconfig, we have:
```
 charset = utf-8
```

Both files were in sync, but apparently this [commit](https://github.com/spring-projects/spring-security/commit/a8b438587b129d455f4c2c93f556fd6c080a19aa#diff-6a3371457528722a734f3c51d9238c13) which converted Contribution.md to Contributing.adoc, did not use the latest version and some modifications have been lost.
