### PR TITLE
Enables empty authorityPrefix in JwtGrantedAuthoritisConverter

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtGrantedAuthoritiesConverter.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtGrantedAuthoritiesConverter.java
@@ -68,7 +68,7 @@ public final class JwtGrantedAuthoritiesConverter implements Converter<Jwt, Coll
 	 * @since 5.2
 	 */
 	public void setAuthorityPrefix(String authorityPrefix) {
-		Assert.hasText(authorityPrefix, "authorityPrefix cannot be empty");
+		Assert.notNull(authorityPrefix, "authorityPrefix cannot be null");
 		this.authorityPrefix = authorityPrefix;
 	}
 

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtGrantedAuthoritiesConverterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtGrantedAuthoritiesConverterTests.java
@@ -37,6 +37,12 @@ import static org.springframework.security.oauth2.jwt.TestJwts.jwt;
  */
 public class JwtGrantedAuthoritiesConverterTests {
 
+	@Test(expected = IllegalArgumentException.class)
+	public void setAuthorityPrefixWithNullThenException() {
+		JwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new JwtGrantedAuthoritiesConverter();
+		jwtGrantedAuthoritiesConverter.setAuthorityPrefix(null);
+	}
+
 	@Test
 	public void convertWhenTokenHasScopeAttributeThenTranslatedToAuthorities() {
 		Jwt jwt = jwt().claim("scope", "message:read message:write").build();
@@ -60,6 +66,19 @@ public class JwtGrantedAuthoritiesConverterTests {
 		assertThat(authorities).containsExactly(
 				new SimpleGrantedAuthority("ROLE_message:read"),
 				new SimpleGrantedAuthority("ROLE_message:write"));
+	}
+
+	@Test
+	public void convertWithBlankAsCustomAuthorityPrefixWhenTokenHasScopeAttributeThenTranslatedToAuthorities() {
+		Jwt jwt = jwt().claim("scope", "message:read message:write").build();
+
+		JwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new JwtGrantedAuthoritiesConverter();
+		jwtGrantedAuthoritiesConverter.setAuthorityPrefix("");
+		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
+
+		assertThat(authorities).containsExactly(
+				new SimpleGrantedAuthority("message:read"),
+				new SimpleGrantedAuthority("message:write"));
 	}
 
 	@Test
@@ -95,6 +114,19 @@ public class JwtGrantedAuthoritiesConverterTests {
 		assertThat(authorities).containsExactly(
 				new SimpleGrantedAuthority("ROLE_message:read"),
 				new SimpleGrantedAuthority("ROLE_message:write"));
+	}
+
+	@Test
+	public void convertWithBlankAsCustomAuthorityPrefixWhenTokenHasScpAttributeThenTranslatedToAuthorities() {
+		Jwt jwt = jwt().claim("scp", "message:read message:write").build();
+
+		JwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new JwtGrantedAuthoritiesConverter();
+		jwtGrantedAuthoritiesConverter.setAuthorityPrefix("");
+		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
+
+		assertThat(authorities).containsExactly(
+				new SimpleGrantedAuthority("message:read"),
+				new SimpleGrantedAuthority("message:write"));
 	}
 
 	@Test


### PR DESCRIPTION
- docs stated that empty authorityPrefix are allowed but implementation denied to use `""`
- commit removes the `hasText`-limitation but restricts to `notNull`

Fixes gh-8421
