### PR TITLE
Aggregate TestExecutionListener orders

### DIFF
--- a/test/src/main/java/org/springframework/security/test/context/SpringSecurityTestExecutionListenerOrder.java
+++ b/test/src/main/java/org/springframework/security/test/context/SpringSecurityTestExecutionListenerOrder.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.test.context;
+
+import org.springframework.test.context.TestExecutionListener;
+
+/**
+ * Aggregates the orders of the {@link TestExecutionListener}s
+ * defined by Spring Security Test.
+ *
+ * @author Andrei Dragnea
+ * @since 5.4.0
+ * @see org.springframework.core.Ordered
+ * @see TestExecutionListener
+ */
+public enum SpringSecurityTestExecutionListenerOrder {
+
+	/**
+	 * Order of {@link org.springframework.security.test.context.support.WithSecurityContextTestExecutionListener}.
+	 */
+	WITH_SECURITY_CONTEXT(10_000),
+
+	/**
+	 * Order of {@link org.springframework.security.test.context.support.ReactorContextTestExecutionListener}.
+	 */
+	REACTOR_CONTEXT(11_000);
+
+	private final int value;
+
+	SpringSecurityTestExecutionListenerOrder(int value) {
+		this.value = value;
+	}
+
+	public int getValue() {
+		return value;
+	}
+
+}

--- a/test/src/main/java/org/springframework/security/test/context/support/ReactorContextTestExecutionListener.java
+++ b/test/src/main/java/org/springframework/security/test/context/support/ReactorContextTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,19 +17,21 @@
 package org.springframework.security.test.context.support;
 
 import org.reactivestreams.Subscription;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.ReactiveSecurityContextHolder;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.test.context.TestSecurityContextHolder;
-import org.springframework.test.context.TestContext;
-import org.springframework.test.context.TestExecutionListener;
-import org.springframework.test.context.support.AbstractTestExecutionListener;
-import org.springframework.util.ClassUtils;
 import reactor.core.CoreSubscriber;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Operators;
 import reactor.util.context.Context;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.test.context.SpringSecurityTestExecutionListenerOrder;
+import org.springframework.security.test.context.TestSecurityContextHolder;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.TestExecutionListener;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+import org.springframework.util.ClassUtils;
 
 /**
  * Sets up the Reactor Context with the Authentication from the TestSecurityContextHolder
@@ -122,6 +124,6 @@ public class ReactorContextTestExecutionListener
 	 */
 	@Override
 	public int getOrder() {
-		return 11000;
+		return SpringSecurityTestExecutionListenerOrder.REACTOR_CONTEXT.getValue();
 	}
 }

--- a/test/src/main/java/org/springframework/security/test/context/support/WithSecurityContextTestExecutionListener.java
+++ b/test/src/main/java/org/springframework/security/test/context/support/WithSecurityContextTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.SpringSecurityTestExecutionListenerOrder;
 import org.springframework.security.test.context.TestSecurityContextHolder;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.TestContext;
@@ -175,7 +176,7 @@ public class WithSecurityContextTestExecutionListener
 	 */
 	@Override
 	public int getOrder() {
-		return 10000;
+		return SpringSecurityTestExecutionListenerOrder.WITH_SECURITY_CONTEXT.getValue();
 	}
 
 	static class TestSecurityContext {


### PR DESCRIPTION
Aggregated `TestExecutionListener` orders into `SpringSecurityTestExecutionListenerOrder`, in order to help third-party integrators when choosing the order for a new listener.

The re-ordering of the imports happened because I used the import order specified [here](https://github.com/spring-projects/spring-framework/wiki/IntelliJ-IDEA-Editor-Settings), as I did not find one in the `spring-security` project itself. There also seem to be inconsistencies in the code base when it comes to import order (e.g. `DelegatingApplicationListener` vs `RsaKeyConverters`, two classes I randomly opened). Newer code seems to respect the import order I used from the `spring-framework` project.

I have done two similar PRs in [spring-framework](https://github.com/spring-projects/spring-framework/pull/24977) and [spring-boot](https://github.com/spring-projects/spring-boot/pull/21133) projects.