### PR TITLE
"client secret jwt" and "private key jwt" auth methods

### DIFF
--- a/config/src/main/java/org/springframework/security/config/oauth2/client/ClientRegistrationsBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/oauth2/client/ClientRegistrationsBeanDefinitionParser.java
@@ -50,6 +50,11 @@ public final class ClientRegistrationsBeanDefinitionParser implements BeanDefini
 	private static final String ATT_CLIENT_ID = "client-id";
 	private static final String ATT_CLIENT_SECRET = "client-secret";
 	private static final String ATT_CLIENT_AUTHENTICATION_METHOD = "client-authentication-method";
+	private static final String ATT_CLIENT_AUTHENTICATION_KEY_STORE = "client-authentication-key-store";
+	private static final String ATT_CLIENT_AUTHENTICATION_KEY_STORE_TYPE = "client-authentication-key-store-type";
+	private static final String ATT_CLIENT_AUTHENTICATION_KEY_STORE_PASSWORD = "client-authentication-key-store-password";
+	private static final String ATT_CLIENT_AUTHENTICATION_KEY_ALIAS = "client-authentication-key-alias";
+	private static final String ATT_CLIENT_AUTHENTICATION_KEY_PASSWORD = "client-authentication-key-password";
 	private static final String ATT_AUTHORIZATION_GRANT_TYPE = "authorization-grant-type";
 	private static final String ATT_REDIRECT_URI = "redirect-uri";
 	private static final String ATT_SCOPE = "scope";
@@ -110,6 +115,16 @@ public final class ClientRegistrationsBeanDefinitionParser implements BeanDefini
 			getOptionalIfNotEmpty(clientRegistrationElt.getAttribute(ATT_CLIENT_AUTHENTICATION_METHOD))
 					.map(ClientAuthenticationMethod::new)
 					.ifPresent(builder::clientAuthenticationMethod);
+			getOptionalIfNotEmpty(clientRegistrationElt.getAttribute(ATT_CLIENT_AUTHENTICATION_KEY_STORE))
+					.map(builder::clientAuthenticationKeyStore);
+			getOptionalIfNotEmpty(clientRegistrationElt.getAttribute(ATT_CLIENT_AUTHENTICATION_KEY_STORE_TYPE))
+					.map(builder::clientAuthenticationKeyStoreType);
+			getOptionalIfNotEmpty(clientRegistrationElt.getAttribute(ATT_CLIENT_AUTHENTICATION_KEY_STORE_PASSWORD))
+					.map(builder::clientAuthenticationKeyStorePassword);
+			getOptionalIfNotEmpty(clientRegistrationElt.getAttribute(ATT_CLIENT_AUTHENTICATION_KEY_ALIAS))
+					.map(builder::clientAuthenticationKeyAlias);
+			getOptionalIfNotEmpty(clientRegistrationElt.getAttribute(ATT_CLIENT_AUTHENTICATION_KEY_PASSWORD))
+					.map(builder::clientAuthenticationKeyPassword);
 			getOptionalIfNotEmpty(clientRegistrationElt.getAttribute(ATT_AUTHORIZATION_GRANT_TYPE))
 					.map(AuthorizationGrantType::new)
 					.ifPresent(builder::authorizationGrantType);

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
@@ -15,23 +15,18 @@
  */
 package org.springframework.security.oauth2.client.registration;
 
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Set;
-
 import org.springframework.security.core.SpringSecurityCoreVersion;
 import org.springframework.security.oauth2.core.AuthenticationMethod;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+
+import java.io.FileInputStream;
+import java.io.Serializable;
+import java.security.*;
+import java.security.cert.Certificate;
+import java.util.*;
 
 import static java.util.Collections.EMPTY_MAP;
 
@@ -48,6 +43,12 @@ public final class ClientRegistration implements Serializable {
 	private String clientId;
 	private String clientSecret;
 	private ClientAuthenticationMethod clientAuthenticationMethod = ClientAuthenticationMethod.BASIC;
+	private String clientAuthenticationKeyStore;
+	private String clientAuthenticationKeyStoreType;
+	private String clientAuthenticationKeyStorePassword;
+	private String clientAuthenticationKeyAlias;
+	private String clientAuthenticationKeyPassword;
+	private KeyPair clientAuthenticationKeyPair;
 	private AuthorizationGrantType authorizationGrantType;
 	private String redirectUriTemplate;
 	private Set<String> scopes = Collections.emptySet();
@@ -93,6 +94,64 @@ public final class ClientRegistration implements Serializable {
 	public ClientAuthenticationMethod getClientAuthenticationMethod() {
 		return this.clientAuthenticationMethod;
 	}
+
+	/**
+	 * Returns the client authentication key store path used
+	 * when authenticating with method {@link ClientAuthenticationMethod#PRIVATE_KEY_JWT}.
+	 *
+	 * @return the client authentication key store path
+	 */
+	public String getClientAuthenticationKeyStore() {
+		return this.clientAuthenticationKeyStore;
+	}
+
+	/**
+	 * Returns the client authentication key store type used
+	 * when authenticating with method {@link ClientAuthenticationMethod#PRIVATE_KEY_JWT}.
+	 *
+	 * @return the client authentication key store type
+	 */
+	public String getClientAuthenticationKeyStoreType() {
+		return this.clientAuthenticationKeyStoreType;
+	}
+
+	/**
+	 * Returns the client authentication key store password used
+	 * when authenticating with method {@link ClientAuthenticationMethod#PRIVATE_KEY_JWT}.
+	 *
+	 * @return the client authentication key store password
+	 */
+	public String getClientAuthenticationKeyStorePassword() {
+		return this.clientAuthenticationKeyStorePassword;
+	}
+
+	/**
+	 * Returns the client authentication key store key alias used
+	 * when authenticating with method {@link ClientAuthenticationMethod#PRIVATE_KEY_JWT}.
+	 *
+	 * @return the client authentication key store key alias
+	 */
+	public String getClientAuthenticationKeyAlias() {
+		return this.clientAuthenticationKeyAlias;
+	}
+
+	/**
+	 * Returns the client authentication key store key password used
+	 * when authenticating with method {@link ClientAuthenticationMethod#PRIVATE_KEY_JWT}.
+	 *
+	 * @return the client authentication key store key password
+	 */
+	public String getClientAuthenticationKeyPassword() {
+		return this.clientAuthenticationKeyPassword;
+	}
+
+	/**
+	 * Returns the client authentication key pair used
+	 * when authenticating with method {@link ClientAuthenticationMethod#PRIVATE_KEY_JWT}.
+	 *
+	 * @return the client authentication key pair
+	 */
+	public KeyPair getClientAuthenticationKeyPair() { return this.clientAuthenticationKeyPair; }
 
 	/**
 	 * Returns the {@link AuthorizationGrantType authorization grant type} used for the client.
@@ -146,6 +205,11 @@ public final class ClientRegistration implements Serializable {
 			+ ", clientId='" + this.clientId + '\''
 			+ ", clientSecret='" + this.clientSecret + '\''
 			+ ", clientAuthenticationMethod=" + this.clientAuthenticationMethod
+			+ ", clientAuthenticationKeyStore=" + this.clientAuthenticationKeyStore
+			+ ", clientAuthenticationKeyStoreType=" + this.clientAuthenticationKeyStoreType
+			+ ", clientAuthenticationKeyStorePassword=" + this.clientAuthenticationKeyStorePassword
+			+ ", clientAuthenticationKeyAlias=" + this.clientAuthenticationKeyAlias
+			+ ", clientAuthenticationKeyPassword=" + this.clientAuthenticationKeyPassword
 			+ ", authorizationGrantType=" + this.authorizationGrantType
 			+ ", redirectUriTemplate='" + this.redirectUriTemplate + '\''
 			+ ", scopes=" + this.scopes
@@ -287,6 +351,12 @@ public final class ClientRegistration implements Serializable {
 		private String clientId;
 		private String clientSecret;
 		private ClientAuthenticationMethod clientAuthenticationMethod = ClientAuthenticationMethod.BASIC;
+		private String clientAuthenticationKeyStore;
+		private String clientAuthenticationKeyStoreType;
+		private String clientAuthenticationKeyStorePassword;
+		private String clientAuthenticationKeyAlias;
+		private String clientAuthenticationKeyPassword;
+		private KeyPair clientAuthenticationKeyPair;
 		private AuthorizationGrantType authorizationGrantType;
 		private String redirectUriTemplate;
 		private Set<String> scopes;
@@ -308,6 +378,12 @@ public final class ClientRegistration implements Serializable {
 			this.clientId = clientRegistration.clientId;
 			this.clientSecret = clientRegistration.clientSecret;
 			this.clientAuthenticationMethod = clientRegistration.clientAuthenticationMethod;
+			this.clientAuthenticationKeyStore = clientRegistration.clientAuthenticationKeyStore;
+			this.clientAuthenticationKeyStoreType = clientRegistration.clientAuthenticationKeyStoreType;
+			this.clientAuthenticationKeyStorePassword = clientRegistration.clientAuthenticationKeyStorePassword;
+			this.clientAuthenticationKeyAlias = clientRegistration.clientAuthenticationKeyAlias;
+			this.clientAuthenticationKeyPassword = clientRegistration.clientAuthenticationKeyPassword;
+			this.clientAuthenticationKeyPair = clientRegistration.clientAuthenticationKeyPair;
 			this.authorizationGrantType = clientRegistration.authorizationGrantType;
 			this.redirectUriTemplate = clientRegistration.redirectUriTemplate;
 			this.scopes = clientRegistration.scopes == null ? null : new HashSet<>(clientRegistration.scopes);
@@ -366,6 +442,66 @@ public final class ClientRegistration implements Serializable {
 		 */
 		public Builder clientAuthenticationMethod(ClientAuthenticationMethod clientAuthenticationMethod) {
 			this.clientAuthenticationMethod = clientAuthenticationMethod;
+			return this;
+		}
+
+		/**
+		 * Sets the client authentication key store path used
+		 * when authenticating with method {@link ClientAuthenticationMethod#PRIVATE_KEY_JWT}.
+		 *
+		 * @return the client authentication key store path
+		 */
+		public Builder clientAuthenticationKeyStore(String clientAuthenticationKeyStore) {
+			this.clientAuthenticationKeyStore = clientAuthenticationKeyStore;
+			return this;
+		}
+
+		/**
+		 * Sets the client authentication key store type used
+		 * when authenticating with method {@link ClientAuthenticationMethod#PRIVATE_KEY_JWT}.
+		 *
+		 * @return the client authentication key store type
+		 */
+		public Builder clientAuthenticationKeyStoreType(String clientAuthenticationKeyStoreType) {
+			this.clientAuthenticationKeyStore = clientAuthenticationKeyStoreType;
+			return this;
+		}
+
+		/**
+		 * Sets the client authentication key store password used
+		 * when authenticating with method {@link ClientAuthenticationMethod#PRIVATE_KEY_JWT}.
+		 *
+		 * @return the client authentication key store password
+		 */
+		public Builder clientAuthenticationKeyStorePassword(String clientAuthenticationKeyStorePassword) {
+			this.clientAuthenticationKeyStorePassword = clientAuthenticationKeyStorePassword;
+			return this;
+		}
+
+		/**
+		 * Sets the client authentication key store key alias used
+		 * when authenticating with method {@link ClientAuthenticationMethod#PRIVATE_KEY_JWT}.
+		 *
+		 * @return the client authentication key store key alias
+		 */
+		public Builder clientAuthenticationKeyAlias(String clientAuthenticationKeyAlias) {
+			this.clientAuthenticationKeyAlias = clientAuthenticationKeyAlias;
+			return this;
+		}
+
+		/**
+		 * Sets the client authentication key store key password used
+		 * when authenticating with method {@link ClientAuthenticationMethod#PRIVATE_KEY_JWT}.
+		 *
+		 * @return the client authentication key store key password
+		 */
+		public Builder clientAuthenticationKeyPassword(String clientAuthenticationKeyPassword) {
+			this.clientAuthenticationKeyPassword = clientAuthenticationKeyPassword;
+			return this;
+		}
+
+		public Builder clientAuthenticationKeyPair(KeyPair clientAuthenticationKeyPair) {
+			this.clientAuthenticationKeyPair = clientAuthenticationKeyPair;
 			return this;
 		}
 
@@ -527,6 +663,13 @@ public final class ClientRegistration implements Serializable {
 			} else if (AuthorizationGrantType.AUTHORIZATION_CODE.equals(this.authorizationGrantType)) {
 				this.validateAuthorizationCodeGrantType();
 			}
+
+			if (ClientAuthenticationMethod.JWT.equals(this.clientAuthenticationMethod)) {
+				this.validateClientSecretJwtAuthenticationMethod();
+			} else if (ClientAuthenticationMethod.PRIVATE_KEY_JWT.equals(this.clientAuthenticationMethod)) {
+				this.validatePrivateKeyJwtAuthenticationMethod();
+			}
+
 			this.validateScopes();
 			return this.create();
 		}
@@ -539,8 +682,27 @@ public final class ClientRegistration implements Serializable {
 			clientRegistration.clientSecret = StringUtils.hasText(this.clientSecret) ? this.clientSecret : "";
 			clientRegistration.clientAuthenticationMethod = this.clientAuthenticationMethod;
 			if (AuthorizationGrantType.AUTHORIZATION_CODE.equals(this.authorizationGrantType) &&
+					!ClientAuthenticationMethod.PRIVATE_KEY_JWT.equals(this.clientAuthenticationMethod) &&
 					!StringUtils.hasText(this.clientSecret)) {
 				clientRegistration.clientAuthenticationMethod = ClientAuthenticationMethod.NONE;
+			}
+
+			clientRegistration.clientAuthenticationKeyStore = this.clientAuthenticationKeyStore;
+			clientRegistration.clientAuthenticationKeyStoreType = this.clientAuthenticationKeyStoreType;
+			clientRegistration.clientAuthenticationKeyStorePassword = this.clientAuthenticationKeyStorePassword;
+			clientRegistration.clientAuthenticationKeyAlias = this.clientAuthenticationKeyAlias;
+			clientRegistration.clientAuthenticationKeyPassword = this.clientAuthenticationKeyPassword;
+
+			if (ClientAuthenticationMethod.PRIVATE_KEY_JWT.equals(this.clientAuthenticationMethod) &&
+					this.clientAuthenticationKeyPair == null
+			) {
+				clientRegistration.clientAuthenticationKeyPair = keyPair(
+						clientRegistration.clientAuthenticationKeyStore,
+						clientRegistration.clientAuthenticationKeyStorePassword,
+						clientRegistration.clientAuthenticationKeyAlias,
+						clientRegistration.clientAuthenticationKeyPassword,
+						clientRegistration.clientAuthenticationKeyStoreType
+				);
 			}
 
 			clientRegistration.authorizationGrantType = this.authorizationGrantType;
@@ -598,6 +760,23 @@ public final class ClientRegistration implements Serializable {
 			Assert.hasText(this.tokenUri, "tokenUri cannot be empty");
 		}
 
+		private void validateClientSecretJwtAuthenticationMethod() {
+			Assert.isTrue(ClientAuthenticationMethod.JWT.equals(this.clientAuthenticationMethod),
+					() -> "clientAuthenticationMethod must be " + ClientAuthenticationMethod.JWT.getValue());
+			Assert.hasText(this.clientSecret, "clientSecret cannot be empty");
+		}
+
+		private void validatePrivateKeyJwtAuthenticationMethod() {
+			Assert.isTrue(ClientAuthenticationMethod.PRIVATE_KEY_JWT.equals(this.clientAuthenticationMethod),
+					() -> "clientAuthenticationMethod must be " + ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue());
+			if(this.clientAuthenticationKeyPair == null) {
+				Assert.hasText(this.clientAuthenticationKeyStore, "clientAuthenticationKeyStore cannot be empty");
+				Assert.hasText(this.clientAuthenticationKeyAlias, "clientAuthenticationKeyAlias cannot be empty");
+				Assert.isTrue((this.clientAuthenticationKeyStorePassword != null) ||
+						(this.clientAuthenticationKeyPassword != null), "clientAuthenticationKeyStorePassword and clientAuthenticationKeyPassword cannot both be null");
+			}
+		}
+
 		private void validateScopes() {
 			if (this.scopes == null) {
 				return;
@@ -618,6 +797,35 @@ public final class ClientRegistration implements Serializable {
 
 		private static boolean withinTheRangeOf(int c, int min, int max) {
 			return c >= min && c <= max;
+		}
+
+		private static KeyPair keyPair(String keyStorePath, String keyStorePassword, String keyAlias, String keyPassword, String keyStoreType) {
+			KeyPair keyPair = null;
+			try {
+				String type = KeyStore.getDefaultType();
+				if (keyStoreType != null) {
+					type = keyStoreType;
+				}
+				KeyStore keyStore = KeyStore.getInstance(type);
+
+				FileInputStream keyStoreStream = new FileInputStream(keyStorePath);
+				keyStore.load(keyStoreStream, keyStorePassword.toCharArray());
+
+				char[] password = null;
+				if (keyPassword != null) {
+					password = keyPassword.toCharArray();
+				}
+				Key key = keyStore.getKey(keyAlias, password);
+
+				if (key instanceof PrivateKey) {
+					Certificate certificate = keyStore.getCertificate(keyAlias);
+					PublicKey publicKey = certificate.getPublicKey();
+					keyPair =  new KeyPair(publicKey, (PrivateKey) key);
+				}
+			} catch (Exception e) {
+				return null;
+			}
+			return keyPair;
 		}
 	}
 }

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistrations.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistrations.java
@@ -16,20 +16,12 @@
 
 package org.springframework.security.oauth2.client.registration;
 
-import java.net.URI;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-
 import com.nimbusds.oauth2.sdk.GrantType;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.as.AuthorizationServerMetadata;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
 import net.minidev.json.JSONObject;
-
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.RequestEntity;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
@@ -40,6 +32,13 @@ import org.springframework.util.Assert;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Allows creating a {@link ClientRegistration.Builder} from an
@@ -260,10 +259,17 @@ public final class ClientRegistrations {
 		if (metadataAuthMethods.contains(com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod.CLIENT_SECRET_POST)) {
 			return ClientAuthenticationMethod.POST;
 		}
+		if (metadataAuthMethods.contains(com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod.CLIENT_SECRET_JWT)) {
+			return ClientAuthenticationMethod.JWT;
+		}
+		if (metadataAuthMethods.contains(com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod.PRIVATE_KEY_JWT)) {
+			return ClientAuthenticationMethod.PRIVATE_KEY_JWT;
+		}
 		if (metadataAuthMethods.contains(com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod.NONE)) {
 			return ClientAuthenticationMethod.NONE;
 		}
-		throw new IllegalArgumentException("Only ClientAuthenticationMethod.BASIC, ClientAuthenticationMethod.POST and "
+		throw new IllegalArgumentException("Only ClientAuthenticationMethod.BASIC, ClientAuthenticationMethod.POST, "
+				+ "ClientAuthenticationMethod.JWT, ClientAuthenticationMethod.PRIVATE_KEY_JWT, and "
 				+ "ClientAuthenticationMethod.NONE are supported. The issuer \"" + issuer + "\" returned a configuration of " + metadataAuthMethods);
 	}
 

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClientAuthenticationMethod.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClientAuthenticationMethod.java
@@ -31,6 +31,8 @@ public final class ClientAuthenticationMethod implements Serializable {
 	private static final long serialVersionUID = SpringSecurityCoreVersion.SERIAL_VERSION_UID;
 	public static final ClientAuthenticationMethod BASIC = new ClientAuthenticationMethod("basic");
 	public static final ClientAuthenticationMethod POST = new ClientAuthenticationMethod("post");
+	public static final ClientAuthenticationMethod JWT = new ClientAuthenticationMethod("jwt");
+	public static final ClientAuthenticationMethod PRIVATE_KEY_JWT = new ClientAuthenticationMethod("private_key_jwt");
 
 	/**
 	 * @since 5.2

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/OAuth2ParameterNames.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/OAuth2ParameterNames.java
@@ -96,6 +96,16 @@ public interface OAuth2ParameterNames {
 	String PASSWORD = "password";
 
 	/**
+	 * {@code client_assertion} - used in Access Token Request.
+	 */
+	String CLIENT_ASSERTION = "client_assertion";
+
+	/**
+	 * {@code client_assertion} - used in Access Token Request.
+	 */
+	String CLIENT_ASSERTION_TYPE = "client_assertion_type";
+
+	/**
 	 * {@code error} - used in Authorization Response and Access Token Response.
 	 */
 	String ERROR = "error";


### PR DESCRIPTION
This PR is to address the  #6881 issue of supporting OAuth 2.0 Client authentication methods, namely "client_secret_jwt" and "private_key_jwt" methods.

My understanding comes from reading the [spec](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication), but also from useful resources such as Authlete:

- [OAuth 2.0 Client Authentication - Takahiko Kawasaki
](https://medium.com/@darutk/oauth-2-0-client-authentication-4b5f929305d4)
- [private key jwt](https://kb.authlete.com/en/s/oauth-and-openid-connect/a/client-auth-private-key-jwt)
- [client secret jwt](https://kb.authlete.com/en/s/oauth-and-openid-connect/a/client-secret-jwt)

My use case has been to integrate with Login.gov, so my starting approach has been to add logic in order to simplify their `private_key_jwt` method, according to [login.gov docs](https://developers.login.gov/oidc/)

The major difficulty and difference when comparing the `private_key_jwt` method to other examples is the overhead of:
1. generating a JWT from scratch, using information derived from the OAuth client registry information
1. configuring and managing a keystore which can be used to sign the `client_assertion` JWT in the token request.
1. finding a handle on the right place to sign the JWT before issuing the token request

Further complications exist downstream on the resource server side, primarily:
1. Making a clear connection that `private_key_jwt` with Login.gov returns something that Spring refers to as an "opaque" token, meaning, it is not in the form of a JWT as you might expect, and the configuration on the resource side is slightly different.
2. Once you make the connection that the following should be used:

```
.oauth2ResourceServer()
          .opaqueToken();  // as opposed to `.jwt()`
```

Then it also must be recognized that a custom `@Bean OpaqueTokenIntrospector` must be setup to make another trip to the authorization server and extract user info. This implementation of course, could vary greatly between authorization servers.

This last point I feel could be improved by adding concrete use-cases to the documentation that spell out the connection between the "opaque" token and "private_key_jwt" authentication method specifically.

**What I've done so far:**
- Added new client registration properties to configure a key store for signing.
- Modified `AbstractWebClientReactiveOAuth2AccessTokenResponseClient` to handle the two new authentication methods that add `client_assertion` and `client_assertion_type` to the body of the token request. This includes some logic to create and sign the JWT using the key store configuration added above.
- Create a client registrations utility to return a java `KeyPair` directly from the builder or from config, later simplifying the ability to sign with `JWSSigner`
- Create new constants for `ClientAuthenticationMethod`:
  - JWT (client secret)
  - PRIVATE_KEY_JWT
- Create new constants for OAuth param keys:
  - CLIENT_ASSERTION = 'client_assertion'
  - CLIENT_ASSERTION_TYPE = 'client_assertion_type'

**Where I could use some guidance:**

- General feedback on if I've been putting logic in the right places or if I should be creating new classes and what their naming conventions should be.
- I've been dealing only with the reactive token response client, so I haven't begun to realize how this might impact non-reactive.
- In the case where I am creating a gateway to retrieve the opaque token, it is unclear to me whether or not a session can be managed at the gateway to prevent this 2nd round trip by forwarding the JWT available at the gateway before proxying with the opaque token, and I could use some guidance.
- I had initially implemented the key store and JWT signing logic using the `com.auth0:java-jwt` dependency; however, for this PR directly with spring-security, I have re-written some of that logic  using `com.nimbusds.jose` available on this project's classpath -- and that re-write may require some proper testing.
- In general, I haven't yet added any testing, and could use help on how you might approach this.