### PR TITLE
Fixed NPE for HTTP requests with non-standard HTTP method for CsrfWebFilter

### DIFF
--- a/web/src/main/java/org/springframework/security/web/server/csrf/CsrfWebFilter.java
+++ b/web/src/main/java/org/springframework/security/web/server/csrf/CsrfWebFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ import static java.lang.Boolean.TRUE;
  * </p>
  *
  * @author Rob Winch
+ * @author Parikshit Dutta
  * @since 5.0
  */
 public class CsrfWebFilter implements WebFilter {
@@ -187,7 +188,7 @@ public class CsrfWebFilter implements WebFilter {
 		@Override
 		public Mono<MatchResult> matches(ServerWebExchange exchange) {
 			return Mono.just(exchange.getRequest())
-				.map(r -> r.getMethod())
+				.flatMap(r -> Mono.justOrEmpty(r.getMethod()))
 				.filter(m -> ALLOWED_METHODS.contains(m))
 				.flatMap(m -> MatchResult.notMatch())
 				.switchIfEmpty(MatchResult.match());

--- a/web/src/test/java/org/springframework/security/web/server/csrf/CsrfWebFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/csrf/CsrfWebFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
@@ -40,11 +42,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.spy;
 import static org.springframework.mock.web.server.MockServerWebExchange.from;
 import static org.springframework.web.reactive.function.BodyInserters.fromMultipartData;
 
 /**
  * @author Rob Winch
+ * @author Parikshit Dutta
  * @since 5.0
  */
 @RunWith(MockitoJUnitRunner.class)
@@ -181,6 +186,18 @@ public class CsrfWebFilterTests {
 			.verifyComplete();
 
 		chainResult.assertWasSubscribed();
+	}
+
+	@Test
+	public void matchesRequireCSRFProtectionWhenNonStandardHTTPMethodIsUsed() {
+		final String NON_STANDARD_HTTP_METHOD = "non-standard-http-method";
+		MockServerWebExchange nonStandardHttpRequest = from(MockServerHttpRequest.method(HttpMethod.resolve(NON_STANDARD_HTTP_METHOD), "/"));
+
+		ServerWebExchangeMatcher serverWebExchangeMatcher = spy(CsrfWebFilter.DEFAULT_CSRF_MATCHER);
+		serverWebExchangeMatcher.matches(nonStandardHttpRequest);
+
+		verify(serverWebExchangeMatcher).matches(nonStandardHttpRequest);
+		assertThat(serverWebExchangeMatcher.matches(nonStandardHttpRequest).block().isMatch()).isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
Fixed NPE for HTTP requests with non-standard HTTP method in CsrfWebFilter

1. CsrfWebFilter code updated to deal with null value while non-standard HTTP methods used
2. Respective test added to validate the scenario with non-standard (custom) HTTP method

Expected Result:
Non-standard HTTP methods should match for CsrfProtection Requirement now, instead of throwing NPE and resulting HTTP 5xx 

Fixes gh-8149