### PR TITLE
Upgrade Freefair AspectJ plugin to v5.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 		classpath 'io.spring.gradle:spring-build-conventions:0.0.31.RELEASE'
 		classpath "org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion"
 		classpath 'io.spring.nohttp:nohttp-gradle:0.0.2.RELEASE'
-		classpath "io.freefair.gradle:aspectj-plugin:4.1.6"
+		classpath "io.freefair.gradle:aspectj-plugin:5.0.1"
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 	}
 	repositories {


### PR DESCRIPTION
Earlier versions of the `io.freefair.aspectj.post-compile-weaving` plugin contain [a bug](https://github.com/freefair/gradle-plugins/issues/212) that modifies compile tasks to incorrectly have compilation outputs configured as a _task input_. This results in those compile tasks not being considered `UP-TO-DATE` when executed after an initial `clean compile`. This issues is likely to also affect the cacheability of these tasks.

Plugin v5.0.1 includes [a fix](https://github.com/freefair/gradle-plugins/pull/213) that addresses this issue. When applied to the spring-security project,  all tasks for `./gradlew classes` will be marked as `UP-TO-DATE` following an initial `./gradlew clean classes`. 
