### PR TITLE
spring-security-test @WithMockOidcuser gh-8459

### DIFF
--- a/test/src/main/java/org/springframework/security/test/context/support/WithMockOidcUser.java
+++ b/test/src/main/java/org/springframework/security/test/context/support/WithMockOidcUser.java
@@ -33,13 +33,14 @@ import java.lang.annotation.*;
  * <ul>
  * <li>The Authentication that is populated in the {@link SecurityContext} is of type {@link OAuth2AuthenticationToken}.</li>
  * <li>The principal on the Authentication is Spring Security’s User object of type {@code OidcUser}.</li>
- * <li>The default User has the username of "user", {@link #value()} or {@link #name()} and does not have to exist.</li>
- * <li>The default User has and a single GrantedAuthority {@link GrantedAuthority} or those that are specified by {@link #authorities()}.</li>
+ * <li>The default User has the user name "user". You can overwrite it the name with {@link #value()} or {@link #name()}.</li>
+ * <li>The default User has "ROLE_USER" and "SCOPE_openid" as {@link GrantedAuthority}.
+ * You can overwrite them with {@link #scopes()} or {@link #authorities()}. </li>
  * </ul>
  *
  * @author Nena Raab
  * @see WithUserDetails
- * @since 5.3
+ * @since 5.4
  */
 @Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
@@ -47,7 +48,6 @@ import java.lang.annotation.*;
 @Documented
 @WithSecurityContext(factory = WithMockOidcUserSecurityContextFactory.class)
 public @interface WithMockOidcUser {
-	String DEFAULT_SCOPE = "SCOPE_openid";
 
 	/**
 	 * Convenience mechanism for specifying the username. The default is "user". If
@@ -57,7 +57,7 @@ public @interface WithMockOidcUser {
 	String value() default "user";
 
 	/**
-	 * The user name oder user id (subject) to be used. Note that {@link #value()} is a synonym for
+	 * The user name or user id (subject) to be used. Note that {@link #value()} is a synonym for
 	 * {@link #name()}, but if {@link #name()} is specified it will take
 	 * precedence.
 	 * @return
@@ -66,33 +66,36 @@ public @interface WithMockOidcUser {
 
 	/**
 	 * <p>
-	 * The authorities, that should be mapped to {@code GrantedAuthority}.
-	 * The default is "SCOPE_openid". A {@link GrantedAuthority} will be created for each value.
+	 * The scopes that should be mapped to {@code GrantedAuthority}.
+	 * The default is "openid". Each value in scopes gets prefixed with "SCOPE_"
+	 * and added to the list of {@link GrantedAuthority}.
 	 * </p>
-	 **
+	 * <p>
+	 * If {@link #authorities()} is specified this property cannot be changed from the default.
+	 * </p>
+	 *
 	 * @return
 	 */
-	String[] authorities() default { "SCOPE_openid" };
+	String[] scopes() default { "openid" };
 
 	/**
-	 * The name of the OIDC token claim that contains the subject identifier that identifies the End-User.
-	 * The default is "sub".
+	 * <p>
+	 * The authorities that should be mapped to {@code GrantedAuthority}.
+	 * </p>
+	 *
+	 * <p>
+	 * If this property is specified then {@link #scopes()} is not used. This differs from
+	 * {@link #scopes()} in that it does not prefix the values passed in automatically.
+	 * </p>
 	 * @return
 	 */
-	String nameTokenClaim() default "sub";
-
-	/**
-	 * The password to be used. The default is "clientId".
-	 * @return
-	 */
-	String clientId() default "clientId";
+	String[] authorities() default { };
 
 	/**
 	 * Determines when the {@link SecurityContext} is setup. The default is before
 	 * {@link TestExecutionEvent#TEST_METHOD} which occurs during
 	 * {@link org.springframework.test.context.TestExecutionListener#beforeTestMethod(TestContext)}
 	 * @return the {@link TestExecutionEvent} to initialize before
-	 * @since 5.1
 	 */
 	@AliasFor(annotation = WithSecurityContext.class)
 	TestExecutionEvent setupBefore() default TestExecutionEvent.TEST_METHOD;

--- a/test/src/main/java/org/springframework/security/test/context/support/WithMockOidcUser.java
+++ b/test/src/main/java/org/springframework/security/test/context/support/WithMockOidcUser.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.test.context.support;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.test.context.support.*;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.lang.annotation.*;
+
+/**
+ * When used with {@link WithSecurityContextTestExecutionListener} this annotation can be
+ * added to a test method to emulate running with a mocked user. In order to work with
+ * {@link MockMvc} The {@link SecurityContext} that is used will have the following
+ * properties:
+ *
+ * <ul>
+ * <li>The Authentication that is populated in the {@link SecurityContext} is of type {@link OAuth2AuthenticationToken}.</li>
+ * <li>The principal on the Authentication is Spring Security’s User object of type {@code OidcUser}.</li>
+ * <li>The default User has the username of "user", {@link #value()} or {@link #name()} and does not have to exist.</li>
+ * <li>The default User has and a single GrantedAuthority {@link GrantedAuthority} or those that are specified by {@link #authorities()}.</li>
+ * </ul>
+ *
+ * @author Nena Raab
+ * @see WithUserDetails
+ * @since 5.3
+ */
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@WithSecurityContext(factory = WithMockOidcUserSecurityContextFactory.class)
+public @interface WithMockOidcUser {
+	/**
+	 * Convenience mechanism for specifying the username. The default is "user". If
+	 * {@link #name()} is specified it will be used instead of {@link #value()}
+	 *
+	 * @return
+	 */
+	String value() default "user";
+
+	/**
+	 * The user name oder user id (subject) to be used. Note that {@link #value()} is a synonym for
+	 * {@link #name()}, but if {@link #name()} is specified it will take
+	 * precedence.
+	 *
+	 * @return
+	 */
+	String name() default "";
+
+	/**
+	 * <p>
+	 * The authorities to use. The default is "openid". A {@link GrantedAuthority} will be created for each value.
+	 * </p>
+	 * *
+	 *
+	 * @return
+	 */
+	String[] authorities() default { "openid" };
+
+	/**
+	 * The name of the OIDC token claim that contains the subject identifier that identifies the End-User.
+	 * The default is "sub".
+	 *
+	 * @return
+	 */
+	String nameTokenClaim() default "sub";
+
+	/**
+	 * The password to be used. The default is "clientId".
+	 *
+	 * @return
+	 */
+	String clientId() default "clientId";
+
+	/**
+	 * Determines when the {@link SecurityContext} is setup. The default is before
+	 * {@link TestExecutionEvent#TEST_METHOD} which occurs during
+	 * {@link org.springframework.test.context.TestExecutionListener#beforeTestMethod(TestContext)}
+	 *
+	 * @return the {@link TestExecutionEvent} to initialize before
+	 * @since 5.1
+	 */
+	@AliasFor(annotation = WithSecurityContext.class)
+	TestExecutionEvent setupBefore() default TestExecutionEvent.TEST_METHOD;
+}

--- a/test/src/main/java/org/springframework/security/test/context/support/WithMockOidcUser.java
+++ b/test/src/main/java/org/springframework/security/test/context/support/WithMockOidcUser.java
@@ -47,10 +47,11 @@ import java.lang.annotation.*;
 @Documented
 @WithSecurityContext(factory = WithMockOidcUserSecurityContextFactory.class)
 public @interface WithMockOidcUser {
+	String DEFAULT_SCOPE = "SCOPE_openid";
+
 	/**
 	 * Convenience mechanism for specifying the username. The default is "user". If
 	 * {@link #name()} is specified it will be used instead of {@link #value()}
-	 *
 	 * @return
 	 */
 	String value() default "user";
@@ -59,32 +60,29 @@ public @interface WithMockOidcUser {
 	 * The user name oder user id (subject) to be used. Note that {@link #value()} is a synonym for
 	 * {@link #name()}, but if {@link #name()} is specified it will take
 	 * precedence.
-	 *
 	 * @return
 	 */
 	String name() default "";
 
 	/**
 	 * <p>
-	 * The authorities to use. The default is "openid". A {@link GrantedAuthority} will be created for each value.
+	 * The authorities, that should be mapped to {@code GrantedAuthority}.
+	 * The default is "SCOPE_openid". A {@link GrantedAuthority} will be created for each value.
 	 * </p>
-	 * *
-	 *
+	 **
 	 * @return
 	 */
-	String[] authorities() default { "openid" };
+	String[] authorities() default { "SCOPE_openid" };
 
 	/**
 	 * The name of the OIDC token claim that contains the subject identifier that identifies the End-User.
 	 * The default is "sub".
-	 *
 	 * @return
 	 */
 	String nameTokenClaim() default "sub";
 
 	/**
 	 * The password to be used. The default is "clientId".
-	 *
 	 * @return
 	 */
 	String clientId() default "clientId";
@@ -93,7 +91,6 @@ public @interface WithMockOidcUser {
 	 * Determines when the {@link SecurityContext} is setup. The default is before
 	 * {@link TestExecutionEvent#TEST_METHOD} which occurs during
 	 * {@link org.springframework.test.context.TestExecutionListener#beforeTestMethod(TestContext)}
-	 *
 	 * @return the {@link TestExecutionEvent} to initialize before
 	 * @since 5.1
 	 */

--- a/test/src/main/java/org/springframework/security/test/context/support/WithMockOidcUser.java
+++ b/test/src/main/java/org/springframework/security/test/context/support/WithMockOidcUser.java
@@ -19,7 +19,6 @@ import org.springframework.core.annotation.AliasFor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-import org.springframework.security.test.context.support.*;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.web.servlet.MockMvc;
 

--- a/test/src/main/java/org/springframework/security/test/context/support/WithMockOidcUserSecurityContextFactory.java
+++ b/test/src/main/java/org/springframework/security/test/context/support/WithMockOidcUserSecurityContextFactory.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.test.context.support;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.util.StringUtils;
+
+import java.time.Instant;
+import java.util.*;
+
+/**
+ * A {@link WithMockOidcUserSecurityContextFactory} that works with {@link WithMockOidcUser}.
+ * <p>
+ * Initializes the Spring Security Context with a OAuth2AuthenticationToken instance, which comes with
+ * an encoded oidc token with some default claims but without header and signature.
+ *
+ * @author Nena Raab
+ * @see WithMockOidcUser
+ * @since 5.3
+ */
+final class WithMockOidcUserSecurityContextFactory implements
+		WithSecurityContextFactory<WithMockOidcUser> {
+
+	public SecurityContext createSecurityContext(WithMockOidcUser withUser) {
+		String userId = StringUtils.hasLength(withUser.name()) ? withUser
+				.name() : withUser.value();
+		if (userId == null) {
+			throw new IllegalArgumentException(withUser
+					+ " cannot have null user name/id on both name and value properties");
+		}
+
+		List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+		for (String authority : withUser.authorities()) {
+			grantedAuthorities.add(new SimpleGrantedAuthority(authority));
+		}
+
+		OidcUser principal = new DefaultOidcUser(grantedAuthorities,
+				new OidcIdTokenFactory(userId, withUser.clientId(), withUser.nameTokenClaim()).build(),
+				withUser.nameTokenClaim());
+
+		Authentication authentication = new OAuth2AuthenticationToken(
+				principal, principal.getAuthorities(), withUser.clientId());
+
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
+		context.setAuthentication(authentication);
+		return context;
+	}
+
+	private class OidcIdTokenFactory {
+		private Map<String, Object> claims = new HashMap<>();
+		final Instant expiredAt = new GregorianCalendar().toInstant().plusSeconds(600);
+		final Instant issuedAt = new GregorianCalendar().toInstant().minusSeconds(3);
+
+		OidcIdTokenFactory(String userId, String clientId, String userIdClaimName) {
+			claims.put("client_id", clientId); // mandatory
+			claims.put("iat", issuedAt.getEpochSecond());
+			claims.put("exp", expiredAt.getEpochSecond());
+			claims.put(userIdClaimName, userId);
+			claims.put("email", userId + "@test.org");
+		}
+
+		public OidcIdToken build() {
+			return new OidcIdToken(emptyTokenBase64Encode(), issuedAt, expiredAt, claims);
+		}
+
+		private String emptyTokenBase64Encode() {
+			byte[] emptyToken = "{}".getBytes();
+			return Base64.getUrlEncoder().withoutPadding().encodeToString(emptyToken);
+		}
+	}
+}

--- a/test/src/main/java/org/springframework/security/test/context/support/WithMockOidcUserSecurityContextFactory.java
+++ b/test/src/main/java/org/springframework/security/test/context/support/WithMockOidcUserSecurityContextFactory.java
@@ -77,7 +77,6 @@ final class WithMockOidcUserSecurityContextFactory implements
 			claims.put("iat", issuedAt.getEpochSecond());
 			claims.put("exp", expiredAt.getEpochSecond());
 			claims.put(userIdClaimName, userId);
-			claims.put("email", userId + "@test.org");
 		}
 
 		public OidcIdToken build() {

--- a/test/src/main/java/org/springframework/security/test/context/support/WithMockOidcUserSecurityContextFactory.java
+++ b/test/src/main/java/org/springframework/security/test/context/support/WithMockOidcUserSecurityContextFactory.java
@@ -47,7 +47,7 @@ final class WithMockOidcUserSecurityContextFactory implements
 				.name() : withUser.value();
 		if (userId == null) {
 			throw new IllegalArgumentException(withUser
-					+ " cannot have null user name/id on both name and value properties");
+					+ " cannot have null userId on both userId and value properties");
 		}
 
 		List<GrantedAuthority> grantedAuthorities = new ArrayList<>();

--- a/test/src/main/java/org/springframework/security/test/context/support/WithSecurityContextTestExecutionListener.java
+++ b/test/src/main/java/org/springframework/security/test/context/support/WithSecurityContextTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/src/main/java/org/springframework/security/test/context/support/WithSecurityContextTestExecutionListener.java
+++ b/test/src/main/java/org/springframework/security/test/context/support/WithSecurityContextTestExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/src/test/java/org/springframework/security/test/context/support/WithMockOidcUserSecurityContextTests.java
+++ b/test/src/test/java/org/springframework/security/test/context/support/WithMockOidcUserSecurityContextTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.test.context.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import java.time.Instant;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WithMockOidcUserSecurityContextTests {
+
+	@Mock
+	private WithMockOidcUser withUser;
+
+	private WithMockOidcUserSecurityContextFactory factory;
+
+	@Before
+	public void setup() {
+		factory = new WithMockOidcUserSecurityContextFactory();
+		when(withUser.value()).thenReturn("valueUser");
+		when(withUser.clientId()).thenReturn("clientid");
+		when(withUser.authorities()).thenReturn(new String[] { "openid" });
+		when(withUser.nameTokenClaim()).thenReturn("sub");
+		when(withUser.name()).thenReturn("");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void userNameValueNullRaiseException() {
+		when(withUser.value()).thenReturn(null);
+		factory.createSecurityContext(withUser);
+	}
+
+	public void valueDefaultsUserIdWhenUserNameIsNull() {
+		when(withUser.name()).thenReturn(null);
+		assertThat(factory.createSecurityContext(withUser).getAuthentication().getName())
+				.isEqualTo("valueUser");
+	}
+
+	@Test
+	public void valueDefaultsUserIdWhenUserNameIsNotSet() {
+		assertThat(factory.createSecurityContext(withUser).getAuthentication().getName())
+				.isEqualTo("valueUser");
+	}
+
+	@Test
+	public void userNamePrioritizedOverValue() {
+		when(withUser.name()).thenReturn("customUser");
+
+		assertThat(factory.createSecurityContext(withUser).getAuthentication().getName())
+				.isEqualTo("customUser");
+	}
+
+	@Test
+	public void overwriteAuthorities() {
+		when(withUser.authorities()).thenReturn(new String[] { "USER", "CUSTOM" });
+
+		assertThat(
+				factory.createSecurityContext(withUser).getAuthentication()
+						.getAuthorities()).extracting("authority").containsOnly(
+				"USER", "CUSTOM");
+	}
+
+	@Test
+	public void overwriteNameTokenClaim() {
+		when(withUser.nameTokenClaim()).thenReturn("userNameClaim");
+
+		Object authn = factory.createSecurityContext(withUser).getAuthentication().getPrincipal();
+		assertThat(authn).isInstanceOf(OidcUser.class);
+		assertThat(((OidcUser) authn).getClaims()).containsKey("userNameClaim");
+		assertThat(((OidcUser) authn).getClaims()).doesNotContainKey("sub");
+		assertThat(((OidcUser) authn).getName()).isEqualTo("valueUser");
+	}
+
+	@Test
+	public void claimNotExpired() {
+		when(withUser.nameTokenClaim()).thenReturn("userNameClaim");
+
+		OidcUser oidcUser = (OidcUser) factory.createSecurityContext(withUser).getAuthentication().getPrincipal();
+		assertThat(oidcUser.getIssuedAt().compareTo(Instant.now())).isNegative();
+		assertThat(oidcUser.getExpiresAt().compareTo(Instant.now())).isPositive();
+	}
+
+}

--- a/test/src/test/java/org/springframework/security/test/context/support/WithMockOidcUserSecurityContextTests.java
+++ b/test/src/test/java/org/springframework/security/test/context/support/WithMockOidcUserSecurityContextTests.java
@@ -81,14 +81,15 @@ public class WithMockOidcUserSecurityContextTests {
 				"USER", "CUSTOM");
 	}
 
+	@SuppressWarnings("checkstyle:WhitespaceAfter")
 	@Test
 	public void overwriteNameTokenClaim() {
 		when(withUser.nameTokenClaim()).thenReturn("userNameClaim");
 
 		Object authn = factory.createSecurityContext(withUser).getAuthentication().getPrincipal();
 		assertThat(authn).isInstanceOf(OidcUser.class);
-		assertThat(((OidcUser)authn).getClaims()).containsKey("userNameClaim");
-		assertThat(((OidcUser)authn).getClaims()).doesNotContainKey("sub");
+		assertThat(((OidcUser) authn).getClaims()).containsKey("userNameClaim");
+		assertThat(((OidcUser) authn).getClaims()).doesNotContainKey("sub");
 		assertThat(((OidcUser) authn).getName()).isEqualTo("valueUser");
 	}
 

--- a/test/src/test/java/org/springframework/security/test/context/support/WithMockOidcUserSecurityContextTests.java
+++ b/test/src/test/java/org/springframework/security/test/context/support/WithMockOidcUserSecurityContextTests.java
@@ -39,8 +39,8 @@ public class WithMockOidcUserSecurityContextTests {
 	public void setup() {
 		factory = new WithMockOidcUserSecurityContextFactory();
 		when(withUser.value()).thenReturn("valueUser");
-		when(withUser.clientId()).thenReturn("clientid");
-		when(withUser.authorities()).thenReturn(new String[] { "openid" });
+		when(withUser.clientId()).thenReturn("clientId");
+		when(withUser.authorities()).thenReturn(new String[] { WithMockOidcUser.DEFAULT_SCOPE });
 		when(withUser.nameTokenClaim()).thenReturn("sub");
 		when(withUser.name()).thenReturn("");
 	}
@@ -87,8 +87,8 @@ public class WithMockOidcUserSecurityContextTests {
 
 		Object authn = factory.createSecurityContext(withUser).getAuthentication().getPrincipal();
 		assertThat(authn).isInstanceOf(OidcUser.class);
-		assertThat(((OidcUser) authn).getClaims()).containsKey("userNameClaim");
-		assertThat(((OidcUser) authn).getClaims()).doesNotContainKey("sub");
+		assertThat(((OidcUser)authn).getClaims()).containsKey("userNameClaim");
+		assertThat(((OidcUser)authn).getClaims()).doesNotContainKey("sub");
 		assertThat(((OidcUser) authn).getName()).isEqualTo("valueUser");
 	}
 

--- a/test/src/test/java/org/springframework/security/test/context/support/WithMockOidcUserTests.java
+++ b/test/src/test/java/org/springframework/security/test/context/support/WithMockOidcUserTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.test.context.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+public class WithMockOidcUserTests {
+
+	@Test
+	public void defaults() {
+		WithMockOidcUser mockUser = AnnotatedElementUtils.findMergedAnnotation(Annotated.class,
+				WithMockOidcUser.class);
+		assertThat(mockUser.value()).isEqualTo("user");
+		assertThat(mockUser.name()).isEmpty();
+		assertThat(mockUser.authorities()).containsOnly("openid");
+		assertThat(mockUser.clientId()).isEqualTo("clientId");
+		assertThat(mockUser.setupBefore()).isEqualByComparingTo(TestExecutionEvent.TEST_METHOD);
+
+		WithSecurityContext context = AnnotatedElementUtils.findMergedAnnotation(Annotated.class,
+				WithSecurityContext.class);
+
+		assertThat(context.setupBefore()).isEqualTo(TestExecutionEvent.TEST_METHOD);
+	}
+
+	@WithMockOidcUser
+	private class Annotated {
+	}
+
+	@Test
+	public void findMergedAnnotationWhenSetupExplicitThenOverridden() {
+		WithSecurityContext context = AnnotatedElementUtils
+				.findMergedAnnotation(SetupExplicit.class,
+						WithSecurityContext.class);
+
+		assertThat(context.setupBefore()).isEqualTo(TestExecutionEvent.TEST_METHOD);
+	}
+
+	@WithMockOidcUser(setupBefore = TestExecutionEvent.TEST_METHOD)
+	private class SetupExplicit {
+	}
+
+	@Test
+	public void findMergedAnnotationWhenSetupOverriddenThenOverridden() {
+		WithSecurityContext context = AnnotatedElementUtils.findMergedAnnotation(SetupOverridden.class,
+				WithSecurityContext.class);
+
+		assertThat(context.setupBefore()).isEqualTo(TestExecutionEvent.TEST_EXECUTION);
+	}
+
+	@WithMockOidcUser(setupBefore = TestExecutionEvent.TEST_EXECUTION)
+	private class SetupOverridden {
+	}
+}

--- a/test/src/test/java/org/springframework/security/test/context/support/WithMockOidcUserTests.java
+++ b/test/src/test/java/org/springframework/security/test/context/support/WithMockOidcUserTests.java
@@ -28,7 +28,7 @@ public class WithMockOidcUserTests {
 				WithMockOidcUser.class);
 		assertThat(mockUser.value()).isEqualTo("user");
 		assertThat(mockUser.name()).isEmpty();
-		assertThat(mockUser.authorities()).containsOnly("openid");
+		assertThat(mockUser.authorities()).containsOnly(WithMockOidcUser.DEFAULT_SCOPE);
 		assertThat(mockUser.clientId()).isEqualTo("clientId");
 		assertThat(mockUser.nameTokenClaim()).isEqualTo("sub");
 		assertThat(mockUser.setupBefore()).isEqualByComparingTo(TestExecutionEvent.TEST_METHOD);

--- a/test/src/test/java/org/springframework/security/test/context/support/WithMockOidcUserTests.java
+++ b/test/src/test/java/org/springframework/security/test/context/support/WithMockOidcUserTests.java
@@ -19,8 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.springframework.core.annotation.AnnotatedElementUtils;
-import org.springframework.security.test.context.support.TestExecutionEvent;
-import org.springframework.security.test.context.support.WithSecurityContext;
 
 public class WithMockOidcUserTests {
 
@@ -32,6 +30,7 @@ public class WithMockOidcUserTests {
 		assertThat(mockUser.name()).isEmpty();
 		assertThat(mockUser.authorities()).containsOnly("openid");
 		assertThat(mockUser.clientId()).isEqualTo("clientId");
+		assertThat(mockUser.nameTokenClaim()).isEqualTo("sub");
 		assertThat(mockUser.setupBefore()).isEqualByComparingTo(TestExecutionEvent.TEST_METHOD);
 
 		WithSecurityContext context = AnnotatedElementUtils.findMergedAnnotation(Annotated.class,

--- a/test/src/test/java/org/springframework/security/test/context/support/WithMockOidcUserTests.java
+++ b/test/src/test/java/org/springframework/security/test/context/support/WithMockOidcUserTests.java
@@ -28,9 +28,8 @@ public class WithMockOidcUserTests {
 				WithMockOidcUser.class);
 		assertThat(mockUser.value()).isEqualTo("user");
 		assertThat(mockUser.name()).isEmpty();
-		assertThat(mockUser.authorities()).containsOnly(WithMockOidcUser.DEFAULT_SCOPE);
-		assertThat(mockUser.clientId()).isEqualTo("clientId");
-		assertThat(mockUser.nameTokenClaim()).isEqualTo("sub");
+		assertThat(mockUser.scopes()).containsOnly("openid");
+		assertThat(mockUser.authorities()).isEmpty();
 		assertThat(mockUser.setupBefore()).isEqualByComparingTo(TestExecutionEvent.TEST_METHOD);
 
 		WithSecurityContext context = AnnotatedElementUtils.findMergedAnnotation(Annotated.class,


### PR DESCRIPTION
Adds `@WithMockOidcUser` to `spring-security-test` library that allows you to fill the SecurityContext properly when using `oauth2Login` as I was used to with `@WithMockUser`

Example Web Mvc test:
```java
@Test
@WithMockOidcUser(name = "Alice_salesOrders@test.com", authorities = {"read:salesOrders"})
public void readWith_Alice_salesOrders_200() {
        mockMvc.perform(get("/salesOrders"))
                .andExpect(status().isOk());
}
```
Example **other Spring Tests**:
```java
@Autowired
DataService dataService;
    
@Test
@WithMockOidcUser(authorities = {"Admin"})
public void accessService_authorizedUser() {
        String data = dataService.readSensitiveData();
        assertFalse(data.isEmpty());
}
```

### Github issue
Find further details discussed here: #https://github.com/spring-projects/spring-security/issues/8459