### PR TITLE
Use Opaquetoken properties to configure timeouts

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/servlet/oauth2/oauth2-resourceserver.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/oauth2/oauth2-resourceserver.adoc
@@ -1573,9 +1573,9 @@ To adjust the way in which Resource Server connects to the authorization server,
 
 ```java
 @Bean
-public OpaqueTokenIntrospector introspector(RestTemplateBuilder builder) {
+public OpaqueTokenIntrospector introspector(RestTemplateBuilder builder, OAuth2ResourceServerProperties properties) {
     RestOperations rest = builder
-            .basicAuthentication(clientId, clientSecret)
+            .basicAuthentication(properties.getOpaquetoken().getClientId(), properties.getOpaquetoken().getClientSecret())
             .setConnectionTimeout(60000)
             .setReadTimeout(60000)
             .build();


### PR DESCRIPTION
Improve the documentation to show how to re-use the Opaquetoken properties of `OAuth2ResourceServerProperties` to set up basic auth in the configured `RestTemplate`.