### PR TITLE
fix bearer token resolving logic

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
@@ -38,7 +38,7 @@ import static org.springframework.security.oauth2.server.resource.BearerTokenErr
 public final class DefaultBearerTokenResolver implements BearerTokenResolver {
 
 	private static final Pattern authorizationPattern = Pattern.compile(
-		"^Bearer (?<token>[a-zA-Z0-9-._~+/]+)=*$",
+		"^Bearer (?<token>[a-zA-Z0-9-._~+/]+)(?<padding>=*)$",
 		Pattern.CASE_INSENSITIVE);
 
 	private boolean allowFormEncodedBodyParameter = false;
@@ -111,7 +111,7 @@ public final class DefaultBearerTokenResolver implements BearerTokenResolver {
 				throw new OAuth2AuthenticationException(error);
 			}
 
-			return matcher.group("token") + "=";
+			return matcher.group("token") + matcher.group("padding");
 		}
 		return null;
 	}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
@@ -67,6 +67,7 @@ public final class DefaultBearerTokenResolver implements BearerTokenResolver {
 		return null;
 	}
 
+
 	/**
 	 * Set if transport of access token using form-encoded body parameter is supported. Defaults to {@code false}.
 	 * @param allowFormEncodedBodyParameter if the form-encoded body parameter is supported
@@ -110,7 +111,7 @@ public final class DefaultBearerTokenResolver implements BearerTokenResolver {
 				throw new OAuth2AuthenticationException(error);
 			}
 
-			return matcher.group("token");
+			return matcher.group("token") + "=";
 		}
 		return null;
 	}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
  */
 public class DefaultBearerTokenResolverTests {
 	private static final String CUSTOM_HEADER = "custom-header";
-	private static final String TEST_TOKEN = "lCPmYpr4RZbfBgFn5BhBK1GrfXw=";
+	private static final String TEST_TOKEN = "lCPmYpr4RZbfBgFn5BhBK1GrfXw";
 
 	private DefaultBearerTokenResolver resolver;
 
@@ -49,6 +49,24 @@ public class DefaultBearerTokenResolverTests {
 		request.addHeader("Authorization", "Bearer " + TEST_TOKEN);
 
 		assertThat(this.resolver.resolve(request)).isEqualTo(TEST_TOKEN);
+	}
+
+	@Test
+	public void resolveWhenTokenHasOneBytePaddingIndicator() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		String token = TEST_TOKEN + "=";
+		request.addHeader("Authorization", "Bearer " + token);
+
+		assertThat(this.resolver.resolve(request)).isEqualTo(token);
+	}
+
+	@Test
+	public void resolveWhenTokenHasTwoBytesPaddingIndicator() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		String token = TEST_TOKEN + "==";
+		request.addHeader("Authorization", "Bearer " + token);
+
+		assertThat(this.resolver.resolve(request)).isEqualTo(token);
 	}
 
 	@Test

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
  */
 public class DefaultBearerTokenResolverTests {
 	private static final String CUSTOM_HEADER = "custom-header";
-	private static final String TEST_TOKEN = "test-token";
+	private static final String TEST_TOKEN = "lCPmYpr4RZbfBgFn5BhBK1GrfXw=";
 
 	private DefaultBearerTokenResolver resolver;
 


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->


gh-8502
Add ignored padding indicators to validated bearer token