### PR TITLE
Document NoOpPasswordEncoder will not be removed

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/password/NoOpPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password/NoOpPasswordEncoder.java
@@ -26,7 +26,8 @@ package org.springframework.security.crypto.password;
  * @deprecated This PasswordEncoder is not secure. Instead use an
  * adaptive one way function like BCryptPasswordEncoder, Pbkdf2PasswordEncoder, or
  * SCryptPasswordEncoder. Even better use {@link DelegatingPasswordEncoder} which supports
- * password upgrades.
+ * password upgrades. There are no plans to remove this support. It is deprecated to indicate that
+ * this is a legacy implementation and using it is considered insecure.
  */
 @Deprecated
 public final class NoOpPasswordEncoder implements PasswordEncoder {


### PR DESCRIPTION
This commit adds extension to deprecation notice.

Fixes gh-8506

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
