### PR TITLE
return beaer token with padding indicators after validating it

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
@@ -110,7 +110,7 @@ public final class DefaultBearerTokenResolver implements BearerTokenResolver {
 				throw new OAuth2AuthenticationException(error);
 			}
 
-			return matcher.group("token");
+			return authorization.substring(7);
 		}
 		return null;
 	}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
  */
 public class DefaultBearerTokenResolverTests {
 	private static final String CUSTOM_HEADER = "custom-header";
-	private static final String TEST_TOKEN = "test-token";
+	private static final String TEST_TOKEN = "ab5FG/ywfXPwiPc6ErRQM643QqY";
 
 	private DefaultBearerTokenResolver resolver;
 
@@ -49,6 +49,24 @@ public class DefaultBearerTokenResolverTests {
 		request.addHeader("Authorization", "Bearer " + TEST_TOKEN);
 
 		assertThat(this.resolver.resolve(request)).isEqualTo(TEST_TOKEN);
+	}
+
+	@Test
+	public void resolveWhenValidHeaderIsPresentWithSingleBytePaddingIndicatorThenTokenIsResolved() {
+		String token = TEST_TOKEN + "=";
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Bearer " + token);
+
+		assertThat(this.resolver.resolve(request)).isEqualTo(token);
+	}
+
+	@Test
+	public void resolveWhenValidHeaderIsPresentWithTwoBytesPaddingIndicatorThenTokenIsResolved() {
+		String token = TEST_TOKEN + "==";
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Bearer " + token);
+
+		assertThat(this.resolver.resolve(request)).isEqualTo(token);
 	}
 
 	@Test


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
gh-8502

Include padding indicators in the resolved bearer token, or return original bearer token after validating the format