### PR TITLE
Update AntPathRequestMatcher.java

### DIFF
--- a/web/src/main/java/org/springframework/security/web/util/matcher/AntPathRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/AntPathRequestMatcher.java
@@ -68,7 +68,7 @@ public final class AntPathRequestMatcher
 
 	/**
 	 * Creates a matcher with the specific pattern which will match all HTTP methods in a
-	 * case insensitive manner.
+	 * case sensitive manner.
 	 *
 	 * @param pattern the ant pattern to use for matching
 	 */
@@ -77,7 +77,7 @@ public final class AntPathRequestMatcher
 	}
 
 	/**
-	 * Creates a matcher with the supplied pattern and HTTP method in a case insensitive
+	 * Creates a matcher with the supplied pattern and HTTP method in a case sensitive
 	 * manner.
 	 *
 	 * @param pattern the ant pattern to use for matching


### PR DESCRIPTION
Fixed typo in JavaDoc. Actually, In these two cases, we are calling the constructor with a `boolean caseSensitive` which is equal to true. This means case sensitive
