### PR TITLE
Object ID Identicy conversion to long fails on old schema

### DIFF
--- a/acl/src/main/java/org/springframework/security/acls/jdbc/AclClassIdUtils.java
+++ b/acl/src/main/java/org/springframework/security/acls/jdbc/AclClassIdUtils.java
@@ -118,7 +118,7 @@ class AclClassIdUtils {
 	 */
 	private Long convertToLong(Serializable identifier) {
 		Long idAsLong;
-		if (canConvertFromStringTo(Long.class)) {
+		if (conversionService.canConvert(identifier.getClass(), Long.class)) {
 			idAsLong = conversionService.convert(identifier, Long.class);
 		} else {
 			idAsLong = Long.valueOf(identifier.toString());

--- a/acl/src/test/java/org/springframework/security/acls/jdbc/AclClassIdUtilsTest.java
+++ b/acl/src/test/java/org/springframework/security/acls/jdbc/AclClassIdUtilsTest.java
@@ -24,6 +24,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.convert.ConversionService;
 
 import java.io.Serializable;
+import java.math.BigInteger;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.UUID;
@@ -39,6 +40,7 @@ import static org.mockito.BDDMockito.given;
 public class AclClassIdUtilsTest {
 
 	private static final Long DEFAULT_IDENTIFIER = 999L;
+	private static final BigInteger BIGINT_IDENTIFIER = new BigInteger("999");
 	private static final String DEFAULT_IDENTIFIER_AS_STRING = DEFAULT_IDENTIFIER.toString();
 
 	@Mock
@@ -57,6 +59,15 @@ public class AclClassIdUtilsTest {
 	public void shouldReturnLongIfIdentifierIsLong() throws SQLException {
 		// when
 		Serializable newIdentifier = aclClassIdUtils.identifierFrom(DEFAULT_IDENTIFIER, resultSet);
+
+		// then
+		assertThat(newIdentifier).isEqualTo(DEFAULT_IDENTIFIER);
+	}
+
+	@Test
+	public void shouldReturnLongIfIdentifierIsBigInteger() throws SQLException {
+		// when
+		Serializable newIdentifier = aclClassIdUtils.identifierFrom(BIGINT_IDENTIFIER, resultSet);
 
 		// then
 		assertThat(newIdentifier).isEqualTo(DEFAULT_IDENTIFIER);


### PR DESCRIPTION
This change fixed a bug which tried to convert non-string object as string

Fixes gh-7621

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
