### PR TITLE
Update index.adoc

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/servlet/kotlin-configuration/index.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/kotlin-configuration/index.adoc
@@ -4,7 +4,7 @@
 Spring Security Kotlin Configuration support has been available since Spring Security 5.3.
 It enables users to easily configure Spring Security using a native Kotlin DSL.
 
-NOTE: Spring Security provides https://github.com/spring-projects/spring-security/tree/master/samples/boot/kotlin[a sample applications] which demonstrates the use of Spring Security Kotlin Configuration.
+NOTE: Spring Security provides https://github.com/spring-projects/spring-security/tree/master/samples/boot/kotlin[a sample application] which demonstrates the use of Spring Security Kotlin Configuration.
 
 [[kotlin-config-httpsecurity]]
 == HttpSecurity


### PR DESCRIPTION
Fix typo in docs.

Also, the url here is broken https://docs.spring.io/spring-security/site/docs/5.3.0.RELEASE/reference/html5/#whats-new-documentation
But not sure how to fix it.
