### PR TITLE
Security issue: mentioning the default strength of `BCryptPasswordEncoder`

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/about/authentication/password-storage.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/about/authentication/password-storage.adoc
@@ -324,6 +324,8 @@ https://docs.spring.io/spring-security/site/docs/5.0.x/api/org/springframework/s
 The `BCryptPasswordEncoder` implementation uses the widely supported https://en.wikipedia.org/wiki/Bcrypt[bcrypt] algorithm to hash the passwords.
 In order to make it more resistent to password cracking, bcrypt is deliberately slow.
 Like other adaptive one-way functions, it should be tuned to take about 1 second to verify a password on your system.
+The default implementation of `BCryptPasswordEncoder` uses strength 10 as mentioned on the Javadoc of https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoder.html[BCryptPasswordEncoder]. Your are encouagred to
+tune and test the strength parameter on your own system so that it take roughly 1 second to verify a password.
 
 .BCryptPasswordEncoder
 ====


### PR DESCRIPTION
Hi, 

As mentioned in the Spring security doc on `BCryptPasswordEncoder`

> The strength of   BCryptPasswordEncoder should be tuned to take about 1 second to verify a password on your system.

However, the default implementation of `BCryptPasswordEncoder` uses a **default strength of 10**. 
On my system (Intel Core i5 CPU-1.60Hz 8 GM RAM), I found that the default implementation takes around **220~250 ms** to verify a password which is clearly way less than 1 second lower limit. 

I think it should be worth **mentioning the default strength of BCryptPasswordEncoder** since all of the Spring projects I have worked with developers tend not to change the default strength which according to the Spring security doc is not secure.  

This can make the developers using the default strength of `BCryptPasswordEncoder` more conscious about setting a correct secure strength.
