### PR TITLE
Configuration defaults to SessionRegistry bean

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.GenericApplicationListenerAdapter;
@@ -679,6 +680,9 @@ public final class SessionManagementConfigurer<H extends HttpSecurityBuilder<H>>
 
 	private SessionRegistry getSessionRegistry(H http) {
 		if (this.sessionRegistry == null) {
+			this.sessionRegistry = getBeanOrNull(SessionRegistry.class);
+		}
+		if (this.sessionRegistry == null) {
 			SessionRegistryImpl sessionRegistry = new SessionRegistryImpl();
 			registerDelegateApplicationListener(http, sessionRegistry);
 			this.sessionRegistry = sessionRegistry;
@@ -716,5 +720,18 @@ public final class SessionManagementConfigurer<H extends HttpSecurityBuilder<H>>
 	 */
 	private static SessionAuthenticationStrategy createDefaultSessionFixationProtectionStrategy() {
 			return new ChangeSessionIdAuthenticationStrategy();
+	}
+
+	private <T> T getBeanOrNull(Class<T> type) {
+		ApplicationContext context = getBuilder().getSharedObject(ApplicationContext.class);
+		if (context == null) {
+			return null;
+		}
+		try {
+			return context.getBean(type);
+		}
+		catch (NoSuchBeanDefinitionException e) {
+			return null;
+		}
 	}
 }

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
@@ -692,15 +692,10 @@ public final class SessionManagementConfigurer<H extends HttpSecurityBuilder<H>>
 
 	private void registerDelegateApplicationListener(H http,
 			ApplicationListener<?> delegate) {
-		ApplicationContext context = http.getSharedObject(ApplicationContext.class);
-		if (context == null) {
+		DelegatingApplicationListener delegating = getBeanOrNull(DelegatingApplicationListener.class);
+		if (delegating == null) {
 			return;
 		}
-		if (context.getBeansOfType(DelegatingApplicationListener.class).isEmpty()) {
-			return;
-		}
-		DelegatingApplicationListener delegating = context
-				.getBean(DelegatingApplicationListener.class);
 		SmartApplicationListener smartListener = new GenericApplicationListenerAdapter(
 				delegate);
 		delegating.addListener(smartListener);


### PR DESCRIPTION
If a SessionRegistry is necessary, check for one in the ApplicationContext before creating one.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
See https://github.com/spring-projects/spring-session/issues/1629