### PR TITLE
Polish JDBC Authentication documentation

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/servlet/authentication/unpwd/jdbc.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/authentication/unpwd/jdbc.adoc
@@ -35,7 +35,7 @@ The default schema is also exposed as a classpath resource named `org/springfram
 ----
 create table users(
 	username varchar_ignorecase(50) not null primary key,
-	password varchar_ignorecase(50) not null,
+	password varchar_ignorecase(500) not null,
 	enabled boolean not null
 );
 
@@ -169,7 +169,8 @@ UserDetailsManager users(DataSource dataSource) {
 		.roles("USER", "ADMIN")
 		.build();
 	JdbcUserDetailsManager users = new JdbcUserDetailsManager(dataSource);
-	users.createUser()
+	users.createUser(user);
+	users.createUser(admin);
 }
 ----
 


### PR DESCRIPTION
* Correct documented default schema to match default schema exposed as classpath resource.
  A varchar of size 50 is not large enough for the encoded password.
* Fix Java example of adding users to JdbcUserDetailsManager.

