### PR TITLE
Remove unused field 'digester' in Md4PasswordEncoder

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/password/Md4PasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password/Md4PasswordEncoder.java
@@ -83,8 +83,6 @@ public class Md4PasswordEncoder implements PasswordEncoder {
 	private StringKeyGenerator saltGenerator = new Base64StringKeyGenerator();
 	private boolean encodeHashAsBase64;
 
-	private Digester digester;
-
 
 	public void setEncodeHashAsBase64(boolean encodeHashAsBase64) {
 		this.encodeHashAsBase64 = encodeHashAsBase64;


### PR DESCRIPTION
`private Digester digester;`  defined in Md4PasswordEncoder is never used. So remove it.
