### PR TITLE
Fix typos in BCryptPasswordEncoder documentation

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/about/authentication/password-storage.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/about/authentication/password-storage.adoc
@@ -324,8 +324,8 @@ https://docs.spring.io/spring-security/site/docs/5.0.x/api/org/springframework/s
 The `BCryptPasswordEncoder` implementation uses the widely supported https://en.wikipedia.org/wiki/Bcrypt[bcrypt] algorithm to hash the passwords.
 In order to make it more resistent to password cracking, bcrypt is deliberately slow.
 Like other adaptive one-way functions, it should be tuned to take about 1 second to verify a password on your system.
-The default implementation of `BCryptPasswordEncoder` uses strength 10 as mentioned on the Javadoc of https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoder.html[BCryptPasswordEncoder]. Your are encouagred to
-tune and test the strength parameter on your own system so that it take roughly 1 second to verify a password.
+The default implementation of `BCryptPasswordEncoder` uses strength 10 as mentioned in the Javadoc of https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoder.html[BCryptPasswordEncoder]. You are encouraged to
+tune and test the strength parameter on your own system so that it takes roughly 1 second to verify a password.
 
 .BCryptPasswordEncoder
 ====


### PR DESCRIPTION
Resolves gh-8585

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
