### PR TITLE
Add ServerRequestCache setter in OAuth2AuthorizationCodeGrantWebFilter

### DIFF
--- a/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
@@ -236,6 +236,7 @@ import static org.springframework.security.web.server.util.matcher.ServerWebExch
  * @author Rafiullah Hamedy
  * @author Eddú Meléndez
  * @author Joe Grandja
+ * @author Parikshit Dutta
  * @since 5.0
  */
 public class ServerHttpSecurity {
@@ -1511,10 +1512,17 @@ public class ServerHttpSecurity {
 			OAuth2AuthorizationCodeGrantWebFilter codeGrantWebFilter = new OAuth2AuthorizationCodeGrantWebFilter(
 					authenticationManager, authenticationConverter, authorizedClientRepository);
 			codeGrantWebFilter.setAuthorizationRequestRepository(getAuthorizationRequestRepository());
+			if (http.requestCache != null) {
+				codeGrantWebFilter.setRequestCache(http.requestCache.requestCache);
+			}
 
 			OAuth2AuthorizationRequestRedirectWebFilter oauthRedirectFilter = new OAuth2AuthorizationRequestRedirectWebFilter(
 					clientRegistrationRepository);
 			oauthRedirectFilter.setAuthorizationRequestRepository(getAuthorizationRequestRepository());
+			if (http.requestCache != null) {
+				oauthRedirectFilter.setRequestCache(http.requestCache.requestCache);
+			}
+
 			http.addFilterAt(codeGrantWebFilter, SecurityWebFiltersOrder.OAUTH2_AUTHORIZATION_CODE);
 			http.addFilterAt(oauthRedirectFilter, SecurityWebFiltersOrder.HTTP_BASIC);
 		}

--- a/config/src/test/java/org/springframework/security/config/web/server/OAuth2ClientSpecTests.java
+++ b/config/src/test/java/org/springframework/security/config/web/server/OAuth2ClientSpecTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.springframework.security.config.web.server;
+
+import java.net.URI;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,6 +50,7 @@ import org.springframework.security.test.context.annotation.SecurityTestExecutio
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.authentication.ServerAuthenticationConverter;
+import org.springframework.security.web.server.savedrequest.ServerRequestCache;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -62,6 +65,7 @@ import static org.mockito.Mockito.when;
 
 /**
  * @author Rob Winch
+ * @author Parikshit Dutta
  * @since 5.1
  */
 @RunWith(SpringRunner.class)
@@ -147,6 +151,8 @@ public class OAuth2ClientSpecTests {
 		ReactiveAuthenticationManager manager = config.manager;
 		ServerAuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository = config.authorizationRequestRepository;
 
+		ServerRequestCache requestCache = config.requestCache;
+
 		OAuth2AuthorizationRequest authorizationRequest = TestOAuth2AuthorizationRequests.request()
 				.redirectUri("/authorize/oauth2/code/registration-id")
 				.build();
@@ -163,6 +169,7 @@ public class OAuth2ClientSpecTests {
 		when(authorizationRequestRepository.loadAuthorizationRequest(any())).thenReturn(Mono.just(authorizationRequest));
 		when(converter.convert(any())).thenReturn(Mono.just(new TestingAuthenticationToken("a", "b", "c")));
 		when(manager.authenticate(any())).thenReturn(Mono.just(result));
+		when(requestCache.getRedirectUri(any())).thenReturn(Mono.just(URI.create("saved-request")));
 
 		this.client.get()
 				.uri(uriBuilder ->
@@ -175,6 +182,7 @@ public class OAuth2ClientSpecTests {
 
 		verify(converter).convert(any());
 		verify(manager).authenticate(any());
+		verify(requestCache).getRedirectUri(any());
 	}
 
 	@EnableWebFlux
@@ -197,13 +205,17 @@ public class OAuth2ClientSpecTests {
 
 		ServerAuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository = mock(ServerAuthorizationRequestRepository.class);
 
+		ServerRequestCache requestCache = mock(ServerRequestCache.class);
+
 		@Bean
 		public SecurityWebFilterChain springSecurityFilter(ServerHttpSecurity http) {
 			http
 				.oauth2Client()
 					.authenticationConverter(this.authenticationConverter)
 					.authenticationManager(this.manager)
-					.authorizationRequestRepository(this.authorizationRequestRepository);
+					.authorizationRequestRepository(this.authorizationRequestRepository)
+					.and()
+					.requestCache(c -> c.requestCache(this.requestCache));
 			return http.build();
 		}
 	}
@@ -217,6 +229,8 @@ public class OAuth2ClientSpecTests {
 		ServerAuthenticationConverter converter = config.authenticationConverter;
 		ReactiveAuthenticationManager manager = config.manager;
 		ServerAuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository = config.authorizationRequestRepository;
+
+		ServerRequestCache requestCache = config.requestCache;
 
 		OAuth2AuthorizationRequest authorizationRequest = TestOAuth2AuthorizationRequests.request()
 				.redirectUri("/authorize/oauth2/code/registration-id")
@@ -234,6 +248,7 @@ public class OAuth2ClientSpecTests {
 		when(authorizationRequestRepository.loadAuthorizationRequest(any())).thenReturn(Mono.just(authorizationRequest));
 		when(converter.convert(any())).thenReturn(Mono.just(new TestingAuthenticationToken("a", "b", "c")));
 		when(manager.authenticate(any())).thenReturn(Mono.just(result));
+		when(requestCache.getRedirectUri(any())).thenReturn(Mono.just(URI.create("saved-request")));
 
 		this.client.get()
 				.uri(uriBuilder ->
@@ -246,6 +261,7 @@ public class OAuth2ClientSpecTests {
 
 		verify(converter).convert(any());
 		verify(manager).authenticate(any());
+		verify(requestCache).getRedirectUri(any());
 	}
 
 	@Configuration
@@ -256,6 +272,8 @@ public class OAuth2ClientSpecTests {
 
 		ServerAuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository = mock(ServerAuthorizationRequestRepository.class);
 
+		ServerRequestCache requestCache = mock(ServerRequestCache.class);
+
 		@Bean
 		public SecurityWebFilterChain springSecurityFilter(ServerHttpSecurity http) {
 			http
@@ -264,6 +282,8 @@ public class OAuth2ClientSpecTests {
 						.authenticationConverter(this.authenticationConverter)
 						.authenticationManager(this.manager)
 						.authorizationRequestRepository(this.authorizationRequestRepository)
+						.and()
+						.requestCache(c -> c.requestCache(this.requestCache))
 				);
 			return http.build();
 		}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/server/OAuth2AuthorizationCodeGrantWebFilter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/server/OAuth2AuthorizationCodeGrantWebFilter.java
@@ -35,6 +35,7 @@ import org.springframework.security.web.server.authentication.RedirectServerAuth
 import org.springframework.security.web.server.authentication.ServerAuthenticationConverter;
 import org.springframework.security.web.server.authentication.ServerAuthenticationFailureHandler;
 import org.springframework.security.web.server.authentication.ServerAuthenticationSuccessHandler;
+import org.springframework.security.web.server.savedrequest.ServerRequestCache;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
 import org.springframework.util.Assert;
 import org.springframework.web.server.ServerWebExchange;
@@ -80,6 +81,7 @@ import java.util.Set;
  *
  * @author Rob Winch
  * @author Joe Grandja
+ * @author Parikshit Dutta
  * @since 5.1
  * @see OAuth2AuthorizationCodeAuthenticationToken
  * @see org.springframework.security.oauth2.client.authentication.OAuth2AuthorizationCodeReactiveAuthenticationManager
@@ -100,6 +102,8 @@ public class OAuth2AuthorizationCodeGrantWebFilter implements WebFilter {
 
 	private ServerAuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository =
 			new WebSessionOAuth2ServerAuthorizationRequestRepository();
+
+	private ServerRequestCache requestCache;
 
 	private ServerAuthenticationSuccessHandler authenticationSuccessHandler;
 
@@ -167,6 +171,23 @@ public class OAuth2AuthorizationCodeGrantWebFilter implements WebFilter {
 			((ServerOAuth2AuthorizationCodeAuthenticationTokenConverter) this.authenticationConverter)
 					.setAuthorizationRequestRepository(this.authorizationRequestRepository);
 		}
+	}
+
+	/**
+	 * Sets the {@link ServerRequestCache} used for loading a previously saved request (if available)
+	 * and replaying it after completing the processing of the OAuth 2.0 Authorization Response.
+	 *
+	 * @since 5.4
+	 * @param requestCache the cache used for loading a previously saved request (if available)
+	 */
+	public final void setRequestCache(ServerRequestCache requestCache) {
+		Assert.notNull(requestCache, "requestCache cannot be null");
+		this.requestCache = requestCache;
+		updateDefaultAuthenticationSuccessHandler();
+	}
+
+	private void updateDefaultAuthenticationSuccessHandler() {
+		((RedirectServerAuthenticationSuccessHandler) this.authenticationSuccessHandler).setRequestCache(this.requestCache);
 	}
 
 	@Override


### PR DESCRIPTION
- added setter to make ServerRequestCache injectable
- added respective test to validate serverRequestCache can not be set to null
- added test that asserts the supplied ServerRequestCache is actually used
- updated ServerHttpSecurity.OAuth2ClientSpec to set the configured requestCache
- updated tests in OAuth2ClientSpecTests to verify provided ServerRequestCache in OAuth2ClientSpec is used as custom configuration
- updated tests in OAuth2ClientSpecTests to verify provided ServerRequestCache in OAuth2ClientSpec is used as custom lambda configuration

closes gh-8536 [#8536]