### PR TITLE
Using SHA-256 to calculate the digital signature to be put in the cookie

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/servlet/authentication/rememberme.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/authentication/rememberme.adoc
@@ -21,7 +21,7 @@ In essence a cookie is sent to the browser upon successful interactive authentic
 [source,txt]
 ----
 base64(username + ":" + expirationTime + ":" +
-md5Hex(username + ":" + expirationTime + ":" password + ":" + key))
+sha256Hex(username + ":" + expirationTime + ":" password + ":" + key))
 
 username:          As identifiable to the UserDetailsService
 password:          That matches the one in the retrieved UserDetails

--- a/web/src/main/java/org/springframework/security/web/authentication/rememberme/TokenBasedRememberMeServices.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/rememberme/TokenBasedRememberMeServices.java
@@ -55,7 +55,7 @@ import java.util.Date;
  *
  * <pre>
  * username + &quot;:&quot; + expiryTime + &quot;:&quot;
- * 		+ Md5Hex(username + &quot;:&quot; + expiryTime + &quot;:&quot; + password + &quot;:&quot; + key)
+ * 		+ sha256Hex(username + &quot;:&quot; + expiryTime + &quot;:&quot; + password + &quot;:&quot; + key)
  * </pre>
  *
  * <p>
@@ -103,7 +103,7 @@ public class TokenBasedRememberMeServices extends AbstractRememberMeServices {
 		long tokenExpiryTime;
 
 		try {
-			tokenExpiryTime = new Long(cookieTokens[1]);
+			tokenExpiryTime = Long.parseLong(cookieTokens[1]);
 		}
 		catch (NumberFormatException nfe) {
 			throw new InvalidCookieException(
@@ -147,21 +147,21 @@ public class TokenBasedRememberMeServices extends AbstractRememberMeServices {
 	}
 
 	/**
-	 * Calculates the digital signature to be put in the cookie. Default value is MD5
+	 * Calculates the digital signature to be put in the cookie. Default value is SHA-256
 	 * ("username:tokenExpiryTime:password:key")
 	 */
 	protected String makeTokenSignature(long tokenExpiryTime, String username,
 			String password) {
 		String data = username + ":" + tokenExpiryTime + ":" + password + ":" + getKey();
-		MessageDigest digest;
+		MessageDigest md;
 		try {
-			digest = MessageDigest.getInstance("MD5");
+			md = MessageDigest.getInstance("SHA-256");
 		}
 		catch (NoSuchAlgorithmException e) {
-			throw new IllegalStateException("No MD5 algorithm available!");
+			throw new IllegalStateException("No SHA-256 algorithm available!");
 		}
 
-		return new String(Hex.encode(digest.digest(data.getBytes())));
+		return String.valueOf(Hex.encode(md.digest(data.getBytes())));
 	}
 
 	protected boolean isTokenExpired(long tokenExpiryTime) {
@@ -267,7 +267,7 @@ public class TokenBasedRememberMeServices extends AbstractRememberMeServices {
 
 	private static byte[] bytesUtf8(String s) {
 		if (s == null) {
-			return null;
+			return new byte[0];
 		}
 		return Utf8.encode(s);
 	}

--- a/web/src/test/java/org/springframework/security/web/authentication/rememberme/TokenBasedRememberMeServicesTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/rememberme/TokenBasedRememberMeServicesTests.java
@@ -92,9 +92,9 @@ public class TokenBasedRememberMeServicesTests {
 	private String generateCorrectCookieContentForToken(long expiryTime, String username,
 			String password, String key) {
 		// format is:
-		// username + ":" + expiryTime + ":" + Md5Hex(username + ":" + expiryTime + ":" +
+		// username + ":" + expiryTime + ":" + sha256Hex(username + ":" + expiryTime + ":" +
 		// password + ":" + key)
-		String signatureValue = DigestUtils.md5Hex(username + ":" + expiryTime + ":"
+		String signatureValue = DigestUtils.sha256Hex(username + ":" + expiryTime + ":"
 				+ password + ":" + key);
 		String tokenValue = username + ":" + expiryTime + ":" + signatureValue;
 


### PR DESCRIPTION
### Fix for the issue gh-8549 (Replacing `MD5` hashing for remember me token)

- Using **`SHA-256`** instead of **`MD5`** algorithm to calculate the digital signature to be put in the cookie.

- Updated the tests to use **`sha256Hex`** instead of **`md5Hex`**

- Updated the documentation to use **`sha256Hex`** instead of **`md5Hex`**

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
