### PR TITLE
Fix broken link in spring security reference document

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/servlet/integrations/websocket.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/integrations/websocket.adoc
@@ -4,7 +4,7 @@
 Spring Security 4 added support for securing https://docs.spring.io/spring/docs/current/spring-framework-reference/html/websocket.html[Spring's WebSocket support].
 This section describes how to use Spring Security's WebSocket support.
 
-NOTE: You can find a complete working sample of WebSocket security at https://github.com/spring-projects/spring-session/tree/master/samples/boot/websocket.
+NOTE: You can find a complete working sample of WebSocket security at https://github.com/spring-projects/spring-session/tree/master/spring-session-samples/spring-session-sample-boot-websocket.
 
 .Direct JSR-356 Support
 ****


### PR DESCRIPTION
Fixes: #8593

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
