### PR TITLE
Make OAuth's RestTemplate and WebClient customizable

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/reactive/ReactiveOAuth2ClientImportSelector.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/reactive/ReactiveOAuth2ClientImportSelector.java
@@ -24,9 +24,9 @@ import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClient
 import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientProviderBuilder;
 import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultReactiveOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.web.reactive.result.method.annotation.OAuth2AuthorizedClientArgumentResolver;
 import org.springframework.security.oauth2.client.web.server.AuthenticatedPrincipalServerOAuth2AuthorizedClientRepository;
-import org.springframework.security.oauth2.client.web.DefaultReactiveOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizedClientRepository;
 import org.springframework.util.ClassUtils;
 import org.springframework.web.reactive.config.WebFluxConfigurer;
@@ -63,15 +63,19 @@ final class ReactiveOAuth2ClientImportSelector implements ImportSelector {
 
 		private ReactiveOAuth2AuthorizedClientService authorizedClientService;
 
+		private ReactiveOAuth2AuthorizedClientProviderBuilder.RefreshTokenGrantBuilderCustomizer refreshTokenGrantBuilderCustomizer;
+		private ReactiveOAuth2AuthorizedClientProviderBuilder.ClientCredentialsGrantBuilderCustomizer clientCredentialsGrantBuilderCustomizer;
+		private ReactiveOAuth2AuthorizedClientProviderBuilder.PasswordGrantBuilderCustomizer passwordGrantBuilderCustomizer;
+
 		@Override
 		public void configureArgumentResolvers(ArgumentResolverConfigurer configurer) {
 			if (this.authorizedClientRepository != null && this.clientRegistrationRepository != null) {
 				ReactiveOAuth2AuthorizedClientProvider authorizedClientProvider =
 						ReactiveOAuth2AuthorizedClientProviderBuilder.builder()
 								.authorizationCode()
-								.refreshToken()
-								.clientCredentials()
-								.password()
+								.refreshToken(refreshTokenGrantBuilderCustomizer)
+								.clientCredentials(clientCredentialsGrantBuilderCustomizer)
+								.password(passwordGrantBuilderCustomizer)
 								.build();
 				DefaultReactiveOAuth2AuthorizedClientManager authorizedClientManager = new DefaultReactiveOAuth2AuthorizedClientManager(
 						this.clientRegistrationRepository, getAuthorizedClientRepository());
@@ -95,6 +99,27 @@ final class ReactiveOAuth2ClientImportSelector implements ImportSelector {
 		public void setAuthorizedClientService(List<ReactiveOAuth2AuthorizedClientService> authorizedClientService) {
 			if (authorizedClientService.size() == 1) {
 				this.authorizedClientService = authorizedClientService.get(0);
+			}
+		}
+
+		@Autowired(required = false)
+		public void setRefreshTokenGrantBuilderCustomizer(List<ReactiveOAuth2AuthorizedClientProviderBuilder.RefreshTokenGrantBuilderCustomizer> beans) {
+			if (beans.size() == 1) {
+				this.refreshTokenGrantBuilderCustomizer = beans.get(0);
+			}
+		}
+
+		@Autowired(required = false)
+		public void setClientCredentialsGrantBuilderCustomizer(List<ReactiveOAuth2AuthorizedClientProviderBuilder.ClientCredentialsGrantBuilderCustomizer> beans) {
+			if (beans.size() == 1) {
+				this.clientCredentialsGrantBuilderCustomizer = beans.get(0);
+			}
+		}
+
+		@Autowired(required = false)
+		public void setPasswordGrantBuilderCustomizer(List<ReactiveOAuth2AuthorizedClientProviderBuilder.PasswordGrantBuilderCustomizer> beans) {
+			if (beans.size() == 1) {
+				this.passwordGrantBuilderCustomizer = beans.get(0);
 			}
 		}
 

--- a/config/src/main/java/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParser.java
@@ -24,6 +24,7 @@ import org.w3c.dom.Element;
 
 import org.springframework.beans.BeanMetadataElement;
 import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanReference;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
@@ -50,6 +51,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
+import org.springframework.web.client.RestOperations;
 
 /**
  * A {@link BeanDefinitionParser} for &lt;http&gt;'s &lt;oauth2-resource-server&gt; element.
@@ -322,6 +324,7 @@ final class StaticAuthenticationManagerResolver implements
 
 final class NimbusJwtDecoderJwkSetUriFactoryBean implements FactoryBean<JwtDecoder> {
 	private final String jwkSetUri;
+	private RestOperations restOperations;
 
 	NimbusJwtDecoderJwkSetUriFactoryBean(String jwkSetUri) {
 		this.jwkSetUri = jwkSetUri;
@@ -329,12 +332,20 @@ final class NimbusJwtDecoderJwkSetUriFactoryBean implements FactoryBean<JwtDecod
 
 	@Override
 	public JwtDecoder getObject() {
-		return NimbusJwtDecoder.withJwkSetUri(this.jwkSetUri).build();
+		final NimbusJwtDecoder.JwkSetUriJwtDecoderBuilder builder = NimbusJwtDecoder.withJwkSetUri(this.jwkSetUri);
+		return restOperations == null
+				? builder.build()
+				: builder.restOperations(restOperations).build();
 	}
 
 	@Override
 	public Class<?> getObjectType() {
 		return JwtDecoder.class;
+	}
+
+	@Autowired(required = false)
+	public void setRestOperations(RestOperations restOperations) {
+		this.restOperations = restOperations;
 	}
 }
 

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerOpaqueTokenDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerOpaqueTokenDsl.kt
@@ -16,7 +16,9 @@
 
 package org.springframework.security.config.web.server
 
+import org.springframework.security.config.web.servlet.oauth2.resourceserver.OAuth2ResourceServerSecurityMarker
 import org.springframework.security.oauth2.server.resource.introspection.ReactiveOpaqueTokenIntrospector
+import org.springframework.web.reactive.function.client.WebClient
 
 /**
  * A Kotlin DSL to configure [ServerHttpSecurity] Opaque Token Resource Server support using idiomatic Kotlin code.
@@ -30,6 +32,7 @@ import org.springframework.security.oauth2.server.resource.introspection.Reactiv
 class ServerOpaqueTokenDsl {
     private var _introspectionUri: String? = null
     private var _introspector: ReactiveOpaqueTokenIntrospector? = null
+    private var _webClient: WebClient? = null
     private var clientCredentials: Pair<String, String>? = null
 
     var introspectionUri: String?
@@ -38,12 +41,19 @@ class ServerOpaqueTokenDsl {
             _introspectionUri = value
             _introspector = null
         }
+
     var introspector: ReactiveOpaqueTokenIntrospector?
         get() = _introspector
         set(value) {
             _introspector = value
             _introspectionUri = null
             clientCredentials = null
+        }
+
+    var webClient: WebClient?
+        get() = _webClient
+        set(value) {
+            _webClient = value
         }
 
     /**
@@ -59,6 +69,7 @@ class ServerOpaqueTokenDsl {
 
     internal fun get(): (ServerHttpSecurity.OAuth2ResourceServerSpec.OpaqueTokenSpec) -> Unit {
         return { opaqueToken ->
+            webClient?.also { opaqueToken.webClient(webClient) }
             introspectionUri?.also { opaqueToken.introspectionUri(introspectionUri) }
             clientCredentials?.also { opaqueToken.introspectionClientCredentials(clientCredentials!!.first, clientCredentials!!.second) }
             introspector?.also { opaqueToken.introspector(introspector) }

--- a/config/src/main/kotlin/org/springframework/security/config/web/servlet/oauth2/login/UserInfoEndpointDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/servlet/oauth2/login/UserInfoEndpointDsl.kt
@@ -23,6 +23,7 @@ import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
 import org.springframework.security.oauth2.client.registration.ClientRegistration
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserServiceRestTemplateFactory
 import org.springframework.security.oauth2.core.oidc.user.OidcUser
 import org.springframework.security.oauth2.core.user.OAuth2User
 
@@ -37,12 +38,14 @@ import org.springframework.security.oauth2.core.user.OAuth2User
  * @property oidcUserService the OpenID Connect 1.0 service used for obtaining the user attributes of the
  * End-User from the UserInfo Endpoint.
  * @property userAuthoritiesMapper the [GrantedAuthoritiesMapper] used for mapping [OAuth2User.getAuthorities]
+ * @property oAuth2UserServiceRestTemplateFactory the [OAuth2UserServiceRestTemplateFactory] used for creating RestTemplate
  */
 @OAuth2LoginSecurityMarker
 class UserInfoEndpointDsl {
     var userService: OAuth2UserService<OAuth2UserRequest, OAuth2User>? = null
     var oidcUserService: OAuth2UserService<OidcUserRequest, OidcUser>? = null
     var userAuthoritiesMapper: GrantedAuthoritiesMapper? = null
+    var oAuth2UserServiceRestTemplateFactory: OAuth2UserServiceRestTemplateFactory? = null
 
     private var customUserTypePair: Pair<Class<out OAuth2User>, String>? = null
 
@@ -62,6 +65,7 @@ class UserInfoEndpointDsl {
             userService?.also { userInfoEndpoint.userService(userService) }
             oidcUserService?.also { userInfoEndpoint.oidcUserService(oidcUserService) }
             userAuthoritiesMapper?.also { userInfoEndpoint.userAuthoritiesMapper(userAuthoritiesMapper) }
+            oAuth2UserServiceRestTemplateFactory?.also { userInfoEndpoint.restTemplateFactory(oAuth2UserServiceRestTemplateFactory) }
             customUserTypePair?.also { userInfoEndpoint.customUserType(customUserTypePair!!.first, customUserTypePair!!.second) }
         }
     }

--- a/config/src/main/kotlin/org/springframework/security/config/web/servlet/oauth2/resourceserver/JwtDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/servlet/oauth2/resourceserver/JwtDsl.kt
@@ -22,6 +22,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.web.client.RestOperations
 
 /**
  * A Kotlin DSL to configure JWT Resource Server Support using idiomatic Kotlin code.
@@ -38,6 +39,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder
 class JwtDsl {
     private var _jwtDecoder: JwtDecoder? = null
     private var _jwkSetUri: String? = null
+    private var _restOperations: RestOperations? = null
 
     var jwtAuthenticationConverter: Converter<Jwt, out AbstractAuthenticationToken>? = null
     var jwtDecoder: JwtDecoder?
@@ -53,10 +55,17 @@ class JwtDsl {
             _jwtDecoder = null
         }
 
+    var restOperations: RestOperations?
+        get() = _restOperations
+        set(value) {
+            _restOperations = value
+        }
+
     internal fun get(): (OAuth2ResourceServerConfigurer<HttpSecurity>.JwtConfigurer) -> Unit {
         return { jwt ->
             jwtAuthenticationConverter?.also { jwt.jwtAuthenticationConverter(jwtAuthenticationConverter) }
             jwtDecoder?.also { jwt.decoder(jwtDecoder) }
+            restOperations?.also { jwt.restOperations(restOperations) }
             jwkSetUri?.also { jwt.jwkSetUri(jwkSetUri) }
         }
     }

--- a/gradle/dependency-management.gradle
+++ b/gradle/dependency-management.gradle
@@ -35,7 +35,7 @@ dependencies {
 		management "com.google.appengine:appengine-testing:$gaeVersion"
 		management "com.google.appengine:appengine:$gaeVersion"
 		management "com.google.inject:guice:3.0"
-		management "com.nimbusds:nimbus-jose-jwt:latest.release"
+		management "com.nimbusds:nimbus-jose-jwt:8.17.1"
 		management "com.nimbusds:oauth2-oidc-sdk:latest.release"
 		management "com.squareup.okhttp3:mockwebserver:3.+"
 		management "com.squareup.okhttp3:okhttp:3.+"

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/OAuth2AuthorizedClientProviderBuilder.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/OAuth2AuthorizedClientProviderBuilder.java
@@ -110,20 +110,22 @@ public final class OAuth2AuthorizedClientProviderBuilder {
 	 * @return the {@link OAuth2AuthorizedClientProviderBuilder}
 	 */
 	public OAuth2AuthorizedClientProviderBuilder refreshToken() {
-		this.builders.computeIfAbsent(RefreshTokenOAuth2AuthorizedClientProvider.class, k -> new RefreshTokenGrantBuilder());
+		refreshToken(null);
 		return OAuth2AuthorizedClientProviderBuilder.this;
 	}
 
 	/**
 	 * Configures support for the {@code refresh_token} grant.
 	 *
-	 * @param builderConsumer a {@code Consumer} of {@link RefreshTokenGrantBuilder} used for further configuration
+	 * @param customizer of {@link RefreshTokenGrantBuilder} used for further configuration
 	 * @return the {@link OAuth2AuthorizedClientProviderBuilder}
 	 */
-	public OAuth2AuthorizedClientProviderBuilder refreshToken(Consumer<RefreshTokenGrantBuilder> builderConsumer) {
+	public OAuth2AuthorizedClientProviderBuilder refreshToken(RefreshTokenGrantBuilderCustomizer customizer) {
 		RefreshTokenGrantBuilder builder = (RefreshTokenGrantBuilder) this.builders.computeIfAbsent(
 				RefreshTokenOAuth2AuthorizedClientProvider.class, k -> new RefreshTokenGrantBuilder());
-		builderConsumer.accept(builder);
+		if (customizer != null) {
+			customizer.accept(builder);
+		}
 		return OAuth2AuthorizedClientProviderBuilder.this;
 	}
 
@@ -199,20 +201,22 @@ public final class OAuth2AuthorizedClientProviderBuilder {
 	 * @return the {@link OAuth2AuthorizedClientProviderBuilder}
 	 */
 	public OAuth2AuthorizedClientProviderBuilder clientCredentials() {
-		this.builders.computeIfAbsent(ClientCredentialsOAuth2AuthorizedClientProvider.class, k -> new ClientCredentialsGrantBuilder());
+		clientCredentials(null);
 		return OAuth2AuthorizedClientProviderBuilder.this;
 	}
 
 	/**
 	 * Configures support for the {@code client_credentials} grant.
 	 *
-	 * @param builderConsumer a {@code Consumer} of {@link ClientCredentialsGrantBuilder} used for further configuration
+	 * @param customizer of {@link ClientCredentialsGrantBuilder} used for further configuration
 	 * @return the {@link OAuth2AuthorizedClientProviderBuilder}
 	 */
-	public OAuth2AuthorizedClientProviderBuilder clientCredentials(Consumer<ClientCredentialsGrantBuilder> builderConsumer) {
+	public OAuth2AuthorizedClientProviderBuilder clientCredentials(ClientCredentialsGrantBuilderCustomizer customizer) {
 		ClientCredentialsGrantBuilder builder = (ClientCredentialsGrantBuilder) this.builders.computeIfAbsent(
 				ClientCredentialsOAuth2AuthorizedClientProvider.class, k -> new ClientCredentialsGrantBuilder());
-		builderConsumer.accept(builder);
+		if (customizer != null) {
+			customizer.accept(builder);
+		}
 		return OAuth2AuthorizedClientProviderBuilder.this;
 	}
 
@@ -288,20 +292,22 @@ public final class OAuth2AuthorizedClientProviderBuilder {
 	 * @return the {@link OAuth2AuthorizedClientProviderBuilder}
 	 */
 	public OAuth2AuthorizedClientProviderBuilder password() {
-		this.builders.computeIfAbsent(PasswordOAuth2AuthorizedClientProvider.class, k -> new PasswordGrantBuilder());
+		password(null);
 		return OAuth2AuthorizedClientProviderBuilder.this;
 	}
 
 	/**
 	 * Configures support for the {@code password} grant.
 	 *
-	 * @param builderConsumer a {@code Consumer} of {@link PasswordGrantBuilder} used for further configuration
+	 * @param customizer of {@link PasswordGrantBuilder} used for further configuration
 	 * @return the {@link OAuth2AuthorizedClientProviderBuilder}
 	 */
-	public OAuth2AuthorizedClientProviderBuilder password(Consumer<PasswordGrantBuilder> builderConsumer) {
+	public OAuth2AuthorizedClientProviderBuilder password(PasswordGrantBuilderCustomizer customizer) {
 		PasswordGrantBuilder builder = (PasswordGrantBuilder) this.builders.computeIfAbsent(
 				PasswordOAuth2AuthorizedClientProvider.class, k -> new PasswordGrantBuilder());
-		builderConsumer.accept(builder);
+		if (customizer != null) {
+			customizer.accept(builder);
+		}
 		return OAuth2AuthorizedClientProviderBuilder.this;
 	}
 
@@ -387,5 +393,14 @@ public final class OAuth2AuthorizedClientProviderBuilder {
 
 	interface Builder {
 		OAuth2AuthorizedClientProvider build();
+	}
+
+	public interface RefreshTokenGrantBuilderCustomizer extends Consumer<RefreshTokenGrantBuilder> {
+	}
+
+	public interface ClientCredentialsGrantBuilderCustomizer extends Consumer<ClientCredentialsGrantBuilder> {
+	}
+
+	public interface PasswordGrantBuilderCustomizer extends Consumer<PasswordGrantBuilder> {
 	}
 }

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/ReactiveOAuth2AuthorizedClientProviderBuilder.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/ReactiveOAuth2AuthorizedClientProviderBuilder.java
@@ -110,20 +110,21 @@ public final class ReactiveOAuth2AuthorizedClientProviderBuilder {
 	 * @return the {@link ReactiveOAuth2AuthorizedClientProviderBuilder}
 	 */
 	public ReactiveOAuth2AuthorizedClientProviderBuilder refreshToken() {
-		this.builders.computeIfAbsent(RefreshTokenReactiveOAuth2AuthorizedClientProvider.class, k -> new RefreshTokenGrantBuilder());
-		return ReactiveOAuth2AuthorizedClientProviderBuilder.this;
+		return refreshToken(null);
 	}
 
 	/**
 	 * Configures support for the {@code refresh_token} grant.
 	 *
-	 * @param builderConsumer a {@code Consumer} of {@link RefreshTokenGrantBuilder} used for further configuration
+	 * @param customizer of {@link RefreshTokenGrantBuilder} used for further configuration
 	 * @return the {@link ReactiveOAuth2AuthorizedClientProviderBuilder}
 	 */
-	public ReactiveOAuth2AuthorizedClientProviderBuilder refreshToken(Consumer<RefreshTokenGrantBuilder> builderConsumer) {
+	public ReactiveOAuth2AuthorizedClientProviderBuilder refreshToken(RefreshTokenGrantBuilderCustomizer customizer) {
 		RefreshTokenGrantBuilder builder = (RefreshTokenGrantBuilder) this.builders.computeIfAbsent(
 				RefreshTokenReactiveOAuth2AuthorizedClientProvider.class, k -> new RefreshTokenGrantBuilder());
-		builderConsumer.accept(builder);
+		if (customizer != null) {
+			customizer.accept(builder);
+		}
 		return ReactiveOAuth2AuthorizedClientProviderBuilder.this;
 	}
 
@@ -199,20 +200,21 @@ public final class ReactiveOAuth2AuthorizedClientProviderBuilder {
 	 * @return the {@link ReactiveOAuth2AuthorizedClientProviderBuilder}
 	 */
 	public ReactiveOAuth2AuthorizedClientProviderBuilder clientCredentials() {
-		this.builders.computeIfAbsent(ClientCredentialsReactiveOAuth2AuthorizedClientProvider.class, k -> new ClientCredentialsGrantBuilder());
-		return ReactiveOAuth2AuthorizedClientProviderBuilder.this;
+		return clientCredentials(null);
 	}
 
 	/**
 	 * Configures support for the {@code client_credentials} grant.
 	 *
-	 * @param builderConsumer a {@code Consumer} of {@link ClientCredentialsGrantBuilder} used for further configuration
+	 * @param customizer of {@link ClientCredentialsGrantBuilder} used for further configuration
 	 * @return the {@link ReactiveOAuth2AuthorizedClientProviderBuilder}
 	 */
-	public ReactiveOAuth2AuthorizedClientProviderBuilder clientCredentials(Consumer<ClientCredentialsGrantBuilder> builderConsumer) {
+	public ReactiveOAuth2AuthorizedClientProviderBuilder clientCredentials(ClientCredentialsGrantBuilderCustomizer customizer) {
 		ClientCredentialsGrantBuilder builder = (ClientCredentialsGrantBuilder) this.builders.computeIfAbsent(
 				ClientCredentialsReactiveOAuth2AuthorizedClientProvider.class, k -> new ClientCredentialsGrantBuilder());
-		builderConsumer.accept(builder);
+		if (customizer != null) {
+			customizer.accept(builder);
+		}
 		return ReactiveOAuth2AuthorizedClientProviderBuilder.this;
 	}
 
@@ -288,20 +290,21 @@ public final class ReactiveOAuth2AuthorizedClientProviderBuilder {
 	 * @return the {@link ReactiveOAuth2AuthorizedClientProviderBuilder}
 	 */
 	public ReactiveOAuth2AuthorizedClientProviderBuilder password() {
-		this.builders.computeIfAbsent(PasswordReactiveOAuth2AuthorizedClientProvider.class, k -> new PasswordGrantBuilder());
-		return ReactiveOAuth2AuthorizedClientProviderBuilder.this;
+		return password(null);
 	}
 
 	/**
 	 * Configures support for the {@code password} grant.
 	 *
-	 * @param builderConsumer a {@code Consumer} of {@link PasswordGrantBuilder} used for further configuration
+	 * @param customizer of {@link PasswordGrantBuilder} used for further configuration
 	 * @return the {@link ReactiveOAuth2AuthorizedClientProviderBuilder}
 	 */
-	public ReactiveOAuth2AuthorizedClientProviderBuilder password(Consumer<PasswordGrantBuilder> builderConsumer) {
+	public ReactiveOAuth2AuthorizedClientProviderBuilder password(PasswordGrantBuilderCustomizer customizer) {
 		PasswordGrantBuilder builder = (PasswordGrantBuilder) this.builders.computeIfAbsent(
 				PasswordReactiveOAuth2AuthorizedClientProvider.class, k -> new PasswordGrantBuilder());
-		builderConsumer.accept(builder);
+		if (customizer != null) {
+			customizer.accept(builder);
+		}
 		return ReactiveOAuth2AuthorizedClientProviderBuilder.this;
 	}
 
@@ -387,5 +390,14 @@ public final class ReactiveOAuth2AuthorizedClientProviderBuilder {
 
 	interface Builder {
 		ReactiveOAuth2AuthorizedClientProvider build();
+	}
+
+	public interface RefreshTokenGrantBuilderCustomizer extends Consumer<RefreshTokenGrantBuilder> {
+	}
+
+	public interface ClientCredentialsGrantBuilderCustomizer extends Consumer<ClientCredentialsGrantBuilder> {
+	}
+
+	public interface PasswordGrantBuilderCustomizer extends Consumer<PasswordGrantBuilder> {
 	}
 }

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractWebClientReactiveOAuth2AccessTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractWebClientReactiveOAuth2AccessTokenResponseClient.java
@@ -54,7 +54,7 @@ import static org.springframework.security.oauth2.core.web.reactive.function.OAu
 abstract class AbstractWebClientReactiveOAuth2AccessTokenResponseClient<T extends AbstractOAuth2AuthorizationGrantRequest>
 		implements ReactiveOAuth2AccessTokenResponseClient<T> {
 
-	private WebClient webClient = WebClient.builder().build();
+	private WebClient webClient = WebClient.create();
 
 	@Override
 	public Mono<OAuth2AccessTokenResponse> getTokenResponse(T grantRequest) {

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/DefaultAuthorizationCodeTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/DefaultAuthorizationCodeTokenResponseClient.java
@@ -31,9 +31,6 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestOperations;
-import org.springframework.web.client.RestTemplate;
-
-import java.util.Arrays;
 
 /**
  * The default implementation of an {@link OAuth2AccessTokenResponseClient}
@@ -57,11 +54,13 @@ public final class DefaultAuthorizationCodeTokenResponseClient implements OAuth2
 
 	private RestOperations restOperations;
 
+	public DefaultAuthorizationCodeTokenResponseClient(OAuth2RestTemplateFactory restTemplateFactory) {
+		Assert.notNull(restTemplateFactory, "restTemplateFactory cannot be null");
+		this.restOperations = restTemplateFactory.create();
+	}
+
 	public DefaultAuthorizationCodeTokenResponseClient() {
-		RestTemplate restTemplate = new RestTemplate(Arrays.asList(
-				new FormHttpMessageConverter(), new OAuth2AccessTokenResponseHttpMessageConverter()));
-		restTemplate.setErrorHandler(new OAuth2ErrorResponseErrorHandler());
-		this.restOperations = restTemplate;
+		this(OAuth2RestTemplateFactory.DEFAULT);
 	}
 
 	@Override

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/DefaultClientCredentialsTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/DefaultClientCredentialsTokenResponseClient.java
@@ -31,9 +31,6 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestOperations;
-import org.springframework.web.client.RestTemplate;
-
-import java.util.Arrays;
 
 /**
  * The default implementation of an {@link OAuth2AccessTokenResponseClient}
@@ -57,11 +54,13 @@ public final class DefaultClientCredentialsTokenResponseClient implements OAuth2
 
 	private RestOperations restOperations;
 
+	public DefaultClientCredentialsTokenResponseClient(OAuth2RestTemplateFactory restTemplateFactory) {
+		Assert.notNull(restTemplateFactory, "restTemplateFactory cannot be null");
+		this.restOperations = restTemplateFactory.create();
+	}
+
 	public DefaultClientCredentialsTokenResponseClient() {
-		RestTemplate restTemplate = new RestTemplate(Arrays.asList(
-				new FormHttpMessageConverter(), new OAuth2AccessTokenResponseHttpMessageConverter()));
-		restTemplate.setErrorHandler(new OAuth2ErrorResponseErrorHandler());
-		this.restOperations = restTemplate;
+		this(OAuth2RestTemplateFactory.DEFAULT);
 	}
 
 	@Override

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/DefaultPasswordTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/DefaultPasswordTokenResponseClient.java
@@ -31,9 +31,6 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestOperations;
-import org.springframework.web.client.RestTemplate;
-
-import java.util.Arrays;
 
 /**
  * The default implementation of an {@link OAuth2AccessTokenResponseClient}
@@ -57,11 +54,13 @@ public final class DefaultPasswordTokenResponseClient implements OAuth2AccessTok
 
 	private RestOperations restOperations;
 
+	public DefaultPasswordTokenResponseClient(OAuth2RestTemplateFactory restTemplateFactory) {
+		Assert.notNull(restTemplateFactory, "restTemplateFactory cannot be null");
+		this.restOperations = restTemplateFactory.create();
+	}
+
 	public DefaultPasswordTokenResponseClient() {
-		RestTemplate restTemplate = new RestTemplate(Arrays.asList(
-				new FormHttpMessageConverter(), new OAuth2AccessTokenResponseHttpMessageConverter()));
-		restTemplate.setErrorHandler(new OAuth2ErrorResponseErrorHandler());
-		this.restOperations = restTemplate;
+		this(OAuth2RestTemplateFactory.DEFAULT);
 	}
 
 	@Override

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/DefaultRefreshTokenTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/DefaultRefreshTokenTokenResponseClient.java
@@ -31,9 +31,6 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestOperations;
-import org.springframework.web.client.RestTemplate;
-
-import java.util.Arrays;
 
 /**
  * The default implementation of an {@link OAuth2AccessTokenResponseClient}
@@ -56,11 +53,13 @@ public final class DefaultRefreshTokenTokenResponseClient implements OAuth2Acces
 
 	private RestOperations restOperations;
 
+	public DefaultRefreshTokenTokenResponseClient(OAuth2RestTemplateFactory restTemplateFactory) {
+		Assert.notNull(restTemplateFactory, "restTemplateFactory cannot be null");
+		this.restOperations = restTemplateFactory.create();
+	}
+
 	public DefaultRefreshTokenTokenResponseClient() {
-		RestTemplate restTemplate = new RestTemplate(Arrays.asList(
-				new FormHttpMessageConverter(), new OAuth2AccessTokenResponseHttpMessageConverter()));
-		restTemplate.setErrorHandler(new OAuth2ErrorResponseErrorHandler());
-		this.restOperations = restTemplate;
+		this(OAuth2RestTemplateFactory.DEFAULT);
 	}
 
 	@Override

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2RestTemplateFactory.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2RestTemplateFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.client.endpoint;
+
+import org.springframework.http.converter.FormHttpMessageConverter;
+import org.springframework.security.oauth2.client.http.OAuth2ErrorResponseErrorHandler;
+import org.springframework.security.oauth2.core.http.converter.OAuth2AccessTokenResponseHttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+
+/**
+ * Factory for creating {@link RestTemplate} used by various OAuth2 classes.
+ *
+ * @since 5.3
+ */
+public class OAuth2RestTemplateFactory {
+	public static final OAuth2RestTemplateFactory DEFAULT = new OAuth2RestTemplateFactory();
+
+	private final Customizer customizer;
+
+	public OAuth2RestTemplateFactory() {
+		this(null);
+	}
+
+	public OAuth2RestTemplateFactory(Customizer customizer) {
+		this.customizer = customizer;
+	}
+
+	/**
+	 * Create OAuth2 {@link RestTemplate}
+	 */
+	public RestTemplate create() {
+		RestTemplate restTemplate = new RestTemplate(Arrays.asList(
+				new FormHttpMessageConverter(),
+				new OAuth2AccessTokenResponseHttpMessageConverter()));
+		restTemplate.setErrorHandler(new OAuth2ErrorResponseErrorHandler());
+		if (customizer != null) {
+			customizer.customize(restTemplate);
+		}
+		return restTemplate;
+
+	}
+
+	/**
+	 * Callback interface that can be used to customize a {@link RestTemplate}.
+	 *
+	 * @since 5.3
+	 */
+	@FunctionalInterface
+	interface Customizer {
+		/**
+		 * Callback to customize a {@link RestTemplate} instance.
+		 *
+		 * @param restTemplate the template to customize
+		 */
+		void customize(RestTemplate restTemplate);
+	}
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/authentication/ReactiveOidcIdTokenDecoderFactory.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/authentication/ReactiveOidcIdTokenDecoderFactory.java
@@ -46,6 +46,7 @@ import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoderFactory;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import static org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder.withJwkSetUri;
 import static org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder.withSecretKey;
@@ -79,6 +80,7 @@ public final class ReactiveOidcIdTokenDecoderFactory implements ReactiveJwtDecod
 	private Function<ClientRegistration, JwsAlgorithm> jwsAlgorithmResolver = clientRegistration -> SignatureAlgorithm.RS256;
 	private Function<ClientRegistration, Converter<Map<String, Object>, Map<String, Object>>> claimTypeConverterFactory =
 			clientRegistration -> DEFAULT_CLAIM_TYPE_CONVERTER;
+	private WebClient webClient;
 
 	/**
 	 * Returns the default {@link Converter}'s used for type conversion of claim values for an {@link OidcIdToken}.
@@ -153,7 +155,12 @@ public final class ReactiveOidcIdTokenDecoderFactory implements ReactiveJwtDecod
 				);
 				throw new OAuth2AuthenticationException(oauth2Error, oauth2Error.toString());
 			}
-			return withJwkSetUri(jwkSetUri).jwsAlgorithm((SignatureAlgorithm) jwsAlgorithm).build();
+			final NimbusReactiveJwtDecoder.JwkSetUriReactiveJwtDecoderBuilder builder = withJwkSetUri(jwkSetUri)
+					.jwsAlgorithm((SignatureAlgorithm) jwsAlgorithm);
+			if (webClient != null) {
+				builder.webClient(webClient);
+			}
+			return builder.build();
 		} else if (jwsAlgorithm != null && MacAlgorithm.class.isAssignableFrom(jwsAlgorithm.getClass())) {
 			// https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
 			//
@@ -225,5 +232,9 @@ public final class ReactiveOidcIdTokenDecoderFactory implements ReactiveJwtDecod
 	public void setClaimTypeConverterFactory(Function<ClientRegistration, Converter<Map<String, Object>, Map<String, Object>>> claimTypeConverterFactory) {
 		Assert.notNull(claimTypeConverterFactory, "claimTypeConverterFactory cannot be null");
 		this.claimTypeConverterFactory = claimTypeConverterFactory;
+	}
+
+	public void setWebClient(WebClient webClient) {
+		this.webClient = webClient;
 	}
 }

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcUserService.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcUserService.java
@@ -30,8 +30,10 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserServiceRestTemplateFactory;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserServiceRestTemplateFactory;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -66,7 +68,7 @@ public class OidcUserService implements OAuth2UserService<OidcUserRequest, OidcU
 			new ClaimTypeConverter(createDefaultClaimTypeConverters());
 	private Set<String> accessibleScopes = new HashSet<>(Arrays.asList(
 			OidcScopes.PROFILE, OidcScopes.EMAIL, OidcScopes.ADDRESS, OidcScopes.PHONE));
-	private OAuth2UserService<OAuth2UserRequest, OAuth2User> oauth2UserService = new DefaultOAuth2UserService();
+	private OAuth2UserService<OAuth2UserRequest, OAuth2User> oauth2UserService;
 	private Function<ClientRegistration, Converter<Map<String, Object>, Map<String, Object>>> claimTypeConverterFactory =
 			clientRegistration -> DEFAULT_CLAIM_TYPE_CONVERTER;
 
@@ -90,6 +92,15 @@ public class OidcUserService implements OAuth2UserService<OidcUserRequest, OidcU
 	private static Converter<Object, ?> getConverter(TypeDescriptor targetDescriptor) {
 		final TypeDescriptor sourceDescriptor = TypeDescriptor.valueOf(Object.class);
 		return source -> ClaimConversionService.getSharedInstance().convert(source, sourceDescriptor, targetDescriptor);
+	}
+
+	public OidcUserService() {
+		this(DefaultOAuth2UserServiceRestTemplateFactory.DEFAULT);
+	}
+
+	public OidcUserService(OAuth2UserServiceRestTemplateFactory restTemplateFactory) {
+		Assert.notNull(restTemplateFactory, "restTemplateFactory cannot be null");
+		this.oauth2UserService = new DefaultOAuth2UserService(restTemplateFactory);
 	}
 
 	@Override

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/userinfo/CustomUserTypesOAuth2UserService.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/userinfo/CustomUserTypesOAuth2UserService.java
@@ -27,7 +27,6 @@ import org.springframework.util.Assert;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestOperations;
-import org.springframework.web.client.RestTemplate;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -62,11 +61,21 @@ public class CustomUserTypesOAuth2UserService implements OAuth2UserService<OAuth
 	 * @param customUserTypes a {@code Map} of {@link OAuth2User} type(s) keyed by {@link ClientRegistration#getRegistrationId() Registration Id}
 	 */
 	public CustomUserTypesOAuth2UserService(Map<String, Class<? extends OAuth2User>> customUserTypes) {
+		this(customUserTypes, DefaultOAuth2UserServiceRestTemplateFactory.DEFAULT);
+	}
+
+	/**
+	 * Variant of {@link #CustomUserTypesOAuth2UserService(Map)} with customizable {@link OAuth2UserServiceRestTemplateFactory}.
+	 *
+	 * @param restTemplateFactory for creating {@link org.springframework.web.client.RestTemplate}
+	 * @since 5.3
+	 */
+	public CustomUserTypesOAuth2UserService(Map<String, Class<? extends OAuth2User>> customUserTypes,
+			OAuth2UserServiceRestTemplateFactory restTemplateFactory) {
 		Assert.notEmpty(customUserTypes, "customUserTypes cannot be empty");
+		Assert.notNull(restTemplateFactory, "restTemplateFactory cannot be null");
 		this.customUserTypes = Collections.unmodifiableMap(new LinkedHashMap<>(customUserTypes));
-		RestTemplate restTemplate = new RestTemplate();
-		restTemplate.setErrorHandler(new OAuth2ErrorResponseErrorHandler());
-		this.restOperations = restTemplate;
+		this.restOperations = restTemplateFactory.create();
 	}
 
 	@Override

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/userinfo/DefaultOAuth2UserService.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/userinfo/DefaultOAuth2UserService.java
@@ -39,7 +39,6 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestOperations;
-import org.springframework.web.client.RestTemplate;
 
 /**
  * An implementation of an {@link OAuth2UserService} that supports standard OAuth 2.0 Provider's.
@@ -73,9 +72,12 @@ public class DefaultOAuth2UserService implements OAuth2UserService<OAuth2UserReq
 	private RestOperations restOperations;
 
 	public DefaultOAuth2UserService() {
-		RestTemplate restTemplate = new RestTemplate();
-		restTemplate.setErrorHandler(new OAuth2ErrorResponseErrorHandler());
-		this.restOperations = restTemplate;
+		this(DefaultOAuth2UserServiceRestTemplateFactory.DEFAULT);
+	}
+
+	public DefaultOAuth2UserService(OAuth2UserServiceRestTemplateFactory restTemplateFactory) {
+		Assert.notNull(restTemplateFactory, "restTemplateFactory cannot be null");
+		this.restOperations = restTemplateFactory.create();
 	}
 
 	@Override

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/userinfo/DefaultOAuth2UserServiceRestTemplateFactory.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/userinfo/DefaultOAuth2UserServiceRestTemplateFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.client.userinfo;
+
+import org.springframework.security.oauth2.client.http.OAuth2ErrorResponseErrorHandler;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Preconfigured and customizable {@link OAuth2UserServiceRestTemplateFactory}
+ */
+public class DefaultOAuth2UserServiceRestTemplateFactory implements OAuth2UserServiceRestTemplateFactory {
+	public static final DefaultOAuth2UserServiceRestTemplateFactory DEFAULT = new DefaultOAuth2UserServiceRestTemplateFactory();
+
+	private final Customizer customizer;
+
+	public DefaultOAuth2UserServiceRestTemplateFactory() {
+		this(null);
+	}
+
+	public DefaultOAuth2UserServiceRestTemplateFactory(Customizer customizer) {
+		this.customizer = customizer;
+	}
+
+	@Override
+	public RestTemplate create() {
+		RestTemplate restTemplate = new RestTemplate();
+		restTemplate.setErrorHandler(new OAuth2ErrorResponseErrorHandler());
+		if (customizer != null) {
+			customizer.customize(restTemplate);
+		}
+		return restTemplate;
+	}
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/userinfo/OAuth2UserServiceRestTemplateFactory.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/userinfo/OAuth2UserServiceRestTemplateFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.client.userinfo;
+
+import org.springframework.web.client.RestTemplate;
+
+public interface OAuth2UserServiceRestTemplateFactory {
+	RestTemplate create();
+
+	interface Customizer {
+		void customize(RestTemplate restTemplate);
+	}
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServletOAuth2AuthorizedClientExchangeFilterFunction.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServletOAuth2AuthorizedClientExchangeFilterFunction.java
@@ -209,6 +209,15 @@ public final class ServletOAuth2AuthorizedClientExchangeFilterFunction implement
 	public ServletOAuth2AuthorizedClientExchangeFilterFunction(
 			ClientRegistrationRepository clientRegistrationRepository,
 			OAuth2AuthorizedClientRepository authorizedClientRepository) {
+		this(clientRegistrationRepository, authorizedClientRepository, null, null, null);
+	}
+
+	public ServletOAuth2AuthorizedClientExchangeFilterFunction(
+			ClientRegistrationRepository clientRegistrationRepository,
+			OAuth2AuthorizedClientRepository authorizedClientRepository,
+			OAuth2AuthorizedClientProviderBuilder.RefreshTokenGrantBuilderCustomizer refreshTokenGrantBuilderCustomizer,
+			OAuth2AuthorizedClientProviderBuilder.ClientCredentialsGrantBuilderCustomizer clientCredentialsGrantBuilderCustomizer,
+			OAuth2AuthorizedClientProviderBuilder.PasswordGrantBuilderCustomizer passwordGrantBuilderCustomizer) {
 
 		OAuth2AuthorizationFailureHandler authorizationFailureHandler =
 				new RemoveAuthorizedClientOAuth2AuthorizationFailureHandler(
@@ -218,7 +227,11 @@ public final class ServletOAuth2AuthorizedClientExchangeFilterFunction implement
 										(HttpServletResponse) attributes.get(HttpServletResponse.class.getName())));
 		DefaultOAuth2AuthorizedClientManager defaultAuthorizedClientManager =
 				new DefaultOAuth2AuthorizedClientManager(
-						clientRegistrationRepository, authorizedClientRepository);
+						clientRegistrationRepository,
+						authorizedClientRepository,
+						refreshTokenGrantBuilderCustomizer,
+						clientCredentialsGrantBuilderCustomizer,
+						passwordGrantBuilderCustomizer);
 		defaultAuthorizedClientManager.setAuthorizationFailureHandler(authorizationFailureHandler);
 		this.authorizedClientManager = defaultAuthorizedClientManager;
 		this.defaultAuthorizedClientManager = true;
@@ -296,6 +309,7 @@ public final class ServletOAuth2AuthorizedClientExchangeFilterFunction implement
 	 * {@link RequestContextHolder}. It also provides defaults for the {@link Authentication} using
 	 * {@link SecurityContextHolder}. It also can default the {@link OAuth2AuthorizedClient} using the
 	 * {@link #clientRegistrationId(String)} or the {@link #authentication(Authentication)}.
+	 *
 	 * @return the {@link Consumer} to populate the attributes
 	 */
 	public Consumer<WebClient.RequestHeadersSpec<?>> defaultRequest() {

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/reactive/result/method/annotation/OAuth2AuthorizedClientArgumentResolver.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/reactive/result/method/annotation/OAuth2AuthorizedClientArgumentResolver.java
@@ -26,6 +26,7 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientProviderBuilder;
 import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
@@ -81,12 +82,34 @@ public final class OAuth2AuthorizedClientArgumentResolver implements HandlerMeth
 	 * @param clientRegistrationRepository the repository of client registrations
 	 * @param authorizedClientRepository the repository of authorized clients
 	 */
-	public OAuth2AuthorizedClientArgumentResolver(ReactiveClientRegistrationRepository clientRegistrationRepository,
-													ServerOAuth2AuthorizedClientRepository authorizedClientRepository) {
+	public OAuth2AuthorizedClientArgumentResolver(
+			ReactiveClientRegistrationRepository clientRegistrationRepository,
+			ServerOAuth2AuthorizedClientRepository authorizedClientRepository) {
+		this(clientRegistrationRepository, authorizedClientRepository, null, null, null);
+	}
+
+	/**
+	 * Variant of {@link #OAuth2AuthorizedClientArgumentResolver(ReactiveClientRegistrationRepository, ServerOAuth2AuthorizedClientRepository)}
+	 * with {@literal refresh-token}, {@literal client-credentials}, and {@literal password} grant builder customizers.
+	 *
+	 * @param refreshTokenGrantBuilderCustomizer
+	 * @param clientCredentialsGrantBuilderCustomizer
+	 * @param passwordGrantBuilderCustomizer
+	 */
+	public OAuth2AuthorizedClientArgumentResolver(
+			ReactiveClientRegistrationRepository clientRegistrationRepository,
+			ServerOAuth2AuthorizedClientRepository authorizedClientRepository,
+			ReactiveOAuth2AuthorizedClientProviderBuilder.RefreshTokenGrantBuilderCustomizer refreshTokenGrantBuilderCustomizer,
+			ReactiveOAuth2AuthorizedClientProviderBuilder.ClientCredentialsGrantBuilderCustomizer clientCredentialsGrantBuilderCustomizer,
+			ReactiveOAuth2AuthorizedClientProviderBuilder.PasswordGrantBuilderCustomizer passwordGrantBuilderCustomizer) {
 		Assert.notNull(clientRegistrationRepository, "clientRegistrationRepository cannot be null");
 		Assert.notNull(authorizedClientRepository, "authorizedClientRepository cannot be null");
 		this.authorizedClientManager = new DefaultReactiveOAuth2AuthorizedClientManager(
-				clientRegistrationRepository, authorizedClientRepository);
+				clientRegistrationRepository,
+				authorizedClientRepository,
+				refreshTokenGrantBuilderCustomizer,
+				clientCredentialsGrantBuilderCustomizer,
+				passwordGrantBuilderCustomizer);
 	}
 
 	@Override

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoderProviderConfigurationUtils.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoderProviderConfigurationUtils.java
@@ -19,6 +19,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -39,17 +40,23 @@ import java.util.Map;
 class JwtDecoderProviderConfigurationUtils {
 	private static final String OIDC_METADATA_PATH = "/.well-known/openid-configuration";
 	private static final String OAUTH_METADATA_PATH = "/.well-known/oauth-authorization-server";
-	private static final RestTemplate rest = new RestTemplate();
+	private static final RestTemplate DEFAULT_REST = new RestTemplate();
 	private static final ParameterizedTypeReference<Map<String, Object>> typeReference =
 			new ParameterizedTypeReference<Map<String, Object>>() {};
 
-	static Map<String, Object> getConfigurationForOidcIssuerLocation(String oidcIssuerLocation) {
-		return getConfiguration(oidcIssuerLocation, oidc(URI.create(oidcIssuerLocation)));
+	static Map<String, Object> getConfigurationForOidcIssuerLocation(String oidcIssuerLocation,
+			RestOperations restOperations) {
+		return getConfiguration(oidcIssuerLocation, restOperations == null ? DEFAULT_REST : restOperations,
+				oidc(URI.create(oidcIssuerLocation)));
 	}
 
-	static Map<String, Object> getConfigurationForIssuerLocation(String issuer) {
+	static Map<String, Object> getConfigurationForIssuerLocation(String issuer,
+			RestOperations restOperations) {
 		URI uri = URI.create(issuer);
-		return getConfiguration(issuer, oidc(uri), oidcRfc8414(uri), oauth(uri));
+		return getConfiguration(issuer, restOperations == null ? DEFAULT_REST : restOperations,
+				oidc(uri),
+				oidcRfc8414(uri),
+				oauth(uri));
 	}
 
 	static void validateIssuer(Map<String, Object> configuration, String issuer) {
@@ -63,13 +70,13 @@ class JwtDecoderProviderConfigurationUtils {
 		}
 	}
 
-	private static Map<String, Object> getConfiguration(String issuer, URI... uris) {
+	private static Map<String, Object> getConfiguration(String issuer, RestOperations restOperations, URI... uris) {
 		String errorMessage = "Unable to resolve the Configuration with the provided Issuer of " +
 				"\"" + issuer + "\"";
 		for (URI uri : uris) {
 			try {
 				RequestEntity<Void> request = RequestEntity.get(uri).build();
-				ResponseEntity<Map<String, Object>> response = rest.exchange(request, typeReference);
+				ResponseEntity<Map<String, Object>> response = restOperations.exchange(request, typeReference);
 				Map<String, Object> configuration = response.getBody();
 
 				if (configuration.get("jwks_uri") == null) {

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoder.java
@@ -216,9 +216,10 @@ public final class NimbusJwtDecoder implements JwtDecoder {
 	 * <a target="_blank" href="https://tools.ietf.org/html/rfc7517#section-5">JWK Set</a> uri.
 	 */
 	public static final class JwkSetUriJwtDecoderBuilder {
+		private static final RestTemplate DEFAULT_REST = new RestTemplate();
 		private String jwkSetUri;
 		private Set<SignatureAlgorithm> signatureAlgorithms = new HashSet<>();
-		private RestOperations restOperations = new RestTemplate();
+		private RestOperations restOperations = DEFAULT_REST;
 		private Cache cache;
 
 		private JwkSetUriJwtDecoderBuilder(String jwkSetUri) {

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
@@ -243,9 +243,10 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 	 * @since 5.2
 	 */
 	public static final class JwkSetUriReactiveJwtDecoderBuilder {
+		private static final WebClient DEFAULT_WEBCLIENT = WebClient.create();
 		private final String jwkSetUri;
 		private Set<SignatureAlgorithm> signatureAlgorithms = new HashSet<>();
-		private WebClient webClient = WebClient.create();
+		private WebClient webClient = DEFAULT_WEBCLIENT;
 
 		private JwkSetUriReactiveJwtDecoderBuilder(String jwkSetUri) {
 			Assert.hasText(jwkSetUri, "jwkSetUri cannot be empty");

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
@@ -37,6 +37,7 @@ import org.springframework.security.oauth2.server.resource.InvalidBearerTokenExc
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
 import org.springframework.util.Assert;
+import org.springframework.web.client.RestOperations;
 
 /**
  * An implementation of {@link AuthenticationManagerResolver} that resolves a JWT-based {@link AuthenticationManager}
@@ -63,7 +64,16 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 	 * @param trustedIssuers a whitelist of trusted issuers
 	 */
 	public JwtIssuerAuthenticationManagerResolver(String... trustedIssuers) {
-		this(Arrays.asList(trustedIssuers));
+		this(null, trustedIssuers);
+	}
+
+	/**
+	 * Variant of {@link #JwtIssuerAuthenticationManagerResolver(String...)} with customizable {@link RestOperations}.
+	 *
+	 * @since 5.3
+	 */
+	public JwtIssuerAuthenticationManagerResolver(RestOperations restOperations, String... trustedIssuers) {
+		this(Arrays.asList(trustedIssuers), restOperations);
 	}
 
 	/**
@@ -72,10 +82,19 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 	 * @param trustedIssuers a whitelist of trusted issuers
 	 */
 	public JwtIssuerAuthenticationManagerResolver(Collection<String> trustedIssuers) {
+		this(trustedIssuers, null);
+	}
+
+	/**
+	 * Variant of {@link #JwtIssuerAuthenticationManagerResolver(Collection)} with customizable {@link RestOperations}.
+	 *
+	 * @since 5.3
+	 */
+	public JwtIssuerAuthenticationManagerResolver(Collection<String> trustedIssuers, RestOperations restOperations) {
 		Assert.notEmpty(trustedIssuers, "trustedIssuers cannot be empty");
 		this.issuerAuthenticationManagerResolver =
 				new TrustedIssuerJwtAuthenticationManagerResolver
-						(Collections.unmodifiableCollection(trustedIssuers)::contains);
+						(Collections.unmodifiableCollection(trustedIssuers)::contains, restOperations);
 	}
 
 	/**
@@ -143,16 +162,18 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 
 		private final Map<String, AuthenticationManager> authenticationManagers = new ConcurrentHashMap<>();
 		private final Predicate<String> trustedIssuer;
+		private final RestOperations restOperations;
 
-		TrustedIssuerJwtAuthenticationManagerResolver(Predicate<String> trustedIssuer) {
+		TrustedIssuerJwtAuthenticationManagerResolver(Predicate<String> trustedIssuer, RestOperations restOperations) {
 			this.trustedIssuer = trustedIssuer;
+			this.restOperations = restOperations;
 		}
 
 		@Override
 		public AuthenticationManager resolve(String issuer) {
 			if (this.trustedIssuer.test(issuer)) {
 				return this.authenticationManagers.computeIfAbsent(issuer, k -> {
-					JwtDecoder jwtDecoder = JwtDecoders.fromIssuerLocation(issuer);
+					JwtDecoder jwtDecoder = JwtDecoders.fromIssuerLocation(issuer, restOperations);
 					return new JwtAuthenticationProvider(jwtDecoder)::authenticate;
 				});
 			}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/DefaultOpaqueTokenIntrospectorRestTemplateFactory.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/DefaultOpaqueTokenIntrospectorRestTemplateFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.resource.introspection;
+
+import org.springframework.http.client.support.BasicAuthenticationInterceptor;
+import org.springframework.util.Assert;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Preconfigured and customizable {@link OpaqueTokenIntrospectorRestTemplateFactory}
+ */
+public class DefaultOpaqueTokenIntrospectorRestTemplateFactory implements OpaqueTokenIntrospectorRestTemplateFactory {
+	public static final OpaqueTokenIntrospectorRestTemplateFactory DEFAULT = new DefaultOpaqueTokenIntrospectorRestTemplateFactory();
+
+	private final Customizer customizer;
+
+	public DefaultOpaqueTokenIntrospectorRestTemplateFactory() {
+		this(null);
+	}
+
+	public DefaultOpaqueTokenIntrospectorRestTemplateFactory(Customizer customizer) {
+		this.customizer = customizer;
+	}
+
+	@Override
+	public RestTemplate create(String clientId, String clientSecret) {
+		Assert.notNull(clientId, "clientId cannot be null");
+		Assert.notNull(clientSecret, "clientSecret cannot be null");
+
+		RestTemplate restTemplate = new RestTemplate();
+		restTemplate.getInterceptors().add(new BasicAuthenticationInterceptor(clientId, clientSecret));
+		if (customizer != null) {
+			customizer.customize(restTemplate);
+		}
+		return restTemplate;
+	}
+}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/OpaqueTokenIntrospectorRestTemplateFactory.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/OpaqueTokenIntrospectorRestTemplateFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.server.resource.introspection;
+
+import org.springframework.web.client.RestTemplate;
+
+public interface OpaqueTokenIntrospectorRestTemplateFactory {
+	RestTemplate create(String clientId, String clientSecret);
+
+	interface Customizer {
+		void customize(RestTemplate restTemplate);
+	}
+}


### PR DESCRIPTION
Hi, 
I have created PR which makes `RestTemplate` and `WebClient` used through OAuth2 module customizable (currently there are private instances created). It kind of solves https://github.com/spring-projects/spring-security/issues/7027 .
Basically I found all spots where http-clients were created and made that API customizable. Please review the path I have chosen, if it is ok. I am open for any modification.
Next steps (WIP) on my side are javadoc and tests.
Thx,
Ivos