### PR TITLE
StrictHttpFirewall: Validate headers and parameters

### DIFF
--- a/web/src/main/java/org/springframework/security/web/FilterInvocation.java
+++ b/web/src/main/java/org/springframework/security/web/FilterInvocation.java
@@ -23,6 +23,10 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletRequest;
@@ -31,6 +35,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.web.util.UrlUtils;
 
 /**
@@ -161,6 +166,8 @@ class DummyRequest extends HttpServletRequestWrapper {
 	private String pathInfo;
 	private String queryString;
 	private String method;
+	private final HttpHeaders headers = new HttpHeaders();
+	private final Map<String, String[]> parameters = new LinkedHashMap<>();
 
 	DummyRequest() {
 		super(UNSUPPORTED_REQUEST);
@@ -231,6 +238,61 @@ class DummyRequest extends HttpServletRequestWrapper {
 	@Override
 	public String getServerName() {
 		return null;
+	}
+
+	@Override
+	public String getHeader(String name) {
+		return this.headers.getFirst(name);
+	}
+
+	@Override
+	public Enumeration<String> getHeaders(String name) {
+		return Collections.enumeration(this.headers.get(name));
+	}
+
+	@Override
+	public Enumeration<String> getHeaderNames() {
+		return Collections.enumeration(this.headers.keySet());
+	}
+
+	@Override
+	public int getIntHeader(String name) {
+		String value = this.headers.getFirst(name);
+		if (value == null ) {
+			return -1;
+		}
+		else {
+			return Integer.parseInt(value);
+		}
+	}
+
+	public void addHeader(String name, String value) {
+		this.headers.add(name, value);
+	}
+
+	@Override
+	public String getParameter(String name) {
+		String[] arr = this.parameters.get(name);
+		return (arr != null && arr.length > 0 ? arr[0] : null);
+	}
+
+	@Override
+	public Map<String, String[]> getParameterMap() {
+		return Collections.unmodifiableMap(this.parameters);
+	}
+
+	@Override
+	public Enumeration<String> getParameterNames() {
+		return Collections.enumeration(this.parameters.keySet());
+	}
+
+	@Override
+	public String[] getParameterValues(String name) {
+		return this.parameters.get(name);
+	}
+
+	public void setParameter(String name, String... values) {
+		this.parameters.put(name, values);
 	}
 }
 

--- a/web/src/test/java/org/springframework/security/web/firewall/StrictHttpFirewallTests.java
+++ b/web/src/test/java/org/springframework/security/web/firewall/StrictHttpFirewallTests.java
@@ -23,6 +23,8 @@ import static org.assertj.core.api.Assertions.fail;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.junit.Test;
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -594,5 +596,146 @@ public class StrictHttpFirewallTests {
 		this.firewall.setAllowedHostnames(hostname -> hostname.equals("myexample.org"));
 
 		this.firewall.getFirewalledRequest(this.request);
+	}
+
+	@Test(expected = RequestRejectedException.class)
+	public void getFirewalledRequestGetHeaderWhenNotAllowedHeaderNameThenException() {
+		this.firewall.setAllowedHeaderNames(name -> !name.equals("bad name"));
+
+		HttpServletRequest request = this.firewall.getFirewalledRequest(this.request);
+		request.getHeader("bad name");
+	}
+
+	@Test(expected = RequestRejectedException.class)
+	public void getFirewalledRequestGetHeaderWhenNotAllowedHeaderValueThenException() {
+		this.request.addHeader("good name", "bad value");
+		this.firewall.setAllowedHeaderValues(value -> !value.equals("bad value"));
+
+		HttpServletRequest request = this.firewall.getFirewalledRequest(this.request);
+		request.getHeader("good name");
+	}
+
+	@Test(expected = RequestRejectedException.class)
+	public void getFirewalledRequestGetDateHeaderWhenControlCharacterInHeaderNameThenException() {
+		this.request.addHeader("Bad\0Name", "some value");
+
+		HttpServletRequest request = this.firewall.getFirewalledRequest(this.request);
+		request.getDateHeader("Bad\0Name");
+	}
+
+	@Test(expected = RequestRejectedException.class)
+	public void getFirewalledRequestGetIntHeaderWhenControlCharacterInHeaderNameThenException() {
+		this.request.addHeader("Bad\0Name", "some value");
+
+		HttpServletRequest request = this.firewall.getFirewalledRequest(this.request);
+		request.getIntHeader("Bad\0Name");
+	}
+
+	@Test(expected = RequestRejectedException.class)
+	public void getFirewalledRequestGetHeaderWhenControlCharacterInHeaderNameThenException() {
+		this.request.addHeader("Bad\0Name", "some value");
+
+		HttpServletRequest request = this.firewall.getFirewalledRequest(this.request);
+		request.getHeader("Bad\0Name");
+	}
+
+	@Test(expected = RequestRejectedException.class)
+	public void getFirewalledRequestGetHeaderWhenUndefinedCharacterInHeaderNameThenException() {
+		this.request.addHeader("Bad\uFFFEName", "some value");
+
+		HttpServletRequest request = this.firewall.getFirewalledRequest(this.request);
+		request.getHeader("Bad\uFFFEName");
+	}
+
+	@Test(expected = RequestRejectedException.class)
+	public void getFirewalledRequestGetHeadersWhenControlCharacterInHeaderNameThenException() {
+		this.request.addHeader("Bad\0Name", "some value");
+
+		HttpServletRequest request = this.firewall.getFirewalledRequest(this.request);
+		request.getHeaders("Bad\0Name");
+	}
+
+	@Test(expected = RequestRejectedException.class)
+	public void getFirewalledRequestGetHeaderNamesWhenControlCharacterInHeaderNameThenException() {
+		this.request.addHeader("Bad\0Name", "some value");
+
+		HttpServletRequest request = this.firewall.getFirewalledRequest(this.request);
+		request.getHeaderNames().nextElement();
+	}
+
+	@Test(expected = RequestRejectedException.class)
+	public void getFirewalledRequestGetHeaderWhenControlCharacterInHeaderValueThenException() {
+		this.request.addHeader("Something", "bad\0value");
+
+		HttpServletRequest request = this.firewall.getFirewalledRequest(this.request);
+		request.getHeader("Something");
+	}
+
+	@Test(expected = RequestRejectedException.class)
+	public void getFirewalledRequestGetHeaderWhenUndefinedCharacterInHeaderValueThenException() {
+		this.request.addHeader("Something", "bad\uFFFEvalue");
+
+		HttpServletRequest request = this.firewall.getFirewalledRequest(this.request);
+		request.getHeader("Something");
+	}
+
+	@Test(expected = RequestRejectedException.class)
+	public void getFirewalledRequestGetHeadersWhenControlCharacterInHeaderValueThenException() {
+		this.request.addHeader("Something", "bad\0value");
+
+		HttpServletRequest request = this.firewall.getFirewalledRequest(this.request);
+		request.getHeaders("Something").nextElement();
+	}
+
+	@Test(expected = RequestRejectedException.class)
+	public void getFirewalledRequestGetParameterWhenControlCharacterInParameterNameThenException() {
+		this.request.addParameter("Bad\0Name", "some value");
+
+		HttpServletRequest request = this.firewall.getFirewalledRequest(this.request);
+		request.getParameter("Bad\0Name");
+	}
+
+	@Test(expected = RequestRejectedException.class)
+	public void getFirewalledRequestGetParameterMapWhenControlCharacterInParameterNameThenException() {
+		this.request.addParameter("Bad\0Name", "some value");
+
+		HttpServletRequest request = this.firewall.getFirewalledRequest(this.request);
+		request.getParameterMap();
+	}
+
+	@Test(expected = RequestRejectedException.class)
+	public void getFirewalledRequestGetParameterNamesWhenControlCharacterInParameterNameThenException() {
+		this.request.addParameter("Bad\0Name", "some value");
+
+		HttpServletRequest request = this.firewall.getFirewalledRequest(this.request);
+		request.getParameterNames().nextElement();
+	}
+
+	@Test(expected = RequestRejectedException.class)
+	public void getFirewalledRequestGetParameterNamesWhenUndefinedCharacterInParameterNameThenException() {
+		this.request.addParameter("Bad\uFFFEName", "some value");
+
+		HttpServletRequest request = this.firewall.getFirewalledRequest(this.request);
+		request.getParameterNames().nextElement();
+	}
+
+	@Test(expected = RequestRejectedException.class)
+	public void getFirewalledRequestGetParameterValuesWhenNotAllowedInParameterValueThenException() {
+		this.firewall.setAllowedParameterValues(value -> !value.equals("bad value"));
+
+		this.request.addParameter("Something", "bad value");
+
+		HttpServletRequest request = this.firewall.getFirewalledRequest(this.request);
+		request.getParameterValues("Something");
+	}
+
+	@Test(expected = RequestRejectedException.class)
+	public void getFirewalledRequestGetParameterValuesWhenNotAllowedInParameterNameThenException() {
+		this.firewall.setAllowedParameterNames(value -> !value.equals("bad name"));
+
+		this.request.addParameter("bad name", "good value");
+
+		HttpServletRequest request = this.firewall.getFirewalledRequest(this.request);
+		request.getParameterValues("bad name");
 	}
 }


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
Improvements to StrictHttpFirewall:
* Headers names values should never contain [ISO control characters](https://docs.oracle.com/javase/8/docs/api/java/lang/Character.html#isISOControl-int-) such as NUL, CR, and LF.
* Similarly, parameter names should never contain ISO control characters either. Parameter values can (imagine a multiline text input - that can and should submit CR/LF in its value)