### PR TITLE
Getting response attributes from Saml2AuthenticatedPrincipal

### DIFF
--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/Saml2AuthenticatedPrincipal.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/Saml2AuthenticatedPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,13 @@
 
 package org.springframework.security.saml2.provider.service.authentication;
 
+import org.springframework.lang.Nullable;
 import org.springframework.security.core.AuthenticatedPrincipal;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Saml2 representation of an {@link AuthenticatedPrincipal}.
@@ -25,4 +31,40 @@ import org.springframework.security.core.AuthenticatedPrincipal;
  * @since 5.2.2
  */
 public interface Saml2AuthenticatedPrincipal extends AuthenticatedPrincipal {
+	/**
+	 * Get the first value of Saml2 token attribute by name
+	 *
+	 * @param name the name of the attribute
+	 * @param <A> the type of the attribute
+	 * @return the first attribute value or {@code null} otherwise
+	 * @since 5.4
+	 */
+	@Nullable
+	default <A> A getFirstAttribute(String name) {
+		List<A> values = getAttribute(name);
+		return CollectionUtils.firstElement(values);
+	}
+
+	/**
+	 * Get the Saml2 token attribute by name
+	 *
+	 * @param name the name of the attribute
+	 * @param <A> the type of the attribute
+	 * @return the attribute or {@code null} otherwise
+	 * @since 5.4
+	 */
+	@Nullable
+	default <A> List<A> getAttribute(String name) {
+		return (List<A>) getAttributes().get(name);
+	}
+
+	/**
+	 * Get the Saml2 token attributes
+	 *
+	 * @return the Saml2 token attributes
+	 * @since 5.4
+	 */
+	default Map<String, List<Object>> getAttributes() {
+		return Collections.emptyMap();
+	}
 }

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/SimpleSaml2AuthenticatedPrincipal.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/SimpleSaml2AuthenticatedPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package org.springframework.security.saml2.provider.service.authentication;
 
 import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Default implementation of a {@link Saml2AuthenticatedPrincipal}.
@@ -27,13 +29,20 @@ import java.io.Serializable;
 class SimpleSaml2AuthenticatedPrincipal implements Saml2AuthenticatedPrincipal, Serializable {
 
 	private final String name;
+	private final Map<String, List<Object>> attributes;
 
-	SimpleSaml2AuthenticatedPrincipal(String name) {
+	SimpleSaml2AuthenticatedPrincipal(String name, Map<String, List<Object>> attributes) {
 		this.name = name;
+		this.attributes = attributes;
 	}
 
 	@Override
 	public String getName() {
 		return this.name;
+	}
+
+	@Override
+	public Map<String, List<Object>> getAttributes() {
+		return this.attributes;
 	}
 }

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/SimpleSaml2AuthenticatedPrincipalTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/SimpleSaml2AuthenticatedPrincipalTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,58 @@
 
 package org.springframework.security.saml2.provider.service.authentication;
 
-import org.junit.Assert;
+import org.joda.time.DateTime;
 import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SimpleSaml2AuthenticatedPrincipalTests {
 
 	@Test
 	public void createSimpleSaml2AuthenticatedPrincipal() {
-		SimpleSaml2AuthenticatedPrincipal principal = new SimpleSaml2AuthenticatedPrincipal("user");
+		Map<String, List<Object>> attributes = new LinkedHashMap<>();
+		attributes.put("email", Arrays.asList("john.doe@example.com", "doe.john@example.com"));
+		SimpleSaml2AuthenticatedPrincipal principal = new SimpleSaml2AuthenticatedPrincipal("user", attributes);
+		assertThat(principal.getName()).isEqualTo("user");
+		assertThat(principal.getAttributes()).isEqualTo(attributes);
+	}
 
-		Assert.assertEquals("user", principal.getName());
+	@Test
+	public void getFirstAttributeWhenStringValueThenReturnsValue() {
+		Map<String, List<Object>> attributes = new LinkedHashMap<>();
+		attributes.put("email", Arrays.asList("john.doe@example.com", "doe.john@example.com"));
+		SimpleSaml2AuthenticatedPrincipal principal = new SimpleSaml2AuthenticatedPrincipal("user", attributes);
+		assertThat(principal.<String>getFirstAttribute("email")).isEqualTo(attributes.get("email").get(0));
+	}
+
+	@Test
+	public void getAttributeWhenStringValuesThenReturnsValues() {
+		Map<String, List<Object>> attributes = new LinkedHashMap<>();
+		attributes.put("email", Arrays.asList("john.doe@example.com", "doe.john@example.com"));
+		SimpleSaml2AuthenticatedPrincipal principal = new SimpleSaml2AuthenticatedPrincipal("user", attributes);
+		assertThat(principal.<String>getAttribute("email")).isEqualTo(attributes.get("email"));
+	}
+
+	@Test
+	public void getAttributeWhenDistinctValuesThenReturnsValues() {
+		final Boolean registered = true;
+		final Instant registeredDate = Instant.ofEpochMilli(DateTime.parse("1970-01-01T00:00:00Z").getMillis());
+
+		Map<String, List<Object>> attributes = new LinkedHashMap<>();
+		attributes.put("registration", Arrays.asList(registered, registeredDate));
+
+		SimpleSaml2AuthenticatedPrincipal principal = new SimpleSaml2AuthenticatedPrincipal("user", attributes);
+
+		List<Object> registrationInfo = principal.getAttribute("registration");
+
+		assertThat(registrationInfo).isNotNull();
+		assertThat((Boolean) registrationInfo.get(0)).isEqualTo(registered);
+		assertThat((Instant) registrationInfo.get(1)).isEqualTo(registeredDate);
 	}
 }

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/TestOpenSamlObjects.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/TestOpenSamlObjects.java
@@ -19,6 +19,8 @@ package org.springframework.security.saml2.provider.service.authentication;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.UUID;
+import java.util.List;
+import java.util.ArrayList;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -26,9 +28,26 @@ import org.apache.xml.security.encryption.XMLCipherParameters;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.opensaml.core.xml.io.MarshallingException;
+
+import org.opensaml.core.xml.schema.XSAny;
+import org.opensaml.core.xml.schema.XSBoolean;
+import org.opensaml.core.xml.schema.XSBooleanValue;
+import org.opensaml.core.xml.schema.XSDateTime;
+import org.opensaml.core.xml.schema.XSInteger;
+import org.opensaml.core.xml.schema.XSString;
+import org.opensaml.core.xml.schema.XSURI;
+import org.opensaml.core.xml.schema.impl.XSAnyBuilder;
+import org.opensaml.core.xml.schema.impl.XSBooleanBuilder;
+import org.opensaml.core.xml.schema.impl.XSDateTimeBuilder;
+import org.opensaml.core.xml.schema.impl.XSIntegerBuilder;
+import org.opensaml.core.xml.schema.impl.XSStringBuilder;
+import org.opensaml.core.xml.schema.impl.XSURIBuilder;
 import org.opensaml.saml.common.SAMLVersion;
 import org.opensaml.saml.common.SignableSAMLObject;
 import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import org.opensaml.saml.saml2.core.AttributeValue;
 import org.opensaml.saml.saml2.core.Conditions;
 import org.opensaml.saml.saml2.core.EncryptedAssertion;
 import org.opensaml.saml.saml2.core.EncryptedID;
@@ -38,6 +57,8 @@ import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.core.Subject;
 import org.opensaml.saml.saml2.core.SubjectConfirmation;
 import org.opensaml.saml.saml2.core.SubjectConfirmationData;
+import org.opensaml.saml.saml2.core.impl.AttributeBuilder;
+import org.opensaml.saml.saml2.core.impl.AttributeStatementBuilder;
 import org.opensaml.saml.saml2.encryption.Encrypter;
 import org.opensaml.security.SecurityException;
 import org.opensaml.security.credential.BasicCredential;
@@ -221,5 +242,67 @@ final class TestOpenSamlObjects {
 		encrypter.setKeyPlacement(keyPlacement);
 
 		return encrypter;
+	}
+
+	static List<AttributeStatement> attributeStatements() {
+		List<AttributeStatement> attributeStatements = new ArrayList<>();
+
+		AttributeStatementBuilder attributeStatementBuilder = new AttributeStatementBuilder();
+		AttributeBuilder attributeBuilder = new AttributeBuilder();
+
+		AttributeStatement attrStmt1 = attributeStatementBuilder.buildObject();
+
+		Attribute emailAttr = attributeBuilder.buildObject();
+		emailAttr.setName("email");
+		XSAny email1 = new XSAnyBuilder().buildObject(AttributeValue.DEFAULT_ELEMENT_NAME);
+		email1.setTextContent("john.doe@example.com");
+		emailAttr.getAttributeValues().add(email1);
+		XSAny email2 = new XSAnyBuilder().buildObject(AttributeValue.DEFAULT_ELEMENT_NAME);
+		email2.setTextContent("doe.john@example.com");
+		emailAttr.getAttributeValues().add(email2);
+		attrStmt1.getAttributes().add(emailAttr);
+
+		Attribute nameAttr = attributeBuilder.buildObject();
+		nameAttr.setName("name");
+		XSString name = new XSStringBuilder().buildObject(AttributeValue.DEFAULT_ELEMENT_NAME, XSString.TYPE_NAME);
+		name.setValue("John Doe");
+		nameAttr.getAttributeValues().add(name);
+		attrStmt1.getAttributes().add(nameAttr);
+
+		Attribute ageAttr = attributeBuilder.buildObject();
+		ageAttr.setName("age");
+		XSInteger age = new XSIntegerBuilder().buildObject(AttributeValue.DEFAULT_ELEMENT_NAME, XSInteger.TYPE_NAME);
+		age.setValue(21);
+		ageAttr.getAttributeValues().add(age);
+		attrStmt1.getAttributes().add(ageAttr);
+
+		attributeStatements.add(attrStmt1);
+
+		AttributeStatement attrStmt2 = attributeStatementBuilder.buildObject();
+
+		Attribute websiteAttr = attributeBuilder.buildObject();
+		websiteAttr.setName("website");
+		XSURI uri = new XSURIBuilder().buildObject(AttributeValue.DEFAULT_ELEMENT_NAME, XSURI.TYPE_NAME);
+		uri.setValue("https://johndoe.com/");
+		websiteAttr.getAttributeValues().add(uri);
+		attrStmt2.getAttributes().add(websiteAttr);
+
+		Attribute registeredAttr = attributeBuilder.buildObject();
+		registeredAttr.setName("registered");
+		XSBoolean registered = new XSBooleanBuilder().buildObject(AttributeValue.DEFAULT_ELEMENT_NAME, XSBoolean.TYPE_NAME);
+		registered.setValue(new XSBooleanValue(true, false));
+		registeredAttr.getAttributeValues().add(registered);
+		attrStmt2.getAttributes().add(registeredAttr);
+
+		Attribute registeredDateAttr = attributeBuilder.buildObject();
+		registeredDateAttr.setName("registeredDate");
+		XSDateTime registeredDate = new XSDateTimeBuilder().buildObject(AttributeValue.DEFAULT_ELEMENT_NAME, XSDateTime.TYPE_NAME);
+		registeredDate.setValue(DateTime.parse("1970-01-01T00:00:00Z"));
+		registeredDateAttr.getAttributeValues().add(registeredDate);
+		attrStmt2.getAttributes().add(registeredDateAttr);
+
+		attributeStatements.add(attrStmt2);
+
+		return attributeStatements;
 	}
 }


### PR DESCRIPTION
It's not possible to read attribute values from SAML response after successful login because `Saml2AuthenticatedPrincipal` doesn't have `getAttributes()` method like `OAuth2AuthenticatedPrincipal` does. I've added the `getAttributes()` method to the interface. The map is being populated in `OpenSamlAuthenticationProvider`.

With this patch, I won't have to parse SAML response the second time by myself if I want to read some attribute value.

fixes gh-8661