### PR TITLE
Set up Github Actions pipeline for PRs

### DIFF
--- a/.github/workflows/pr-build-workflow.yml
+++ b/.github/workflows/pr-build-workflow.yml
@@ -1,0 +1,25 @@
+name: PR Build
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: '8'
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+      - name: Build with Gradle
+        run: ./gradlew clean build --continue


### PR DESCRIPTION
## Context

We want to migrate our build pipelines to Github Actions for consistency and ease of use.

##  Solution
Created Github Actions build pipeline for PR requests. This is includes setting up the appropriate JDK, caching Gradle dependencies, and running a Gradle clean build. I've confirmed that the pipeline runs correctly against my forked version of spring-security.