### PR TITLE
JwtDecoders and ReactiveJwtDecoders with customizable RestTemplate and WebClient

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
@@ -49,6 +49,7 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
+import org.springframework.web.client.RestOperations;
 
 import static org.springframework.security.oauth2.jwt.NimbusJwtDecoder.withJwkSetUri;
 
@@ -283,6 +284,8 @@ public final class OAuth2ResourceServerConfigurer<H extends HttpSecurityBuilder<
 
 		private Converter<Jwt, ? extends AbstractAuthenticationToken> jwtAuthenticationConverter;
 
+		private RestOperations restOperations;
+
 		JwtConfigurer(ApplicationContext context) {
 			this.context = context;
 		}
@@ -299,7 +302,15 @@ public final class OAuth2ResourceServerConfigurer<H extends HttpSecurityBuilder<
 		}
 
 		public JwtConfigurer jwkSetUri(String uri) {
-			this.decoder = withJwkSetUri(uri).build();
+			final NimbusJwtDecoder.JwkSetUriJwtDecoderBuilder builder = withJwkSetUri(uri);
+			this.decoder = restOperations == null
+					? builder.build()
+					: builder.restOperations(restOperations).build();
+			return this;
+		}
+
+		public JwtConfigurer restOperations(RestOperations restOperations) {
+			this.restOperations = restOperations;
 			return this;
 		}
 

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerJwtDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerJwtDsl.kt
@@ -22,6 +22,7 @@ import org.springframework.security.authentication.ReactiveAuthenticationManager
 import org.springframework.security.core.Authentication
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder
+import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
 import java.security.interfaces.RSAPublicKey
 
@@ -44,6 +45,7 @@ class ServerJwtDsl {
     private var _jwtDecoder: ReactiveJwtDecoder? = null
     private var _publicKey: RSAPublicKey? = null
     private var _jwkSetUri: String? = null
+    private var _webClient: WebClient? = null
 
     var authenticationManager: ReactiveAuthenticationManager? = null
     var jwtAuthenticationConverter: Converter<Jwt, out Mono<out AbstractAuthenticationToken>>? = null
@@ -69,14 +71,20 @@ class ServerJwtDsl {
             _jwtDecoder = null
             _publicKey = null
         }
+    var webClient: WebClient?
+        get() = _webClient
+        set(value) {
+            _webClient = value
+        }
 
     internal fun get(): (ServerHttpSecurity.OAuth2ResourceServerSpec.JwtSpec) -> Unit {
         return { jwt ->
             authenticationManager?.also { jwt.authenticationManager(authenticationManager) }
             jwtAuthenticationConverter?.also { jwt.jwtAuthenticationConverter(jwtAuthenticationConverter) }
-            jwtDecoder?.also { jwt.jwtDecoder(jwtDecoder) }
             publicKey?.also { jwt.publicKey(publicKey) }
+            webClient?.also { jwt.webClient(webClient) }
             jwkSetUri?.also { jwt.jwkSetUri(jwkSetUri) }
+            jwtDecoder?.also { jwt.jwtDecoder(jwtDecoder) }
         }
     }
 }

--- a/config/src/main/kotlin/org/springframework/security/config/web/servlet/oauth2/resourceserver/JwtDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/servlet/oauth2/resourceserver/JwtDsl.kt
@@ -22,6 +22,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.web.client.RestOperations
 
 /**
  * A Kotlin DSL to configure JWT Resource Server Support using idiomatic Kotlin code.
@@ -38,6 +39,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder
 class JwtDsl {
     private var _jwtDecoder: JwtDecoder? = null
     private var _jwkSetUri: String? = null
+    private var _restOperations: RestOperations? = null
 
     var jwtAuthenticationConverter: Converter<Jwt, out AbstractAuthenticationToken>? = null
     var jwtDecoder: JwtDecoder?
@@ -53,10 +55,17 @@ class JwtDsl {
             _jwtDecoder = null
         }
 
+    var restOperations: RestOperations?
+        get() = _restOperations
+        set(value) {
+            _restOperations = value
+        }
+
     internal fun get(): (OAuth2ResourceServerConfigurer<HttpSecurity>.JwtConfigurer) -> Unit {
         return { jwt ->
             jwtAuthenticationConverter?.also { jwt.jwtAuthenticationConverter(jwtAuthenticationConverter) }
             jwtDecoder?.also { jwt.decoder(jwtDecoder) }
+            restOperations?.also { jwt.restOperations(restOperations) }
             jwkSetUri?.also { jwt.jwkSetUri(jwkSetUri) }
         }
     }

--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.4.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.4.xsd
@@ -124,7 +124,7 @@
       </xs:annotation>
       <xs:complexType/>
    </xs:element>
-  
+
   <xs:attributeGroup name="password-encoder.attlist">
       <xs:attribute name="ref" type="xs:token">
          <xs:annotation>
@@ -408,7 +408,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="ldap-ap.attlist">
       <xs:attribute name="server-ref" type="xs:token">
          <xs:annotation>
@@ -488,7 +488,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="password-compare.attlist">
       <xs:attribute name="password-attribute" type="xs:token">
          <xs:annotation>
@@ -541,7 +541,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="protect.attlist">
       <xs:attribute name="method" use="required" type="xs:token">
          <xs:annotation>
@@ -785,13 +785,13 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
   <xs:attributeGroup name="protect-pointcut.attlist">
       <xs:attribute name="expression" use="required" type="xs:string">
          <xs:annotation>
@@ -1240,7 +1240,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="access-denied-handler.attlist">
       <xs:attribute name="ref" type="xs:token">
          <xs:annotation>
@@ -1265,7 +1265,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="intercept-url.attlist">
       <xs:attribute name="pattern" type="xs:token">
          <xs:annotation>
@@ -1322,7 +1322,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="logout.attlist">
       <xs:attribute name="logout-url" type="xs:token">
          <xs:annotation>
@@ -1369,7 +1369,7 @@
          <xs:attributeGroup ref="security:ref"/>
       </xs:complexType>
    </xs:element>
-  
+
   <xs:attributeGroup name="form-login.attlist">
       <xs:attribute name="login-processing-url" type="xs:token">
          <xs:annotation>
@@ -1834,6 +1834,12 @@
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="rest-operations-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to a RestOperations bean
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
       <xs:attribute name="decoder-ref" type="xs:token">
          <xs:annotation>
             <xs:documentation>Reference to a JwtDecoder
@@ -1882,7 +1888,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:element name="attribute-exchange">
       <xs:annotation>
          <xs:documentation>Sets up an attribute exchange configuration to request specified attributes from the
@@ -2085,7 +2091,7 @@
          </xs:simpleType>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="http-basic.attlist">
       <xs:attribute name="entry-point-ref" type="xs:token">
          <xs:annotation>
@@ -2101,7 +2107,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="session-management.attlist">
       <xs:attribute name="session-fixation-protection">
          <xs:annotation>
@@ -2157,7 +2163,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="concurrency-control.attlist">
       <xs:attribute name="max-sessions" type="xs:integer">
          <xs:annotation>
@@ -2204,7 +2210,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="remember-me.attlist">
       <xs:attribute name="key" type="xs:token">
          <xs:annotation>
@@ -2302,7 +2308,7 @@
   <xs:attributeGroup name="remember-me-data-source-ref">
       <xs:attributeGroup ref="security:data-source-ref"/>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="anonymous.attlist">
       <xs:attribute name="key" type="xs:token">
          <xs:annotation>
@@ -2335,8 +2341,8 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
-  
+
+
   <xs:attributeGroup name="http-port">
       <xs:attribute name="http" use="required" type="xs:token">
          <xs:annotation>
@@ -2353,7 +2359,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="x509.attlist">
       <xs:attribute name="subject-principal-regex" type="xs:token">
          <xs:annotation>
@@ -2490,7 +2496,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="ap.attlist">
       <xs:attribute name="ref" type="xs:token">
          <xs:annotation>
@@ -2542,7 +2548,7 @@
          </xs:annotation>
       </xs:attribute>
   </xs:attributeGroup>
-  
+
   <xs:attributeGroup name="user.attlist">
       <xs:attribute name="name" use="required" type="xs:token">
          <xs:annotation>

--- a/config/src/test/java/org/springframework/security/config/util/AlwaysRethrowAuthenticationEntryPoint.java
+++ b/config/src/test/java/org/springframework/security/config/util/AlwaysRethrowAuthenticationEntryPoint.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2009-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.config.util;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class AlwaysRethrowAuthenticationEntryPoint implements AuthenticationEntryPoint {
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) {
+		throw authException;
+	}
+}

--- a/config/src/test/resources/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParserTests-JwkSetUriRestOperations.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParserTests-JwkSetUriRestOperations.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2002-2020 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<b:beans xmlns:b="http://www.springframework.org/schema/beans"
+		 xmlns:c="http://www.springframework.org/schema/context"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xmlns="http://www.springframework.org/schema/security"
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
+
+	<c:property-placeholder local-override="true"/>
+
+	<b:bean name="restOperations" class="org.mockito.Mockito" factory-method="mock">
+		<b:constructor-arg value="org.springframework.web.client.RestOperations"/>
+	</b:bean>
+
+	<b:bean name="alwaysRethrowAuthenticationEntryPoint" class="org.springframework.security.config.util.AlwaysRethrowAuthenticationEntryPoint"/>
+
+	<http>
+		<intercept-url pattern="/**" access="authenticated"/>
+		<oauth2-resource-server entry-point-ref="alwaysRethrowAuthenticationEntryPoint">
+			<jwt jwk-set-uri="${jwk-set-uri:https://idp.example.org}" rest-operations-ref="restOperations"/>
+		</oauth2-resource-server>
+	</http>
+
+	<b:import resource="userservice.xml"/>
+</b:beans>

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/appendix/namespace.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/appendix/namespace.adoc
@@ -1187,6 +1187,10 @@ Reference to a `JwtDecoder`. This is a larger component that overrides `jwk-set-
 * **jwk-set-uri**
 The JWK Set Uri used to load signing verification keys from an OAuth 2.0 Authorization Server
 
+[[nsa-jwt-rest-operations-ref]]
+* **rest-operations-ref**
+The reference to bean of RestOperations used to load JWK Set from Uri from an OAuth 2.0 Authorization Server
+
 [[nsa-opaque-token]]
 ==== <opaque-token>
 Represents an OAuth 2.0 Resource Server that will authorize opaque tokens

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/authentication/ReactiveOidcIdTokenDecoderFactory.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/authentication/ReactiveOidcIdTokenDecoderFactory.java
@@ -46,6 +46,7 @@ import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoderFactory;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import static org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder.withJwkSetUri;
 import static org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder.withSecretKey;
@@ -79,6 +80,7 @@ public final class ReactiveOidcIdTokenDecoderFactory implements ReactiveJwtDecod
 	private Function<ClientRegistration, JwsAlgorithm> jwsAlgorithmResolver = clientRegistration -> SignatureAlgorithm.RS256;
 	private Function<ClientRegistration, Converter<Map<String, Object>, Map<String, Object>>> claimTypeConverterFactory =
 			clientRegistration -> DEFAULT_CLAIM_TYPE_CONVERTER;
+	private WebClient webClient;
 
 	/**
 	 * Returns the default {@link Converter}'s used for type conversion of claim values for an {@link OidcIdToken}.
@@ -153,7 +155,12 @@ public final class ReactiveOidcIdTokenDecoderFactory implements ReactiveJwtDecod
 				);
 				throw new OAuth2AuthenticationException(oauth2Error, oauth2Error.toString());
 			}
-			return withJwkSetUri(jwkSetUri).jwsAlgorithm((SignatureAlgorithm) jwsAlgorithm).build();
+			final NimbusReactiveJwtDecoder.JwkSetUriReactiveJwtDecoderBuilder builder = withJwkSetUri(jwkSetUri)
+					.jwsAlgorithm((SignatureAlgorithm) jwsAlgorithm);
+			if (webClient != null) {
+				builder.webClient(webClient);
+			}
+			return builder.build();
 		} else if (jwsAlgorithm != null && MacAlgorithm.class.isAssignableFrom(jwsAlgorithm.getClass())) {
 			// https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
 			//
@@ -225,5 +232,9 @@ public final class ReactiveOidcIdTokenDecoderFactory implements ReactiveJwtDecod
 	public void setClaimTypeConverterFactory(Function<ClientRegistration, Converter<Map<String, Object>, Map<String, Object>>> claimTypeConverterFactory) {
 		Assert.notNull(claimTypeConverterFactory, "claimTypeConverterFactory cannot be null");
 		this.claimTypeConverterFactory = claimTypeConverterFactory;
+	}
+
+	public void setWebClient(WebClient webClient) {
+		this.webClient = webClient;
 	}
 }

--- a/oauth2/oauth2-jose/spring-security-oauth2-jose.gradle
+++ b/oauth2/oauth2-jose/spring-security-oauth2-jose.gradle
@@ -13,4 +13,5 @@ dependencies {
 	testCompile 'com.squareup.okhttp3:mockwebserver'
 	testCompile 'io.projectreactor.netty:reactor-netty'
 	testCompile 'com.fasterxml.jackson.core:jackson-databind'
+	testCompile 'com.nimbusds:oauth2-oidc-sdk'
 }

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoders.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoders.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.util.Assert;
+import org.springframework.web.client.RestOperations;
 
 import static org.springframework.security.oauth2.jwt.NimbusJwtDecoder.withJwkSetUri;
 
@@ -46,9 +47,25 @@ public final class JwtDecoders {
 	 * @return a {@link JwtDecoder} that was initialized by the OpenID Provider Configuration.
 	 */
 	public static JwtDecoder fromOidcIssuerLocation(String oidcIssuerLocation) {
+		return fromOidcIssuerLocation(oidcIssuerLocation, null);
+	}
+
+	/**
+	 * Creates a {@link JwtDecoder} using the provided
+	 * <a href="https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a> by making an
+	 * <a href="https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest">OpenID Provider
+	 * Configuration Request</a> and using the values in the
+	 * <a href="https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse">OpenID
+	 * Provider Configuration Response</a> to initialize the {@link JwtDecoder}.
+	 *
+	 * @param oidcIssuerLocation the <a href="https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a>
+	 * @param restOperations used as http-client (if not specified default http-client is used)
+	 * @return a {@link JwtDecoder} that was initialized by the OpenID Provider Configuration.
+	 */
+	public static JwtDecoder fromOidcIssuerLocation(String oidcIssuerLocation, RestOperations restOperations) {
 		Assert.hasText(oidcIssuerLocation, "oidcIssuerLocation cannot be empty");
-		Map<String, Object> configuration = JwtDecoderProviderConfigurationUtils.getConfigurationForOidcIssuerLocation(oidcIssuerLocation);
-		return withProviderConfiguration(configuration, oidcIssuerLocation);
+		Map<String, Object> configuration = JwtDecoderProviderConfigurationUtils.getConfigurationForOidcIssuerLocation(oidcIssuerLocation, restOperations);
+		return withProviderConfiguration(configuration, oidcIssuerLocation, restOperations);
 	}
 
 	/**
@@ -84,9 +101,46 @@ public final class JwtDecoders {
 	 * @return a {@link JwtDecoder} that was initialized by one of the described endpoints
 	 */
 	public static JwtDecoder fromIssuerLocation(String issuer) {
+		return fromIssuerLocation(issuer, null);
+	}
+
+	/**
+	 * Creates a {@link JwtDecoder} using the provided
+	 * <a href="https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a> by querying
+	 * three different discovery endpoints serially, using the values in the first successful response to
+	 * initialize. If an endpoint returns anything other than a 200 or a 4xx, the method will exit without
+	 * attempting subsequent endpoints.
+	 *
+	 * The three endpoints are computed as follows, given that the {@code issuer} is composed of a {@code host}
+	 * and a {@code path}:
+	 *
+	 * <ol>
+	 * 	<li>
+	 * 	   {@code host/.well-known/openid-configuration/path}, as defined in
+	 * 	   <a href="https://tools.ietf.org/html/rfc8414#section-5">RFC 8414's Compatibility Notes</a>.
+	 *  </li>
+	 *  <li>
+	 *      {@code issuer/.well-known/openid-configuration}, as defined in
+	 *  	<a href="https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest">
+	 * 	    OpenID Provider Configuration</a>.
+	 *  </li>
+	 *  <li>
+	 *      {@code host/.well-known/oauth-authorization-server/path}, as defined in
+	 *  	<a href="https://tools.ietf.org/html/rfc8414#section-3.1">Authorization Server Metadata Request</a>.
+	 *  </li>
+	 * </ol>
+	 *
+	 * Note that the second endpoint is the equivalent of calling
+	 * {@link JwtDecoders#fromOidcIssuerLocation(String)}
+	 *
+	 * @param issuer the <a href="https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a>
+	 * @param restOperations used as http-client (if not specified default http-client is used)
+	 * @return a {@link JwtDecoder} that was initialized by one of the described endpoints
+	 */
+	public static JwtDecoder fromIssuerLocation(String issuer, RestOperations restOperations) {
 		Assert.hasText(issuer, "issuer cannot be empty");
-		Map<String, Object> configuration = JwtDecoderProviderConfigurationUtils.getConfigurationForIssuerLocation(issuer);
-		return withProviderConfiguration(configuration, issuer);
+		Map<String, Object> configuration = JwtDecoderProviderConfigurationUtils.getConfigurationForIssuerLocation(issuer, restOperations);
+		return withProviderConfiguration(configuration, issuer, restOperations);
 	}
 
 	/**
@@ -97,12 +151,20 @@ public final class JwtDecoders {
 	 *
 	 * @param configuration the configuration values
 	 * @param issuer the <a href="https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a>
+	 * @param restOperations used as http-client (if not specified default http-client is used)
 	 * @return {@link JwtDecoder}
 	 */
-	private static JwtDecoder withProviderConfiguration(Map<String, Object> configuration, String issuer) {
+	private static JwtDecoder withProviderConfiguration(
+			Map<String, Object> configuration,
+			String issuer,
+			RestOperations restOperations) {
 		JwtDecoderProviderConfigurationUtils.validateIssuer(configuration, issuer);
 		OAuth2TokenValidator<Jwt> jwtValidator = JwtValidators.createDefaultWithIssuer(issuer);
-		NimbusJwtDecoder jwtDecoder = withJwkSetUri(configuration.get("jwks_uri").toString()).build();
+		final NimbusJwtDecoder.JwkSetUriJwtDecoderBuilder builder = withJwkSetUri(configuration.get("jwks_uri").toString());
+		if (restOperations != null) {
+			builder.restOperations(restOperations);
+		}
+		NimbusJwtDecoder jwtDecoder = builder.build();
 		jwtDecoder.setJwtValidator(jwtValidator);
 
 		return jwtDecoder;

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoder.java
@@ -215,9 +215,10 @@ public final class NimbusJwtDecoder implements JwtDecoder {
 	 * <a target="_blank" href="https://tools.ietf.org/html/rfc7517#section-5">JWK Set</a> uri.
 	 */
 	public static final class JwkSetUriJwtDecoderBuilder {
-		private String jwkSetUri;
-		private Set<SignatureAlgorithm> signatureAlgorithms = new HashSet<>();
-		private RestOperations restOperations = new RestTemplate();
+		private static final RestTemplate DEFAULT_REST = new RestTemplate();
+		private final String jwkSetUri;
+		private final Set<SignatureAlgorithm> signatureAlgorithms = new HashSet<>();
+		private RestOperations restOperations = DEFAULT_REST;
 		private Cache cache;
 
 		private JwkSetUriJwtDecoderBuilder(String jwkSetUri) {

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
@@ -87,6 +87,9 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 	 *
 	 * @param jwkSetUrl the JSON Web Key (JWK) Set {@code URL}
 	 */
+	public NimbusReactiveJwtDecoder(String jwkSetUrl, WebClient webClient) {
+		this(withJwkSetUri(jwkSetUrl).webClient(webClient).processor());
+	}
 	public NimbusReactiveJwtDecoder(String jwkSetUrl) {
 		this(withJwkSetUri(jwkSetUrl).processor());
 	}
@@ -242,9 +245,10 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 	 * @since 5.2
 	 */
 	public static final class JwkSetUriReactiveJwtDecoderBuilder {
+		private static final WebClient DEFAULT_WEBCLIENT = WebClient.create();
 		private final String jwkSetUri;
 		private Set<SignatureAlgorithm> signatureAlgorithms = new HashSet<>();
-		private WebClient webClient = WebClient.create();
+		private WebClient webClient = DEFAULT_WEBCLIENT;
 
 		private JwkSetUriReactiveJwtDecoderBuilder(String jwkSetUri) {
 			Assert.hasText(jwkSetUri, "jwkSetUri cannot be empty");

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/ReactiveJwtDecoders.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/ReactiveJwtDecoders.java
@@ -19,6 +19,8 @@ import java.util.Map;
 
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.util.Assert;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import static org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder.withJwkSetUri;
 
@@ -45,9 +47,28 @@ public final class ReactiveJwtDecoders {
 	 * @return a {@link ReactiveJwtDecoder} that was initialized by the OpenID Provider Configuration.
 	 */
 	public static ReactiveJwtDecoder fromOidcIssuerLocation(String oidcIssuerLocation) {
+		return fromOidcIssuerLocation(oidcIssuerLocation, null, null);
+	}
+
+	/**
+	 * Creates a {@link ReactiveJwtDecoder} using the provided
+	 * <a href="https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a> by making an
+	 * <a href="https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest">OpenID Provider
+	 * Configuration Request</a> and using the values in the
+	 * <a href="https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse">OpenID
+	 * Provider Configuration Response</a> to initialize the {@link ReactiveJwtDecoder}.
+	 *
+	 * @param oidcIssuerLocation the <a href="https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a>
+	 * @param webClient used as http-client (if not specified default http-client is used) for reactive operations
+	 * @param restOperations used as http-client (if not specified default http-client is used)
+	 * @return a {@link ReactiveJwtDecoder} that was initialized by the OpenID Provider Configuration.
+	 */
+	public static ReactiveJwtDecoder fromOidcIssuerLocation(String oidcIssuerLocation,
+			RestOperations restOperations,
+			WebClient webClient) {
 		Assert.hasText(oidcIssuerLocation, "oidcIssuerLocation cannot be empty");
-		Map<String, Object> configuration = JwtDecoderProviderConfigurationUtils.getConfigurationForOidcIssuerLocation(oidcIssuerLocation);
-		return withProviderConfiguration(configuration, oidcIssuerLocation);
+		Map<String, Object> configuration = JwtDecoderProviderConfigurationUtils.getConfigurationForOidcIssuerLocation(oidcIssuerLocation, restOperations);
+		return withProviderConfiguration(configuration, oidcIssuerLocation, webClient);
 	}
 
 	/**
@@ -83,9 +104,49 @@ public final class ReactiveJwtDecoders {
 	 * @return a {@link ReactiveJwtDecoder} that was initialized by one of the described endpoints
 	 */
 	public static ReactiveJwtDecoder fromIssuerLocation(String issuer) {
+		return fromIssuerLocation(issuer, null, null);
+	}
+
+	/**
+	 * Creates a {@link ReactiveJwtDecoder} using the provided
+	 * <a href="https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a> by querying
+	 * three different discovery endpoints serially, using the values in the first successful response to
+	 * initialize. If an endpoint returns anything other than a 200 or a 4xx, the method will exit without
+	 * attempting subsequent endpoints.
+	 *
+	 * The three endpoints are computed as follows, given that the {@code issuer} is composed of a {@code host}
+	 * and a {@code path}:
+	 *
+	 * <ol>
+	 * 	<li>
+	 * 	   {@code host/.well-known/openid-configuration/path}, as defined in
+	 * 	   <a href="https://tools.ietf.org/html/rfc8414#section-5">RFC 8414's Compatibility Notes</a>.
+	 *  </li>
+	 *  <li>
+	 *      {@code issuer/.well-known/openid-configuration}, as defined in
+	 *  	<a href="https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest">
+	 * 	    OpenID Provider Configuration</a>.
+	 *  </li>
+	 *  <li>
+	 *      {@code host/.well-known/oauth-authorization-server/path}, as defined in
+	 *  	<a href="https://tools.ietf.org/html/rfc8414#section-3.1">Authorization Server Metadata Request</a>.
+	 *  </li>
+	 * </ol>
+	 *
+	 * Note that the second endpoint is the equivalent of calling
+	 * {@link ReactiveJwtDecoders#fromOidcIssuerLocation(String)}
+	 *
+	 * @param issuer the <a href="https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a>
+	 * @param webClient used as http-client (if not specified default http-client is used) for reactive operations
+	 * @param restOperations used as http-client (if not specified default http-client is used)
+	 * @return a {@link ReactiveJwtDecoder} that was initialized by one of the described endpoints
+	 */
+	public static ReactiveJwtDecoder fromIssuerLocation(String issuer,
+			RestOperations restOperations,
+			WebClient webClient) {
 		Assert.hasText(issuer, "issuer cannot be empty");
-		Map<String, Object> configuration = JwtDecoderProviderConfigurationUtils.getConfigurationForIssuerLocation(issuer);
-		return withProviderConfiguration(configuration, issuer);
+		Map<String, Object> configuration = JwtDecoderProviderConfigurationUtils.getConfigurationForIssuerLocation(issuer, restOperations);
+		return withProviderConfiguration(configuration, issuer, webClient);
 	}
 
 	/**
@@ -95,13 +156,21 @@ public final class ReactiveJwtDecoders {
 	 * Response</a>.
 	 *
 	 * @param configuration the configuration values
-	 * @param issuer the <a href="https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a>
+	 * @param issuer        the <a href="https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a>
+	 * @param webClient used as http-client (if not specified default http-client is used) for reactive operations
 	 * @return {@link ReactiveJwtDecoder}
 	 */
-	private static ReactiveJwtDecoder withProviderConfiguration(Map<String, Object> configuration, String issuer) {
+	private static ReactiveJwtDecoder withProviderConfiguration(Map<String, Object> configuration,
+			String issuer,
+			WebClient webClient) {
 		JwtDecoderProviderConfigurationUtils.validateIssuer(configuration, issuer);
 		OAuth2TokenValidator<Jwt> jwtValidator = JwtValidators.createDefaultWithIssuer(issuer);
-		NimbusReactiveJwtDecoder jwtDecoder = withJwkSetUri(configuration.get("jwks_uri").toString()).build();
+		final NimbusReactiveJwtDecoder.JwkSetUriReactiveJwtDecoderBuilder builder =
+				withJwkSetUri(configuration.get("jwks_uri").toString());
+		if (webClient != null) {
+			builder.webClient(webClient);
+		}
+		NimbusReactiveJwtDecoder jwtDecoder = builder.build();
 		jwtDecoder.setJwtValidator(jwtValidator);
 
 		return jwtDecoder;

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jose/TestKeys.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jose/TestKeys.java
@@ -96,7 +96,7 @@ public class TestKeys {
 
 	public static final RSAPrivateKey DEFAULT_PRIVATE_KEY = privateKey();
 
-	private static RSAPrivateKey privateKey() {
+	public static RSAPrivateKey privateKey() {
 		PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(DEFAULT_RSA_PRIVATE_KEY));
 		try {
 			return (RSAPrivateKey) kf.generatePrivate(spec);

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoderTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoderTests.java
@@ -429,6 +429,19 @@ public class NimbusReactiveJwtDecoderTests {
 				.isTrue();
 	}
 
+	@Test
+	public void jwtDecoderWithCustomWebClient() {
+		final WebClient webClient = WebClient.builder()
+				.exchangeFunction(request -> Mono.error(new IllegalStateException("custom webClient")))
+				.build();
+
+		NimbusReactiveJwtDecoder decoder = withJwkSetUri(this.jwkSetUri).webClient(webClient).build();
+
+		assertThatCode(() -> decoder.decode(messageReadToken).block())
+				.hasRootCauseInstanceOf(IllegalStateException.class)
+				.hasRootCauseMessage("custom webClient");
+	}
+
 	private SignedJWT signedJwt(SecretKey secretKey, MacAlgorithm jwsAlgorithm, JWTClaimsSet claimsSet) throws Exception {
 		SignedJWT signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.parse(jwsAlgorithm.getName())), claimsSet);
 		JWSSigner signer = new MACSigner(secretKey);


### PR DESCRIPTION
Hi, 
I have created PR that makes `JwtDecoders` and `ReactiveJwtDecoders` customizable with passed `RestTemplate` or `WebClient`. Changes are around all related classes that use this classes. This PR is related to my second PR https://github.com/spring-projects/spring-security/pull/8624 that has to be changed in size.
I am open any changes you propose.
Thx,
Ivos