### PR TITLE
ProviderManager Should Use CollectionUtils#contains

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
@@ -30,6 +30,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.CredentialsContainer;
 import org.springframework.security.core.SpringSecurityMessageSource;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 
 /**
  * Iterates an {@link Authentication} request through a list of
@@ -145,7 +146,7 @@ public class ProviderManager implements AuthenticationManager, MessageSourceAwar
 			throw new IllegalArgumentException(
 					"A parent AuthenticationManager or a list "
 							+ "of AuthenticationProviders is required");
-		} else if (providers.contains(null)) {
+		} else if (CollectionUtils.contains(providers.iterator(), null)) {
 			throw new IllegalArgumentException(
 					"providers list cannot contain null values");
 		}

--- a/core/src/test/java/org/springframework/security/authentication/ProviderManagerTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/ProviderManagerTests.java
@@ -102,6 +102,31 @@ public class ProviderManagerTests {
 		new ProviderManager((AuthenticationProvider) null);
 	}
 
+	@Test(expected = IllegalArgumentException.class)
+	public void testStartupFailsIfProvidersContainNullElement() {
+		new ProviderManager(Arrays.asList(mock(AuthenticationProvider.class), null));
+	}
+
+	@Test
+	public void testUsingNullNotPermittedList() {
+		// imitated Java9 List.of(e) object, which disallows null elements and
+		// throws NPE when contains(null) called
+		List<AuthenticationProvider> providers = new ArrayList<AuthenticationProvider>() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public boolean contains(Object o) {
+				if (o == null) {
+					throw new NullPointerException();
+				}
+				return super.contains(o);
+			}
+		};
+
+		providers.add(mock(AuthenticationProvider.class));
+		new ProviderManager(providers);
+	}
+
 	@Test
 	public void detailsAreNotSetOnAuthenticationTokenIfAlreadySetByProvider() {
 		Object requestDetails = "(Request Details)";


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->

Use `stream().anyMatch(Objects::isNull)` insead of `contains(null)`, which may throw `NullPointerException`.

Fixes #8689