### PR TITLE
Fix SecurityContext creation for TEST_EXECUTION

### DIFF
--- a/test/src/test/java/org/springframework/security/test/context/support/WithSecurityContextTestExecutionListenerTests.java
+++ b/test/src/test/java/org/springframework/security/test/context/support/WithSecurityContextTestExecutionListenerTests.java
@@ -21,6 +21,8 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +38,7 @@ import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
 
 import java.lang.reflect.Method;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -102,7 +105,23 @@ public class WithSecurityContextTestExecutionListenerTests {
 		this.listener.beforeTestMethod(this.testContext);
 
 		assertThat(TestSecurityContextHolder.getContext().getAuthentication()).isNull();
-		verify(this.testContext).setAttribute(eq(WithSecurityContextTestExecutionListener.SECURITY_CONTEXT_ATTR_NAME), any(SecurityContext.class));
+		verify(this.testContext).setAttribute(eq(WithSecurityContextTestExecutionListener.SECURITY_CONTEXT_ATTR_NAME)
+				, ArgumentMatchers.<Supplier<SecurityContext>>any());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void beforeTestMethodWhenWithMockUserTestExecutionThenTestContextSupplierOk() throws Exception {
+		Method testMethod = TheTest.class.getMethod("withMockUserTestExecution");
+		when(this.testContext.getApplicationContext()).thenReturn(this.applicationContext);
+		when(this.testContext.getTestMethod()).thenReturn(testMethod);
+
+		this.listener.beforeTestMethod(this.testContext);
+
+		ArgumentCaptor<Supplier<SecurityContext>> supplierCaptor = ArgumentCaptor.forClass(Supplier.class);
+		verify(this.testContext).setAttribute(eq(WithSecurityContextTestExecutionListener.SECURITY_CONTEXT_ATTR_NAME),
+				supplierCaptor.capture());
+		assertThat(supplierCaptor.getValue().get().getAuthentication()).isNotNull();
 	}
 
 	@Test
@@ -116,7 +135,8 @@ public class WithSecurityContextTestExecutionListenerTests {
 	public void beforeTestExecutionWhenTestContextNotNullThenSecurityContextSet() {
 		SecurityContextImpl securityContext = new SecurityContextImpl();
 		securityContext.setAuthentication(new TestingAuthenticationToken("user", "passsword", "ROLE_USER"));
-		when(this.testContext.removeAttribute(WithSecurityContextTestExecutionListener.SECURITY_CONTEXT_ATTR_NAME)).thenReturn(securityContext);
+		Supplier<SecurityContext> supplier = () -> securityContext;
+		when(this.testContext.removeAttribute(WithSecurityContextTestExecutionListener.SECURITY_CONTEXT_ATTR_NAME)).thenReturn(supplier);
 
 		this.listener.beforeTestExecution(this.testContext);
 


### PR DESCRIPTION
Hi,

Currently, there is support for setting up a SecurityContext after @<!-- -->Before by
using TestExecutionEvent.TEST_EXECUTION. The current implementation, however,
already creates the SecurityContext in @<!-- -->Before and just does not set it yet.
This leads to issues like #6591. For the case of @<!-- -->WithUserDetails, the
creation of the SecurityContext already looks up a user from the repository.
If the user was inserted in @<!-- -->Before, the user is not found despite using
TestExecutionEvent.TEST_EXECUTION. This can be especially problematic with
data driven test frameworks like mongoUnit which initialize the database in @<!-- -->Before 
and drop the database after each test. In this case workarounds like described in
#6591 do not work.

This commit changes the creation of the SecurityContext to happen after @<!-- -->Before 
if using TestExecutionEvent.TEST_EXECUTION.

Closes gh-6591.

I have submitted the CLA.
