### PR TITLE
Feature/client assertion auth

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractWebClientReactiveOAuth2AccessTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractWebClientReactiveOAuth2AccessTokenResponseClient.java
@@ -19,6 +19,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.endpoint.ClientAssertionParameterNames;
+import org.springframework.security.oauth2.core.endpoint.ClientAssertionParameterValues;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.util.Assert;
@@ -123,6 +125,11 @@ abstract class AbstractWebClientReactiveOAuth2AccessTokenResponseClient<T extend
 		}
 		if (ClientAuthenticationMethod.POST.equals(clientRegistration.getClientAuthenticationMethod())) {
 			body.with(OAuth2ParameterNames.CLIENT_SECRET, clientRegistration.getClientSecret());
+		}
+		if(ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
+			body.with(ClientAssertionParameterNames.CLIENT_ASSERTION_TYPE, ClientAssertionParameterValues.CLIENT_ASSERTION_TYPE_JWT_BEARER);
+			body.with(ClientAssertionParameterNames.CLIENT_ASSERTION, OAuth2AuthorizationGrantRequestEntityUtils.getClientSecretAssertion(clientRegistration).serialize());
+
 		}
 		Set<String> scopes = scopes(grantRequest);
 		if (!CollectionUtils.isEmpty(scopes)) {

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractWebClientReactiveOAuth2AccessTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractWebClientReactiveOAuth2AccessTokenResponseClient.java
@@ -126,7 +126,7 @@ abstract class AbstractWebClientReactiveOAuth2AccessTokenResponseClient<T extend
 		if (ClientAuthenticationMethod.POST.equals(clientRegistration.getClientAuthenticationMethod())) {
 			body.with(OAuth2ParameterNames.CLIENT_SECRET, clientRegistration.getClientSecret());
 		}
-		if(ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
+		if (ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
 			body.with(ClientAssertionParameterNames.CLIENT_ASSERTION_TYPE, ClientAssertionParameterValues.CLIENT_ASSERTION_TYPE_JWT_BEARER);
 			body.with(ClientAssertionParameterNames.CLIENT_ASSERTION, OAuth2AuthorizationGrantRequestEntityUtils.getClientSecretAssertion(clientRegistration).serialize());
 

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationCodeGrantRequestEntityConverter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationCodeGrantRequestEntityConverter.java
@@ -88,7 +88,7 @@ public class OAuth2AuthorizationCodeGrantRequestEntityConverter implements Conve
 		if (ClientAuthenticationMethod.POST.equals(clientRegistration.getClientAuthenticationMethod())) {
 			formParameters.add(OAuth2ParameterNames.CLIENT_SECRET, clientRegistration.getClientSecret());
 		}
-		if(ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
+		if (ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
 			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION_TYPE, ClientAssertionParameterValues.CLIENT_ASSERTION_TYPE_JWT_BEARER);
 			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION, OAuth2AuthorizationGrantRequestEntityUtils.getClientSecretAssertion(clientRegistration).serialize());
 		}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationCodeGrantRequestEntityConverter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationCodeGrantRequestEntityConverter.java
@@ -24,6 +24,8 @@ import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationExchange;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
+import org.springframework.security.oauth2.core.endpoint.ClientAssertionParameterValues;
+import org.springframework.security.oauth2.core.endpoint.ClientAssertionParameterNames;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -85,6 +87,10 @@ public class OAuth2AuthorizationCodeGrantRequestEntityConverter implements Conve
 		}
 		if (ClientAuthenticationMethod.POST.equals(clientRegistration.getClientAuthenticationMethod())) {
 			formParameters.add(OAuth2ParameterNames.CLIENT_SECRET, clientRegistration.getClientSecret());
+		}
+		if(ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
+			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION_TYPE, ClientAssertionParameterValues.CLIENT_ASSERTION_TYPE_JWT_BEARER);
+			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION, OAuth2AuthorizationGrantRequestEntityUtils.getClientSecretAssertion(clientRegistration).serialize());
 		}
 		if (codeVerifier != null) {
 			formParameters.add(PkceParameterNames.CODE_VERIFIER, codeVerifier);

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationGrantRequestEntityUtils.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationGrantRequestEntityUtils.java
@@ -77,7 +77,7 @@ final class OAuth2AuthorizationGrantRequestEntityUtils {
 
 		JWT clientAssertion = null;
 
-		if(ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())) {
+		if (ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())) {
 
 			try {
 				ClientID clientID = new ClientID(clientRegistration.getClientId());
@@ -92,13 +92,13 @@ final class OAuth2AuthorizationGrantRequestEntityUtils {
 						, secret).getClientAssertion();
 			} catch (JOSEException e) {
 				OAuth2Error oauth2Error = new OAuth2Error("Client_secret_jwt",
-						"Encountered an error generating a client secret JWT",null);
-				throw new OAuth2AuthenticationException(oauth2Error,e.getMessage());
+						"Encountered an error generating a client secret JWT", null);
+				throw new OAuth2AuthenticationException(oauth2Error, e.getMessage());
 
 			} catch(URISyntaxException e){
 				OAuth2Error oauth2Error = new OAuth2Error("token_endpoint",
-						"The token endpoint provided or configured doesn't conform to a standard URI Pattern",null);
-				throw new OAuth2AuthenticationException(oauth2Error,e.getMessage());
+						"The token endpoint provided or configured doesn't conform to a standard URI Pattern", null);
+				throw new OAuth2AuthenticationException(oauth2Error, e.getMessage());
 			}
 		}
 

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2ClientCredentialsGrantRequestEntityConverter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2ClientCredentialsGrantRequestEntityConverter.java
@@ -21,6 +21,8 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.RequestEntity;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.endpoint.ClientAssertionParameterNames;
+import org.springframework.security.oauth2.core.endpoint.ClientAssertionParameterValues;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
@@ -81,7 +83,10 @@ public class OAuth2ClientCredentialsGrantRequestEntityConverter implements Conve
 			formParameters.add(OAuth2ParameterNames.CLIENT_ID, clientRegistration.getClientId());
 			formParameters.add(OAuth2ParameterNames.CLIENT_SECRET, clientRegistration.getClientSecret());
 		}
-
+		if(ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
+			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION_TYPE, ClientAssertionParameterValues.CLIENT_ASSERTION_TYPE_JWT_BEARER);
+			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION, OAuth2AuthorizationGrantRequestEntityUtils.getClientSecretAssertion(clientRegistration).serialize());
+		}
 		return formParameters;
 	}
 }

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2ClientCredentialsGrantRequestEntityConverter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2ClientCredentialsGrantRequestEntityConverter.java
@@ -83,7 +83,7 @@ public class OAuth2ClientCredentialsGrantRequestEntityConverter implements Conve
 			formParameters.add(OAuth2ParameterNames.CLIENT_ID, clientRegistration.getClientId());
 			formParameters.add(OAuth2ParameterNames.CLIENT_SECRET, clientRegistration.getClientSecret());
 		}
-		if(ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
+		if (ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
 			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION_TYPE, ClientAssertionParameterValues.CLIENT_ASSERTION_TYPE_JWT_BEARER);
 			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION, OAuth2AuthorizationGrantRequestEntityUtils.getClientSecretAssertion(clientRegistration).serialize());
 		}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2PasswordGrantRequestEntityConverter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2PasswordGrantRequestEntityConverter.java
@@ -21,6 +21,8 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.RequestEntity;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.endpoint.ClientAssertionParameterNames;
+import org.springframework.security.oauth2.core.endpoint.ClientAssertionParameterValues;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
@@ -83,7 +85,10 @@ public class OAuth2PasswordGrantRequestEntityConverter implements Converter<OAut
 			formParameters.add(OAuth2ParameterNames.CLIENT_ID, clientRegistration.getClientId());
 			formParameters.add(OAuth2ParameterNames.CLIENT_SECRET, clientRegistration.getClientSecret());
 		}
-
+		if(ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
+			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION_TYPE, ClientAssertionParameterValues.CLIENT_ASSERTION_TYPE_JWT_BEARER);
+			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION, OAuth2AuthorizationGrantRequestEntityUtils.getClientSecretAssertion(clientRegistration).serialize());
+		}
 		return formParameters;
 	}
 }

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2PasswordGrantRequestEntityConverter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2PasswordGrantRequestEntityConverter.java
@@ -85,7 +85,7 @@ public class OAuth2PasswordGrantRequestEntityConverter implements Converter<OAut
 			formParameters.add(OAuth2ParameterNames.CLIENT_ID, clientRegistration.getClientId());
 			formParameters.add(OAuth2ParameterNames.CLIENT_SECRET, clientRegistration.getClientSecret());
 		}
-		if(ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
+		if (ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
 			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION_TYPE, ClientAssertionParameterValues.CLIENT_ASSERTION_TYPE_JWT_BEARER);
 			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION, OAuth2AuthorizationGrantRequestEntityUtils.getClientSecretAssertion(clientRegistration).serialize());
 		}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2RefreshTokenGrantRequestEntityConverter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2RefreshTokenGrantRequestEntityConverter.java
@@ -21,6 +21,8 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.RequestEntity;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.endpoint.ClientAssertionParameterNames;
+import org.springframework.security.oauth2.core.endpoint.ClientAssertionParameterValues;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
@@ -83,7 +85,10 @@ public class OAuth2RefreshTokenGrantRequestEntityConverter implements Converter<
 			formParameters.add(OAuth2ParameterNames.CLIENT_ID, clientRegistration.getClientId());
 			formParameters.add(OAuth2ParameterNames.CLIENT_SECRET, clientRegistration.getClientSecret());
 		}
-
+		if(ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
+			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION_TYPE, ClientAssertionParameterValues.CLIENT_ASSERTION_TYPE_JWT_BEARER);
+			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION, OAuth2AuthorizationGrantRequestEntityUtils.getClientSecretAssertion(clientRegistration).serialize());
+		}
 		return formParameters;
 	}
 }

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2RefreshTokenGrantRequestEntityConverter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/OAuth2RefreshTokenGrantRequestEntityConverter.java
@@ -85,7 +85,7 @@ public class OAuth2RefreshTokenGrantRequestEntityConverter implements Converter<
 			formParameters.add(OAuth2ParameterNames.CLIENT_ID, clientRegistration.getClientId());
 			formParameters.add(OAuth2ParameterNames.CLIENT_SECRET, clientRegistration.getClientSecret());
 		}
-		if(ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
+		if (ClientAuthenticationMethod.SECRET_JWT.equals(clientRegistration.getClientAuthenticationMethod())){
 			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION_TYPE, ClientAssertionParameterValues.CLIENT_ASSERTION_TYPE_JWT_BEARER);
 			formParameters.add(ClientAssertionParameterNames.CLIENT_ASSERTION, OAuth2AuthorizationGrantRequestEntityUtils.getClientSecretAssertion(clientRegistration).serialize());
 		}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/StdConverters.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/StdConverters.java
@@ -50,7 +50,9 @@ abstract class StdConverters {
 			if (ClientAuthenticationMethod.BASIC.getValue().equalsIgnoreCase(value)) {
 				return ClientAuthenticationMethod.BASIC;
 			} else if (ClientAuthenticationMethod.POST.getValue().equalsIgnoreCase(value)) {
-				return ClientAuthenticationMethod.POST;
+				return ClientAuthenticationMethod.POST;}
+			else if (ClientAuthenticationMethod.SECRET_JWT.getValue().equalsIgnoreCase(value)) {
+				return ClientAuthenticationMethod.SECRET_JWT;
 			} else if (ClientAuthenticationMethod.NONE.getValue().equalsIgnoreCase(value)) {
 				return ClientAuthenticationMethod.NONE;
 			}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/StdConverters.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/StdConverters.java
@@ -50,8 +50,8 @@ abstract class StdConverters {
 			if (ClientAuthenticationMethod.BASIC.getValue().equalsIgnoreCase(value)) {
 				return ClientAuthenticationMethod.BASIC;
 			} else if (ClientAuthenticationMethod.POST.getValue().equalsIgnoreCase(value)) {
-				return ClientAuthenticationMethod.POST;}
-			else if (ClientAuthenticationMethod.SECRET_JWT.getValue().equalsIgnoreCase(value)) {
+				return ClientAuthenticationMethod.POST;
+			} else if (ClientAuthenticationMethod.SECRET_JWT.getValue().equalsIgnoreCase(value)) {
 				return ClientAuthenticationMethod.SECRET_JWT;
 			} else if (ClientAuthenticationMethod.NONE.getValue().equalsIgnoreCase(value)) {
 				return ClientAuthenticationMethod.NONE;

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.security.oauth2.client.registration;
 
+import com.nimbusds.jose.JWSAlgorithm;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
@@ -30,6 +31,7 @@ import org.springframework.security.core.SpringSecurityCoreVersion;
 import org.springframework.security.oauth2.core.AuthenticationMethod;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -47,6 +49,7 @@ public final class ClientRegistration implements Serializable {
 	private String registrationId;
 	private String clientId;
 	private String clientSecret;
+	private String clientAssertionSigningAlgorithm = JwsAlgorithms.HS256;
 	private ClientAuthenticationMethod clientAuthenticationMethod = ClientAuthenticationMethod.BASIC;
 	private AuthorizationGrantType authorizationGrantType;
 	private String redirectUriTemplate;
@@ -139,6 +142,15 @@ public final class ClientRegistration implements Serializable {
 		return this.clientName;
 	}
 
+	/**
+	 * Returns the Signing Algorithm used for Client Assertion
+	 *
+	 * @return the {@link String}
+	 */
+	public String getClientAssertionSigningAlgorithm() {
+		return this.clientAssertionSigningAlgorithm;
+	}
+
 	@Override
 	public String toString() {
 		return "ClientRegistration{"
@@ -151,6 +163,7 @@ public final class ClientRegistration implements Serializable {
 			+ ", scopes=" + this.scopes
 			+ ", providerDetails=" + this.providerDetails
 			+ ", clientName='" + this.clientName
+			+ ", clientAssertionSigningAlgorithm='" + this.clientAssertionSigningAlgorithm
 			+ '\'' + '}';
 	}
 
@@ -311,6 +324,7 @@ public final class ClientRegistration implements Serializable {
 		private String issuerUri;
 		private Map<String, Object> configurationMetadata = Collections.emptyMap();
 		private String clientName;
+		private String clientAssertionSigningAlgorithm = JwsAlgorithms.HS256;
 
 		private Builder(String registrationId) {
 			this.registrationId = registrationId;
@@ -336,6 +350,7 @@ public final class ClientRegistration implements Serializable {
 				this.configurationMetadata = new HashMap<>(configurationMetadata);
 			}
 			this.clientName = clientRegistration.clientName;
+			this.clientAssertionSigningAlgorithm = clientRegistration.clientAssertionSigningAlgorithm;
 		}
 
 		/**
@@ -537,6 +552,16 @@ public final class ClientRegistration implements Serializable {
 			this.clientName = clientName;
 			return this;
 		}
+		/**
+		 * Sets the Client Assertion Signature Algorithm
+		 *
+		 * @param clientAssertionSigningAlgorithm the client or registration name
+		 * @return the {@link Builder}
+		 */
+		public Builder clientAssertionSigningAlgorithm(String clientAssertionSigningAlgorithm) {
+			this.clientAssertionSigningAlgorithm = clientAssertionSigningAlgorithm;
+			return this;
+		}
 
 		/**
 		 * Builds a new {@link ClientRegistration}.
@@ -588,6 +613,7 @@ public final class ClientRegistration implements Serializable {
 			clientRegistration.clientName = StringUtils.hasText(this.clientName) ?
 					this.clientName : this.registrationId;
 
+			clientRegistration.clientAssertionSigningAlgorithm = this.clientAssertionSigningAlgorithm;
 			return clientRegistration;
 		}
 

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.security.oauth2.client.registration;
 
-import com.nimbusds.jose.JWSAlgorithm;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistrations.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistrations.java
@@ -261,6 +261,9 @@ public final class ClientRegistrations {
 		if (metadataAuthMethods.contains(com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod.CLIENT_SECRET_POST)) {
 			return ClientAuthenticationMethod.POST;
 		}
+		if (metadataAuthMethods.contains(com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod.CLIENT_SECRET_JWT)) {
+			return ClientAuthenticationMethod.SECRET_JWT;
+		}
 		if (metadataAuthMethods.contains(com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod.NONE)) {
 			return ClientAuthenticationMethod.NONE;
 		}

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/DefaultAuthorizationCodeTokenResponseClientTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/DefaultAuthorizationCodeTokenResponseClientTests.java
@@ -172,6 +172,31 @@ public class DefaultAuthorizationCodeTokenResponseClientTests {
 		assertThat(formParameters).contains("client_secret=secret");
 	}
 
+
+	@Test
+	public void getTokenResponseWhenClientAuthenticationSecretJWTThenFormParametersAreSent() throws Exception {
+		String accessTokenSuccessResponse = "{\n" +
+				"	\"access_token\": \"access-token-1234\",\n" +
+				"   \"token_type\": \"bearer\",\n" +
+				"   \"expires_in\": \"3600\"\n" +
+				"}\n";
+		this.server.enqueue(jsonResponse(accessTokenSuccessResponse));
+
+		ClientRegistration clientRegistration = this.from(this.clientRegistration)
+				.clientAuthenticationMethod(ClientAuthenticationMethod.SECRET_JWT)
+				.clientSecret("2ae2135579004d5d87ae8241603c0a5c")
+				.build();
+
+		this.tokenResponseClient.getTokenResponse(this.authorizationCodeGrantRequest(clientRegistration));
+
+		RecordedRequest recordedRequest = this.server.takeRequest();
+		assertThat(recordedRequest.getHeader(HttpHeaders.AUTHORIZATION)).isNull();
+
+		String formParameters = recordedRequest.getBody().readUtf8();
+		assertThat(formParameters).contains("client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer");
+		assertThat(formParameters).contains("client_assertion");
+	}
+
 	@Test
 	public void getTokenResponseWhenSuccessResponseAndNotBearerTokenTypeThenThrowOAuth2AuthorizationException() {
 		String accessTokenSuccessResponse = "{\n" +

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/DefaultClientCredentialsTokenResponseClientTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/DefaultClientCredentialsTokenResponseClientTests.java
@@ -170,6 +170,34 @@ public class DefaultClientCredentialsTokenResponseClientTests {
 	}
 
 	@Test
+	public void getTokenResponseWhenClientAuthenticationSecretJWTThenFormParametersAreSent() throws Exception {
+		String accessTokenSuccessResponse = "{\n" +
+				"	\"access_token\": \"access-token-1234\",\n" +
+				"   \"token_type\": \"bearer\",\n" +
+				"   \"expires_in\": \"3600\"\n" +
+				"}\n";
+		this.server.enqueue(jsonResponse(accessTokenSuccessResponse));
+
+		ClientRegistration clientRegistration = this.from(this.clientRegistration)
+				.clientAuthenticationMethod(ClientAuthenticationMethod.SECRET_JWT)
+				.clientSecret("2ae2135579004d5d87ae8241603c0a5c")
+				.build();
+
+
+		OAuth2ClientCredentialsGrantRequest clientCredentialsGrantRequest =
+				new OAuth2ClientCredentialsGrantRequest(clientRegistration);
+
+		this.tokenResponseClient.getTokenResponse(clientCredentialsGrantRequest);
+
+		RecordedRequest recordedRequest = this.server.takeRequest();
+		assertThat(recordedRequest.getHeader(HttpHeaders.AUTHORIZATION)).isNull();
+
+		String formParameters = recordedRequest.getBody().readUtf8();
+		assertThat(formParameters).contains("client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer");
+		assertThat(formParameters).contains("client_assertion");
+	}
+
+	@Test
 	public void getTokenResponseWhenSuccessResponseAndNotBearerTokenTypeThenThrowOAuth2AuthorizationException() {
 		String accessTokenSuccessResponse = "{\n" +
 				"	\"access_token\": \"access-token-1234\",\n" +

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/DefaultRefreshTokenTokenResponseClientTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/DefaultRefreshTokenTokenResponseClientTests.java
@@ -146,6 +146,32 @@ public class DefaultRefreshTokenTokenResponseClientTests {
 		assertThat(formParameters).contains("client_id=client-id");
 		assertThat(formParameters).contains("client_secret=client-secret");
 	}
+	@Test
+	public void getTokenResponseWhenClientAuthenticationSecretJWTThenFormParametersAreSent() throws Exception {
+		String accessTokenSuccessResponse = "{\n" +
+				"	\"access_token\": \"access-token-1234\",\n" +
+				"   \"token_type\": \"bearer\",\n" +
+				"   \"expires_in\": \"3600\"\n" +
+				"}\n";
+		this.server.enqueue(jsonResponse(accessTokenSuccessResponse));
+
+		ClientRegistration clientRegistration = this.clientRegistrationBuilder
+				.clientAuthenticationMethod(ClientAuthenticationMethod.SECRET_JWT)
+				.clientSecret("2ae2135579004d5d87ae8241603c0a5c")
+				.build();
+
+		OAuth2RefreshTokenGrantRequest refreshTokenGrantRequest =
+				new OAuth2RefreshTokenGrantRequest(clientRegistration, this.accessToken, this.refreshToken);
+
+		this.tokenResponseClient.getTokenResponse(refreshTokenGrantRequest);
+
+		RecordedRequest recordedRequest = this.server.takeRequest();
+		assertThat(recordedRequest.getHeader(HttpHeaders.AUTHORIZATION)).isNull();
+
+		String formParameters = recordedRequest.getBody().readUtf8();
+		assertThat(formParameters).contains("client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer");
+		assertThat(formParameters).contains("client_assertion");
+	}
 
 	@Test
 	public void getTokenResponseWhenSuccessResponseAndNotBearerTokenTypeThenThrowOAuth2AuthorizationException() {

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationCodeGrantRequestEntityConverterTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationCodeGrantRequestEntityConverterTests.java
@@ -15,6 +15,9 @@
  */
 package org.springframework.security.oauth2.client.endpoint;
 
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.MACVerifier;
+import com.nimbusds.jwt.SignedJWT;
 import org.junit.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -23,19 +26,25 @@ import org.springframework.http.RequestEntity;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.endpoint.ClientAssertionParameterNames;
+import org.springframework.security.oauth2.core.endpoint.ClientAssertionParameterValues;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationExchange;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponse;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
+import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
 import org.springframework.util.MultiValueMap;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
 
 /**
@@ -58,6 +67,7 @@ public class OAuth2AuthorizationCodeGrantRequestEntityConverterTests {
 				.userInfoUri("https://provider.com/user")
 				.userNameAttributeName("id")
 				.clientName("client-1");
+
 	private OAuth2AuthorizationRequest.Builder authorizationRequestBuilder = OAuth2AuthorizationRequest
 				.authorizationCode()
 				.clientId("client-1")
@@ -70,37 +80,6 @@ public class OAuth2AuthorizationCodeGrantRequestEntityConverterTests {
 				.state("state-1234")
 				.redirectUri("https://client.com/callback/client-1");
 
-	@SuppressWarnings("unchecked")
-	@Test
-	public void convertWhenGrantRequestValidThenConverts() {
-		ClientRegistration clientRegistration = clientRegistrationBuilder.build();
-		OAuth2AuthorizationRequest authorizationRequest = authorizationRequestBuilder.build();
-		OAuth2AuthorizationResponse authorizationResponse = authorizationResponseBuilder.build();
-		OAuth2AuthorizationExchange authorizationExchange =
-				new OAuth2AuthorizationExchange(authorizationRequest, authorizationResponse);
-		OAuth2AuthorizationCodeGrantRequest authorizationCodeGrantRequest = new OAuth2AuthorizationCodeGrantRequest(
-				clientRegistration, authorizationExchange);
-
-		RequestEntity<?> requestEntity = this.converter.convert(authorizationCodeGrantRequest);
-
-		assertThat(requestEntity.getMethod()).isEqualTo(HttpMethod.POST);
-		assertThat(requestEntity.getUrl().toASCIIString()).isEqualTo(
-				clientRegistration.getProviderDetails().getTokenUri());
-
-		HttpHeaders headers = requestEntity.getHeaders();
-		assertThat(headers.getAccept()).contains(MediaType.APPLICATION_JSON_UTF8);
-		assertThat(headers.getContentType()).isEqualTo(
-				MediaType.valueOf(APPLICATION_FORM_URLENCODED_VALUE + ";charset=UTF-8"));
-		assertThat(headers.getFirst(HttpHeaders.AUTHORIZATION)).startsWith("Basic ");
-
-		MultiValueMap<String, String> formParameters = (MultiValueMap<String, String>) requestEntity.getBody();
-		assertThat(formParameters.getFirst(OAuth2ParameterNames.GRANT_TYPE)).isEqualTo(
-				AuthorizationGrantType.AUTHORIZATION_CODE.getValue());
-		assertThat(formParameters.getFirst(OAuth2ParameterNames.CODE)).isEqualTo("code-1234");
-		assertThat(formParameters.getFirst(OAuth2ParameterNames.CLIENT_ID)).isNull();
-		assertThat(formParameters.getFirst(OAuth2ParameterNames.REDIRECT_URI)).isEqualTo(
-				clientRegistration.getRedirectUriTemplate());
-	}
 
 	@SuppressWarnings("unchecked")
 	@Test
@@ -147,5 +126,154 @@ public class OAuth2AuthorizationCodeGrantRequestEntityConverterTests {
 				clientRegistration.getRedirectUriTemplate());
 		assertThat(formParameters.getFirst(OAuth2ParameterNames.CLIENT_ID)).isEqualTo("client-1");
 		assertThat(formParameters.getFirst(PkceParameterNames.CODE_VERIFIER)).isEqualTo("code-verifier-1234");
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void convertWhenGrantRequestValidWithAssertionThenConverts() {
+		ClientRegistration clientRegistration = clientRegistrationBuilder.build();
+		OAuth2AuthorizationRequest authorizationRequest = authorizationRequestBuilder.build();
+		OAuth2AuthorizationResponse authorizationResponse = authorizationResponseBuilder.build();
+		OAuth2AuthorizationExchange authorizationExchange =
+				new OAuth2AuthorizationExchange(authorizationRequest, authorizationResponse);
+		OAuth2AuthorizationCodeGrantRequest authorizationCodeGrantRequest = new OAuth2AuthorizationCodeGrantRequest(
+				clientRegistration, authorizationExchange);
+
+		RequestEntity<?> requestEntity = this.converter.convert(authorizationCodeGrantRequest);
+
+		assertThat(requestEntity.getMethod()).isEqualTo(HttpMethod.POST);
+		assertThat(requestEntity.getUrl().toASCIIString()).isEqualTo(
+				clientRegistration.getProviderDetails().getTokenUri());
+
+		HttpHeaders headers = requestEntity.getHeaders();
+		assertThat(headers.getAccept()).contains(MediaType.APPLICATION_JSON_UTF8);
+		assertThat(headers.getContentType()).isEqualTo(
+				MediaType.valueOf(APPLICATION_FORM_URLENCODED_VALUE + ";charset=UTF-8"));
+		assertThat(headers.getFirst(HttpHeaders.AUTHORIZATION)).startsWith("Basic ");
+
+		MultiValueMap<String, String> formParameters = (MultiValueMap<String, String>) requestEntity.getBody();
+		assertThat(formParameters.getFirst(OAuth2ParameterNames.GRANT_TYPE)).isEqualTo(
+				AuthorizationGrantType.AUTHORIZATION_CODE.getValue());
+		assertThat(formParameters.getFirst(OAuth2ParameterNames.CODE)).isEqualTo("code-1234");
+		assertThat(formParameters.getFirst(OAuth2ParameterNames.CLIENT_ID)).isNull();
+		assertThat(formParameters.getFirst(OAuth2ParameterNames.REDIRECT_URI)).isEqualTo(
+				clientRegistration.getRedirectUriTemplate());
+	}
+
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void convertWhenGrantRequestValidThenConverts() {
+
+		ClientRegistration clientRegistration = this.from(clientRegistrationBuilder.build())
+				.clientAuthenticationMethod(ClientAuthenticationMethod.SECRET_JWT)
+				.clientSecret("2ae2135579004d5d87ae8241603c0a5c")
+				.clientId("client-1").build();
+
+		OAuth2AuthorizationRequest authorizationRequest = authorizationRequestBuilder.build();
+		OAuth2AuthorizationResponse authorizationResponse = authorizationResponseBuilder.build();
+		OAuth2AuthorizationExchange authorizationExchange =
+				new OAuth2AuthorizationExchange(authorizationRequest, authorizationResponse);
+		OAuth2AuthorizationCodeGrantRequest authorizationCodeGrantRequest = new OAuth2AuthorizationCodeGrantRequest(
+				clientRegistration, authorizationExchange);
+
+		RequestEntity<?> requestEntity = this.converter.convert(authorizationCodeGrantRequest);
+
+		assertThat(requestEntity.getMethod()).isEqualTo(HttpMethod.POST);
+		assertThat(requestEntity.getUrl().toASCIIString()).isEqualTo(
+				clientRegistration.getProviderDetails().getTokenUri());
+
+		HttpHeaders headers = requestEntity.getHeaders();
+		assertThat(headers.getAccept()).contains(MediaType.APPLICATION_JSON_UTF8);
+		assertThat(headers.getContentType()).isEqualTo(
+				MediaType.valueOf(APPLICATION_FORM_URLENCODED_VALUE + ";charset=UTF-8"));
+
+		MultiValueMap<String, String> formParameters = (MultiValueMap<String, String>) requestEntity.getBody();
+		assertThat(formParameters.getFirst(OAuth2ParameterNames.GRANT_TYPE)).isEqualTo(
+				AuthorizationGrantType.AUTHORIZATION_CODE.getValue());
+		assertThat(formParameters.getFirst(OAuth2ParameterNames.CODE)).isEqualTo("code-1234");
+		assertThat(formParameters.getFirst(OAuth2ParameterNames.CLIENT_ID)).isEqualTo("client-1");
+		assertThat(formParameters.getFirst(OAuth2ParameterNames.REDIRECT_URI)).isEqualTo(
+				clientRegistration.getRedirectUriTemplate());
+		assertThat(formParameters.getFirst(ClientAssertionParameterNames.CLIENT_ASSERTION_TYPE))
+				.isEqualTo(ClientAssertionParameterValues.CLIENT_ASSERTION_TYPE_JWT_BEARER);
+		assertThat(formParameters.getFirst(ClientAssertionParameterNames.CLIENT_ASSERTION))
+				.isNotEmpty();
+		assertTrue(validateJWTSecret(formParameters.getFirst(ClientAssertionParameterNames.CLIENT_ASSERTION),clientRegistration));
+
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test(expected = OAuth2AuthenticationException.class)
+	public void convertWhenGrantRequestInValidTokenThenConvertFails() {
+
+		ClientRegistration clientRegistration = this.from(clientRegistrationBuilder.build())
+				.clientAuthenticationMethod(ClientAuthenticationMethod.SECRET_JWT)
+				.clientSecret("2ae2135579004d5d87ae8241603c0a5c")
+				.tokenUri("/http$$$##://token.com").build();
+
+		OAuth2AuthorizationRequest authorizationRequest = authorizationRequestBuilder.build();
+		OAuth2AuthorizationResponse authorizationResponse = authorizationResponseBuilder.build();
+		OAuth2AuthorizationExchange authorizationExchange =
+				new OAuth2AuthorizationExchange(authorizationRequest, authorizationResponse);
+		OAuth2AuthorizationCodeGrantRequest authorizationCodeGrantRequest = new OAuth2AuthorizationCodeGrantRequest(
+				clientRegistration, authorizationExchange);
+
+		RequestEntity<?> requestEntity = this.converter.convert(authorizationCodeGrantRequest);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test(expected = OAuth2AuthenticationException.class)
+	public void convertWhenGrantRequestInValidSecretLengthThenConvertFails() {
+
+		ClientRegistration clientRegistration = this.from(clientRegistrationBuilder.build())
+				.clientAuthenticationMethod(ClientAuthenticationMethod.SECRET_JWT)
+				.clientSecret("2ae2135579004d5d87ae8241600a5c").build();
+
+		OAuth2AuthorizationRequest authorizationRequest = authorizationRequestBuilder.build();
+		OAuth2AuthorizationResponse authorizationResponse = authorizationResponseBuilder.build();
+		OAuth2AuthorizationExchange authorizationExchange =
+				new OAuth2AuthorizationExchange(authorizationRequest, authorizationResponse);
+		OAuth2AuthorizationCodeGrantRequest authorizationCodeGrantRequest = new OAuth2AuthorizationCodeGrantRequest(
+				clientRegistration, authorizationExchange);
+
+		RequestEntity<?> requestEntity = this.converter.convert(authorizationCodeGrantRequest);
+	}
+
+	private boolean validateJWTSecret(String jwt,ClientRegistration registration ){
+
+		boolean success;
+
+		try{
+			SignedJWT signedJWT = SignedJWT.parse(jwt);
+			JWSVerifier jwsVerifier = new MACVerifier(registration.getClientSecret());
+			signedJWT.verify(jwsVerifier);
+			assertThat(signedJWT.getJWTClaimsSet().getAudience().equals(registration.getProviderDetails().getTokenUri()));
+			assertThat(signedJWT.getJWTClaimsSet().getSubject().equals(registration.getClientId()));
+			assertThat(new Date().before(signedJWT.getJWTClaimsSet().getExpirationTime()));
+			success = true;
+
+		}catch(Exception e){
+			success = false;
+		}
+
+		return success;
+
+	}
+
+
+	private ClientRegistration.Builder from(ClientRegistration registration) {
+		return ClientRegistration.withRegistrationId(registration.getRegistrationId())
+				.clientId(registration.getClientId())
+				.clientSecret(registration.getClientSecret())
+				.clientAuthenticationMethod(registration.getClientAuthenticationMethod())
+				.authorizationGrantType(registration.getAuthorizationGrantType())
+				.redirectUriTemplate(registration.getRedirectUriTemplate())
+				.scope(registration.getScopes())
+				.authorizationUri(registration.getProviderDetails().getAuthorizationUri())
+				.tokenUri(registration.getProviderDetails().getTokenUri())
+				.userInfoUri(registration.getProviderDetails().getUserInfoEndpoint().getUri())
+				.userNameAttributeName(registration.getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName())
+				.clientName(registration.getClientName());
 	}
 }

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationCodeGrantRequestEntityConverterTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/OAuth2AuthorizationCodeGrantRequestEntityConverterTests.java
@@ -34,7 +34,6 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequ
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponse;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
-import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
 import org.springframework.util.MultiValueMap;
 
 import java.util.Arrays;
@@ -44,7 +43,6 @@ import java.util.Map;
 import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
 
 /**
@@ -199,7 +197,7 @@ public class OAuth2AuthorizationCodeGrantRequestEntityConverterTests {
 				.isEqualTo(ClientAssertionParameterValues.CLIENT_ASSERTION_TYPE_JWT_BEARER);
 		assertThat(formParameters.getFirst(ClientAssertionParameterNames.CLIENT_ASSERTION))
 				.isNotEmpty();
-		assertTrue(validateJWTSecret(formParameters.getFirst(ClientAssertionParameterNames.CLIENT_ASSERTION),clientRegistration));
+		assertThat(validateJWTSecret(formParameters.getFirst(ClientAssertionParameterNames.CLIENT_ASSERTION), clientRegistration)).isTrue();
 
 	}
 
@@ -240,7 +238,7 @@ public class OAuth2AuthorizationCodeGrantRequestEntityConverterTests {
 		RequestEntity<?> requestEntity = this.converter.convert(authorizationCodeGrantRequest);
 	}
 
-	private boolean validateJWTSecret(String jwt,ClientRegistration registration ){
+	private boolean validateJWTSecret(String jwt, ClientRegistration registration ){
 
 		boolean success;
 

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveClientCredentialsTokenResponseClientTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveClientCredentialsTokenResponseClientTests.java
@@ -113,6 +113,34 @@ public class WebClientReactiveClientCredentialsTokenResponseClientTests {
 	}
 
 	@Test
+	public void getTokenResponseWhenJWTSecretThenSuccess() throws Exception {
+		ClientRegistration registration = this.clientRegistration
+				.clientAuthenticationMethod(ClientAuthenticationMethod.SECRET_JWT)
+				.clientSecret("2ae2135579004d5d87ae8241603c0a5c")
+				.build();
+
+		enqueueJson("{\n"
+				+ "  \"access_token\":\"MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI3\",\n"
+				+ "  \"token_type\":\"bearer\",\n"
+				+ "  \"expires_in\":3600,\n"
+				+ "  \"refresh_token\":\"IwOGYzYTlmM2YxOTQ5MGE3YmNmMDFkNTVk\",\n"
+				+ "  \"scope\":\"create\"\n"
+				+ "}");
+
+		OAuth2ClientCredentialsGrantRequest request = new OAuth2ClientCredentialsGrantRequest(registration);
+
+		OAuth2AccessTokenResponse response = this.client.getTokenResponse(request).block();
+		RecordedRequest actualRequest = this.server.takeRequest();
+		String body = actualRequest.getUtf8Body();
+
+		assertThat(response.getAccessToken()).isNotNull();
+		assertThat(actualRequest.getHeader(HttpHeaders.AUTHORIZATION)).isNull();
+		assertThat(body).contains("grant_type=client_credentials");
+		assertThat(body).contains("scope=read%3Auser");
+		assertThat(body).contains("client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer");
+	}
+
+	@Test
 	public void getTokenResponseWhenNoScopeThenClientRegistrationScopesDefaulted() {
 		ClientRegistration registration = this.clientRegistration.build();
 		enqueueJson("{\n"

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactivePasswordTokenResponseClientTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactivePasswordTokenResponseClientTests.java
@@ -134,6 +134,31 @@ public class WebClientReactivePasswordTokenResponseClientTests {
 		assertThat(formParameters).contains("client_id=client-id");
 		assertThat(formParameters).contains("client_secret=client-secret");
 	}
+	@Test
+	public void getTokenResponseWhenClientAuthenticationJWTSecretThenFormParametersAreSent() throws Exception {
+		String accessTokenSuccessResponse = "{\n" +
+				"	\"access_token\": \"access-token-1234\",\n" +
+				"   \"token_type\": \"bearer\",\n" +
+				"   \"expires_in\": \"3600\"\n" +
+				"}\n";
+		this.server.enqueue(jsonResponse(accessTokenSuccessResponse));
+
+		ClientRegistration clientRegistration = this.clientRegistrationBuilder
+				.clientAuthenticationMethod(ClientAuthenticationMethod.SECRET_JWT)
+				.clientSecret("2ae2135579004d5d87ae8241603c0a5c")
+				.build();
+
+		OAuth2PasswordGrantRequest passwordGrantRequest = new OAuth2PasswordGrantRequest(
+				clientRegistration, this.username, this.password);
+
+		this.tokenResponseClient.getTokenResponse(passwordGrantRequest).block();
+
+		RecordedRequest recordedRequest = this.server.takeRequest();
+		assertThat(recordedRequest.getHeader(HttpHeaders.AUTHORIZATION)).isNull();
+
+		String formParameters = recordedRequest.getBody().readUtf8();
+		assertThat(formParameters).contains("client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer");
+	}
 
 	@Test
 	public void getTokenResponseWhenSuccessResponseAndNotBearerTokenTypeThenThrowOAuth2AuthorizationException() {

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveRefreshTokenTokenResponseClientTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveRefreshTokenTokenResponseClientTests.java
@@ -141,6 +141,32 @@ public class WebClientReactiveRefreshTokenTokenResponseClientTests {
 	}
 
 	@Test
+	public void getTokenResponseWhenClientAuthenticationJWTSecretThenFormParametersAreSent() throws Exception {
+		String accessTokenSuccessResponse = "{\n" +
+				"	\"access_token\": \"access-token-1234\",\n" +
+				"   \"token_type\": \"bearer\",\n" +
+				"   \"expires_in\": \"3600\"\n" +
+				"}\n";
+		this.server.enqueue(jsonResponse(accessTokenSuccessResponse));
+
+		ClientRegistration clientRegistration = this.clientRegistrationBuilder
+				.clientAuthenticationMethod(ClientAuthenticationMethod.SECRET_JWT)
+				.clientSecret("2ae2135579004d5d87ae8241603c0a5c")
+				.build();
+
+		OAuth2RefreshTokenGrantRequest refreshTokenGrantRequest = new OAuth2RefreshTokenGrantRequest(
+				clientRegistration, this.accessToken, this.refreshToken);
+
+		this.tokenResponseClient.getTokenResponse(refreshTokenGrantRequest).block();
+
+		RecordedRequest recordedRequest = this.server.takeRequest();
+		assertThat(recordedRequest.getHeader(HttpHeaders.AUTHORIZATION)).isNull();
+
+		String formParameters = recordedRequest.getBody().readUtf8();
+		assertThat(formParameters).contains("client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer");
+	}
+
+	@Test
 	public void getTokenResponseWhenSuccessResponseAndNotBearerTokenTypeThenThrowOAuth2AuthorizationException() {
 		String accessTokenSuccessResponse = "{\n" +
 				"	\"access_token\": \"access-token-1234\",\n" +

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthorizedClientMixinTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthorizedClientMixinTests.java
@@ -257,6 +257,7 @@ public class OAuth2AuthorizedClientMixinTests {
 				"    \"registrationId\": \"" + clientRegistration.getRegistrationId() + "\",\n" +
 				"    \"clientId\": \"" + clientRegistration.getClientId() + "\",\n" +
 				"    \"clientSecret\": \"" + clientRegistration.getClientSecret() + "\",\n" +
+				"    \"clientAssertionSigningAlgorithm\": \"" + clientRegistration.getClientAssertionSigningAlgorithm() + "\",\n" +
 				"    \"clientAuthenticationMethod\": {\n" +
 				"      \"value\": \"" + clientRegistration.getClientAuthenticationMethod().getValue() + "\"\n" +
 				"    },\n" +

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/ClientRegistrationTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/ClientRegistrationTests.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.springframework.security.oauth2.core.AuthenticationMethod;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -50,6 +51,9 @@ public class ClientRegistrationTests {
 	private static final String JWK_SET_URI = "https://provider.com/oauth2/keys";
 	private static final String ISSUER_URI = "https://provider.com";
 	private static final String CLIENT_NAME = "Client 1";
+	private static final String CLIENT_ASSERTION_SIGN_ALG_HS_256 = JwsAlgorithms.HS256;
+	private static final String CLIENT_ASSERTION_SIGN_ALG_HS_512 = JwsAlgorithms.HS512;
+	private static final String CLIENT_ASSERTION_SIGN_ALG_INVALID = "RS784";
 	private static final Map<String, Object> PROVIDER_CONFIGURATION_METADATA =
 			Collections.unmodifiableMap(createProviderConfigurationMetadata());
 
@@ -74,6 +78,7 @@ public class ClientRegistrationTests {
 			.userInfoAuthenticationMethod(AuthenticationMethod.FORM)
 			.jwkSetUri(JWK_SET_URI)
 			.clientName(CLIENT_NAME)
+			.clientAssertionSigningAlgorithm(CLIENT_ASSERTION_SIGN_ALG_HS_256)
 			.build();
 	}
 
@@ -771,4 +776,78 @@ public class ClientRegistrationTests {
 		assertThat(updated.getProviderDetails().getConfigurationMetadata())
 				.containsOnlyKeys("a-new-config").containsValue("a-new-value");
 	}
+
+	@Test
+	public void buildWhenAuthorizationCodeGrantAllAttributesProvidedThenAllAttributesAreSetAndClientAssertionNotSet() {
+		ClientRegistration registration = ClientRegistration.withRegistrationId(REGISTRATION_ID)
+				.clientId(CLIENT_ID)
+				.clientSecret(CLIENT_SECRET)
+				.clientAuthenticationMethod(ClientAuthenticationMethod.SECRET_JWT)
+				.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+				.redirectUriTemplate(REDIRECT_URI)
+				.scope(SCOPES.toArray(new String[0]))
+				.authorizationUri(AUTHORIZATION_URI)
+				.tokenUri(TOKEN_URI)
+				.userInfoAuthenticationMethod(AuthenticationMethod.FORM)
+				.jwkSetUri(JWK_SET_URI)
+				.issuerUri(ISSUER_URI)
+				.providerConfigurationMetadata(PROVIDER_CONFIGURATION_METADATA)
+				.clientName(CLIENT_NAME)
+
+				.build();
+
+		assertThat(registration.getRegistrationId()).isEqualTo(REGISTRATION_ID);
+		assertThat(registration.getClientId()).isEqualTo(CLIENT_ID);
+		assertThat(registration.getClientSecret()).isEqualTo(CLIENT_SECRET);
+		assertThat(registration.getClientAuthenticationMethod()).isEqualTo(ClientAuthenticationMethod.SECRET_JWT);
+		assertThat(registration.getAuthorizationGrantType()).isEqualTo(AuthorizationGrantType.AUTHORIZATION_CODE);
+		assertThat(registration.getRedirectUriTemplate()).isEqualTo(REDIRECT_URI);
+		assertThat(registration.getScopes()).isEqualTo(SCOPES);
+		assertThat(registration.getProviderDetails().getAuthorizationUri()).isEqualTo(AUTHORIZATION_URI);
+		assertThat(registration.getProviderDetails().getTokenUri()).isEqualTo(TOKEN_URI);
+		assertThat(registration.getProviderDetails().getUserInfoEndpoint().getAuthenticationMethod()).isEqualTo(AuthenticationMethod.FORM);
+		assertThat(registration.getProviderDetails().getJwkSetUri()).isEqualTo(JWK_SET_URI);
+		assertThat(registration.getProviderDetails().getIssuerUri()).isEqualTo(ISSUER_URI);
+		assertThat(registration.getProviderDetails().getConfigurationMetadata()).isEqualTo(PROVIDER_CONFIGURATION_METADATA);
+		assertThat(registration.getClientName()).isEqualTo(CLIENT_NAME);
+		assertThat(registration.getClientAssertionSigningAlgorithm()).isEqualTo(CLIENT_ASSERTION_SIGN_ALG_HS_256);
+	}
+
+	@Test
+	public void buildWhenAuthorizationCodeGrantAllAttributesProvidedThenAllAttributesAreSetAndClientAssertionIsSet() {
+		ClientRegistration registration = ClientRegistration.withRegistrationId(REGISTRATION_ID)
+				.clientId(CLIENT_ID)
+				.clientSecret(CLIENT_SECRET)
+				.clientAuthenticationMethod(ClientAuthenticationMethod.SECRET_JWT)
+				.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+				.redirectUriTemplate(REDIRECT_URI)
+				.scope(SCOPES.toArray(new String[0]))
+				.authorizationUri(AUTHORIZATION_URI)
+				.tokenUri(TOKEN_URI)
+				.userInfoAuthenticationMethod(AuthenticationMethod.FORM)
+				.jwkSetUri(JWK_SET_URI)
+				.issuerUri(ISSUER_URI)
+				.providerConfigurationMetadata(PROVIDER_CONFIGURATION_METADATA)
+				.clientName(CLIENT_NAME)
+				.clientAssertionSigningAlgorithm(CLIENT_ASSERTION_SIGN_ALG_HS_512)
+				.build();
+
+		assertThat(registration.getRegistrationId()).isEqualTo(REGISTRATION_ID);
+		assertThat(registration.getClientId()).isEqualTo(CLIENT_ID);
+		assertThat(registration.getClientSecret()).isEqualTo(CLIENT_SECRET);
+		assertThat(registration.getClientAuthenticationMethod()).isEqualTo(ClientAuthenticationMethod.SECRET_JWT);
+		assertThat(registration.getAuthorizationGrantType()).isEqualTo(AuthorizationGrantType.AUTHORIZATION_CODE);
+		assertThat(registration.getRedirectUriTemplate()).isEqualTo(REDIRECT_URI);
+		assertThat(registration.getScopes()).isEqualTo(SCOPES);
+		assertThat(registration.getProviderDetails().getAuthorizationUri()).isEqualTo(AUTHORIZATION_URI);
+		assertThat(registration.getProviderDetails().getTokenUri()).isEqualTo(TOKEN_URI);
+		assertThat(registration.getProviderDetails().getUserInfoEndpoint().getAuthenticationMethod()).isEqualTo(AuthenticationMethod.FORM);
+		assertThat(registration.getProviderDetails().getJwkSetUri()).isEqualTo(JWK_SET_URI);
+		assertThat(registration.getProviderDetails().getIssuerUri()).isEqualTo(ISSUER_URI);
+		assertThat(registration.getProviderDetails().getConfigurationMetadata()).isEqualTo(PROVIDER_CONFIGURATION_METADATA);
+		assertThat(registration.getClientName()).isEqualTo(CLIENT_NAME);
+		assertThat(registration.getClientAssertionSigningAlgorithm()).isEqualTo(CLIENT_ASSERTION_SIGN_ALG_HS_512);
+	}
+
+
 }

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClientAuthenticationMethod.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClientAuthenticationMethod.java
@@ -31,6 +31,7 @@ public final class ClientAuthenticationMethod implements Serializable {
 	private static final long serialVersionUID = SpringSecurityCoreVersion.SERIAL_VERSION_UID;
 	public static final ClientAuthenticationMethod BASIC = new ClientAuthenticationMethod("basic");
 	public static final ClientAuthenticationMethod POST = new ClientAuthenticationMethod("post");
+	public static final ClientAuthenticationMethod SECRET_JWT = new ClientAuthenticationMethod("secret_jwt");
 
 	/**
 	 * @since 5.2

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/ClientAssertionParameterNames.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/ClientAssertionParameterNames.java
@@ -1,0 +1,44 @@
+/*
+ *
+ *
+ *  * Copyright 2020 Paychex, Inc.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.springframework.security.oauth2.core.endpoint;
+
+/**
+ * @author visweshwarganesh
+ * @Created 06/20/2020 - 9:13 AM
+ * RFC-7521 Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants
+ * https://tools.ietf.org/html/rfc7521#section-9
+ */
+public interface ClientAssertionParameterNames {
+
+	/**
+	 * {@code assertion} - used in Access Token Request.
+	 */
+	String ASSERTION = "assertion";
+
+	/**
+	 * {@code client_assertion} - used in Access Token Request.
+	 */
+	String CLIENT_ASSERTION = "client_assertion";
+
+	/**
+	 * {@code client_assertion_type} - used in Access Token Request.
+	 */
+	String CLIENT_ASSERTION_TYPE = "client_assertion_type";
+}

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/ClientAssertionParameterNames.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/ClientAssertionParameterNames.java
@@ -1,20 +1,17 @@
 /*
+ * Copyright 2002-2019 the original author or authors.
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * Copyright 2020 Paychex, Inc.
- *  *
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *      https://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.springframework.security.oauth2.core.endpoint;

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/ClientAssertionParameterValues.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/ClientAssertionParameterValues.java
@@ -1,0 +1,39 @@
+/*
+ *
+ *
+ *  * Copyright 2020 Paychex, Inc.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.springframework.security.oauth2.core.endpoint;
+
+/**
+ * @author visweshwarganesh
+ * @Created 06/20/2020 - 9:21 AM
+ * RFC-7523  JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants
+ * https://tools.ietf.org/html/rfc7523#section-8
+ */
+public interface ClientAssertionParameterValues {
+
+	/**
+	 * {@code urn:ietf:params:oauth:client-assertion-type:jwt-bearer} - used in Access Token Request.
+	 */
+	String CLIENT_ASSERTION_TYPE_JWT_BEARER = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+
+	/**
+	 * {@code urn:ietf:params:oauth:grant-type:jwt-bearer} - used in Access Token Request.
+	 */
+	String CLIENT_GRANT_TYPE_JWT_BEARER = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+}

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/ClientAssertionParameterValues.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/ClientAssertionParameterValues.java
@@ -1,20 +1,17 @@
 /*
+ * Copyright 2002-2019 the original author or authors.
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * Copyright 2020 Paychex, Inc.
- *  *
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *      https://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.springframework.security.oauth2.core.endpoint;


### PR DESCRIPTION
One of the protocols support by OAuth is Client Assertion as authentication

A client uses an assertion to authenticate to the authorization server's token endpoint by using the "client_assertion_type" and "client_assertion" parameters

https://tools.ietf.org/html/rfc7521#section-6.1

Current Behavior

No Support

Context

This is something supported by jose.nimbus and as consumer and provider of OAuth we want to secure our authentication to the token endpoint using this protocol.

#8735