### PR TITLE
Add support for dynamic JWS signature algorithm with JWKs - Issue 7160

### DIFF
--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoderBuilder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoderBuilder.java
@@ -17,7 +17,10 @@ package org.springframework.security.oauth2.jwt;
 
 import com.nimbusds.jose.Algorithm;
 import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.jwk.*;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKMatcher;
+import com.nimbusds.jose.jwk.JWKSelector;
+import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 import org.apache.commons.logging.Log;
@@ -29,13 +32,14 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.*;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
  * An abstraction of the common functionality for the two main JwtDecoderBuilder instances
  * ({@link NimbusJwtDecoder}, and {@link NimbusReactiveJwtDecoder}).
- * @param <T>
+ * @param <T> The parent class type
+ *
+ * @author Nick Hitchan
  */
 public abstract class JwtDecoderBuilder<T> {
 

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoderBuilder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoderBuilder.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.jwt;
+
+import com.nimbusds.jose.Algorithm;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.*;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
+import org.springframework.util.Assert;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * An abstraction of the common functionality for the two main JwtDecoderBuilder instances
+ * ({@link NimbusJwtDecoder}, and {@link NimbusReactiveJwtDecoder}).
+ * @param <T>
+ */
+public abstract class JwtDecoderBuilder<T> {
+
+	private static final Log log = LogFactory.getLog(JwtDecoderBuilder.class);
+
+	private final String jwkSetUri;
+
+	private final Set<SignatureAlgorithm> signatureAlgorithms = new HashSet<>();
+
+	protected JwtDecoderBuilder(String jwkSetUri) {
+		Assert.hasText(jwkSetUri, "jwkSetUri cannot be empty");
+		this.jwkSetUri = jwkSetUri;
+	}
+
+	protected abstract T self();
+
+	/**
+	 * Provides access to the location of the JWK Set.
+	 * @return the JWK Set URI.
+	 */
+	protected String getJwkSetUri() {
+		return jwkSetUri;
+	}
+
+	/**
+	 * Append the given signing
+	 * <a href="https://tools.ietf.org/html/rfc7515#section-4.1.1" target="_blank">algorithm</a>
+	 * to the set of algorithms to use.
+	 *
+	 * @param signatureAlgorithm the algorithm to use
+	 * @return a {@link NimbusReactiveJwtDecoder.JwkSetUriReactiveJwtDecoderBuilder} for further configurations
+	 */
+	public T jwsAlgorithm(SignatureAlgorithm signatureAlgorithm) {
+		Assert.notNull(signatureAlgorithm, "sig cannot be null");
+		this.signatureAlgorithms.add(signatureAlgorithm);
+		return self();
+	}
+
+	/**
+	 * Configure the list of
+	 * <a href="https://tools.ietf.org/html/rfc7515#section-4.1.1" target="_blank">algorithms</a>
+	 * to use with the given {@link Consumer}.
+	 *
+	 * @param signatureAlgorithmsConsumer a {@link Consumer} for further configuring the algorithm list
+	 * @return a {@link NimbusReactiveJwtDecoder.JwkSetUriReactiveJwtDecoderBuilder} for further configurations
+	 */
+	public T jwsAlgorithms(Consumer<Set<SignatureAlgorithm>> signatureAlgorithmsConsumer) {
+		Assert.notNull(signatureAlgorithmsConsumer, "signatureAlgorithmsConsumer cannot be null");
+		signatureAlgorithmsConsumer.accept(this.signatureAlgorithms);
+		return self();
+	}
+
+	/**
+	 * Fetches {@link SignatureAlgorithm}s based on the configured {@link JWKSource}s keys.
+	 * @param jwkSource
+	 * @return A set of {@link JWSAlgorithm}s to be used for JWT signature verification.
+	 */
+	protected Set<JWSAlgorithm> getSignatureAlgorithms(JWKSource<SecurityContext> jwkSource) {
+		Set<SignatureAlgorithm> jwkAlgorithms = getDefaultAlgorithms();
+		try {
+			jwkAlgorithms.addAll(fetchSignatureVerificationAlgorithms(jwkSource));
+		} catch (Exception ex) {
+			log.error("Error fetching Signature Verification algorithms");
+		}
+		return convertToJwsAlgorithms(jwkAlgorithms);
+	}
+
+	/**
+	 * Fetches {@link SignatureAlgorithm}s based on the configured {@link ReactiveJWKSource}s keys.
+	 * @param jwkSource
+	 * @return A set of {@link JWSAlgorithm}s to be used for JWT signature verification.
+	 */
+	protected Set<JWSAlgorithm> getSignatureAlgorithms(ReactiveJWKSource jwkSource) {
+		Set<SignatureAlgorithm> jwkAlgorithms = getDefaultAlgorithms();
+		try {
+			jwkAlgorithms.addAll(fetchSignatureVerificationAlgorithms(jwkSource));
+		} catch (Exception ex) {
+			log.error("Error fetching Signature Verification algorithms");
+		}
+		return convertToJwsAlgorithms(jwkAlgorithms);
+	}
+
+	/**
+	 * Retains the original functionality for adding {@link SignatureAlgorithm#RS256} as a default algorithm if none are provided.
+	 * @return A set of default {@link SignatureAlgorithm}s
+	 */
+	private Set<SignatureAlgorithm> getDefaultAlgorithms() {
+		Set<SignatureAlgorithm> jwkAlgorithms = new HashSet<>();
+		if (this.signatureAlgorithms.isEmpty()) {
+			jwkAlgorithms.add(SignatureAlgorithm.RS256);
+		} else {
+			jwkAlgorithms.addAll(this.signatureAlgorithms);
+		}
+		return jwkAlgorithms;
+	}
+
+	private Set<JWSAlgorithm> convertToJwsAlgorithms(Set<SignatureAlgorithm> algorithms) {
+		return algorithms.stream()
+				.map(algorithm -> JWSAlgorithm.parse(algorithm.getName()))
+				.collect(Collectors.toSet());
+	}
+
+	/**
+	 * Given a valid {@link JWKSource}, fetches, and parses out the algorithms of available JWKs.
+	 * @param jwkSource
+	 * @return A set of {@link SignatureAlgorithm} instances that may be used to validate a JWT (JWS).
+	 */
+	private Set<SignatureAlgorithm> fetchSignatureVerificationAlgorithms(JWKSource<SecurityContext> jwkSource) {
+		return fetchSignatureVerificationAlgorithms(fetchSignatureVerificationJwks(jwkSource));
+	}
+
+	/**
+	 * Given a valid {@link ReactiveJWKSource}, fetches, and parses out the algorithms of available JWKs.
+	 * @param jwkSource
+	 * @return A set of {@link SignatureAlgorithm} instances that may be used to validate a JWT (JWS).
+	 */
+	private Set<SignatureAlgorithm> fetchSignatureVerificationAlgorithms(ReactiveJWKSource jwkSource) {
+		return fetchSignatureVerificationAlgorithms(fetchSignatureVerificationJwks(jwkSource));
+	}
+
+	/**
+	 * Converts a list of {@link JWK}s into a set of {@link SignatureAlgorithm}s.
+	 * @param jwks
+	 * @return A set of {@link SignatureAlgorithm} instances that may be used to validate a JWT (JWS).
+	 */
+	private Set<SignatureAlgorithm> fetchSignatureVerificationAlgorithms(List<JWK> jwks) {
+		if (jwks == null) {
+			return Collections.emptySet();
+		}
+		return jwks.stream().map(jwk -> {
+			Algorithm algorithm = jwk.getAlgorithm();
+			if (algorithm != null) {
+				return SignatureAlgorithm.from(algorithm.getName());
+			}
+			return null;
+		}).filter(Objects::nonNull).collect(Collectors.toSet());
+	}
+
+	/**
+	 * Given a valid {@link JWKSource}, fetches the raw list of available {@link JWK}s.
+	 * @param jwkSource
+	 * @return An filtered list of available {@link JWK}s from the given source that may be used for JWT signature verification.
+	 */
+	private List<JWK> fetchSignatureVerificationJwks(JWKSource<SecurityContext> jwkSource) {
+		try {
+			return jwkSource.get(getSignatureVerificationKeySelector(), null);
+		} catch (Exception ex) {
+			log.error("Error fetching Signature Algorithms from JWK source.");
+		}
+		return Collections.emptyList();
+	}
+
+	/**
+	 * Given a valid {@link ReactiveJWKSource}, fetches the raw list of available {@link JWK}s.
+	 * @param jwkSource
+	 * @return An filtered list of available {@link JWK}s from the given source that may be used for JWT signature verification.
+	 */
+	private List<JWK> fetchSignatureVerificationJwks(ReactiveJWKSource jwkSource) {
+		return jwkSource.get(getSignatureVerificationKeySelector()).block();
+	}
+
+	private JWKSelector getSignatureVerificationKeySelector() {
+		return new JWKSelector(new JWKMatcher.Builder()
+				.keyUse(KeyUse.SIGNATURE)
+				.build());
+	}
+
+	/**
+	 * Converts a {@link String} into a {@link URL}.
+	 * @param url the source URL string.
+	 * @return a {@link URL} version of the source URL string.
+	 */
+	protected static URL toURL(String url) {
+		try {
+			return new URL(url);
+		} catch (MalformedURLException ex) {
+			throw new IllegalArgumentException("Invalid JWK Set URL \"" + url + "\" : " + ex.getMessage(), ex);
+		}
+	}
+
+}

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtDecodersTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtDecodersTests.java
@@ -265,6 +265,7 @@ public class JwtDecodersTests {
 	private void prepareConfigurationResponse(String body) {
 		this.server.enqueue(response(body));
 		this.server.enqueue(response(JWK_SET));
+		this.server.enqueue(response(JWK_SET));
 	}
 
 	private void prepareConfigurationResponseOidc() {

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoderJwkSupportTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoderJwkSupportTests.java
@@ -63,8 +63,6 @@ public class NimbusJwtDecoderJwkSupportTests {
 	private static final String MALFORMED_JWT = "eyJhbGciOiJSUzI1NiJ9.eyJuYmYiOnt9LCJleHAiOjQ2ODQyMjUwODd9.guoQvujdWvd3xw7FYQEn4D6-gzM_WqFvXdmvAUNSLbxG7fv2_LLCNujPdrBHJoYPbOwS1BGNxIKQWS1tylvqzmr1RohQ-RZ2iAM1HYQzboUlkoMkcd8ENM__ELqho8aNYBfqwkNdUOyBFoy7Syu_w2SoJADw2RTjnesKO6CVVa05bW118pDS4xWxqC4s7fnBjmZoTn4uQ-Kt9YSQZQk8YQxkJSiyanozzgyfgXULA6mPu1pTNU3FVFaK1i1av_xtH_zAPgb647ZeaNe4nahgqC5h8nhOlm8W2dndXbwAt29nd2ZWBsru_QwZz83XSKLhTPFz-mPBByZZDsyBbIHf9A";
 	private static final String UNSIGNED_JWT = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJleHAiOi0yMDMzMjI0OTcsImp0aSI6IjEyMyIsInR5cCI6IkpXVCJ9.";
 
-	private NimbusJwtDecoderJwkSupport jwtDecoder = new NimbusJwtDecoderJwkSupport(JWK_SET_URL, JWS_ALGORITHM);
-
 	@Test
 	public void constructorWhenJwkSetUrlIsNullThenThrowIllegalArgumentException() {
 		assertThatThrownBy(() -> new NimbusJwtDecoderJwkSupport(null))
@@ -85,13 +83,15 @@ public class NimbusJwtDecoderJwkSupportTests {
 
 	@Test
 	public void setRestOperationsWhenNullThenThrowIllegalArgumentException() {
-		Assertions.assertThatThrownBy(() -> this.jwtDecoder.setRestOperations(null))
+		NimbusJwtDecoderJwkSupport jwtDecoder = new NimbusJwtDecoderJwkSupport(JWK_SET_URL, JWS_ALGORITHM);
+		Assertions.assertThatThrownBy(() -> jwtDecoder.setRestOperations(null))
 				.isInstanceOf(IllegalArgumentException.class);
 	}
 
 	@Test
 	public void decodeWhenJwtInvalidThenThrowJwtException() {
-		assertThatThrownBy(() -> this.jwtDecoder.decode("invalid"))
+		NimbusJwtDecoderJwkSupport jwtDecoder = new NimbusJwtDecoderJwkSupport(JWK_SET_URL, JWS_ALGORITHM);
+		assertThatThrownBy(() -> jwtDecoder.decode("invalid"))
 				.isInstanceOf(JwtException.class);
 	}
 
@@ -111,7 +111,8 @@ public class NimbusJwtDecoderJwkSupportTests {
 	// gh-5457
 	@Test
 	public void decodeWhenPlainJwtThenExceptionDoesNotMentionClass() {
-		assertThatCode(() -> this.jwtDecoder.decode(UNSIGNED_JWT))
+		NimbusJwtDecoderJwkSupport jwtDecoder = new NimbusJwtDecoderJwkSupport(JWK_SET_URL, JWS_ALGORITHM);
+		assertThatCode(() -> jwtDecoder.decode(UNSIGNED_JWT))
 				.isInstanceOf(JwtException.class)
 				.hasMessageContaining("Unsupported algorithm of none");
 	}
@@ -133,6 +134,7 @@ public class NimbusJwtDecoderJwkSupportTests {
 	public void decodeWhenJwkResponseIsMalformedThenReturnsStockException() throws Exception {
 		try ( MockWebServer server = new MockWebServer() ) {
 			server.enqueue(new MockResponse().setBody(MALFORMED_JWK_SET));
+			server.enqueue(new MockResponse().setBody(MALFORMED_JWK_SET));
 			String jwkSetUrl = server.url("/.well-known/jwks.json").toString();
 			NimbusJwtDecoderJwkSupport jwtDecoder = new NimbusJwtDecoderJwkSupport(jwkSetUrl);
 			assertThatCode(() -> jwtDecoder.decode(SIGNED_JWT))
@@ -145,6 +147,7 @@ public class NimbusJwtDecoderJwkSupportTests {
 	@Test
 	public void decodeWhenJwkEndpointIsUnresponsiveThenReturnsJwtException() throws Exception {
 		try ( MockWebServer server = new MockWebServer() ) {
+			server.enqueue(new MockResponse().setBody(MALFORMED_JWK_SET));
 			server.enqueue(new MockResponse().setBody(MALFORMED_JWK_SET));
 			String jwkSetUrl = server.url("/.well-known/jwks.json").toString();
 			NimbusJwtDecoderJwkSupport jwtDecoder = new NimbusJwtDecoderJwkSupport(jwkSetUrl);
@@ -159,6 +162,7 @@ public class NimbusJwtDecoderJwkSupportTests {
 	@Test
 	public void decodeWhenCustomRestOperationsSetThenUsed() throws Exception {
 		try ( MockWebServer server = new MockWebServer() ) {
+			server.enqueue(new MockResponse().setBody(JWK_SET));
 			server.enqueue(new MockResponse().setBody(JWK_SET));
 			String jwkSetUrl = server.url("/.well-known/jwks.json").toString();
 			NimbusJwtDecoderJwkSupport jwtDecoder = new NimbusJwtDecoderJwkSupport(jwkSetUrl);
@@ -233,6 +237,7 @@ public class NimbusJwtDecoderJwkSupportTests {
 
 	@Test
 	public void setClaimSetConverterWhenIsNullThenThrowsIllegalArgumentException() {
+		NimbusJwtDecoderJwkSupport jwtDecoder = new NimbusJwtDecoderJwkSupport(JWK_SET_URL, JWS_ALGORITHM);
 		assertThatCode(() -> jwtDecoder.setClaimSetConverter(null))
 				.isInstanceOf(IllegalArgumentException.class);
 	}


### PR DESCRIPTION
CLA has been submitted.

This PR adds support for creating a JWSVerificationKeySelector dynamically based on the availability of JWK algorithms from a given JWK Set provided by an OIDC discovery document (Issue 7160). Non-standard or unknown algorithms will be silently ignored (see SignatureAlgorithm class). A warning log has also been added to let developers know if there was a problem fetching the JWK Set, although this does not halt the application from starting.

The original functionality is still in place that adds the RS256 algorithm if none are provided during initial configuration for backwards compatibility.

This functionality has been implemented for both standard and reactive versions.