### PR TITLE
optimize-methods

### DIFF
--- a/core/src/main/java/org/springframework/security/core/context/GlobalSecurityContextHolderStrategy.java
+++ b/core/src/main/java/org/springframework/security/core/context/GlobalSecurityContextHolderStrategy.java
@@ -52,8 +52,4 @@ final class GlobalSecurityContextHolderStrategy implements SecurityContextHolder
 		Assert.notNull(context, "Only non-null SecurityContext instances are permitted");
 		contextHolder = context;
 	}
-
-	public SecurityContext createEmptyContext() {
-		return new SecurityContextImpl();
-	}
 }

--- a/core/src/main/java/org/springframework/security/core/context/InheritableThreadLocalSecurityContextHolderStrategy.java
+++ b/core/src/main/java/org/springframework/security/core/context/InheritableThreadLocalSecurityContextHolderStrategy.java
@@ -55,8 +55,4 @@ final class InheritableThreadLocalSecurityContextHolderStrategy implements
 		Assert.notNull(context, "Only non-null SecurityContext instances are permitted");
 		contextHolder.set(context);
 	}
-
-	public SecurityContext createEmptyContext() {
-		return new SecurityContextImpl();
-	}
 }

--- a/core/src/main/java/org/springframework/security/core/context/SecurityContextHolderStrategy.java
+++ b/core/src/main/java/org/springframework/security/core/context/SecurityContextHolderStrategy.java
@@ -57,5 +57,7 @@ public interface SecurityContextHolderStrategy {
 	 *
 	 * @return the empty context.
 	 */
-	SecurityContext createEmptyContext();
+	default SecurityContext createEmptyContext(){
+		return new SecurityContextImpl();
+	}
 }

--- a/core/src/main/java/org/springframework/security/core/context/ThreadLocalSecurityContextHolderStrategy.java
+++ b/core/src/main/java/org/springframework/security/core/context/ThreadLocalSecurityContextHolderStrategy.java
@@ -56,8 +56,4 @@ final class ThreadLocalSecurityContextHolderStrategy implements
 		Assert.notNull(context, "Only non-null SecurityContext instances are permitted");
 		contextHolder.set(context);
 	}
-
-	public SecurityContext createEmptyContext() {
-		return new SecurityContextImpl();
-	}
 }


### PR DESCRIPTION
The method of SecurityContextHolderStrategy#createEmptyContext  is the  same in three implement class (GlobalSecurityContextHolderStrategy,ThreadLocalSecurityContextHolderStrategy and InheritableThreadLocalSecurityContextHolderStrategy).

If we use the method of  createEmptyContext, a feature of Java8, we can define a default implement in SecurityContextHolderStrategy interface.Then we do not need the same code in these three implement classes any more.