### PR TITLE
Add Configurable secure flag in CookieCsrfTokenRepository

### DIFF
--- a/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
@@ -18,6 +18,7 @@ package org.springframework.security.web.csrf;
 
 import java.util.UUID;
 
+import javax.servlet.ServletRequest;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -53,6 +54,8 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 
 	private String cookieDomain;
 
+	private Boolean secure;
+
 	public CookieCsrfTokenRepository() {
 	}
 
@@ -67,7 +70,12 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 			HttpServletResponse response) {
 		String tokenValue = token == null ? "" : token.getToken();
 		Cookie cookie = new Cookie(this.cookieName, tokenValue);
-		cookie.setSecure(request.isSecure());
+		if (secure == null) {
+			cookie.setSecure(request.isSecure());
+		} else {
+			cookie.setSecure(secure);
+		}
+
 		if (this.cookiePath != null && !this.cookiePath.isEmpty()) {
 				cookie.setPath(this.cookiePath);
 		} else {
@@ -194,5 +202,18 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 	public void setCookieDomain(String cookieDomain) {
 		this.cookieDomain = cookieDomain;
 	}
+
+	/**
+	 * Sets secure flag of the cookie that the expected CSRF token is saved to and read from.
+	 * By default secure flag depends on {@link ServletRequest#isSecure()}
+	 *
+	 * @since 5.4
+	 * @param secure the secure flag of the cookie that the expected CSRF token is saved to
+	 * and read from
+	 */
+	public void setSecure(Boolean secure) {
+		this.secure = secure;
+	}
+
 
 }

--- a/web/src/test/java/org/springframework/security/web/csrf/CookieCsrfTokenRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CookieCsrfTokenRepositoryTests.java
@@ -99,6 +99,33 @@ public class CookieCsrfTokenRepositoryTests {
 	}
 
 	@Test
+	public void saveTokenSecureFlagTrue() {
+		this.request.setSecure(false);
+		this.repository.setSecure(Boolean.TRUE);
+		CsrfToken token = this.repository.generateToken(this.request);
+		this.repository.saveToken(token, this.request, this.response);
+
+		Cookie tokenCookie = this.response
+				.getCookie(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+		assertThat(tokenCookie.getSecure()).isTrue();
+	}
+
+	@Test
+	public void saveTokenSecureFlagFalse() {
+		this.request.setSecure(true);
+		this.repository.setSecure(Boolean.FALSE);
+		CsrfToken token = this.repository.generateToken(this.request);
+		this.repository.saveToken(token, this.request, this.response);
+
+		Cookie tokenCookie = this.response
+				.getCookie(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+
+		assertThat(tokenCookie.getSecure()).isFalse();
+	}
+
+
+	@Test
 	public void saveTokenNull() {
 		this.request.setSecure(true);
 		this.repository.saveToken(null, this.request, this.response);


### PR DESCRIPTION
While using the request's "isSecure" flag is a reasonable default, when webapps sit behind firewalls, sometimes the firewall does the SSL, and the traffic between the firewall and the app is plain HTTP (not HTTPS). In this case the "isSecure" flag on the request is always false, but we still want th XSRF-TOKEN cookie to be secure (the firewall forwards all cookies to the app, and the browser sends the secure cookie to the firewall).

It would be nice if we could configure the desired value for the secure flag of the cookie, just like we can configure the value for the httpOnly flag of the cookie.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
