### PR TITLE
Add support for dynamic JWS signature algorithm with JWKs (2) - Issue 7160

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
@@ -217,6 +217,7 @@ public class OAuth2ResourceServerConfigurerTests {
 	public void getWhenUsingJwkSetUriThenAcceptsRequest() throws Exception {
 		this.spring.register(WebServerConfig.class, JwkSetUriConfig.class, BasicController.class).autowire();
 		mockWebServer(jwks("Default"));
+		mockWebServer(jwks("Default"));
 		String token = this.token("ValidNoScopes");
 
 		this.mvc.perform(get("/").with(bearerToken(token)))
@@ -227,6 +228,7 @@ public class OAuth2ResourceServerConfigurerTests {
 	@Test
 	public void getWhenUsingJwkSetUriInLambdaThenAcceptsRequest() throws Exception {
 		this.spring.register(WebServerConfig.class, JwkSetUriInLambdaConfig.class, BasicController.class).autowire();
+		mockWebServer(jwks("Default"));
 		mockWebServer(jwks("Default"));
 		String token = this.token("ValidNoScopes");
 
@@ -1398,6 +1400,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 		mockWebServer(String.format(metadata, issuerOne, issuerOne));
 		mockWebServer(jwkSet);
+		mockWebServer(jwkSet);
 
 		this.mvc.perform(get("/authenticated")
 				.with(bearerToken(jwtOne)))
@@ -1405,6 +1408,7 @@ public class OAuth2ResourceServerConfigurerTests {
 				.andExpect(content().string("test-subject"));
 
 		mockWebServer(String.format(metadata, issuerTwo, issuerTwo));
+		mockWebServer(jwkSet);
 		mockWebServer(jwkSet);
 
 		this.mvc.perform(get("/authenticated")

--- a/config/src/test/java/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParserTests.java
+++ b/config/src/test/java/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParserTests.java
@@ -151,6 +151,7 @@ public class OAuth2ResourceServerBeanDefinitionParserTests {
 	public void getWhenUsingJwkSetUriThenAcceptsRequest() throws Exception {
 		this.spring.configLocations(xml("WebServer"), xml("JwkSetUri")).autowire();
 		mockWebServer(jwks("Default"));
+		mockWebServer(jwks("Default"));
 		String token = this.token("ValidNoScopes");
 
 		this.mvc.perform(get("/")

--- a/config/src/test/java/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParserTests.java
+++ b/config/src/test/java/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParserTests.java
@@ -834,6 +834,7 @@ public class OAuth2ResourceServerBeanDefinitionParserTests {
 
 		mockWebServer(String.format(metadata, issuerOne, issuerOne));
 		mockWebServer(jwkSet);
+		mockWebServer(jwkSet);
 
 		this.mvc.perform(get("/authenticated")
 				.header("Authorization", "Bearer " + jwtOne))
@@ -841,12 +842,14 @@ public class OAuth2ResourceServerBeanDefinitionParserTests {
 
 		mockWebServer(String.format(metadata, issuerTwo, issuerTwo));
 		mockWebServer(jwkSet);
+		mockWebServer(jwkSet);
 
 		this.mvc.perform(get("/authenticated")
 				.header("Authorization", "Bearer " + jwtTwo))
 				.andExpect(status().isNotFound());
 
 		mockWebServer(String.format(metadata, issuerThree, issuerThree));
+		mockWebServer(jwkSet);
 		mockWebServer(jwkSet);
 
 		this.mvc.perform(get("/authenticated")

--- a/config/src/test/java/org/springframework/security/config/web/server/OAuth2ResourceServerSpecTests.java
+++ b/config/src/test/java/org/springframework/security/config/web/server/OAuth2ResourceServerSpecTests.java
@@ -235,6 +235,7 @@ public class OAuth2ResourceServerSpecTests {
 
 		MockWebServer mockWebServer = this.spring.getContext().getBean(MockWebServer.class);
 		mockWebServer.enqueue(new MockResponse().setBody(this.jwkSet));
+		mockWebServer.enqueue(new MockResponse().setBody(this.jwkSet));
 
 		this.client.get()
 				.headers(headers -> headers.setBearerAuth(this.messageReadTokenWithKid))
@@ -247,6 +248,7 @@ public class OAuth2ResourceServerSpecTests {
 		this.spring.register(JwkSetUriInLambdaConfig.class, RootController.class).autowire();
 
 		MockWebServer mockWebServer = this.spring.getContext().getBean(MockWebServer.class);
+		mockWebServer.enqueue(new MockResponse().setBody(this.jwkSet));
 		mockWebServer.enqueue(new MockResponse().setBody(this.jwkSet));
 
 		this.client.get()

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerJwtDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerJwtDslTests.kt
@@ -161,6 +161,7 @@ class ServerJwtDslTests {
         this.spring.register(CustomJwkSetUriConfig::class.java).autowire()
 
         CustomJwkSetUriConfig.MOCK_WEB_SERVER.enqueue(MockResponse().setBody(jwkSet))
+        CustomJwkSetUriConfig.MOCK_WEB_SERVER.enqueue(MockResponse().setBody(jwkSet))
 
         this.client.get()
                 .uri("/")

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoder.java
@@ -304,7 +304,7 @@ public final class NimbusJwtDecoder implements JwtDecoder {
 				return Collections.emptySet();
 			}
 			try {
-				return parseAlgorithms(JWKSet.load(toURL(jwkSetUri)));
+				return parseAlgorithms(JWKSet.load(toURL(jwkSetUri), 5000, 5000, 0));
 			} catch (Exception ex) {
 				log.error("Failed to load Signature Algorithms from remote JWK source.");
 				return Collections.emptySet();
@@ -316,10 +316,13 @@ public final class NimbusJwtDecoder implements JwtDecoder {
 				return Collections.emptySet();
 			}
 
-			JWKSelector selector = new JWKSelector(new JWKMatcher.Builder()
-					.keyUse(KeyUse.SIGNATURE)
-					.build());
-			List<JWK> jwks = selector.select(jwkSet);
+			List<JWK> jwks = new ArrayList<>();
+			for (JWK jwk : jwkSet.getKeys()) {
+				KeyUse keyUse = jwk.getKeyUse();
+				if (keyUse != null && keyUse.equals(KeyUse.SIGNATURE)) {
+					jwks.add(jwk);
+				}
+			}
 
 			Set<SignatureAlgorithm> algorithms = new HashSet<>();
 			for (JWK jwk : jwks) {

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
@@ -318,7 +318,7 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 				return Collections.emptySet();
 			}
 			try {
-				return parseAlgorithms(JWKSet.load(toURL(jwkSetUri)));
+				return parseAlgorithms(JWKSet.load(toURL(jwkSetUri), 5000, 5000, 0));
 			} catch (Exception ex) {
 				log.error("Failed to load Signature Algorithms from remote JWK source.");
 				return Collections.emptySet();
@@ -330,10 +330,13 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 				return Collections.emptySet();
 			}
 
-			JWKSelector selector = new JWKSelector(new JWKMatcher.Builder()
-					.keyUse(KeyUse.SIGNATURE)
-					.build());
-			List<JWK> jwks = selector.select(jwkSet);
+			List<JWK> jwks = new ArrayList<>();
+			for (JWK jwk : jwkSet.getKeys()) {
+				KeyUse keyUse = jwk.getKeyUse();
+				if (keyUse != null && keyUse.equals(KeyUse.SIGNATURE)) {
+					jwks.add(jwk);
+				}
+			}
 
 			Set<SignatureAlgorithm> algorithms = new HashSet<>();
 			for (JWK jwk : jwks) {

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
@@ -320,14 +320,13 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 			try {
 				return parseAlgorithms(JWKSet.load(toURL(jwkSetUri), 5000, 5000, 0));
 			} catch (Exception ex) {
-				log.error("Failed to load Signature Algorithms from remote JWK source.");
-				return Collections.emptySet();
+				throw new IllegalArgumentException("Failed to load Signature Algorithms from remote JWK source.", ex);
 			}
 		}
 
 		private Set<SignatureAlgorithm> parseAlgorithms(JWKSet jwkSet) {
 			if (jwkSet == null) {
-				return Collections.emptySet();
+				throw new IllegalArgumentException(String.format("No JWKs received from %s", jwkSetUri));
 			}
 
 			List<JWK> jwks = new ArrayList<>();

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtDecodersTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtDecodersTests.java
@@ -265,6 +265,7 @@ public class JwtDecodersTests {
 	private void prepareConfigurationResponse(String body) {
 		this.server.enqueue(response(body));
 		this.server.enqueue(response(JWK_SET));
+		this.server.enqueue(response(JWK_SET));
 	}
 
 	private void prepareConfigurationResponseOidc() {

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoderJwkSupportTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoderJwkSupportTests.java
@@ -63,8 +63,6 @@ public class NimbusJwtDecoderJwkSupportTests {
 	private static final String MALFORMED_JWT = "eyJhbGciOiJSUzI1NiJ9.eyJuYmYiOnt9LCJleHAiOjQ2ODQyMjUwODd9.guoQvujdWvd3xw7FYQEn4D6-gzM_WqFvXdmvAUNSLbxG7fv2_LLCNujPdrBHJoYPbOwS1BGNxIKQWS1tylvqzmr1RohQ-RZ2iAM1HYQzboUlkoMkcd8ENM__ELqho8aNYBfqwkNdUOyBFoy7Syu_w2SoJADw2RTjnesKO6CVVa05bW118pDS4xWxqC4s7fnBjmZoTn4uQ-Kt9YSQZQk8YQxkJSiyanozzgyfgXULA6mPu1pTNU3FVFaK1i1av_xtH_zAPgb647ZeaNe4nahgqC5h8nhOlm8W2dndXbwAt29nd2ZWBsru_QwZz83XSKLhTPFz-mPBByZZDsyBbIHf9A";
 	private static final String UNSIGNED_JWT = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJleHAiOi0yMDMzMjI0OTcsImp0aSI6IjEyMyIsInR5cCI6IkpXVCJ9.";
 
-	private NimbusJwtDecoderJwkSupport jwtDecoder = new NimbusJwtDecoderJwkSupport(JWK_SET_URL, JWS_ALGORITHM);
-
 	@Test
 	public void constructorWhenJwkSetUrlIsNullThenThrowIllegalArgumentException() {
 		assertThatThrownBy(() -> new NimbusJwtDecoderJwkSupport(null))
@@ -85,13 +83,15 @@ public class NimbusJwtDecoderJwkSupportTests {
 
 	@Test
 	public void setRestOperationsWhenNullThenThrowIllegalArgumentException() {
-		Assertions.assertThatThrownBy(() -> this.jwtDecoder.setRestOperations(null))
+		NimbusJwtDecoderJwkSupport jwtDecoder = new NimbusJwtDecoderJwkSupport(JWK_SET_URL, JWS_ALGORITHM);
+		Assertions.assertThatThrownBy(() -> jwtDecoder.setRestOperations(null))
 				.isInstanceOf(IllegalArgumentException.class);
 	}
 
 	@Test
 	public void decodeWhenJwtInvalidThenThrowJwtException() {
-		assertThatThrownBy(() -> this.jwtDecoder.decode("invalid"))
+		NimbusJwtDecoderJwkSupport jwtDecoder = new NimbusJwtDecoderJwkSupport(JWK_SET_URL, JWS_ALGORITHM);
+		assertThatThrownBy(() -> jwtDecoder.decode("invalid"))
 				.isInstanceOf(JwtException.class);
 	}
 
@@ -111,7 +111,8 @@ public class NimbusJwtDecoderJwkSupportTests {
 	// gh-5457
 	@Test
 	public void decodeWhenPlainJwtThenExceptionDoesNotMentionClass() {
-		assertThatCode(() -> this.jwtDecoder.decode(UNSIGNED_JWT))
+		NimbusJwtDecoderJwkSupport jwtDecoder = new NimbusJwtDecoderJwkSupport(JWK_SET_URL, JWS_ALGORITHM);
+		assertThatCode(() -> jwtDecoder.decode(UNSIGNED_JWT))
 				.isInstanceOf(JwtException.class)
 				.hasMessageContaining("Unsupported algorithm of none");
 	}
@@ -133,6 +134,7 @@ public class NimbusJwtDecoderJwkSupportTests {
 	public void decodeWhenJwkResponseIsMalformedThenReturnsStockException() throws Exception {
 		try ( MockWebServer server = new MockWebServer() ) {
 			server.enqueue(new MockResponse().setBody(MALFORMED_JWK_SET));
+			server.enqueue(new MockResponse().setBody(MALFORMED_JWK_SET));
 			String jwkSetUrl = server.url("/.well-known/jwks.json").toString();
 			NimbusJwtDecoderJwkSupport jwtDecoder = new NimbusJwtDecoderJwkSupport(jwkSetUrl);
 			assertThatCode(() -> jwtDecoder.decode(SIGNED_JWT))
@@ -145,6 +147,7 @@ public class NimbusJwtDecoderJwkSupportTests {
 	@Test
 	public void decodeWhenJwkEndpointIsUnresponsiveThenReturnsJwtException() throws Exception {
 		try ( MockWebServer server = new MockWebServer() ) {
+			server.enqueue(new MockResponse().setBody(MALFORMED_JWK_SET));
 			server.enqueue(new MockResponse().setBody(MALFORMED_JWK_SET));
 			String jwkSetUrl = server.url("/.well-known/jwks.json").toString();
 			NimbusJwtDecoderJwkSupport jwtDecoder = new NimbusJwtDecoderJwkSupport(jwkSetUrl);
@@ -159,6 +162,7 @@ public class NimbusJwtDecoderJwkSupportTests {
 	@Test
 	public void decodeWhenCustomRestOperationsSetThenUsed() throws Exception {
 		try ( MockWebServer server = new MockWebServer() ) {
+			server.enqueue(new MockResponse().setBody(JWK_SET));
 			server.enqueue(new MockResponse().setBody(JWK_SET));
 			String jwkSetUrl = server.url("/.well-known/jwks.json").toString();
 			NimbusJwtDecoderJwkSupport jwtDecoder = new NimbusJwtDecoderJwkSupport(jwkSetUrl);
@@ -233,6 +237,7 @@ public class NimbusJwtDecoderJwkSupportTests {
 
 	@Test
 	public void setClaimSetConverterWhenIsNullThenThrowsIllegalArgumentException() {
+		NimbusJwtDecoderJwkSupport jwtDecoder = new NimbusJwtDecoderJwkSupport(JWK_SET_URL, JWS_ALGORITHM);
 		assertThatCode(() -> jwtDecoder.setClaimSetConverter(null))
 				.isInstanceOf(IllegalArgumentException.class);
 	}

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoderTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoderTests.java
@@ -50,6 +50,7 @@ import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.jwt.proc.BadJWTException;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import com.nimbusds.jwt.proc.JWTProcessor;
+import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.assertj.core.api.Assertions;
 import org.junit.BeforeClass;
@@ -95,6 +96,33 @@ import static org.springframework.security.oauth2.jwt.NimbusJwtDecoder.withSecre
  */
 public class NimbusJwtDecoderTests {
 	private static final String JWK_SET = "{\"keys\":[{\"p\":\"49neceJFs8R6n7WamRGy45F5Tv0YM-R2ODK3eSBUSLOSH2tAqjEVKOkLE5fiNA3ygqq15NcKRadB2pTVf-Yb5ZIBuKzko8bzYIkIqYhSh_FAdEEr0vHF5fq_yWSvc6swsOJGqvBEtuqtJY027u-G2gAQasCQdhyejer68zsTn8M\",\"kty\":\"RSA\",\"q\":\"tWR-ysspjZ73B6p2vVRVyHwP3KQWL5KEQcdgcmMOE_P_cPs98vZJfLhxobXVmvzuEWBpRSiqiuyKlQnpstKt94Cy77iO8m8ISfF3C9VyLWXi9HUGAJb99irWABFl3sNDff5K2ODQ8CmuXLYM25OwN3ikbrhEJozlXg_NJFSGD4E\",\"d\":\"FkZHYZlw5KSoqQ1i2RA2kCUygSUOf1OqMt3uomtXuUmqKBm_bY7PCOhmwbvbn4xZYEeHuTR8Xix-0KpHe3NKyWrtRjkq1T_un49_1LLVUhJ0dL-9_x0xRquVjhl_XrsRXaGMEHs8G9pLTvXQ1uST585gxIfmCe0sxPZLvwoic-bXf64UZ9BGRV3lFexWJQqCZp2S21HfoU7wiz6kfLRNi-K4xiVNB1gswm_8o5lRuY7zB9bRARQ3TS2G4eW7p5sxT3CgsGiQD3_wPugU8iDplqAjgJ5ofNJXZezoj0t6JMB_qOpbrmAM1EnomIPebSLW7Ky9SugEd6KMdL5lW6AuAQ\",\"e\":\"AQAB\",\"use\":\"sig\",\"kid\":\"one\",\"qi\":\"wdkFu_tV2V1l_PWUUimG516Zvhqk2SWDw1F7uNDD-Lvrv_WNRIJVzuffZ8WYiPy8VvYQPJUrT2EXL8P0ocqwlaSTuXctrORcbjwgxDQDLsiZE0C23HYzgi0cofbScsJdhcBg7d07LAf7cdJWG0YVl1FkMCsxUlZ2wTwHfKWf-v4\",\"dp\":\"uwnPxqC-IxG4r33-SIT02kZC1IqC4aY7PWq0nePiDEQMQWpjjNH50rlq9EyLzbtdRdIouo-jyQXB01K15-XXJJ60dwrGLYNVqfsTd0eGqD1scYJGHUWG9IDgCsxyEnuG3s0AwbW2UolWVSsU2xMZGb9PurIUZECeD1XDZwMp2s0\",\"dq\":\"hra786AunB8TF35h8PpROzPoE9VJJMuLrc6Esm8eZXMwopf0yhxfN2FEAvUoTpLJu93-UH6DKenCgi16gnQ0_zt1qNNIVoRfg4rw_rjmsxCYHTVL3-RDeC8X_7TsEySxW0EgFTHh-nr6I6CQrAJjPM88T35KHtdFATZ7BCBB8AE\",\"n\":\"oXJ8OyOv_eRnce4akdanR4KYRfnC2zLV4uYNQpcFn6oHL0dj7D6kxQmsXoYgJV8ZVDn71KGmuLvolxsDncc2UrhyMBY6DVQVgMSVYaPCTgW76iYEKGgzTEw5IBRQL9w3SRJWd3VJTZZQjkXef48Ocz06PGF3lhbz4t5UEZtdF4rIe7u-977QwHuh7yRPBQ3sII-cVoOUMgaXB9SHcGF2iZCtPzL_IffDUcfhLQteGebhW8A6eUHgpD5A1PQ-JCw_G7UOzZAjjDjtNM2eqm8j-Ms_gqnm4MiCZ4E-9pDN77CAAPVN7kuX6ejs9KBXpk01z48i9fORYk9u7rAkh1HuQw\"}]}";
+	private static final String JWK_SET_MULTIPLE = "{\n" +
+			"  \"keys\": [\n" +
+			"    {\n" +
+			"      \"kty\": \"EC\",\n" +
+			"      \"use\": \"sig\",\n" +
+			"      \"crv\": \"P-256\",\n" +
+			"      \"x\": \"9w9ddaCKCdOfyKsENWI_cf90XmWRDISBrWf2vNo-TpE\",\n" +
+			"      \"y\": \"CThkQsCBR6dC-Y8-MVf6NFTYvMiJtjBx1x0Pbr-kP5c\",\n" +
+			"      \"alg\": \"ES256\"\n" +
+			"    },\n" +
+			"    {\n" +
+			"      \"kty\": \"RSA\",\n" +
+			"      \"e\": \"AQAB\",\n" +
+			"      \"use\": \"sig\",\n" +
+			"      \"alg\": \"RS256\",\n" +
+			"      \"n\": \"rNXfHmPwwPcmyjIG0gfBdera44Y6C6jhqgGAxCFlxrhveOAy12ff3Z0oyu0fsB-q2eVQ1amBYUWaNCopVuZEBx9GcNs0KmkAmh0bQVAT9rI81CE6thuZiNfnNaqcIHnvUa__1wnR1PzX7mDyvcVtxSC6VbQo9jt6ouBXaW6ZolqzlfbDAU-2FJpE2YLoqMs1PtSss_gYiXrP0f9GLomcQTWgsw-VNc9iYJZG5K8kIKlo_bu6YQf7GoGt4IEUd-dQBpavIBL7jjRKp30zY94J4QAwPo_UnO_EpDuUa9QyO6kuk6A3yv0nfstK-4wE1Jr42tlDO1SFzRzy_aYAjT7Ozw\"\n" +
+			"    },\n" +
+			"    {\n" +
+			"      \"kty\": \"EC\",\n" +
+			"      \"use\": \"sig\",\n" +
+			"      \"crv\": \"P-384\",\n" +
+			"      \"x\": \"71M1BlzONOc9LYuOB-xmK8Y3njqqGTJLguDLd7geILqYDiWrH5ELb9SKtVYcQvD1\",\n" +
+			"      \"y\": \"Lv8lK0ukUNFa1Vhlzbi8VDdIfHrd2IEmUp21fmLNwPwTMJLbDGYoPm4DgYfzOfSm\"\n" +
+			"    }\n" +
+			"  ]\n" +
+			"}";
+
 	private static final String MALFORMED_JWK_SET = "malformed";
 
 	private static final String SIGNED_JWT = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXN1YmplY3QiLCJzY3AiOlsibWVzc2FnZTpyZWFkIl0sImV4cCI6NDY4Mzg5Nzc3Nn0.LtMVtIiRIwSyc3aX35Zl0JVwLTcQZAB3dyBOMHNaHCKUljwMrf20a_gT79LfhjDzE_fUVUmFiAO32W1vFnYpZSVaMDUgeIOIOpxfoe9shj_uYenAwIS-_UxqGVIJiJoXNZh_MK80ShNpvsQwamxWEEOAMBtpWNiVYNDMdfgho9n3o5_Z7Gjy8RLBo1tbDREbO9kTFwGIxm_EYpezmRCRq4w1DdS6UDW321hkwMxPnCMSWOvp-hRpmgY2yjzLgPJ6Aucmg9TJ8jloAP1DjJoF1gRR7NTAk8LOGkSjTzVYDYMbCF51YdpojhItSk80YzXiEsv1mTz4oMM49jXBmfXFMA";
@@ -244,9 +272,9 @@ public class NimbusJwtDecoderTests {
 	public void decodeWhenJwkEndpointIsUnresponsiveThenReturnsJwtException() throws Exception {
 		try ( MockWebServer server = new MockWebServer() ) {
 			String jwkSetUri = server.url("/.well-known/jwks.json").toString();
+			server.shutdown();
 			NimbusJwtDecoder jwtDecoder = withJwkSetUri(jwkSetUri).build();
 
-			server.shutdown();
 			assertThatCode(() -> jwtDecoder.decode(SIGNED_JWT))
 					.isInstanceOf(JwtException.class)
 					.isNotInstanceOf(BadJwtException.class)
@@ -259,9 +287,9 @@ public class NimbusJwtDecoderTests {
 		try ( MockWebServer server = new MockWebServer() ) {
 			Cache cache = new ConcurrentMapCache("test-jwk-set-cache");
 			String jwkSetUri = server.url("/.well-known/jwks.json").toString();
+			server.shutdown();
 			NimbusJwtDecoder jwtDecoder = withJwkSetUri(jwkSetUri).cache(cache).build();
 
-			server.shutdown();
 			assertThatCode(() -> jwtDecoder.decode(SIGNED_JWT))
 					.isInstanceOf(JwtException.class)
 					.isNotInstanceOf(BadJwtException.class)
@@ -447,6 +475,22 @@ public class NimbusJwtDecoderTests {
 				.isTrue();
 		assertThat(jwsAlgorithmMapKeySelector.isAllowed(JWSAlgorithm.RS512))
 				.isTrue();
+	}
+
+	@Test
+	public void jwsKeySetWithMultipleJWKThenMultipleAlgorithmsInSelector() throws Exception {
+		try ( MockWebServer server = new MockWebServer() ) {
+			Cache cache = new ConcurrentMapCache("test-jwk-set-cache");
+			server.enqueue(new MockResponse().setBody(JWK_SET_MULTIPLE));
+			String jwkSetUri = server.url("/.well-known/jwks.json").toString();
+			NimbusJwtDecoder.JwkSetUriJwtDecoderBuilder builder = withJwkSetUri(jwkSetUri);
+			builder.cache(cache);
+			DefaultJWTProcessor<SecurityContext> processor = (DefaultJWTProcessor<SecurityContext>) builder.processor();
+			JWSVerificationKeySelector<SecurityContext> selector = (JWSVerificationKeySelector<SecurityContext>) processor.getJWSKeySelector();
+			server.shutdown();
+			assertThat(selector.isAllowed(JWSAlgorithm.RS256)).isTrue();
+			assertThat(selector.isAllowed(JWSAlgorithm.ES256)).isTrue();
+		}
 	}
 
 	// gh-7290

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/ReactiveJwtDecodersTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/ReactiveJwtDecodersTests.java
@@ -251,6 +251,7 @@ public class ReactiveJwtDecodersTests {
 	private void prepareConfigurationResponse(String body) {
 		this.server.enqueue(response(body));
 		this.server.enqueue(response(JWK_SET));
+		this.server.enqueue(response(JWK_SET));
 	}
 
 	private void prepareConfigurationResponseOidc() {

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolverTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolverTests.java
@@ -66,6 +66,7 @@ public class JwtIssuerAuthenticationManagerResolverTests {
 					.setResponseCode(200)
 					.setHeader("Content-Type", "application/json")
 					.setBody(String.format(DEFAULT_RESPONSE_TEMPLATE, issuer, issuer)));
+			server.enqueue(new MockResponse().setResponseCode(200));
 			JWSObject jws = new JWSObject(new JWSHeader(JWSAlgorithm.RS256),
 					new Payload(new JSONObject(Collections.singletonMap(ISS, issuer))));
 			jws.sign(new RSASSASigner(TestKeys.DEFAULT_PRIVATE_KEY));

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolverTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolverTests.java
@@ -67,6 +67,7 @@ public class JwtIssuerReactiveAuthenticationManagerResolverTests {
 					.setResponseCode(200)
 					.setHeader("Content-Type", "application/json")
 					.setBody(String.format(DEFAULT_RESPONSE_TEMPLATE, issuer, issuer)));
+			server.enqueue(new MockResponse().setResponseCode(200));
 			JWSObject jws = new JWSObject(new JWSHeader(JWSAlgorithm.RS256),
 					new Payload(new JSONObject(Collections.singletonMap(ISS, issuer))));
 			jws.sign(new RSASSASigner(TestKeys.DEFAULT_PRIVATE_KEY));


### PR DESCRIPTION
CLA has been submitted.

This PR adds support for creating a JWSVerificationKeySelector dynamically based on the availability of JWK algorithms from a given JWK Set provided by an OIDC discovery document (Issue 7160). Non-standard or unknown algorithms will be silently ignored (see SignatureAlgorithm class). A warning log has also been added to let developers know if there was a problem fetching the JWK Set, although this does not halt the application from starting.

The original functionality is still in place that adds the RS256 algorithm if none are provided during initial configuration for backwards compatibility.

This functionality has been implemented for both standard and reactive versions.
This is the second version of this [Pull Request](https://github.com/spring-projects/spring-security/pull/8742). That simplifies the implementation and fixes unit tests.