### PR TITLE
gh-8753 Change to use `getDelegate()` method

### DIFF
--- a/test/src/main/java/org/springframework/security/test/web/servlet/setup/SecurityMockMvcConfigurer.java
+++ b/test/src/main/java/org/springframework/security/test/web/servlet/setup/SecurityMockMvcConfigurer.java
@@ -92,7 +92,7 @@ final class SecurityMockMvcConfigurer extends MockMvcConfigurerAdapter {
 	}
 
 	private Filter getSpringSecurityFilterChain() {
-		return this.delegateFilter.delegate;
+		return this.delegateFilter.getDelegate();
 	}
 
 	/**


### PR DESCRIPTION
Change to use `getDelegate()` method

```java
private Filter getSpringSecurityFilterChain() {
	return this.delegateFilter.delegate;
}
```

The following null check will not work.

```java
Filter getDelegate() {
	Filter result = this.delegate;
	if (result == null) {
		throw new IllegalStateException("delegate cannot be null. Ensure a Bean with the name "
				+ BeanIds.SPRING_SECURITY_FILTER_CHAIN
				+ " implementing Filter is present or inject the Filter to be used.");
	}
	return result;
}
```

This method seems to have to be changed as follows.

```java
private Filter getSpringSecurityFilterChain() {
	return this.delegateFilter.getDelegate();
}
```
