### PR TITLE
OAuth2AccessTokenResponse.Builder.expiresIn works after withResponse

### DIFF
--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/OAuth2AccessTokenResponse.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/OAuth2AccessTokenResponse.java
@@ -140,6 +140,7 @@ public final class OAuth2AccessTokenResponse {
 		 */
 		public Builder expiresIn(long expiresIn) {
 			this.expiresIn = expiresIn;
+			this.expiresAt = null;
 			return this;
 		}
 

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/OAuth2AccessTokenResponseTests.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/OAuth2AccessTokenResponseTests.java
@@ -153,4 +153,22 @@ public class OAuth2AccessTokenResponseTests {
 
 		assertThat(withResponse.getRefreshToken()).isNull();
 	}
+
+	@Test
+	public void buildWhenResponseThenChangeExpiresInThenExpiresAtMatchIssueAtPlusExpiresIn() {
+		long originalExpiresIn = 10;
+		OAuth2AccessTokenResponse tokenResponse = OAuth2AccessTokenResponse
+				.withToken(TOKEN_VALUE)
+				.tokenType(OAuth2AccessToken.TokenType.BEARER)
+				.expiresIn(originalExpiresIn)
+				.build();
+
+		long alteredExpiresIn = 30;
+		OAuth2AccessTokenResponse withResponse = OAuth2AccessTokenResponse.withResponse(tokenResponse)
+				.expiresIn(alteredExpiresIn)
+				.build();
+
+		assertThat(withResponse.getAccessToken().getExpiresAt()).isEqualTo(
+				withResponse.getAccessToken().getIssuedAt().plusSeconds(alteredExpiresIn));
+	}
 }


### PR DESCRIPTION
`OAuth2AccessTokenResponse.Builder.expiresIn` was ignored when the Builder was initiated from `withReponse`, because `OAuth2AccessTokenResponse.expiresAt` was already initiated.

This PR reset `OAuth2AccessTokenResponse.expiresAt` status every time `OAuth2AccessTokenResponse.Builder.expiresIn` is called.

Closes gh-8702
I have submitted the CLA
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
