### PR TITLE
tutorial uses hasRole but should use hasAuthority

### DIFF
--- a/samples/xml/tutorial/src/main/webapp/WEB-INF/applicationContext-security.xml
+++ b/samples/xml/tutorial/src/main/webapp/WEB-INF/applicationContext-security.xml
@@ -61,4 +61,8 @@
 		</authentication-provider>
 	</authentication-manager>
 
+	<beans:bean id="grantedAuthorityDefaults" class="org.springframework.security.config.core.GrantedAuthorityDefaults">
+		<beans:constructor-arg value="" />
+	</beans:bean>
+
 </beans:beans>


### PR DESCRIPTION
Without the change the prefix role is default "ROLE_ and the demo throws the following exception:
`org.springframework.security.access.AccessDeniedException: Access is denied`
while access to `/post.html?id=1&amount=20.00`.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
