### PR TITLE
Add Static Factories to Saml2X509Credential

### DIFF
--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/credentials/Saml2X509Credential.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/credentials/Saml2X509Credential.java
@@ -46,6 +46,40 @@ public class Saml2X509Credential {
 	private final Set<Saml2X509CredentialType> credentialTypes;
 
 	/**
+	 * Create a {@link Saml2X509Credential} that can be used for encryption.
+	 * @param certificate the certificate to use for encryption
+	 */
+	public static Saml2X509Credential encryption(X509Certificate certificate) {
+		return new Saml2X509Credential(certificate, Saml2X509CredentialType.ENCRYPTION);
+	}
+
+	/**
+	 * Create a {@link Saml2X509Credential} that can be used for verification.
+	 * @param certificate the certificate to use for verification
+	 */
+	public static Saml2X509Credential verification(X509Certificate certificate) {
+		return new Saml2X509Credential(certificate, Saml2X509CredentialType.VERIFICATION);
+	}
+
+	/**
+	 * Create a {@link Saml2X509Credential} that can be used for decryption.
+	 * @param privateKey the private key to use for decryption
+	 * @param certificate the certificate to use for decryption
+	 */
+	public static Saml2X509Credential decryption(PrivateKey privateKey, X509Certificate certificate) {
+		return new Saml2X509Credential(privateKey, certificate, Saml2X509CredentialType.DECRYPTION);
+	}
+
+	/**
+	 * Create a {@link Saml2X509Credential} that can be used for signing.
+	 * @param privateKey the private key to use for signing
+	 * @param certificate the certificate to use for signing
+	 */
+	public static Saml2X509Credential signing(PrivateKey privateKey, X509Certificate certificate) {
+		return new Saml2X509Credential(privateKey, certificate, Saml2X509CredentialType.SIGNING);
+	}
+
+	/**
 	 * Creates a Saml2X509Credentials representing Identity Provider credentials for
 	 * verification, encryption or both.
 	 * @param certificate an IDP X509Certificate, cannot be null

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/credentials/Saml2X509CredentialTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/credentials/Saml2X509CredentialTests.java
@@ -16,12 +16,11 @@
 
 package org.springframework.security.saml2.credentials;
 
-import org.springframework.security.converter.RsaKeyConverters;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.springframework.security.converter.RsaKeyConverters;
 
 import java.io.ByteArrayInputStream;
 import java.security.PrivateKey;
@@ -88,6 +87,8 @@ public class Saml2X509CredentialTests {
 		new Saml2X509Credential(key, certificate, SIGNING);
 		new Saml2X509Credential(key, certificate, SIGNING, DECRYPTION);
 		new Saml2X509Credential(key, certificate, DECRYPTION);
+		Saml2X509Credential.signing(key, certificate);
+		Saml2X509Credential.decryption(key, certificate);
 	}
 
 	@Test
@@ -95,6 +96,8 @@ public class Saml2X509CredentialTests {
 		new Saml2X509Credential(certificate, VERIFICATION);
 		new Saml2X509Credential(certificate, VERIFICATION, ENCRYPTION);
 		new Saml2X509Credential(certificate, ENCRYPTION);
+		Saml2X509Credential.verification(certificate);
+		Saml2X509Credential.encryption(certificate);
 	}
 
 	@Test
@@ -145,5 +148,51 @@ public class Saml2X509CredentialTests {
 		new Saml2X509Credential(certificate, DECRYPTION);
 	}
 
+	@Test
+	public void factoryWhenRelyingPartyForSigningWithoutCredentialsThenItFails() {
+		exception.expect(IllegalArgumentException.class);
+		Saml2X509Credential.signing(null, null);
+	}
 
+	@Test
+	public void factoryWhenRelyingPartyForSigningWithoutPrivateKeyThenItFails() {
+		exception.expect(IllegalArgumentException.class);
+		Saml2X509Credential.signing(null, certificate);
+	}
+
+	@Test
+	public void factoryWhenRelyingPartyForSigningWithoutCertificateThenItFails() {
+		exception.expect(IllegalArgumentException.class);
+		Saml2X509Credential.signing(key, null);
+	}
+
+	@Test
+	public void factoryWhenRelyingPartyForDecryptionWithoutCredentialsThenItFails() {
+		exception.expect(IllegalArgumentException.class);
+		Saml2X509Credential.decryption(null, null);
+	}
+
+	@Test
+	public void factoryWhenRelyingPartyForDecryptionWithoutPrivateKeyThenItFails() {
+		exception.expect(IllegalArgumentException.class);
+		Saml2X509Credential.decryption(null, certificate);
+	}
+
+	@Test
+	public void factoryWhenRelyingPartyForDecryptionWithoutCertificateThenItFails() {
+		exception.expect(IllegalArgumentException.class);
+		Saml2X509Credential.decryption(key, null);
+	}
+
+	@Test
+	public void factoryWhenAssertingPartyForVerificationWithoutCertificateThenItFails() {
+		exception.expect(IllegalArgumentException.class);
+		Saml2X509Credential.verification(null);
+	}
+
+	@Test
+	public void factoryWhenAssertingPartyForEncryptionWithoutCertificateThenItFails() {
+		exception.expect(IllegalArgumentException.class);
+		Saml2X509Credential.encryption(null);
+	}
 }


### PR DESCRIPTION
- Add static factories to Saml2X509Credential for verification, encryption,
signing, and decryption.
- Add unit tests for new static factories in Saml2X509Credential.

Fixes gh-8789