### PR TITLE
Fix #8797: Add OAuth2AuthenticationException to allowlist

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthenticationExceptionMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthenticationExceptionMixin.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.security.oauth2.client.jackson2;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -32,6 +33,8 @@ import org.springframework.security.oauth2.core.OAuth2Error;
  * @see OAuth2ClientJackson2Module
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+				isGetterVisibility = JsonAutoDetect.Visibility.NONE)
 @JsonIgnoreProperties(ignoreUnknown = true, value = {"cause", "stackTrace"})
 abstract class OAuth2AuthenticationExceptionMixin {
 

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthenticationExceptionMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthenticationExceptionMixin.java
@@ -35,12 +35,12 @@ import org.springframework.security.oauth2.core.OAuth2Error;
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 				isGetterVisibility = JsonAutoDetect.Visibility.NONE)
-@JsonIgnoreProperties(ignoreUnknown = true, value = {"cause", "stackTrace"})
+@JsonIgnoreProperties(ignoreUnknown = true, value = {"cause", "stackTrace", "suppressedExceptions"})
 abstract class OAuth2AuthenticationExceptionMixin {
 
 	@JsonCreator
 	OAuth2AuthenticationExceptionMixin(
 			@JsonProperty("error") OAuth2Error error,
-			@JsonProperty("message") String message) {
+			@JsonProperty("detailMessage") String message) {
 	}
 }

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthenticationExceptionMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthenticationExceptionMixin.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.client.jackson2;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+/**
+ * This mixin class is used to serialize/deserialize
+ * {@link OAuth2AuthenticationException}.
+ *
+ * @author Dennis Neufeld
+ * @since 5.4
+ * @see OAuth2AuthenticationException
+ * @see OAuth2ClientJackson2Module
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonIgnoreProperties(ignoreUnknown = true, value = {"cause", "stackTrace"})
+abstract class OAuth2AuthenticationExceptionMixin {
+
+	@JsonCreator
+	OAuth2AuthenticationExceptionMixin(
+			@JsonProperty("error") OAuth2Error error,
+			@JsonProperty("message") String message) {
+	}
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2ClientJackson2Module.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2ClientJackson2Module.java
@@ -52,6 +52,8 @@ import java.util.Collections;
  *     <li>{@link OidcUserAuthorityMixin}</li>
  *     <li>{@link DefaultOidcUserMixin}</li>
  *     <li>{@link OAuth2AuthenticationTokenMixin}</li>
+ *     <li>{@link OAuth2AuthenticationExceptionMixin}</li>
+ *     <li>{@link OAuth2ErrorMixin}</li>
  * </ul>
  *
  * If not already enabled, default typing will be automatically enabled
@@ -80,6 +82,8 @@ import java.util.Collections;
  * @see OidcUserAuthorityMixin
  * @see DefaultOidcUserMixin
  * @see OAuth2AuthenticationTokenMixin
+ * @see OAuth2AuthenticationExceptionMixin
+ * @see OAuth2ErrorMixin
  */
 public class OAuth2ClientJackson2Module extends SimpleModule {
 

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2ClientJackson2Module.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2ClientJackson2Module.java
@@ -22,6 +22,8 @@ import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
@@ -101,5 +103,7 @@ public class OAuth2ClientJackson2Module extends SimpleModule {
 		context.setMixInAnnotations(OidcUserAuthority.class, OidcUserAuthorityMixin.class);
 		context.setMixInAnnotations(DefaultOidcUser.class, DefaultOidcUserMixin.class);
 		context.setMixInAnnotations(OAuth2AuthenticationToken.class, OAuth2AuthenticationTokenMixin.class);
+		context.setMixInAnnotations(OAuth2AuthenticationException.class, OAuth2AuthenticationExceptionMixin.class);
+		context.setMixInAnnotations(OAuth2Error.class, OAuth2ErrorMixin.class);
 	}
 }

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2ErrorMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2ErrorMixin.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.client.jackson2;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+/**
+ * This mixin class is used to serialize/deserialize {@link OAuth2Error} as part of
+ * {@link org.springframework.security.oauth2.core.OAuth2AuthenticationException}.
+ *
+ * @author Dennis Neufeld
+ * @since 5.4
+ * @see OAuth2Error
+ * @see OAuth2AuthenticationExceptionMixin
+ * @see OAuth2ClientJackson2Module
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class OAuth2ErrorMixin {
+
+	@JsonCreator
+	OAuth2ErrorMixin(
+			@JsonProperty("errorCode") String errorCode,
+			@JsonProperty("description") String description,
+			@JsonProperty("uri") String uri) {
+	}
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2ErrorMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2ErrorMixin.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.security.oauth2.client.jackson2;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -32,6 +33,8 @@ import org.springframework.security.oauth2.core.OAuth2Error;
  * @see OAuth2ClientJackson2Module
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+				isGetterVisibility = JsonAutoDetect.Visibility.NONE)
 @JsonIgnoreProperties(ignoreUnknown = true)
 abstract class OAuth2ErrorMixin {
 

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthenticationExceptionMixinTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthenticationExceptionMixinTests.java
@@ -72,6 +72,15 @@ public class OAuth2AuthenticationExceptionMixinTests {
 	}
 
 	@Test
+	public void deserializeWhenMixinNotRegisteredThenThrowJsonProcessingException() {
+		String json = asJson(new OAuth2AuthenticationException(
+				new OAuth2Error("[authorization_request_not_found] ")
+		));
+		assertThatThrownBy(() -> new ObjectMapper().readValue(json, OAuth2AuthorizationRequest.class))
+				.isInstanceOf(JsonProcessingException.class);
+	}
+
+	@Test
 	public void deserializeWhenMixinRegisteredThenDeserializes() throws IOException {
 		OAuth2AuthenticationException expected = new OAuth2AuthenticationException(new OAuth2Error(
 				"[authorization_request_not_found] ",

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthenticationExceptionMixinTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthenticationExceptionMixinTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.security.oauth2.client.jackson2;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.json.JSONException;
+import org.junit.Before;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.springframework.security.jackson2.SecurityJackson2Modules;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link OAuth2AuthenticationExceptionMixin}.
+ *
+ * @author Dennis Neufeld
+ * @since 5.4
+ */
+public class OAuth2AuthenticationExceptionMixinTests {
+
+	private ObjectMapper mapper;
+
+	@Before
+	public void setup() {
+		ClassLoader loader = getClass().getClassLoader();
+		this.mapper = new ObjectMapper();
+		this.mapper.registerModules(SecurityJackson2Modules.getModules(loader));
+	}
+
+	// @formatter:off
+	private static final String EXCEPTION_JSON
+			= "\n{"
+			+ "\n  \"@class\": \"org.springframework.security.oauth2.core.OAuth2AuthenticationException\","
+			+ "\n  \"error\":"
+			+ "\n  {"
+			+ "\n    \"@class\":\"org.springframework.security.oauth2.core.OAuth2Error\","
+			+ "\n    \"errorCode\":\"authorization_request_not_found\","
+			+ "\n    \"description\":null,"
+			+ "\n    \"uri\":null"
+			+ "\n  },"
+			+ "\n  \"message\":\"[authorization_request_not_found] \","
+			+ "\n  \"suppressed\":[\"[Ljava.lang.Throwable;\",[]],"
+			+ "\n  \"localizedMessage\":\"[authorization_request_not_found] \""
+			+ "\n}";
+	// @formatter:on
+
+	@Test
+	public void serializeOAuth2AuthenticationExceptionMixinTest() throws JsonProcessingException, JSONException {
+		OAuth2Error oauth2Error = new OAuth2Error("authorization_request_not_found");
+		OAuth2AuthenticationException exception = new OAuth2AuthenticationException(oauth2Error, oauth2Error.toString());
+		String serializedJson = mapper.writeValueAsString(exception);
+		JSONAssert.assertEquals(EXCEPTION_JSON, serializedJson, true);
+	}
+
+	@Test
+	public void deserializeOAuth2AuthenticationExceptionMixinTest() throws IOException {
+		OAuth2AuthenticationException exception = mapper.readValue(EXCEPTION_JSON, OAuth2AuthenticationException.class);
+		assertThat(exception).isNotNull();
+		assertThat(exception.getCause()).isNull();
+		assertThat(exception.getMessage()).isEqualTo("[authorization_request_not_found] ");
+		assertThat(exception.getLocalizedMessage()).isEqualTo("[authorization_request_not_found] ");
+
+		OAuth2Error oauth2Error = exception.getError();
+		assertThat(oauth2Error).isNotNull();
+		assertThat(oauth2Error.getErrorCode()).isEqualTo("authorization_request_not_found");
+		assertThat(oauth2Error.getDescription()).isNull();
+		assertThat(oauth2Error.getUri()).isNull();
+	}
+
+}


### PR DESCRIPTION
Add mixins for
- OAuth2AuthenticationException
- OAuth2Error

See #8797 for more details.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
