### PR TITLE
Introduce AuthenticationConverterServerWebExchangeMatcher

### DIFF
--- a/web/src/main/java/org/springframework/security/web/server/authentication/AuthenticationConverterServerWebExchangeMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/server/authentication/AuthenticationConverterServerWebExchangeMatcher.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.server.authentication;
+
+import static org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher.MatchResult.match;
+import static org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher.MatchResult.notMatch;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
+import org.springframework.util.Assert;
+import org.springframework.web.server.ServerWebExchange;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Matches if the {@link ServerAuthenticationConverter} can convert a {@link ServerWebExchange} to an {@link Authentication}.
+ *
+ * @author David Kovac
+ * @since 5.4
+ * @see ServerAuthenticationConverter
+ */
+public final class AuthenticationConverterServerWebExchangeMatcher implements ServerWebExchangeMatcher {
+	private final ServerAuthenticationConverter serverAuthenticationConverter;
+
+	public AuthenticationConverterServerWebExchangeMatcher(ServerAuthenticationConverter serverAuthenticationConverter) {
+		Assert.notNull(serverAuthenticationConverter, "serverAuthenticationConverter cannot be null");
+		this.serverAuthenticationConverter = serverAuthenticationConverter;
+	}
+
+	@Override
+	public Mono<MatchResult> matches(ServerWebExchange exchange) {
+		return this.serverAuthenticationConverter.convert(exchange)
+				.flatMap(a -> match())
+				.onErrorResume(e -> notMatch())
+				.switchIfEmpty(notMatch());
+	}
+}

--- a/web/src/test/java/org/springframework/security/web/server/authentication/AuthenticationConverterServerWebExchangeMatcherTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/authentication/AuthenticationConverterServerWebExchangeMatcherTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.server.authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.core.Authentication;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * @author David Kovac
+ * @since 5.4
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AuthenticationConverterServerWebExchangeMatcherTests {
+	private MockServerWebExchange exchange;
+	private AuthenticationConverterServerWebExchangeMatcher matcher;
+	@Mock
+	private ServerAuthenticationConverter converter;
+	@Mock
+	private Authentication authentication;
+
+	@Before
+	public void setup() {
+		MockServerHttpRequest request = MockServerHttpRequest.get("/path").build();
+		exchange = MockServerWebExchange.from(request);
+		matcher = new AuthenticationConverterServerWebExchangeMatcher(converter);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void constructorConverterWhenConverterNullThenThrowsException() {
+		new AuthenticationConverterServerWebExchangeMatcher(null);
+	}
+
+	@Test
+	public void matchesWhenNotEmptyThenReturnTrue() {
+		when(converter.convert(any())).thenReturn(Mono.just(authentication));
+
+		assertThat(matcher.matches(exchange).block().isMatch()).isTrue();
+	}
+
+	@Test
+	public void matchesWhenEmptyThenReturnFalse() {
+		when(converter.convert(any())).thenReturn(Mono.empty());
+
+		assertThat(matcher.matches(exchange).block().isMatch()).isFalse();
+	}
+
+	@Test
+	public void matchesWhenErrorThenReturnFalse() {
+		when(converter.convert(any())).thenReturn(Mono.error(new RuntimeException()));
+
+		assertThat(matcher.matches(exchange).block().isMatch()).isFalse();
+	}
+
+	@Test
+	public void matchesWhenNullThenThrowsException() {
+		when(this.converter.convert(any())).thenReturn(null);
+
+		assertThatCode(() -> matcher.matches(exchange).block())
+				.isInstanceOf(NullPointerException.class);
+	}
+
+	@Test
+	public void matchesWhenExceptionThenPropagates() {
+		when(this.converter.convert(any())).thenThrow(RuntimeException.class);
+
+		assertThatCode(() -> matcher.matches(exchange).block())
+				.isInstanceOf(RuntimeException.class);
+	}
+}


### PR DESCRIPTION
AuthenticationConverterServerWebExchangeMatcher is ServerWebExchangeMatcher implementation based on AuthenticationConverter which matches if ServerWebExchange can be converted to Authentication.
It can be used as a matcher where SecurityFilterChain should be matched based on used authentication method.
BearerTokenServerWebExchangeMatcher was replaced by this matcher.

Closes gh-8824