### PR TITLE
Update SimpleSaml2AuthenticatedPrincipal class name

### DIFF
--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/DefaultSaml2AuthenticatedPrincipal.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/DefaultSaml2AuthenticatedPrincipal.java
@@ -16,6 +16,8 @@
 
 package org.springframework.security.saml2.provider.service.authentication;
 
+import org.springframework.util.Assert;
+
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
@@ -24,14 +26,17 @@ import java.util.Map;
  * Default implementation of a {@link Saml2AuthenticatedPrincipal}.
  *
  * @author Clement Stoquart
- * @since 5.2.2
+ * @since 5.4
  */
-class SimpleSaml2AuthenticatedPrincipal implements Saml2AuthenticatedPrincipal, Serializable {
+public class DefaultSaml2AuthenticatedPrincipal implements Saml2AuthenticatedPrincipal, Serializable {
 
 	private final String name;
 	private final Map<String, List<Object>> attributes;
 
-	SimpleSaml2AuthenticatedPrincipal(String name, Map<String, List<Object>> attributes) {
+	public DefaultSaml2AuthenticatedPrincipal(String name, Map<String, List<Object>> attributes) {
+		Assert.notNull(name, "name cannot be null");
+		Assert.notNull(attributes, "attributes cannot be null");
+
 		this.name = name;
 		this.attributes = attributes;
 	}

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/OpenSamlAuthenticationProvider.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/OpenSamlAuthenticationProvider.java
@@ -183,7 +183,7 @@ public final class OpenSamlAuthenticationProvider implements AuthenticationProvi
 				String username = assertion.getSubject().getNameID().getValue();
 				Map<String, List<Object>> attributes = getAssertionAttributes(assertion);
 				return new Saml2Authentication(
-						new SimpleSaml2AuthenticatedPrincipal(username, attributes), token.getSaml2Response(),
+						new DefaultSaml2AuthenticatedPrincipal(username, attributes), token.getSaml2Response(),
 						this.authoritiesMapper.mapAuthorities(getAssertionAuthorities(assertion)));
 			};
 

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/DefaultSaml2AuthenticatedPrincipalTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/DefaultSaml2AuthenticatedPrincipalTests.java
@@ -26,23 +26,40 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
-public class SimpleSaml2AuthenticatedPrincipalTests {
+public class DefaultSaml2AuthenticatedPrincipalTests {
 
 	@Test
-	public void createSimpleSaml2AuthenticatedPrincipal() {
+	public void createDefaultSaml2AuthenticatedPrincipal() {
 		Map<String, List<Object>> attributes = new LinkedHashMap<>();
 		attributes.put("email", Arrays.asList("john.doe@example.com", "doe.john@example.com"));
-		SimpleSaml2AuthenticatedPrincipal principal = new SimpleSaml2AuthenticatedPrincipal("user", attributes);
+		DefaultSaml2AuthenticatedPrincipal principal = new DefaultSaml2AuthenticatedPrincipal("user", attributes);
 		assertThat(principal.getName()).isEqualTo("user");
 		assertThat(principal.getAttributes()).isEqualTo(attributes);
+	}
+
+	@Test
+	public void createDefaultSaml2AuthenticatedPrincipalWhenNameNullThenException() {
+		Map<String, List<Object>> attributes = new LinkedHashMap<>();
+		attributes.put("email", Arrays.asList("john.doe@example.com", "doe.john@example.com"));
+		assertThatCode(() -> new DefaultSaml2AuthenticatedPrincipal(null, attributes))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("name cannot be null");
+	}
+
+	@Test
+	public void createDefaultSaml2AuthenticatedPrincipalWhenAttributesNullThenException() {
+		assertThatCode(() -> new DefaultSaml2AuthenticatedPrincipal("user", null))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("attributes cannot be null");
 	}
 
 	@Test
 	public void getFirstAttributeWhenStringValueThenReturnsValue() {
 		Map<String, List<Object>> attributes = new LinkedHashMap<>();
 		attributes.put("email", Arrays.asList("john.doe@example.com", "doe.john@example.com"));
-		SimpleSaml2AuthenticatedPrincipal principal = new SimpleSaml2AuthenticatedPrincipal("user", attributes);
+		DefaultSaml2AuthenticatedPrincipal principal = new DefaultSaml2AuthenticatedPrincipal("user", attributes);
 		assertThat(principal.<String>getFirstAttribute("email")).isEqualTo(attributes.get("email").get(0));
 	}
 
@@ -50,7 +67,7 @@ public class SimpleSaml2AuthenticatedPrincipalTests {
 	public void getAttributeWhenStringValuesThenReturnsValues() {
 		Map<String, List<Object>> attributes = new LinkedHashMap<>();
 		attributes.put("email", Arrays.asList("john.doe@example.com", "doe.john@example.com"));
-		SimpleSaml2AuthenticatedPrincipal principal = new SimpleSaml2AuthenticatedPrincipal("user", attributes);
+		DefaultSaml2AuthenticatedPrincipal principal = new DefaultSaml2AuthenticatedPrincipal("user", attributes);
 		assertThat(principal.<String>getAttribute("email")).isEqualTo(attributes.get("email"));
 	}
 
@@ -62,7 +79,7 @@ public class SimpleSaml2AuthenticatedPrincipalTests {
 		Map<String, List<Object>> attributes = new LinkedHashMap<>();
 		attributes.put("registration", Arrays.asList(registered, registeredDate));
 
-		SimpleSaml2AuthenticatedPrincipal principal = new SimpleSaml2AuthenticatedPrincipal("user", attributes);
+		DefaultSaml2AuthenticatedPrincipal principal = new DefaultSaml2AuthenticatedPrincipal("user", attributes);
 
 		List<Object> registrationInfo = principal.getAttribute("registration");
 


### PR DESCRIPTION
Rename it to DefaultSaml2AuthenticatedPrincipal to be more in line with
the respective class in the OAuth2 module.

Also make the class public to be able to whitelist the SAML2 auth classes
in Jackson object mappers for deserialization in e.g. Spring Session MongoDB.

Closes gh-8852

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
