### PR TITLE
 Fix #6594 Legacy Migration Incompatibility

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/password/MessageDigestPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password/MessageDigestPasswordEncoder.java
@@ -169,6 +169,6 @@ public class MessageDigestPasswordEncoder implements PasswordEncoder {
 		if (end < 0) {
 			return "";
 		}
-		return prefixEncodedPassword.substring(start, end + 1);
+		return prefixEncodedPassword.substring(start + 1, end);
 	}
 }


### PR DESCRIPTION
Changes the behaviour of extractSalt to match the documentation (and the expected behaviour). Closes spring-projects#6594

Before:
prefixEncodedPassword = "{this_is_the_salt}hash"
extractSalt(prefixEncodedPassword) == "{this_is_the_salt}"

Now:
prefixEncodedPassword = "{this_is_the_salt}hash"
extractSalt(prefixEncodedPassword) == "this_is_the_salt"