### PR TITLE
Quick javadoc fix for DelegatingPasswordEncoder

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/password/DelegatingPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password/DelegatingPasswordEncoder.java
@@ -234,7 +234,8 @@ public class DelegatingPasswordEncoder implements PasswordEncoder {
 	}
 
 	/**
-	 * Default {@link PasswordEncoder} that throws an exception that a id could
+	 * Default {@link PasswordEncoder} that throws an exception telling that a suitable
+	 * {@link PasswordEncoder} for the id could not be found.
 	 */
 	private class UnmappedIdPasswordEncoder implements PasswordEncoder {
 


### PR DESCRIPTION
Dear all,

I'm pushing a quick fix for the javadoc of the class `UnmappedIdPasswordEncoder` in `DelegatingPasswordEncoder.java`, which appeared incomplete. It looks like if some text got missing at some point, maybe a typing mistake.

I didn't feel this minor detail required opening an issue.

Please feel free to accept or reject the PR as you see fit.