### PR TITLE
Resolve Bearer token after subscribing to publisher

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/server/ServerBearerTokenAuthenticationConverter.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/server/ServerBearerTokenAuthenticationConverter.java
@@ -53,7 +53,7 @@ public class ServerBearerTokenAuthenticationConverter
 	private String bearerTokenHeaderName = HttpHeaders.AUTHORIZATION;
 
 	public Mono<Authentication> convert(ServerWebExchange exchange) {
-		return Mono.justOrEmpty(token(exchange.getRequest()))
+		return Mono.fromCallable(() -> token(exchange.getRequest()))
 			.map(token -> {
 				if (token.isEmpty()) {
 					BearerTokenError error = invalidTokenError();

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/ServerBearerTokenAuthenticationConverterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/ServerBearerTokenAuthenticationConverterTests.java
@@ -142,6 +142,17 @@ public class ServerBearerTokenAuthenticationConverterTests {
 				.hasMessageContaining(("Bearer token is malformed"));
 	}
 
+	// gh-8865
+	@Test
+	public void resolveWhenHeaderWithInvalidCharactersIsPresentAndNotSubscribedThenNoneExceptionIsThrown() {
+		MockServerHttpRequest.BaseBuilder<?> request = MockServerHttpRequest
+				.get("/")
+				.header(HttpHeaders.AUTHORIZATION, "Bearer an\"invalid\"token");
+
+		assertThatCode(() -> this.converter.convert(MockServerWebExchange.from(request)))
+				.doesNotThrowAnyException();
+	}
+
 	@Test
 	public void resolveWhenValidHeaderIsPresentTogetherWithQueryParameterThenAuthenticationExceptionIsThrown() {
 		MockServerHttpRequest.BaseBuilder<?> request = MockServerHttpRequest


### PR DESCRIPTION
Bearer token was resolved immediately after calling method convert. In situations when malformed token was provided or authorization header and access token query param were present in request exception was thrown instead of signalling error.
After this change Bearer token is resolved on subscription and invalid states are handled by signaling error to subscriber.

Closes gh-8865
