### PR TITLE
Refactor - apply java code convention

### DIFF
--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/BindAuthenticator.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/BindAuthenticator.java
@@ -127,7 +127,7 @@ public class BindAuthenticator extends AbstractLdapAuthenticator {
 					.extractControl(ctx);
 
 			logger.debug("Retrieving attributes...");
-			if (attrs == null || attrs.size()==0) {
+			if (attrs == null || attrs.size() == 0) {
 				attrs = ctx.getAttributes(userDn, getUserAttributes());
 			}
 


### PR DESCRIPTION
That code syntax doesn't fit the Java convention.

So, I added whitespace