### PR TITLE
Add BearerTokenAuthenticationConverter

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/BearerTokenAuthenticationConverter.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/BearerTokenAuthenticationConverter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.resource.authentication;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.security.authentication.AuthenticationDetailsSource;
+import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
+import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
+import org.springframework.security.web.authentication.AuthenticationConverter;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.Assert;
+
+/**
+ * Converts from a HttpServletRequest to {@link BearerTokenAuthenticationToken} that can
+ * be authenticated. Null authentication possible if there was no Authorization header
+ * with Bearer Token.
+ *
+ * @author Jeongjin Kim
+ * @since 5.5
+ */
+public final class BearerTokenAuthenticationConverter implements AuthenticationConverter {
+
+	private AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource = new WebAuthenticationDetailsSource();
+
+	private BearerTokenResolver bearerTokenResolver;
+
+	public BearerTokenAuthenticationConverter() {
+		this.bearerTokenResolver = new DefaultBearerTokenResolver();
+	}
+
+	@Override
+	public BearerTokenAuthenticationToken convert(HttpServletRequest request) {
+		String token = this.bearerTokenResolver.resolve(request);
+
+		if (token == null) {
+			return null;
+		}
+
+		BearerTokenAuthenticationToken authenticationRequest = new BearerTokenAuthenticationToken(token);
+		authenticationRequest.setDetails(this.authenticationDetailsSource.buildDetails(request));
+		return authenticationRequest;
+	}
+
+	/**
+	 * Set the {@link BearerTokenResolver} to use. Defaults to
+	 * {@link DefaultBearerTokenResolver}.
+	 * @param bearerTokenResolver the {@code BearerTokenResolver} to use
+	 */
+	public void setBearerTokenResolver(BearerTokenResolver bearerTokenResolver) {
+		Assert.notNull(bearerTokenResolver, "bearerTokenResolver cannot be null");
+		this.bearerTokenResolver = bearerTokenResolver;
+	}
+
+	/**
+	 * Set the {@link AuthenticationDetailsSource} to use. Defaults to
+	 * {@link WebAuthenticationDetailsSource}.
+	 * @param authenticationDetailsSource the {@code AuthenticationDetailsSource} to use
+	 */
+	public void setAuthenticationDetailsSource(
+			AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource) {
+		Assert.notNull(authenticationDetailsSource, "authenticationDetailsSource cannot be null");
+		this.authenticationDetailsSource = authenticationDetailsSource;
+	}
+
+}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/BearerTokenAuthenticationConverterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/BearerTokenAuthenticationConverterTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.resource.authentication;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link BearerTokenAuthenticationConverter}
+ *
+ * @author Jeongjin Kim
+ * @since 5.5
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class BearerTokenAuthenticationConverterTests {
+
+	private BearerTokenAuthenticationConverter converter;
+
+	@Before
+	public void setup() {
+		this.converter = new BearerTokenAuthenticationConverter();
+	}
+
+	@Test
+	public void setBearerTokenResolverWithNullThenThrowsException() {
+		// @formatter:off
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> this.converter.setBearerTokenResolver(null))
+				.withMessageContaining("bearerTokenResolver cannot be null");
+		// @formatter:on
+	}
+
+	@Test
+	public void setAuthenticationDetailsSourceWithNullThenThrowsException() {
+		// @formatter:off
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> this.converter.setAuthenticationDetailsSource(null))
+				.withMessageContaining("authenticationDetailsSource cannot be null");
+		// @formatter:on
+	}
+
+	@Test
+	public void convertWhenNoBearerTokenHeaderThenNull() {
+		HttpServletRequest request = mock(HttpServletRequest.class);
+
+		BearerTokenAuthenticationToken convert = this.converter.convert(request);
+
+		assertThat(convert).isNull();
+	}
+
+	@Test
+	public void convertWhenBearerTokenThenBearerTokenAuthenticationToken() {
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		given(request.getHeader(HttpHeaders.AUTHORIZATION)).willReturn("Bearer token");
+
+		BearerTokenAuthenticationToken token = this.converter.convert(request);
+
+		assertThat(token.getToken()).isEqualTo("token");
+	}
+
+}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/BearerTokenAuthenticationFilterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/BearerTokenAuthenticationFilterTests.java
@@ -188,6 +188,16 @@ public class BearerTokenAuthenticationFilterTests {
 	}
 
 	@Test
+	public void setAuthenticationConverterWhenNullThenThrowsException() {
+		// @formatter:off
+		BearerTokenAuthenticationFilter filter = new BearerTokenAuthenticationFilter(this.authenticationManager);
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> filter.setAuthenticationConverter(null))
+				.withMessageContaining("authenticationConverter cannot be null");
+		// @formatter:on
+	}
+
+	@Test
 	public void constructorWhenNullAuthenticationManagerThenThrowsException() {
 		// @formatter:off
 		assertThatIllegalArgumentException()


### PR DESCRIPTION
BearerTokenAuthenticationConverter is introduced to solve the problem of not being able to change AuthenticationDetailsSource.

Closes gh-8840

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
