### PR TITLE
Replace Deprecated CallableProcessingInterceptorAdapter with CallableProcessingInterceptor

### DIFF
--- a/web/src/main/java/org/springframework/security/web/context/request/async/SecurityContextCallableProcessingInterceptor.java
+++ b/web/src/main/java/org/springframework/security/web/context/request/async/SecurityContextCallableProcessingInterceptor.java
@@ -23,7 +23,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.Assert;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.context.request.async.CallableProcessingInterceptor;
-import org.springframework.web.context.request.async.CallableProcessingInterceptorAdapter;
 
 /**
  * <p>
@@ -40,7 +39,7 @@ import org.springframework.web.context.request.async.CallableProcessingIntercept
  * @author Rob Winch
  * @since 3.2
  */
-public final class SecurityContextCallableProcessingInterceptor extends CallableProcessingInterceptorAdapter {
+public final class SecurityContextCallableProcessingInterceptor implements CallableProcessingInterceptor {
 
 	private volatile SecurityContext securityContext;
 


### PR DESCRIPTION
5.0 after CallableProcessingInterceptor has default methods.


<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
