### PR TITLE
Update requestRejectedHandler via setter

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/WebSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/WebSecurity.java
@@ -182,6 +182,16 @@ public final class WebSecurity extends AbstractConfiguredSecurityBuilder<Filter,
 		this.debugEnabled = debugEnabled;
 		return this;
 	}
+	
+	/**
+	 * Sets the custom RequestRejectedHandler for HttpStrictFirewall filter.
+	 * @param custom implementation of requestRejectedHandler
+	 * @return the {@link WebSecurity} for further customization.
+	 */
+	public WebSecurity requestRejectedHandler(RequestRejectedHandler requestRejectedHandler) {
+		this.requestRejectedHandler = requestRejectedHandler;
+		return this;
+	}
 
 	/**
 	 * <p>


### PR DESCRIPTION
Ability to set requestRejectedHandler via public settter in method WebSecurityConfigurerAdapter.configure(WebSecurity)

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
