### PR TITLE
Add build scans to PR builds

### DIFF
--- a/.github/workflows/pr-build-workflow.yml
+++ b/.github/workflows/pr-build-workflow.yml
@@ -19,4 +19,4 @@ jobs:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
       - name: Build with Gradle
-        run: ./gradlew clean build --continue
+        run: ./gradlew clean build --continue --scan

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,13 @@ allprojects {
 	}
 }
 
+if (hasProperty('buildScan')) {
+	buildScan {
+		termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+		termsOfServiceAgree = 'yes'
+	}
+}
+
 nohttp {
 	allowlistFile = project.file("etc/nohttp/allowlist.lines")
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
 
 plugins {
 	id "com.gradle.enterprise" version "3.2"
-	id "io.spring.gradle-enterprise-conventions" version "0.0.2"
+	id "io.spring.gradle-enterprise-conventions" version "0.0.6"
 }
 
 rootProject.name = 'spring-security'

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
 
 plugins {
 	id "com.gradle.enterprise" version "3.2"
-	id "io.spring.gradle-enterprise-conventions" version "0.0.6"
+	id "io.spring.ge.conventions" version "0.0.6"
 }
 
 rootProject.name = 'spring-security'


### PR DESCRIPTION
This PR adds build scans to PR builds, making it easier for developers to see their error output at the end of a run.