### PR TITLE
Prevent PR builds from running on forks

### DIFF
--- a/.github/workflows/pr-build-workflow.yml
+++ b/.github/workflows/pr-build-workflow.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-
+    if: github.repository == 'spring-projects/spring-security'
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK


### PR DESCRIPTION
An issue was raised in Spring Session (https://github.com/spring-projects/spring-session/issues/1678) detailing how builds were running on forked versions of the repo. I fixed the issue in https://github.com/spring-projects/spring-security/pull/8698, this PR adds similar logic to the Spring Security repo to ensure builds don't run on forks.

More detail:

Github Actions doesn't currently have an elegant way to prevent builds on forks. Following the suggestion outlined here, I added checks for each job to ensure it only runs on spring-projects/spring-session.

I opened a PR on my forked version and confirmed that no builds steps ran. See https://github.com/elliedori/spring-security/pull/6/checks?check_run_id=1062839692 for more.