### PR TITLE
Allow for customization of IssuerResolver

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
@@ -89,25 +89,22 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 	}
 
 	/**
-	 *	Construct a {@link JwtIssuerAuthenticationManagerResolver} with
-	 *	a custom {@link JwtAuthenticationConverter} using the provided parameters
+	 * Construct a {@link JwtIssuerAuthenticationManagerResolver} with a custom
+	 * {@link JwtAuthenticationConverter} using the provided parameters
 	 *
-	 *	A custom {@link JwtAuthenticationConverter} allows to use a
-	 *	custom {@link Converter} (much like {@link JwtGrantedAuthoritiesConverter})
-	 *	to handle an untypical JWT token
-	 *
+	 * A custom {@link JwtAuthenticationConverter} allows to use a custom
+	 * {@link Converter} (much like {@link JwtGrantedAuthoritiesConverter}) to handle an
+	 * untypical JWT token
 	 * @param trustedIssuers a list of trusted issuers
 	 * @param jwtAuthenticationConverter a custom {@link JwtAuthenticationConverter}
 	 * @since 5.4
 	 */
-	public JwtIssuerAuthenticationManagerResolver(
-			Collection<String> trustedIssuers,
+	public JwtIssuerAuthenticationManagerResolver(Collection<String> trustedIssuers,
 			JwtAuthenticationConverter jwtAuthenticationConverter) {
 		Assert.notEmpty(trustedIssuers, "trustedIssuers cannot be empty");
 		Assert.notNull(jwtAuthenticationConverter, "jwtAuthenticationConverter cannot be null");
 		this.issuerAuthenticationManagerResolver = new TrustedIssuerJwtAuthenticationManagerResolver(
-				Collections.unmodifiableCollection(trustedIssuers)::contains,
-				jwtAuthenticationConverter);
+				Collections.unmodifiableCollection(trustedIssuers)::contains, jwtAuthenticationConverter);
 		this.issuerConverter = new JwtClaimIssuerConverter();
 	}
 
@@ -155,18 +152,16 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 	 * </pre>
 	 *
 	 * The keys in the {@link Map} are the allowed issuers.
-	 *
 	 * @param issuerAuthenticationManagerResolver a strategy for resolving the
 	 * {@link AuthenticationManager} by the issuer
-	 *
-	 * @param issuerConverter a custom converter to resolve the token
-	 *	A custom converter allows to use a custom {@link BearerTokenResolver}
+	 * @param issuerConverter a custom converter to resolve the token A custom converter
+	 * allows to use a custom {@link BearerTokenResolver}
 	 *
 	 * @since 5.4
 	 */
 	public JwtIssuerAuthenticationManagerResolver(
 			AuthenticationManagerResolver<String> issuerAuthenticationManagerResolver,
-			Converter<HttpServletRequest, String> issuerConverter){
+			Converter<HttpServletRequest, String> issuerConverter) {
 		Assert.notNull(issuerAuthenticationManagerResolver, "issuerAuthenticationManagerResolver cannot be null");
 		Assert.notNull(issuerConverter, "issuerConverter cannot be null");
 		this.issuerAuthenticationManagerResolver = issuerAuthenticationManagerResolver;
@@ -225,8 +220,7 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 			this(trustedIssuer, null);
 		}
 
-		TrustedIssuerJwtAuthenticationManagerResolver(
-				Predicate<String> trustedIssuer,
+		TrustedIssuerJwtAuthenticationManagerResolver(Predicate<String> trustedIssuer,
 				JwtAuthenticationConverter jwtAuthenticationConverter) {
 			this.trustedIssuer = trustedIssuer;
 			this.jwtAuthenticationConverter = jwtAuthenticationConverter;
@@ -239,13 +233,14 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 						(k) -> {
 							this.logger.debug("Constructing AuthenticationManager");
 							JwtDecoder jwtDecoder = JwtDecoders.fromIssuerLocation(issuer);
-							if(jwtAuthenticationConverter != null) {
+							if (jwtAuthenticationConverter != null) {
 								this.logger.debug(("Using custom JwtAuthenticationConverter"));
-								final JwtAuthenticationProvider jwtAuthenticationProvider =
-										new JwtAuthenticationProvider(jwtDecoder);
+								final JwtAuthenticationProvider jwtAuthenticationProvider = new JwtAuthenticationProvider(
+										jwtDecoder);
 								jwtAuthenticationProvider.setJwtAuthenticationConverter(jwtAuthenticationConverter);
 								return jwtAuthenticationProvider::authenticate;
-							} else {
+							}
+							else {
 								this.logger.debug(("Using default JwtAuthenticationConverter"));
 								return new JwtAuthenticationProvider(jwtDecoder)::authenticate;
 							}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
@@ -92,20 +92,18 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 	 * Construct a {@link JwtIssuerReactiveAuthenticationManagerResolver} using the
 	 * provided parameters
 	 *
-	 *	A custom {@link ReactiveJwtAuthenticationConverterAdapter} allows to use a
-	 *	custom {@link Converter} (much like {@link JwtGrantedAuthoritiesConverter})
-	 * 	to handle an untypical JWT token
-	 *
+	 * A custom {@link ReactiveJwtAuthenticationConverterAdapter} allows to use a custom
+	 * {@link Converter} (much like {@link JwtGrantedAuthoritiesConverter}) to handle an
+	 * untypical JWT token
 	 * @param trustedIssuers a collection of trusted issuers
-	 * @param reactiveJwtAuthenticationConverterAdapter a custom {@link ReactiveJwtAuthenticationConverterAdapter}
+	 * @param reactiveJwtAuthenticationConverterAdapter a custom
+	 * {@link ReactiveJwtAuthenticationConverterAdapter}
 	 */
-	public JwtIssuerReactiveAuthenticationManagerResolver(
-			Collection<String> trustedIssuers,
+	public JwtIssuerReactiveAuthenticationManagerResolver(Collection<String> trustedIssuers,
 			ReactiveJwtAuthenticationConverterAdapter reactiveJwtAuthenticationConverterAdapter) {
 		Assert.notEmpty(trustedIssuers, "trustedIssuers cannot be empty");
 		this.issuerAuthenticationManagerResolver = new TrustedIssuerJwtAuthenticationManagerResolver(
-				new ArrayList<>(trustedIssuers)::contains,
-				reactiveJwtAuthenticationConverterAdapter);
+				new ArrayList<>(trustedIssuers)::contains, reactiveJwtAuthenticationConverterAdapter);
 		this.issuerConverter = new JwtClaimIssuerConverter();
 	}
 
@@ -155,9 +153,8 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 	 * The keys in the {@link Map} are the trusted issuers.
 	 * @param issuerAuthenticationManagerResolver a strategy for resolving the
 	 * {@link ReactiveAuthenticationManager} by the issuer
-	 *
-	 *	@param issuerConverter a custom converter to resolve the token
-	 * 	A custom converter allows to use a custom {@link ServerBearerTokenAuthenticationConverter}
+	 * @param issuerConverter a custom converter to resolve the token A custom converter
+	 * allows to use a custom {@link ServerBearerTokenAuthenticationConverter}
 	 */
 	public JwtIssuerReactiveAuthenticationManagerResolver(
 			ReactiveAuthenticationManagerResolver<String> issuerAuthenticationManagerResolver,
@@ -221,8 +218,7 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 			this(trustedIssuer, null);
 		}
 
-		TrustedIssuerJwtAuthenticationManagerResolver(
-				Predicate<String> trustedIssuer,
+		TrustedIssuerJwtAuthenticationManagerResolver(Predicate<String> trustedIssuer,
 				ReactiveJwtAuthenticationConverterAdapter jwtAuthenticationConverterAdapter) {
 			this.trustedIssuer = trustedIssuer;
 			this.jwtAuthenticationConverterAdapter = jwtAuthenticationConverterAdapter;

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolverTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolverTests.java
@@ -89,32 +89,6 @@ public class JwtIssuerAuthenticationManagerResolverTests {
 	}
 
 	@Test
-	public void resolveWhenUsingTrustedIssuerAndCustomJwtAuthConverterThenReturnsAuthenticationManager()
-			throws Exception {
-		try (MockWebServer server = new MockWebServer()) {
-			server.start();
-			String issuer = server.url("").toString();
-			// @formatter:off
-			server.enqueue(new MockResponse().setResponseCode(200)
-											 .setHeader("Content-Type", "application/json")
-											 .setBody(String.format(DEFAULT_RESPONSE_TEMPLATE, issuer, issuer)
-											 ));
-			// @formatter:on
-			JWSObject jws = new JWSObject(new JWSHeader(JWSAlgorithm.RS256),
-					new Payload(new JSONObject(Collections.singletonMap(JwtClaimNames.ISS, issuer))));
-			jws.sign(new RSASSASigner(TestKeys.DEFAULT_PRIVATE_KEY));
-			JwtIssuerAuthenticationManagerResolver authenticationManagerResolver = new JwtIssuerAuthenticationManagerResolver(
-					Collections.singletonList(issuer), new JwtAuthenticationConverter());
-			MockHttpServletRequest request = new MockHttpServletRequest();
-			request.addHeader("Authorization", "Bearer " + jws.serialize());
-			AuthenticationManager authenticationManager = authenticationManagerResolver.resolve(request);
-			assertThat(authenticationManager).isNotNull();
-			AuthenticationManager cachedAuthenticationManager = authenticationManagerResolver.resolve(request);
-			assertThat(authenticationManager).isSameAs(cachedAuthenticationManager);
-		}
-	}
-
-	@Test
 	public void resolveWhenUsingUntrustedIssuerThenException() {
 		JwtIssuerAuthenticationManagerResolver authenticationManagerResolver = new JwtIssuerAuthenticationManagerResolver(
 				"other", "issuers");

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolverTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolverTests.java
@@ -89,7 +89,8 @@ public class JwtIssuerAuthenticationManagerResolverTests {
 	}
 
 	@Test
-	public void resolveWhenUsingTrustedIssuerAndCustomJwtAuthConverterThenReturnsAuthenticationManager() throws Exception {
+	public void resolveWhenUsingTrustedIssuerAndCustomJwtAuthConverterThenReturnsAuthenticationManager()
+			throws Exception {
 		try (MockWebServer server = new MockWebServer()) {
 			server.start();
 			String issuer = server.url("").toString();
@@ -100,7 +101,7 @@ public class JwtIssuerAuthenticationManagerResolverTests {
 											 ));
 			// @formatter:on
 			JWSObject jws = new JWSObject(new JWSHeader(JWSAlgorithm.RS256),
-										  new Payload(new JSONObject(Collections.singletonMap(JwtClaimNames.ISS, issuer))));
+					new Payload(new JSONObject(Collections.singletonMap(JwtClaimNames.ISS, issuer))));
 			jws.sign(new RSASSASigner(TestKeys.DEFAULT_PRIVATE_KEY));
 			JwtIssuerAuthenticationManagerResolver authenticationManagerResolver = new JwtIssuerAuthenticationManagerResolver(
 					Collections.singletonList(issuer), new JwtAuthenticationConverter());
@@ -139,7 +140,8 @@ public class JwtIssuerAuthenticationManagerResolverTests {
 	@Test
 	public void resolveWhenUsingCustomIssuerAuthenticationManagerResolverAndCustomIssuerConverterThenUses() {
 		AuthenticationManager authenticationManager = mock(AuthenticationManager.class);
-		Converter<HttpServletRequest, String> jwtAuthConverter = (Converter<HttpServletRequest, String>) mock(Converter.class);
+		Converter<HttpServletRequest, String> jwtAuthConverter = (Converter<HttpServletRequest, String>) mock(
+				Converter.class);
 		JwtIssuerAuthenticationManagerResolver authenticationManagerResolver = new JwtIssuerAuthenticationManagerResolver(
 				(issuer) -> authenticationManager, jwtAuthConverter);
 		MockHttpServletRequest request = new MockHttpServletRequest();
@@ -227,11 +229,9 @@ public class JwtIssuerAuthenticationManagerResolverTests {
 
 	@Test
 	public void constructWhenNullIssuerConverterThenException() {
-		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new JwtIssuerAuthenticationManagerResolver(
-						context -> new JwtAuthenticationProvider(
-								JwtDecoders.fromIssuerLocation("trusted"))::authenticate, null)
-				);
+		assertThatIllegalArgumentException().isThrownBy(() -> new JwtIssuerAuthenticationManagerResolver(
+				context -> new JwtAuthenticationProvider(JwtDecoders.fromIssuerLocation("trusted"))::authenticate,
+				null));
 	}
 
 	private String jwt(String claim, String value) {

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolverTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolverTests.java
@@ -90,22 +90,24 @@ public class JwtIssuerReactiveAuthenticationManagerResolverTests {
 	}
 
 	@Test
-	public void resolveWhenUsingTrustedIssuerAndCustomJwtAuthConverterThenReturnsAuthenticationManager() throws Exception {
+	public void resolveWhenUsingTrustedIssuerAndCustomJwtAuthConverterThenReturnsAuthenticationManager()
+			throws Exception {
 		try (MockWebServer server = new MockWebServer()) {
 			String issuer = server.url("").toString();
 			server.enqueue(new MockResponse().setResponseCode(200).setHeader("Content-Type", "application/json")
-											 .setBody(String.format(DEFAULT_RESPONSE_TEMPLATE, issuer, issuer)));
+					.setBody(String.format(DEFAULT_RESPONSE_TEMPLATE, issuer, issuer)));
 			JWSObject jws = new JWSObject(new JWSHeader(JWSAlgorithm.RS256),
-										  new Payload(new JSONObject(Collections.singletonMap(JwtClaimNames.ISS, issuer))));
+					new Payload(new JSONObject(Collections.singletonMap(JwtClaimNames.ISS, issuer))));
 			jws.sign(new RSASSASigner(TestKeys.DEFAULT_PRIVATE_KEY));
 			JwtIssuerReactiveAuthenticationManagerResolver authenticationManagerResolver = new JwtIssuerReactiveAuthenticationManagerResolver(
-					Collections.singletonList(issuer), new ReactiveJwtAuthenticationConverterAdapter(new JwtAuthenticationConverter()));
+					Collections.singletonList(issuer),
+					new ReactiveJwtAuthenticationConverterAdapter(new JwtAuthenticationConverter()));
 			MockServerWebExchange exchange = withBearerToken(jws.serialize());
 			ReactiveAuthenticationManager authenticationManager = authenticationManagerResolver.resolve(exchange)
-																							   .block();
+					.block();
 			assertThat(authenticationManager).isNotNull();
 			ReactiveAuthenticationManager cachedAuthenticationManager = authenticationManagerResolver.resolve(exchange)
-																									 .block();
+					.block();
 			assertThat(authenticationManager).isSameAs(cachedAuthenticationManager);
 		}
 	}
@@ -134,7 +136,8 @@ public class JwtIssuerReactiveAuthenticationManagerResolverTests {
 	@Test
 	public void resolveWhenUsingCustomIssuerAuthenticationManagerResolverAndCustomIssuerConverterThenUses() {
 		ReactiveAuthenticationManager authenticationManager = mock(ReactiveAuthenticationManager.class);
-		Converter<ServerWebExchange, Mono<String>> jwtAuthConverter = (Converter<ServerWebExchange, Mono<String>>) mock(Converter.class);
+		Converter<ServerWebExchange, Mono<String>> jwtAuthConverter = (Converter<ServerWebExchange, Mono<String>>) mock(
+				Converter.class);
 		JwtIssuerReactiveAuthenticationManagerResolver authenticationManagerResolver = new JwtIssuerReactiveAuthenticationManagerResolver(
 				(issuer) -> Mono.just(authenticationManager), jwtAuthConverter);
 		MockServerWebExchange exchange = withBearerToken(this.jwt);
@@ -211,10 +214,10 @@ public class JwtIssuerReactiveAuthenticationManagerResolverTests {
 
 	@Test
 	public void constructWhenNullIssuerConverterThenException() {
-		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new JwtIssuerReactiveAuthenticationManagerResolver(
-						context -> Mono.just(new JwtReactiveAuthenticationManager(
-								ReactiveJwtDecoders.fromIssuerLocation("trusted"))), null));
+		assertThatIllegalArgumentException().isThrownBy(() -> new JwtIssuerReactiveAuthenticationManagerResolver(
+				context -> Mono
+						.just(new JwtReactiveAuthenticationManager(ReactiveJwtDecoders.fromIssuerLocation("trusted"))),
+				null));
 	}
 
 	private String jwt(String claim, String value) {


### PR DESCRIPTION
Customization of IssuerConverter and JwtAuthenticationConverter will make it easier to customize the way JWTs are handled, especially in a multi-tenant env, with the use of the default JwtAuthenticationProvider. This eliminates the need to write a complex implementation for different tasks, that ideally should be quick and easy, such as custom GranthedAuthorities conversion.

Closes gh-8535