### PR TITLE
Fix broken Mono chain

### DIFF
--- a/web/src/main/java/org/springframework/security/web/server/csrf/WebSessionServerCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/server/csrf/WebSessionServerCsrfTokenRepository.java
@@ -52,8 +52,7 @@ public class WebSessionServerCsrfTokenRepository implements ServerCsrfTokenRepos
 
 	@Override
 	public Mono<CsrfToken> generateToken(ServerWebExchange exchange) {
-		Mono.just(exchange).publishOn(Schedulers.boundedElastic());
-		return Mono.fromCallable(() -> createCsrfToken());
+		return Mono.fromCallable(() -> createCsrfToken()).subscribeOn(Schedulers.boundedElastic());
 	}
 
 	@Override


### PR DESCRIPTION
This commit restore broken Mono chain in WebSessionServerCsrfTokenRepository.generateToken(ServerWebExchange).

Closes gh-9017
