### PR TITLE
Replace Tomcat6 URL for SSL Guide to Tomcat 10

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/servlet/authentication/x509.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/authentication/x509.adoc
@@ -15,7 +15,7 @@ It maps the certificate to an application user and loads that user's set of gran
 
 You should be familiar with using certificates and setting up client authentication for your servlet container before attempting to use it with Spring Security.
 Most of the work is in creating and installing suitable certificates and keys.
-For example, if you're using Tomcat then read the instructions here https://tomcat.apache.org/tomcat-6.0-doc/ssl-howto.html[https://tomcat.apache.org/tomcat-6.0-doc/ssl-howto.html].
+For example, if you're using Tomcat then read the instructions here https://tomcat.apache.org/tomcat-9.0-doc/ssl-howto.html[https://tomcat.apache.org/tomcat-9.0-doc/ssl-howto.html].
 It's important that you get this working before trying it out with Spring Security
 
 


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
I suggest SSL setup guide link from tomcat6 to tomcat10.
Tomcat 6 document for ssl (SSL is changed by SSL/TLS in tomcat 7,8,9,10 server document) is old.
So, I create pull request.

Also, I think it would better add xsd format in .ignore, So I suggest this file. 

Regards.