### PR TITLE
Added method to return both ip and port for srv dns lookup requests.

### DIFF
--- a/remoting/src/test/java/org/springframework/security/remoting/dns/JndiDnsResolverTests.java
+++ b/remoting/src/test/java/org/springframework/security/remoting/dns/JndiDnsResolverTests.java
@@ -92,6 +92,16 @@ public class JndiDnsResolverTests {
 		assertThat(ipAddress).isEqualTo("63.246.7.80");
 	}
 
+	@Test
+	public void resolveServiceIpAddressWithPort() throws Exception {
+		BasicAttributes srvRecords = createSrvRecords();
+		BasicAttributes aRecords = new BasicAttributes("A", "63.246.7.80");
+		given(this.context.getAttributes("_ldap._tcp.springsource.com", new String[] { "SRV" })).willReturn(srvRecords);
+		given(this.context.getAttributes("kdc.springsource.com", new String[] { "A" })).willReturn(aRecords);
+		String ipAddress = this.dnsResolver.resolveServiceIpAddressAndPort("ldap", "springsource.com");
+		assertThat(ipAddress).isEqualTo("63.246.7.80:389");
+	}
+
 	@Test(expected = DnsLookupException.class)
 	public void testUnknowError() throws Exception {
 		given(this.context.getAttributes(any(String.class), any(String[].class)))


### PR DESCRIPTION
Closes gh-9030

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
