### PR TITLE
Add convenience authentication handlers returning an HTTP status

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/HttpStatusReturningAuthenticationFailureHandler.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/HttpStatusReturningAuthenticationFailureHandler.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.util.Assert;
+
+/**
+ * An {@link AuthenticationFailureHandler} that returns an HTTP status code of
+ * {@code 401} (Unauthorized) by default.
+ *
+ * @author Matthias Luppi
+ * @since 5.5
+ */
+public class HttpStatusReturningAuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+	private final HttpStatus httpStatus;
+
+	/**
+	 * Constructor which sets the user-defined {@link HttpStatus} that should be returned
+	 * when the authentication failed.
+	 * @param httpStatus The {@link HttpStatus} to return, must not be {@code null}.
+	 */
+	public HttpStatusReturningAuthenticationFailureHandler(HttpStatus httpStatus) {
+		Assert.notNull(httpStatus, "The provided HttpStatus must not be null.");
+		this.httpStatus = httpStatus;
+	}
+
+	/**
+	 * Constructor which initializes the default {@link HttpStatus#UNAUTHORIZED}.
+	 */
+	public HttpStatusReturningAuthenticationFailureHandler() {
+		this.httpStatus = HttpStatus.UNAUTHORIZED;
+	}
+
+	/**
+	 * Implementation of
+	 * {@link AuthenticationFailureHandler#onAuthenticationFailure(HttpServletRequest, HttpServletResponse, AuthenticationException)}.
+	 * Sets the configured status on the {@link HttpServletResponse}.
+	 */
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+			AuthenticationException e) throws IOException {
+		response.setStatus(this.httpStatus.value());
+		response.getWriter().flush();
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/HttpStatusReturningAuthenticationFailureHandler.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/HttpStatusReturningAuthenticationFailureHandler.java
@@ -26,8 +26,8 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.util.Assert;
 
 /**
- * An {@link AuthenticationFailureHandler} that returns an HTTP status code of
- * {@code 401} (Unauthorized) by default.
+ * An {@link AuthenticationFailureHandler} that returns an HTTP status code of {@code 401}
+ * (Unauthorized) by default.
  *
  * @author Matthias Luppi
  * @since 5.5

--- a/web/src/main/java/org/springframework/security/web/authentication/HttpStatusReturningAuthenticationSuccessHandler.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/HttpStatusReturningAuthenticationSuccessHandler.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.util.Assert;
+
+/**
+ * An {@link AuthenticationSuccessHandler} that returns an HTTP status code of
+ * {@code 200} (OK) by default.
+ *
+ * @author Matthias Luppi
+ * @since 5.5
+ */
+public class HttpStatusReturningAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+	private final HttpStatus httpStatus;
+
+	/**
+	 * Constructor which sets the user-defined {@link HttpStatus} that should be returned
+	 * when the authentication was successful.
+	 * @param httpStatus The {@link HttpStatus} to return, must not be {@code null}.
+	 */
+	public HttpStatusReturningAuthenticationSuccessHandler(HttpStatus httpStatus) {
+		Assert.notNull(httpStatus, "The provided HttpStatus must not be null.");
+		this.httpStatus = httpStatus;
+	}
+
+	/**
+	 * Constructor which initializes the default {@link HttpStatus#OK}.
+	 */
+	public HttpStatusReturningAuthenticationSuccessHandler() {
+		this.httpStatus = HttpStatus.OK;
+	}
+
+	/**
+	 * Implementation of
+	 * {@link AuthenticationSuccessHandler#onAuthenticationSuccess(HttpServletRequest, HttpServletResponse, Authentication)}.
+	 * Sets the configured status on the {@link HttpServletResponse}.
+	 */
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+			Authentication authentication) throws IOException {
+		response.setStatus(this.httpStatus.value());
+		response.getWriter().flush();
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/HttpStatusReturningAuthenticationSuccessHandler.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/HttpStatusReturningAuthenticationSuccessHandler.java
@@ -26,8 +26,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.util.Assert;
 
 /**
- * An {@link AuthenticationSuccessHandler} that returns an HTTP status code of
- * {@code 200} (OK) by default.
+ * An {@link AuthenticationSuccessHandler} that returns an HTTP status code of {@code 200}
+ * (OK) by default.
  *
  * @author Matthias Luppi
  * @since 5.5

--- a/web/src/test/java/org/springframework/security/web/authentication/HttpStatusReturningAuthenticationFailureHandlerTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/HttpStatusReturningAuthenticationFailureHandlerTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * Tests the {@link HttpStatusReturningAuthenticationFailureHandler}.
+ *
+ * @author Matthias Luppi
+ */
+public class HttpStatusReturningAuthenticationFailureHandlerTests {
+
+	@Test
+	public void defaultHttpStatusIsReturned() throws IOException {
+		final HttpStatusReturningAuthenticationFailureHandler afh = new HttpStatusReturningAuthenticationFailureHandler();
+		final MockHttpServletRequest request = new MockHttpServletRequest();
+		final MockHttpServletResponse response = new MockHttpServletResponse();
+		afh.onAuthenticationFailure(request, response, new BadCredentialsException("message"));
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+		assertThat(response.getRedirectedUrl()).isNull();
+		assertThat(response.getForwardedUrl()).isNull();
+	}
+
+	@Test
+	public void customHttpStatusIsReturned() throws IOException {
+		final HttpStatusReturningAuthenticationFailureHandler afh = new HttpStatusReturningAuthenticationFailureHandler(
+				HttpStatus.CONFLICT);
+		final MockHttpServletRequest request = new MockHttpServletRequest();
+		final MockHttpServletResponse response = new MockHttpServletResponse();
+		afh.onAuthenticationFailure(request, response, new BadCredentialsException("message"));
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
+		assertThat(response.getRedirectedUrl()).isNull();
+		assertThat(response.getForwardedUrl()).isNull();
+	}
+
+	@Test
+	public void nullStatusCodeThrowsException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> new HttpStatusReturningAuthenticationFailureHandler(null))
+				.withMessage("The provided HttpStatus must not be null.");
+	}
+
+}

--- a/web/src/test/java/org/springframework/security/web/authentication/HttpStatusReturningAuthenticationSuccessHandlerTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/HttpStatusReturningAuthenticationSuccessHandlerTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication;
+
+import org.junit.Test;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests the {@link HttpStatusReturningAuthenticationSuccessHandler}.
+ *
+ * @author Matthias Luppi
+ */
+public class HttpStatusReturningAuthenticationSuccessHandlerTests {
+
+	@Test
+	public void defaultHttpStatusIsReturned() throws Exception {
+		final HttpStatusReturningAuthenticationSuccessHandler ash = new HttpStatusReturningAuthenticationSuccessHandler();
+		final MockHttpServletRequest request = new MockHttpServletRequest();
+		final MockHttpServletResponse response = new MockHttpServletResponse();
+		final Authentication authentication = mock(Authentication.class);
+		ash.onAuthenticationSuccess(request, response, authentication);
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+		assertThat(response.getRedirectedUrl()).isNull();
+		assertThat(response.getForwardedUrl()).isNull();
+	}
+
+	@Test
+	public void customHttpStatusIsReturned() throws Exception {
+		final HttpStatusReturningAuthenticationSuccessHandler ash = new HttpStatusReturningAuthenticationSuccessHandler(
+				HttpStatus.NO_CONTENT);
+		final MockHttpServletRequest request = new MockHttpServletRequest();
+		final MockHttpServletResponse response = new MockHttpServletResponse();
+		final Authentication authentication = mock(Authentication.class);
+		ash.onAuthenticationSuccess(request, response, authentication);
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.NO_CONTENT.value());
+		assertThat(response.getRedirectedUrl()).isNull();
+		assertThat(response.getForwardedUrl()).isNull();
+	}
+
+	@Test
+	public void nullStatusCodeThrowsException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> new HttpStatusReturningAuthenticationSuccessHandler(null))
+				.withMessage("The provided HttpStatus must not be null.");
+	}
+
+}


### PR DESCRIPTION
This PR adds an implementation of `AuthenticationFailureHandler` and `AuthenticationSuccessHandler` which return a HTTP status code. This HTTP status code is configurable and defaults to `401 Unauthorized` (failure) or `200 OK` (success) respectively.

For the `@since` annotation, version 5.5 was used which is the next minor version according to Semantic Versioning.

_Example usage:_
```java
@EnableWebSecurity
public class WebSecurityConfig extends WebSecurityConfigurerAdapter {

    // ...
    
    @Override
    public void configure(HttpSecurity http) throws Exception {
        http.formLogin()
                .successHandler(new HttpStatusReturningAuthenticationSuccessHandler())
                .failureHandler(new HttpStatusReturningAuthenticationFailureHandler());
    }
}
```

_or with user-defined HTTP status codes:_

```java
@EnableWebSecurity
public class WebSecurityConfig extends WebSecurityConfigurerAdapter {

    // ...

    @Override
    public void configure(HttpSecurity http) throws Exception {
        http.formLogin()
                .successHandler(new HttpStatusReturningAuthenticationSuccessHandler(HttpStatus.NO_CONTENT))
                .failureHandler(new HttpStatusReturningAuthenticationFailureHandler(HttpStatus.CONFLICT));
    }
}
```

Closes #9097 