### PR TITLE
getRemoteUser() returns name of object implementing AuthenticatedPrincipal

### DIFF
--- a/web/src/main/java/org/springframework/security/web/servletapi/SecurityContextHolderAwareRequestWrapper.java
+++ b/web/src/main/java/org/springframework/security/web/servletapi/SecurityContextHolderAwareRequestWrapper.java
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletRequestWrapper;
 
 import org.springframework.security.authentication.AuthenticationTrustResolver;
 import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
+import org.springframework.security.core.AuthenticatedPrincipal;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -105,6 +106,9 @@ public class SecurityContextHolderAwareRequestWrapper extends HttpServletRequest
 		}
 		if (auth.getPrincipal() instanceof UserDetails) {
 			return ((UserDetails) auth.getPrincipal()).getUsername();
+		}
+		if (auth.getPrincipal() instanceof AuthenticatedPrincipal) {
+			return ((AuthenticatedPrincipal) auth.getPrincipal()).getName();
 		}
 		return auth.getPrincipal().toString();
 	}

--- a/web/src/test/java/org/springframework/security/web/servletapi/SecurityContextHolderAwareRequestWrapperTests.java
+++ b/web/src/test/java/org/springframework/security/web/servletapi/SecurityContextHolderAwareRequestWrapperTests.java
@@ -21,12 +21,17 @@ import org.junit.Test;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.AuthenticatedPrincipal;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * Tests {@link SecurityContextHolderAwareRequestWrapper}.
@@ -128,6 +133,20 @@ public class SecurityContextHolderAwareRequestWrapperTests {
 				"ROLE_");
 		assertThat(wrapper.isUserInRole("ROLE_HELLO")).isTrue();
 		assertThat(wrapper.isUserInRole("ROLE_FOOBAR")).isTrue();
+	}
+
+	@Test
+	public void testGetRemoteUserStringWithAuthenticatedPrinciple() {
+		String username = "authPrincipleUsername";
+		AuthenticatedPrincipal principal = mock(AuthenticatedPrincipal.class);
+		given(principal.getName()).willReturn(username);
+		Authentication auth = new TestingAuthenticationToken(principal, "user");
+		SecurityContextHolder.getContext().setAuthentication(auth);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setRequestURI("/");
+		SecurityContextHolderAwareRequestWrapper wrapper = new SecurityContextHolderAwareRequestWrapper(request, "");
+		assertThat(wrapper.getRemoteUser()).isEqualTo(username);
+		verify(principal, times(1)).getName();
 	}
 
 }


### PR DESCRIPTION
Returns the name of the authenticated principle instead of falling through to the toString() method which may render a string representation of the entire object rather than a username.

This behavior is helpful in OAuth2 and Saml2 configurations.

Fixes: #3357

