### PR TITLE
Closes gh-8196 appendix indentation

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/servlet/appendix/index.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/appendix/index.adoc
@@ -1,7 +1,7 @@
 
 = Appendix
 
-include::database-schema.adoc[]
+include::database-schema.adoc[leveloffset=+1]
 
 include::namespace.adoc[]
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10791683/95687236-ff9feb00-0bc7-11eb-8b7d-7e5e5500406a.png)



@pivotal-issuemaster This is an Obvious Fix