### PR TITLE
Catch iIlegalStateException when session is already invalidate

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/preauth/AbstractPreAuthenticatedProcessingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/preauth/AbstractPreAuthenticatedProcessingFilter.java
@@ -351,11 +351,20 @@ public abstract class AbstractPreAuthenticatedProcessingFilter extends GenericFi
 				HttpSession session = request.getSession(false);
 				if (session != null) {
 					AbstractPreAuthenticatedProcessingFilter.this.logger.debug("Invalidating existing session");
-					session.invalidate();
+					invalidateSessionIfNotAlreadyInvalidated(session);
 					request.getSession();
 				}
 			}
 			return true;
+		}
+
+		private void invalidateSessionIfNotAlreadyInvalidated(HttpSession session) {
+			try {
+				session.invalidate();
+			}
+			catch (IllegalStateException exception) {
+				AbstractPreAuthenticatedProcessingFilter.this.logger.info("Session already invalidated");
+			}
 		}
 
 	}


### PR DESCRIPTION
When a session is already invalidated then an uncaught exception is thrown. This is a proposed fix for  issue [9127](https://github.com/spring-projects/spring-security/issues/9127). 