### PR TITLE
JwtIssuerValidator handles issuer (iss) claim values as Strings and URLs

### DIFF
--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtIssuerValidator.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtIssuerValidator.java
@@ -16,6 +16,8 @@
 
 package org.springframework.security.oauth2.jwt;
 
+import java.util.function.Predicate;
+
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
 import org.springframework.util.Assert;
@@ -28,7 +30,7 @@ import org.springframework.util.Assert;
  */
 public final class JwtIssuerValidator implements OAuth2TokenValidator<Jwt> {
 
-	private final JwtClaimValidator<String> validator;
+	private final JwtClaimValidator<Object> validator;
 
 	/**
 	 * Constructs a {@link JwtIssuerValidator} using the provided parameters
@@ -36,7 +38,9 @@ public final class JwtIssuerValidator implements OAuth2TokenValidator<Jwt> {
 	 */
 	public JwtIssuerValidator(String issuer) {
 		Assert.notNull(issuer, "issuer cannot be null");
-		this.validator = new JwtClaimValidator(JwtClaimNames.ISS, issuer::equals);
+
+		Predicate<Object> testClaimValue = (claimValue) -> (claimValue != null) && issuer.equals(claimValue.toString());
+		this.validator = new JwtClaimValidator<>(JwtClaimNames.ISS, testClaimValue);
 	}
 
 	@Override

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtIssuerValidatorTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtIssuerValidatorTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.security.oauth2.jwt;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.junit.Test;
 
 import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
@@ -43,9 +46,25 @@ public class JwtIssuerValidatorTests {
 	}
 
 	@Test
+	public void validateWhenIssuerUrlMatchesThenReturnsSuccess() throws MalformedURLException {
+		Jwt jwt = TestJwts.jwt().claim("iss", new URL(ISSUER)).build();
+
+		assertThat(this.validator.validate(jwt)).isEqualTo(OAuth2TokenValidatorResult.success());
+	}
+
+	@Test
 	public void validateWhenIssuerMismatchesThenReturnsError() {
 		Jwt jwt = TestJwts.jwt().claim(JwtClaimNames.ISS, "https://other").build();
 		OAuth2TokenValidatorResult result = this.validator.validate(jwt);
+		assertThat(result.getErrors()).isNotEmpty();
+	}
+
+	@Test
+	public void validateWhenIssuerUrlMismatchesThenReturnsError() throws MalformedURLException {
+		Jwt jwt = TestJwts.jwt().claim(JwtClaimNames.ISS, new URL("https://other")).build();
+
+		OAuth2TokenValidatorResult result = this.validator.validate(jwt);
+
 		assertThat(result.getErrors()).isNotEmpty();
 	}
 


### PR DESCRIPTION
- NimbusJwtDecoder uses claim set converters: issuer claim is converted to an URL object
- JwtIssuerValidator (created by JwtValidators.createDefaultWithIssuer(String)) wraps a JwtClaimValidator<String>
- because of different data types, equal() is always false

This change allows both Strings and URLs as values of the issuer

Issue gh-9136

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
