### PR TITLE
Make salt length configurable in Pbkdf2PasswordEncoder

### DIFF
--- a/crypto/src/test/java/org/springframework/security/crypto/password/Pbkdf2PasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/password/Pbkdf2PasswordEncoderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,10 +24,24 @@ import org.springframework.security.crypto.codec.Hex;
 import org.springframework.security.crypto.keygen.KeyGenerators;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 public class Pbkdf2PasswordEncoderTests {
 
 	private Pbkdf2PasswordEncoder encoder = new Pbkdf2PasswordEncoder("secret");
+
+	private Pbkdf2PasswordEncoder encoderSalt16 = new Pbkdf2PasswordEncoder("", 16);
+
+	private Pbkdf2PasswordEncoder[] encoders = new Pbkdf2PasswordEncoder[] { this.encoder, this.encoderSalt16 };
+
+	@Test
+	public void encodedLengthSuccess() {
+		// encode output is an hex coded String so with 2 chars per encoding result byte
+		// (ie. 1 char for 4 bits).
+		// The encoding result size is : (saltLength * 8) bits + hashWith bits.
+		assertThat(this.encoder.encode("password").length()).isEqualTo((8 * 8 + 256) / 4);
+		assertThat(this.encoderSalt16.encode("password").length()).isEqualTo((16 * 8 + 256) / 4);
+	}
 
 	@Test
 	public void matches() {
@@ -37,15 +51,34 @@ public class Pbkdf2PasswordEncoderTests {
 	}
 
 	@Test
+	public void matchesWhenCustomSaltLengthThenSuccess() {
+		String result = this.encoderSalt16.encode("password");
+		assertThat(result.equals("password")).isFalse();
+		assertThat(this.encoderSalt16.matches("password", result)).isTrue();
+	}
+
+	@Test
 	public void matchesLengthChecked() {
 		String result = this.encoder.encode("password");
 		assertThat(this.encoder.matches("password", result.substring(0, result.length() - 2))).isFalse();
 	}
 
 	@Test
+	public void matchesLengthCheckedWhenCustomSaltLengthThenSuccess() {
+		String result = this.encoderSalt16.encode("password");
+		assertThat(this.encoderSalt16.matches("password", result.substring(0, result.length() - 2))).isFalse();
+	}
+
+	@Test
 	public void notMatches() {
 		String result = this.encoder.encode("password");
 		assertThat(this.encoder.matches("bogus", result)).isFalse();
+	}
+
+	@Test
+	public void notMatchesWhenCustomSaltLengthThenSuccess() {
+		String result = this.encoderSalt16.encode("password");
+		assertThat(this.encoderSalt16.matches("bogus", result)).isFalse();
 	}
 
 	@Test
@@ -57,10 +90,25 @@ public class Pbkdf2PasswordEncoderTests {
 	}
 
 	@Test
+	public void encodeSamePasswordMultipleTimesWhenCustomSaltLengthThenDiffers() {
+		String password = "password";
+		String encodeFirst = this.encoderSalt16.encode(password);
+		String encodeSecond = this.encoderSalt16.encode(password);
+		assertThat(encodeFirst).isNotEqualTo(encodeSecond);
+	}
+
+	@Test
 	public void passivity() {
 		String encodedPassword = "ab1146a8458d4ce4e65789e5a3f60e423373cfa10b01abd23739e5ae2fdc37f8e9ede4ae6da65264";
 		String rawPassword = "password";
 		assertThat(this.encoder.matches(rawPassword, encodedPassword)).isTrue();
+	}
+
+	@Test
+	public void passivityWhenCustomSaltLengthThenSuccess() {
+		String encodedPassword = "0123456789abcdef0123456789abcdef10d883c2a0e653c97175c4a2583a7f1fd3301b319a7657d95f75365ea7c04ce1";
+		String rawPassword = "password";
+		assertThat(this.encoderSalt16.matches(rawPassword, encodedPassword)).isTrue();
 	}
 
 	@Test
@@ -83,6 +131,24 @@ public class Pbkdf2PasswordEncoderTests {
 	}
 
 	@Test
+	public void encodeAndMatchWhenBase64AndCustomSaltLengthThenSuccess() {
+		this.encoderSalt16.setEncodeHashAsBase64(true);
+		String rawPassword = "password";
+		String encodedPassword = this.encoderSalt16.encode(rawPassword);
+		assertThat(this.encoderSalt16.matches(rawPassword, encodedPassword)).isTrue();
+	}
+
+	@Test
+	public void encodeWhenBase64ThenBase64DecodeSuccess() {
+		assertThat(this.encoders).allSatisfy((pe) -> {
+			pe.setEncodeHashAsBase64(true);
+			String encodedPassword = pe.encode("password");
+			// validate can decode as Base64
+			assertThatNoException().isThrownBy(() -> java.util.Base64.getDecoder().decode(encodedPassword));
+		});
+	}
+
+	@Test
 	public void matchWhenBase64ThenSuccess() {
 		this.encoder.setEncodeHashAsBase64(true);
 		String rawPassword = "password";
@@ -90,6 +156,14 @@ public class Pbkdf2PasswordEncoderTests {
 		assertThat(this.encoder.matches(rawPassword, encodedPassword)).isTrue();
 		java.util.Base64.getDecoder().decode(encodedPassword); // validate can decode as
 																// Base64
+	}
+
+	@Test
+	public void matchWhenBase64AndCustomSaltLengthThenSuccess() {
+		this.encoderSalt16.setEncodeHashAsBase64(true);
+		String rawPassword = "password";
+		String encodedPassword = "ASNFZ4mrze8BI0VniavN7xDYg8Kg5lPJcXXEolg6fx/TMBsxmnZX2V91Nl6nwEzh";
+		assertThat(this.encoderSalt16.matches(rawPassword, encodedPassword)).isTrue();
 	}
 
 	@Test
@@ -101,11 +175,27 @@ public class Pbkdf2PasswordEncoderTests {
 	}
 
 	@Test
+	public void encodeAndMatchWhenSha256AndCustomSaltLengthThenSuccess() {
+		this.encoderSalt16.setAlgorithm(Pbkdf2PasswordEncoder.SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA256);
+		String rawPassword = "password";
+		String encodedPassword = this.encoderSalt16.encode(rawPassword);
+		assertThat(this.encoderSalt16.matches(rawPassword, encodedPassword)).isTrue();
+	}
+
+	@Test
 	public void matchWhenSha256ThenSuccess() {
 		this.encoder.setAlgorithm(Pbkdf2PasswordEncoder.SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA256);
 		String rawPassword = "password";
 		String encodedPassword = "821447f994e2b04c5014e31fa9fca4ae1cc9f2188c4ed53d3ddb5ba7980982b51a0ecebfc0b81a79";
 		assertThat(this.encoder.matches(rawPassword, encodedPassword)).isTrue();
+	}
+
+	@Test
+	public void matchWhenSha256AndCustomSaltLengthThenSuccess() {
+		this.encoderSalt16.setAlgorithm(Pbkdf2PasswordEncoder.SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA256);
+		String rawPassword = "password";
+		String encodedPassword = "0123456789abcdef0123456789abcdefc7cfc96cd26b854d096ccbb3308fad860d719eb552ed52ef8352935539158287";
+		assertThat(this.encoderSalt16.matches(rawPassword, encodedPassword)).isTrue();
 	}
 
 	/**


### PR DESCRIPTION
Add constructors with a salt length input parameter.
Default salt length is still 8-byte long like before when
saltGenerator was initialized with call to
KeyGenerators#secureRandom() which use
SecureRandomBytesKeyGenerator#DEFAULT_KEY_LENGTH.

Closes gh-4372

---
This PR is related to #4372 to make salt length configurable in Pbkdf2PasswordEncoder.

Like mention in the #4372 issue, [NIST Special Publication 800-132](https://csrc.nist.gov/publications/detail/sp/800-132/final) section 5.1 said that salt length shall be at least 128 bits (16 bytes). Current [`Pbkdf2PasswordEncoder`](crypto/src/main/java/org/springframework/security/crypto/password/Pbkdf2PasswordEncoder.java) use a 8-byte (64-bit) random salt with no possibility to configure its length.

Users that want to conform to NIST Special Publication 800-132 (or other rules requiring different that 8-byte random salt) for password storage with PBKDF2 algorithm, have no choice to develop their own PBKDF2 PasswordEncoder from scratch. They can't inherit from current `Pbkdf2PasswordEncoder` class because the `saltGenerator` attribute is `private final` and not initialized in a at least protected constructor.
This could be a security problem in case of bad implementation or if a new spring-security version fix a security issue in the `Pbkdf2PasswordEncoder` class an the user not apply this fix to its own PasswordEncoder.


_PS : I've not added `@since` annotation yet because i don't know if constructors are concerned by this annotation and the target version._

_PS : I've submitted the CLA_

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
