### PR TITLE
Promote spring-boot-starter-oauth2-client

### DIFF
--- a/samples/boot/oauth2login/spring-security-samples-boot-oauth2login.gradle
+++ b/samples/boot/oauth2login/spring-security-samples-boot-oauth2login.gradle
@@ -1,9 +1,7 @@
 apply plugin: 'io.spring.convention.spring-sample-boot'
 
 dependencies {
-	compile project(':spring-security-config')
-	compile project(':spring-security-oauth2-client')
-	compile project(':spring-security-oauth2-jose')
+	compile project(':spring-boot-starter-oauth2-client')
 	compile 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	compile 'org.springframework.boot:spring-boot-starter-web'
 	compile 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'

--- a/samples/boot/oauth2login/spring-security-samples-boot-oauth2login.gradle
+++ b/samples/boot/oauth2login/spring-security-samples-boot-oauth2login.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'io.spring.convention.spring-sample-boot'
 
 dependencies {
-	compile project(':spring-boot-starter-oauth2-client')
+	compile 'org.springframework.boot::spring-boot-starter-oauth2-client'
 	compile 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	compile 'org.springframework.boot:spring-boot-starter-web'
 	compile 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'

--- a/samples/boot/oauth2login/spring-security-samples-boot-oauth2login.gradle
+++ b/samples/boot/oauth2login/spring-security-samples-boot-oauth2login.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'io.spring.convention.spring-sample-boot'
 
 dependencies {
-	compile 'org.springframework.boot::spring-boot-starter-oauth2-client'
+	compile 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	compile 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	compile 'org.springframework.boot:spring-boot-starter-web'
 	compile 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'


### PR DESCRIPTION
Since spring-security-config, oauth client *and* jose are necessary on the classpath to actually configure  OIDC via the DelegatingReactiveAuthenticationManager, and the starter will provide all these, I'd rather adapt the example projects accordingly.

Background: Tried to get the Spring Cloud Gateway [example](https://spring.io/blog/2019/08/16/securing-services-with-spring-cloud-gateway) to work with Boot 2.4.0-M4, had to navigate the dependencies a bit, gradually adding 
- spring-security-config for ReactiveClientRegistrationRepository
- spring-security-oauth2-client for the OidcAuthorizationCodeReactiveAuthenticationManager

What was missing that it didn't delegate to OidcAuthorizationCodeReactiveAuthenticationManager, due to JwtDecoder missing on the classpath, due to spring-security-oauth2-jose missing. Then finally I found out that spring-boot-starter-oauth2-client provides all these.

So, there may be a point to include all three, but I'd rather see spring-boot-starter-oauth2-client in the docs as well as in the example projects. Not sure if that's the right way to proceed, so feel free to decline this PR. Just wanted to make sure you are aware of it.
