### PR TITLE
Preconfigure class loader for message source

### DIFF
--- a/core/src/main/java/org/springframework/security/core/SpringSecurityMessageSource.java
+++ b/core/src/main/java/org/springframework/security/core/SpringSecurityMessageSource.java
@@ -38,7 +38,9 @@ public class SpringSecurityMessageSource extends ResourceBundleMessageSource {
 	}
 
 	public static MessageSourceAccessor getAccessor() {
-		return new MessageSourceAccessor(new SpringSecurityMessageSource());
+		final SpringSecurityMessageSource source = new SpringSecurityMessageSource();
+		source.setBundleClassLoader(SpringSecurityMessageSource.class.getClassLoader());
+		return new MessageSourceAccessor(source);
 	}
 
 }


### PR DESCRIPTION
The helper method SpringSecurityMessageSource.getAccessor does not
configure a bundle classloader on the message source instance it
creates. This means it will use the default configured by
ResourceBundleMessageSource which is ClassUtils.getDefaultClassLoader().
In a classpath constrained environment like OSGi, this will very likely
be a different classloader to the one which loaded the Spring Security
classes.

This commit explicitly configures a classloader on the message source
with a better default value.

Closes #8999