### PR TITLE
Enable customization of BearerTokenResolver by adding a setter for JwtClaimIssuerConverter on JwtIssuerAuthenticationManagerResolver

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
@@ -131,7 +131,7 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 	}
 
 	/**
-	 * Set a custom issuer converter
+	 * Set a custom bearer token resolver
 	 *
 	 * @since 5.5
 	 */
@@ -142,10 +142,10 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 
 	private static class JwtClaimIssuerConverter implements Converter<HttpServletRequest, String> {
 
-		private BearerTokenResolver resolver;
+		private final BearerTokenResolver resolver;
 
 		JwtClaimIssuerConverter() {
-			this.resolver = new DefaultBearerTokenResolver();
+			this(new DefaultBearerTokenResolver());
 		}
 
 		JwtClaimIssuerConverter(BearerTokenResolver bearerTokenResolver) {

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
@@ -135,14 +135,23 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 	 *
 	 * @since 5.5
 	 */
-	public void setIssuerConverter(Converter<HttpServletRequest, String> issuerConverter) {
-		Assert.notNull(issuerConverter, "issuerConverter cannot be null");
-		this.issuerConverter = issuerConverter;
+	public void setBearerTokenResolver(BearerTokenResolver bearerTokenResolver) {
+		Assert.notNull(bearerTokenResolver, "bearerTokenResolver cannot be null");
+		this.issuerConverter = new JwtClaimIssuerConverter(bearerTokenResolver);
 	}
 
 	private static class JwtClaimIssuerConverter implements Converter<HttpServletRequest, String> {
 
-		private final BearerTokenResolver resolver = new DefaultBearerTokenResolver();
+		private BearerTokenResolver resolver;
+
+		JwtClaimIssuerConverter() {
+			this.resolver = new DefaultBearerTokenResolver();
+		}
+
+		JwtClaimIssuerConverter(BearerTokenResolver bearerTokenResolver) {
+			Assert.notNull(bearerTokenResolver, "bearerTokenResolver cannot be null");
+			this.resolver = bearerTokenResolver;
+		}
 
 		@Override
 		public String convert(@NonNull HttpServletRequest request) {

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
@@ -65,7 +65,7 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 
 	private final AuthenticationManagerResolver<String> issuerAuthenticationManagerResolver;
 
-	private final Converter<HttpServletRequest, String> issuerConverter = new JwtClaimIssuerConverter();
+	private Converter<HttpServletRequest, String> issuerConverter = new JwtClaimIssuerConverter();
 
 	/**
 	 * Construct a {@link JwtIssuerAuthenticationManagerResolver} using the provided
@@ -128,6 +128,16 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 			throw new InvalidBearerTokenException("Invalid issuer");
 		}
 		return authenticationManager;
+	}
+
+	/**
+	 * Set a custom issuer converter
+	 *
+	 * @since 5.5
+	 */
+	public void setIssuerConverter(Converter<HttpServletRequest, String> issuerConverter) {
+		Assert.notNull(issuerConverter, "issuerConverter cannot be null");
+		this.issuerConverter = issuerConverter;
 	}
 
 	private static class JwtClaimIssuerConverter implements Converter<HttpServletRequest, String> {

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
@@ -136,8 +136,10 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 	 *
 	 * @since 5.5
 	 */
-	public void setServerBearerTokenAuthenticationConverter(ServerBearerTokenAuthenticationConverter serverBearerTokenAuthenticationConverter) {
-		Assert.notNull(serverBearerTokenAuthenticationConverter, "serverBearerTokenAuthenticationConverter cannot be null");
+	public void setServerBearerTokenAuthenticationConverter(
+			ServerBearerTokenAuthenticationConverter serverBearerTokenAuthenticationConverter) {
+		Assert.notNull(serverBearerTokenAuthenticationConverter,
+				"serverBearerTokenAuthenticationConverter cannot be null");
 		this.issuerConverter = new JwtClaimIssuerConverter(serverBearerTokenAuthenticationConverter);
 	}
 
@@ -150,7 +152,8 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 		}
 
 		JwtClaimIssuerConverter(ServerBearerTokenAuthenticationConverter serverBearerTokenAuthenticationConverter) {
-			Assert.notNull(serverBearerTokenAuthenticationConverter, "serverBearerTokenAuthenticationConverter cannot be null");
+			Assert.notNull(serverBearerTokenAuthenticationConverter,
+					"serverBearerTokenAuthenticationConverter cannot be null");
 			this.converter = serverBearerTokenAuthenticationConverter;
 		}
 

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
@@ -136,14 +136,23 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 	 *
 	 * @since 5.5
 	 */
-	public void setIssuerConverter(Converter<ServerWebExchange, Mono<String>> issuerConverter) {
-		Assert.notNull(issuerConverter, "converter cannot be null");
-		this.issuerConverter = issuerConverter;
+	public void setServerBearerTokenAuthenticationConverter(ServerBearerTokenAuthenticationConverter serverBearerTokenAuthenticationConverter) {
+		Assert.notNull(serverBearerTokenAuthenticationConverter, "serverBearerTokenAuthenticationConverter cannot be null");
+		this.issuerConverter = new JwtClaimIssuerConverter(serverBearerTokenAuthenticationConverter);
 	}
 
 	private static class JwtClaimIssuerConverter implements Converter<ServerWebExchange, Mono<String>> {
 
-		private final ServerBearerTokenAuthenticationConverter converter = new ServerBearerTokenAuthenticationConverter();
+		private ServerBearerTokenAuthenticationConverter converter;
+
+		JwtClaimIssuerConverter() {
+			this.converter = new ServerBearerTokenAuthenticationConverter();
+		}
+
+		JwtClaimIssuerConverter(ServerBearerTokenAuthenticationConverter serverBearerTokenAuthenticationConverter) {
+			Assert.notNull(serverBearerTokenAuthenticationConverter, "serverBearerTokenAuthenticationConverter cannot be null");
+			this.converter = serverBearerTokenAuthenticationConverter;
+		}
 
 		@Override
 		public Mono<String> convert(@NonNull ServerWebExchange exchange) {

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
@@ -132,7 +132,7 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 	}
 
 	/**
-	 * Set a custom issuer converter
+	 * Set a custom server bearer token authentication converter
 	 *
 	 * @since 5.5
 	 */
@@ -145,10 +145,10 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 
 	private static class JwtClaimIssuerConverter implements Converter<ServerWebExchange, Mono<String>> {
 
-		private ServerBearerTokenAuthenticationConverter converter;
+		private final ServerBearerTokenAuthenticationConverter converter;
 
 		JwtClaimIssuerConverter() {
-			this.converter = new ServerBearerTokenAuthenticationConverter();
+			this(new ServerBearerTokenAuthenticationConverter());
 		}
 
 		JwtClaimIssuerConverter(ServerBearerTokenAuthenticationConverter serverBearerTokenAuthenticationConverter) {

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
@@ -65,7 +65,7 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 
 	private final ReactiveAuthenticationManagerResolver<String> issuerAuthenticationManagerResolver;
 
-	private final Converter<ServerWebExchange, Mono<String>> issuerConverter = new JwtClaimIssuerConverter();
+	private Converter<ServerWebExchange, Mono<String>> issuerConverter = new JwtClaimIssuerConverter();
 
 	/**
 	 * Construct a {@link JwtIssuerReactiveAuthenticationManagerResolver} using the
@@ -129,6 +129,16 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 						.switchIfEmpty(Mono.error(() -> new InvalidBearerTokenException("Invalid issuer " + issuer)))
 				);
 		// @formatter:on
+	}
+
+	/**
+	 * Set a custom issuer converter
+	 *
+	 * @since 5.5
+	 */
+	public void setIssuerConverter(Converter<ServerWebExchange, Mono<String>> issuerConverter) {
+		Assert.notNull(issuerConverter, "converter cannot be null");
+		this.issuerConverter = issuerConverter;
 	}
 
 	private static class JwtClaimIssuerConverter implements Converter<ServerWebExchange, Mono<String>> {

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolverTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolverTests.java
@@ -41,11 +41,15 @@ import org.springframework.security.authentication.ReactiveAuthenticationManager
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.jose.TestKeys;
 import org.springframework.security.oauth2.jwt.JwtClaimNames;
+import org.springframework.security.oauth2.server.resource.web.server.ServerBearerTokenAuthenticationConverter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link JwtIssuerReactiveAuthenticationManagerResolver}
@@ -109,6 +113,20 @@ public class JwtIssuerReactiveAuthenticationManagerResolverTests {
 				(issuer) -> Mono.just(authenticationManager));
 		MockServerWebExchange exchange = withBearerToken(this.jwt);
 		assertThat(authenticationManagerResolver.resolve(exchange).block()).isSameAs(authenticationManager);
+	}
+
+	@Test
+	public void resolveWhenUsingCustomIssuerAuthenticationManagerResolverAndCustomServerBearerTokenAuthenticationConverterThenUses() {
+		ReactiveAuthenticationManager authenticationManager = mock(ReactiveAuthenticationManager.class);
+		JwtIssuerReactiveAuthenticationManagerResolver authenticationManagerResolver = new JwtIssuerReactiveAuthenticationManagerResolver(
+				(issuer) -> Mono.just(authenticationManager));
+		ServerBearerTokenAuthenticationConverter serverBearerTokenAuthenticationConverterSpy = spy(
+				new ServerBearerTokenAuthenticationConverter());
+		authenticationManagerResolver
+				.setServerBearerTokenAuthenticationConverter(serverBearerTokenAuthenticationConverterSpy);
+		MockServerWebExchange exchange = withBearerToken(this.jwt);
+		assertThat(authenticationManagerResolver.resolve(exchange).block()).isSameAs(authenticationManager);
+		verify(serverBearerTokenAuthenticationConverterSpy).convert(any());
 	}
 
 	@Test


### PR DESCRIPTION
**Description**
When using the `JwtIssuerAuthenticationManagerResolver` there should be a way to replace the `DefaultBearerTokenResolver` (or here the entire `JwtClaimIssuerConverter`) by a custom implementation which is requested in #8535. 

I decided to set the entire `JwtClaimIssuerConverter` because it is declared as type `Converter<HttpServletRequest,String>` and implementing a setter or new constructor on it would required to change the type of the attribute directly to `JwtClaimIssuerConverter` class.

**Context**
I use the JwtIssuerAuthenticationManagerResolver in a web socket backend which receives the JWT not in the Authorization Header but in a custom X-Authorization Cookie Header. Therefore, I need to use my own BearerTokenResolver implementation which gets the JWT from there. This seems not to be possible at the moment.