### PR TITLE
SecurityWebApplicationContextUtils cleanup gh-8868

### DIFF
--- a/web/src/main/java/org/springframework/security/web/context/support/SecurityWebApplicationContextUtils.java
+++ b/web/src/main/java/org/springframework/security/web/context/support/SecurityWebApplicationContextUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  */
 
 package org.springframework.security.web.context.support;
-
-import java.util.Enumeration;
 
 import javax.servlet.ServletContext;
 
@@ -48,32 +46,11 @@ public abstract class SecurityWebApplicationContextUtils extends WebApplicationC
 	 * @see ServletContext#getAttributeNames()
 	 */
 	public static WebApplicationContext findRequiredWebApplicationContext(ServletContext servletContext) {
-		WebApplicationContext webApplicationContext = compatiblyFindWebApplicationContext(servletContext);
+		WebApplicationContext webApplicationContext = findWebApplicationContext(servletContext);
 		Assert.state(webApplicationContext != null,
 				"No WebApplicationContext found: no ContextLoaderListener registered?");
 		return webApplicationContext;
 	}
 
-	/**
-	 * Copy of {@link #findWebApplicationContext(ServletContext)} for compatibility with
-	 * spring framework 4.1.x.
-	 * @see #findWebApplicationContext(ServletContext)
-	 */
-	private static WebApplicationContext compatiblyFindWebApplicationContext(ServletContext sc) {
-		WebApplicationContext webApplicationContext = getWebApplicationContext(sc);
-		if (webApplicationContext == null) {
-			Enumeration<String> attrNames = sc.getAttributeNames();
-			while (attrNames.hasMoreElements()) {
-				String attrName = attrNames.nextElement();
-				Object attrValue = sc.getAttribute(attrName);
-				if (attrValue instanceof WebApplicationContext) {
-					Assert.state(webApplicationContext == null, "No unique WebApplicationContext found: more than one "
-							+ "DispatcherServlet registered with publishContext=true?");
-					webApplicationContext = (WebApplicationContext) attrValue;
-				}
-			}
-		}
-		return webApplicationContext;
-	}
 
 }

--- a/web/src/main/java/org/springframework/security/web/context/support/SecurityWebApplicationContextUtils.java
+++ b/web/src/main/java/org/springframework/security/web/context/support/SecurityWebApplicationContextUtils.java
@@ -52,5 +52,4 @@ public abstract class SecurityWebApplicationContextUtils extends WebApplicationC
 		return webApplicationContext;
 	}
 
-
 }


### PR DESCRIPTION
Change to cleanup SecurityWebApplicationContextUtils. Based on the recommendation in the tagged issue. 

> We no longer need to support versions of Spring Framework that old, so we should now call WebApplicationContextUtils.findWebApplicationContext


Closes gh-8868

