### PR TITLE
Allow maximum age of csrf cookie to be configured

### DIFF
--- a/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
@@ -57,6 +57,8 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 
 	private Boolean secure;
 
+	private int cookieMaxAge = -1;
+
 	public CookieCsrfTokenRepository() {
 	}
 
@@ -71,7 +73,7 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 		Cookie cookie = new Cookie(this.cookieName, tokenValue);
 		cookie.setSecure((this.secure != null) ? this.secure : request.isSecure());
 		cookie.setPath(StringUtils.hasLength(this.cookiePath) ? this.cookiePath : this.getRequestContext(request));
-		cookie.setMaxAge((token != null) ? -1 : 0);
+		cookie.setMaxAge((token != null) ? this.cookieMaxAge : 0);
 		cookie.setHttpOnly(this.cookieHttpOnly);
 		if (StringUtils.hasLength(this.cookieDomain)) {
 			cookie.setDomain(this.cookieDomain);
@@ -190,6 +192,32 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 	 */
 	public void setSecure(Boolean secure) {
 		this.secure = secure;
+	}
+
+	/**
+	 * Sets maximum age in seconds for the cookie that the expected CSRF token is saved to
+	 * and read from. By default maximum age value is -1.
+	 *
+	 * <p>
+	 * A positive value indicates that the cookie will expire after that many seconds have
+	 * passed. Note that the value is the <i>maximum</i> age when the cookie will expire,
+	 * not the cookie's current age.
+	 *
+	 * <p>
+	 * A negative value means that the cookie is not stored persistently and will be
+	 * deleted when the Web browser exits.
+	 *
+	 * <p>
+	 * A zero value causes the cookie to be deleted immediately therefore it is not a
+	 * valid value and in that case an {@link IllegalArgumentException} will be thrown.
+	 * @param cookieMaxAge an integer specifying the maximum age of the cookie in seconds;
+	 * if negative, means the cookie is not stored; if zero, the method throws an
+	 * {@link IllegalArgumentException}
+	 * @since 5.5
+	 */
+	public void setCookieMaxAge(int cookieMaxAge) {
+		Assert.isTrue(cookieMaxAge != 0, "cookieMaxAge is not zero");
+		this.cookieMaxAge = cookieMaxAge;
 	}
 
 }

--- a/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
@@ -100,7 +100,7 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 	 * provide a token
 	 */
 	public void setParameterName(String parameterName) {
-		Assert.notNull(parameterName, "parameterName is not null");
+		Assert.notNull(parameterName, "parameterName cannot be null");
 		this.parameterName = parameterName;
 	}
 
@@ -110,7 +110,7 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 	 * token
 	 */
 	public void setHeaderName(String headerName) {
-		Assert.notNull(headerName, "headerName is not null");
+		Assert.notNull(headerName, "headerName cannot be null");
 		this.headerName = headerName;
 	}
 
@@ -120,7 +120,7 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 	 * and read from
 	 */
 	public void setCookieName(String cookieName) {
-		Assert.notNull(cookieName, "cookieName is not null");
+		Assert.notNull(cookieName, "cookieName cannot be null");
 		this.cookieName = cookieName;
 	}
 
@@ -216,7 +216,7 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 	 * @since 5.5
 	 */
 	public void setCookieMaxAge(int cookieMaxAge) {
-		Assert.isTrue(cookieMaxAge != 0, "cookieMaxAge is not zero");
+		Assert.isTrue(cookieMaxAge != 0, "cookieMaxAge cannot be zero");
 		this.cookieMaxAge = cookieMaxAge;
 	}
 

--- a/web/src/test/java/org/springframework/security/web/csrf/CookieCsrfTokenRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CookieCsrfTokenRepositoryTests.java
@@ -191,6 +191,16 @@ public class CookieCsrfTokenRepositoryTests {
 	}
 
 	@Test
+	public void saveTokenWithCookieMaxAge() {
+		int maxAge = 1200;
+		this.repository.setCookieMaxAge(maxAge);
+		CsrfToken token = this.repository.generateToken(this.request);
+		this.repository.saveToken(token, this.request, this.response);
+		Cookie tokenCookie = this.response.getCookie(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+		assertThat(tokenCookie.getMaxAge()).isEqualTo(maxAge);
+	}
+
+	@Test
 	public void loadTokenNoCookiesNull() {
 		assertThat(this.repository.loadToken(this.request)).isNull();
 	}
@@ -249,6 +259,11 @@ public class CookieCsrfTokenRepositoryTests {
 	@Test
 	public void setHeaderNameNullIllegalArgumentException() {
 		assertThatIllegalArgumentException().isThrownBy(() -> this.repository.setHeaderName(null));
+	}
+
+	@Test
+	public void setCookieMaxAgeZeroIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.repository.setCookieMaxAge(0));
 	}
 
 }


### PR DESCRIPTION
Allows maxAge of the generated cookie by CookieCsrfTokenRepository
to be configurable.

Prior to this commit, maximum age was set with a value of -1.

After this commit, it will be configured by the user with an either
positive or negative value. If the user does not provide a value,
it will be set -1.

An IllegalArgumentException will be thrown when
this value is set to zero.

Closes gh-9195

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
