### PR TITLE
LdapAuthoritiesPopulator should be postProcessed

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/ldap/LdapAuthenticationProviderConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/ldap/LdapAuthenticationProviderConfigurer.java
@@ -140,7 +140,7 @@ public class LdapAuthenticationProviderConfigurer<B extends ProviderManagerBuild
 		defaultAuthoritiesPopulator.setGroupSearchFilter(this.groupSearchFilter);
 		defaultAuthoritiesPopulator.setSearchSubtree(this.groupSearchSubtree);
 		defaultAuthoritiesPopulator.setRolePrefix(this.rolePrefix);
-		this.ldapAuthoritiesPopulator = defaultAuthoritiesPopulator;
+		this.ldapAuthoritiesPopulator = postProcess(defaultAuthoritiesPopulator);
 		return defaultAuthoritiesPopulator;
 	}
 


### PR DESCRIPTION
Currently we can set an `LdapAuthoritiesPopulator` and override the default one. However, the current implementation doesn't allow us to create a delegate to the default populator, because it isn't post processed

This simple fix will allow an easier customization of the `LdapAuthoritiesPopulator`