### PR TITLE
Consider Aligning MvcRequestMatcher's matching methods

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/AuthorizeHttpRequestsConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/AuthorizeHttpRequestsConfigurerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -312,6 +312,18 @@ public class AuthorizeHttpRequestsConfigurerTests {
 				.roles("USER"));
 		// @formatter:on
 		this.mvc.perform(requestWithUser).andExpect(status().isForbidden());
+	}
+
+	@Test
+	public void getWhenServletPathRoleAdminConfiguredAndRoleIsUserAndWithoutServletPathThenRespondsWithOk()
+			throws Exception {
+		this.spring.register(ServletPathConfig.class, BasicController.class).autowire();
+		// @formatter:off
+		MockHttpServletRequestBuilder requestWithUser = get("/")
+				.with(user("user")
+				.roles("USER"));
+		// @formatter:on
+		this.mvc.perform(requestWithUser).andExpect(status().isOk());
 	}
 
 	@Test

--- a/web/src/main/java/org/springframework/security/web/servlet/util/matcher/MvcRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/servlet/util/matcher/MvcRequestMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import org.springframework.web.util.UrlPathHelper;
  *
  * @author Rob Winch
  * @author Eddú Meléndez
+ * @author Evgeniy Cheban
  * @since 4.1.1
  */
 public class MvcRequestMatcher implements RequestMatcher, RequestVariablesExtractor {
@@ -64,10 +65,7 @@ public class MvcRequestMatcher implements RequestMatcher, RequestVariablesExtrac
 
 	@Override
 	public boolean matches(HttpServletRequest request) {
-		if (this.method != null && !this.method.name().equals(request.getMethod())) {
-			return false;
-		}
-		if (this.servletPath != null && !this.servletPath.equals(request.getServletPath())) {
+		if (notMatchMethodOrServletPath(request)) {
 			return false;
 		}
 		MatchableHandlerMapping mapping = getMapping(request);
@@ -95,12 +93,20 @@ public class MvcRequestMatcher implements RequestMatcher, RequestVariablesExtrac
 
 	@Override
 	public MatchResult matcher(HttpServletRequest request) {
+		if (notMatchMethodOrServletPath(request)) {
+			return MatchResult.notMatch();
+		}
 		MatchableHandlerMapping mapping = getMapping(request);
 		if (mapping == null) {
 			return this.defaultMatcher.matcher(request);
 		}
 		RequestMatchResult result = mapping.match(request, this.pattern);
 		return (result != null) ? MatchResult.match(result.extractUriTemplateVariables()) : MatchResult.notMatch();
+	}
+
+	private boolean notMatchMethodOrServletPath(HttpServletRequest request) {
+		return this.method != null && !this.method.name().equals(request.getMethod())
+				|| this.servletPath != null && !this.servletPath.equals(request.getServletPath());
 	}
 
 	/**

--- a/web/src/test/java/org/springframework/security/web/servlet/util/matcher/MvcRequestMatcherTests.java
+++ b/web/src/test/java/org/springframework/security/web/servlet/util/matcher/MvcRequestMatcherTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2019 the original author or authors.
+ * Copyright 2012-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 /**
  * @author Rob Winch
  * @author Eddú Meléndez
+ * @author Evgeniy Cheban
  */
 @RunWith(MockitoJUnitRunner.class)
 public class MvcRequestMatcherTests {
@@ -218,6 +219,30 @@ public class MvcRequestMatcherTests {
 	@Test
 	public void toStringWhenOnlyPattern() {
 		assertThat(this.matcher.toString()).isEqualTo("Mvc [pattern='/path']");
+	}
+
+	@Test
+	public void matcherWhenMethodNotMatchesThenNotMatchResult() {
+		this.matcher.setMethod(HttpMethod.POST);
+		assertThat(this.matcher.matcher(this.request).isMatch()).isFalse();
+	}
+
+	@Test
+	public void matcherWhenMethodMatchesThenMatchResult() {
+		this.matcher.setMethod(HttpMethod.GET);
+		assertThat(this.matcher.matcher(this.request).isMatch()).isTrue();
+	}
+
+	@Test
+	public void matcherWhenServletPathNotMatchesThenNotMatchResult() {
+		this.matcher.setServletPath("/spring");
+		assertThat(this.matcher.matcher(this.request).isMatch()).isFalse();
+	}
+
+	@Test
+	public void matcherWhenServletPathMatchesThenMatchResult() {
+		this.matcher.setServletPath("/path");
+		assertThat(this.matcher.matcher(this.request).isMatch()).isTrue();
 	}
 
 }


### PR DESCRIPTION
Closes gh-9284

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
