### PR TITLE
Reconsider AntPathRequestMatcher matching logic

### DIFF
--- a/web/src/main/java/org/springframework/security/web/util/matcher/AntPathRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/AntPathRequestMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ import org.springframework.web.util.UrlPathHelper;
  * @author Luke Taylor
  * @author Rob Winch
  * @author Eddú Meléndez
+ * @author Evgeniy Cheban
  * @since 3.1
  * @see org.springframework.util.AntPathMatcher
  */
@@ -159,8 +160,11 @@ public final class AntPathRequestMatcher implements RequestMatcher, RequestVaria
 
 	@Override
 	public MatchResult matcher(HttpServletRequest request) {
-		if (this.matcher == null || !matches(request)) {
+		if (!matches(request)) {
 			return MatchResult.notMatch();
+		}
+		if (this.matcher == null) {
+			return MatchResult.match();
 		}
 		String url = getRequestPath(request);
 		return MatchResult.match(this.matcher.extractUriTemplateVariables(url));

--- a/web/src/test/java/org/springframework/security/web/util/matcher/AntPathRequestMatcherTests.java
+++ b/web/src/test/java/org/springframework/security/web/util/matcher/AntPathRequestMatcherTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import static org.mockito.BDDMockito.given;
 /**
  * @author Luke Taylor
  * @author Rob Winch
+ * @author Evgeniy Cheban
  */
 @RunWith(MockitoJUnitRunner.class)
 public class AntPathRequestMatcherTests {
@@ -194,6 +195,14 @@ public class AntPathRequestMatcherTests {
 		MockHttpServletRequest request = createRequest("/blah");
 		request.setMethod("INVALID");
 		assertThat(matcher.matches(request)).isFalse();
+	}
+
+	// gh-9285
+	@Test
+	public void matcherWhenMatchAllPatternThenMatchResult() {
+		AntPathRequestMatcher matcher = new AntPathRequestMatcher("/**");
+		MockHttpServletRequest request = createRequest("/blah");
+		assertThat(matcher.matcher(request).isMatch()).isTrue();
 	}
 
 	private HttpServletRequest createRequestWithNullMethod(String path) {


### PR DESCRIPTION
Closes gh-9285

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
