### PR TITLE
Fixed NullPointerException with WWW-Authenticate

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/http/OAuth2ErrorResponseErrorHandler.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/http/OAuth2ErrorResponseErrorHandler.java
@@ -70,6 +70,9 @@ public class OAuth2ErrorResponseErrorHandler implements ResponseErrorHandler {
 			return null;
 		}
 		BearerTokenError bearerTokenError = getBearerToken(wwwAuthenticateHeader);
+		if (bearerTokenError == null) {
+			return new OAuth2Error(OAuth2ErrorCodes.SERVER_ERROR, null, null);
+		}
 		String errorCode = (bearerTokenError.getCode() != null) ? bearerTokenError.getCode()
 				: OAuth2ErrorCodes.SERVER_ERROR;
 		String errorDescription = bearerTokenError.getDescription();

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/http/OAuth2ErrorResponseErrorHandlerTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/http/OAuth2ErrorResponseErrorHandlerTests.java
@@ -58,4 +58,13 @@ public class OAuth2ErrorResponseErrorHandlerTests {
 				.withMessage("[insufficient_scope] The access token expired");
 	}
 
+	@Test
+	public void handleErrorWhenErrorResponseWithInvalidWwwAuthenticateHeaderThenHandled() {
+		String invalidWwwAuthenticateHeader = "Unauthorized";
+		MockClientHttpResponse response = new MockClientHttpResponse(new byte[0], HttpStatus.BAD_REQUEST);
+		response.getHeaders().add(HttpHeaders.WWW_AUTHENTICATE, invalidWwwAuthenticateHeader);
+		assertThatExceptionOfType(OAuth2AuthorizationException.class)
+				.isThrownBy(() -> this.errorHandler.handleError(response)).withMessage("[server_error] ");
+	}
+
 }


### PR DESCRIPTION
Fixed possible NullPointerException that happens when the OAuth2 ResourceServer does not return a valid WWW-Authenticate header format.