### PR TITLE
Fix bug with multiple AuthenticationManager beans

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configuration/HttpSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configuration/HttpSecurityConfiguration.java
@@ -60,7 +60,6 @@ class HttpSecurityConfiguration {
 		this.objectPostProcessor = objectPostProcessor;
 	}
 
-	@Autowired(required = false)
 	void setAuthenticationManager(AuthenticationManager authenticationManager) {
 		this.authenticationManager = authenticationManager;
 	}


### PR DESCRIPTION
There is no need to autowire the `AuthenticationManager` since we later get it from `this.authenticationConfiguration.getAuthenticationManager()`.

https://github.com/spring-projects/spring-security/blob/7dde7cffda9b03859c954eb06cfb09baa3bbb54f/config/src/main/java/org/springframework/security/config/annotation/web/configuration/HttpSecurityConfiguration.java#L104-L107
