### PR TITLE
Fix beanResolver missing in CurrentSecurityContextArgumentResolver.

### DIFF
--- a/web/src/main/java/org/springframework/security/web/method/annotation/CurrentSecurityContextArgumentResolver.java
+++ b/web/src/main/java/org/springframework/security/web/method/annotation/CurrentSecurityContextArgumentResolver.java
@@ -98,6 +98,7 @@ public final class CurrentSecurityContextArgumentResolver implements HandlerMeth
 			StandardEvaluationContext context = new StandardEvaluationContext();
 			context.setRootObject(securityContext);
 			context.setVariable("this", securityContext);
+			context.setBeanResolver(this.beanResolver);
 			Expression expression = this.parser.parseExpression(expressionToParse);
 			securityContextResult = expression.getValue(context);
 		}


### PR DESCRIPTION
CurrentSecurityContextArgumentResolver has **'beanResolver'** property, but never used. I think it might be missed.
I test the AuthenticationPrincipal annotation and CurrentSecurityContext annotation, CurrentSecurityContext annotation expression cannot work with bean.