### PR TITLE
Make user info response status check error only

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/userinfo/DefaultReactiveOAuth2UserService.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/userinfo/DefaultReactiveOAuth2UserService.java
@@ -108,7 +108,7 @@ public class DefaultReactiveOAuth2UserService implements ReactiveOAuth2UserServi
 					authenticationMethod);
 			// @formatter:off
 			Mono<Map<String, Object>> userAttributes = requestHeadersSpec.retrieve()
-					.onStatus((s) -> s != HttpStatus.OK, (response) ->
+					.onStatus((s) -> !s.is2xxSuccessful(), (response) ->
 						parse(response)
 							.map((userInfoErrorResponse) -> {
 								String description = userInfoErrorResponse.getErrorObject().getDescription();

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/userinfo/DefaultReactiveOAuth2UserService.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/userinfo/DefaultReactiveOAuth2UserService.java
@@ -108,7 +108,7 @@ public class DefaultReactiveOAuth2UserService implements ReactiveOAuth2UserServi
 					authenticationMethod);
 			// @formatter:off
 			Mono<Map<String, Object>> userAttributes = requestHeadersSpec.retrieve()
-					.onStatus((s) -> !s.is2xxSuccessful(), (response) ->
+					.onStatus(HttpStatus::isError, (response) ->
 						parse(response)
 							.map((userInfoErrorResponse) -> {
 								String description = userInfoErrorResponse.getErrorObject().getDescription();

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/userinfo/DefaultReactiveOAuth2UserServiceTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/userinfo/DefaultReactiveOAuth2UserServiceTests.java
@@ -51,6 +51,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -142,6 +143,24 @@ public class DefaultReactiveOAuth2UserServiceTests {
 		OAuth2UserAuthority userAuthority = (OAuth2UserAuthority) user.getAuthorities().iterator().next();
 		assertThat(userAuthority.getAuthority()).isEqualTo("ROLE_USER");
 		assertThat(userAuthority.getAttributes()).isEqualTo(user.getAttributes());
+	}
+
+	@Test
+	public void loadUserWhenUserInfo201CreatedResponseThenReturnUser() {
+		// @formatter:off
+		String userInfoResponse = "{\n"
+				+ "   \"id\": \"user1\",\n"
+				+ "   \"first-name\": \"first\",\n"
+				+ "   \"last-name\": \"last\",\n"
+				+ "   \"middle-name\": \"middle\",\n"
+				+ "   \"address\": \"address\",\n"
+				+ "   \"email\": \"user1@example.com\"\n"
+				+ "}\n";
+		// @formatter:on
+		this.server.enqueue(
+				new MockResponse().setResponseCode(201).setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE).setBody(userInfoResponse));
+		assertThatNoException()
+				.isThrownBy(() -> this.userService.loadUser(oauth2UserRequest()).block());
 	}
 
 	// gh-5500


### PR DESCRIPTION
This would otherwise fail on anything in the 2xx range thats not 200 OK. For example when i use the user-info-uri: https://vl.api.np.km.playstation.net/vl/api/v1/mobile/users/me/info it returns 201 Created (dont ask me why Sony chose that). Anyway i think this status check will still cover most cases by checking if its a 2xx status.

Also this just works in the non reactive version: org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService because it try catches the request.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
