### PR TITLE
Implement SHA256 algorithm in Remember Me tokens

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/RememberMeConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/RememberMeConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.security.web.authentication.rememberme.AbstractRememb
 import org.springframework.security.web.authentication.rememberme.PersistentTokenBasedRememberMeServices;
 import org.springframework.security.web.authentication.rememberme.PersistentTokenRepository;
 import org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationFilter;
+import org.springframework.security.web.authentication.rememberme.RememberMeHashingAlgorithm;
 import org.springframework.security.web.authentication.rememberme.TokenBasedRememberMeServices;
 import org.springframework.security.web.authentication.ui.DefaultLoginPageGeneratingFilter;
 import org.springframework.util.Assert;
@@ -90,6 +91,8 @@ public final class RememberMeConfigurer<H extends HttpSecurityBuilder<H>>
 	private AuthenticationSuccessHandler authenticationSuccessHandler;
 
 	private String key;
+
+	private RememberMeHashingAlgorithm hashingAlgorithm = RememberMeHashingAlgorithm.UNSET;
 
 	private RememberMeServices rememberMeServices;
 
@@ -183,6 +186,23 @@ public final class RememberMeConfigurer<H extends HttpSecurityBuilder<H>>
 	 */
 	public RememberMeConfigurer<H> key(String key) {
 		this.key = key;
+		return this;
+	}
+
+	/**
+	 * The algorithm to use with {@link TokenBasedRememberMeServices} for hashing the
+	 * digital signature containing the key from {@link #key(String)} and the user's
+	 * password. If unset, the MD5 message digest algorithm will be used.
+	 * <p>
+	 * This configuration is ignored if
+	 * {@link #tokenRepository(PersistentTokenRepository)} or
+	 * {@link #rememberMeServices(RememberMeServices)} are used.
+	 * @param hashingAlgorithm the algorithm used when creating new cookies
+	 * @return the {@link RememberMeConfigurer} for further customization
+	 * @since 5.5
+	 */
+	public RememberMeConfigurer<H> hashingAlgorithm(RememberMeHashingAlgorithm hashingAlgorithm) {
+		this.hashingAlgorithm = hashingAlgorithm;
 		return this;
 	}
 
@@ -380,7 +400,7 @@ public final class RememberMeConfigurer<H extends HttpSecurityBuilder<H>>
 	 */
 	private AbstractRememberMeServices createTokenBasedRememberMeServices(H http, String key) {
 		UserDetailsService userDetailsService = getUserDetailsService(http);
-		return new TokenBasedRememberMeServices(key, userDetailsService);
+		return new TokenBasedRememberMeServices(key, userDetailsService, this.hashingAlgorithm);
 	}
 
 	/**

--- a/config/src/main/java/org/springframework/security/config/http/RememberMeBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/http/RememberMeBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,8 @@ class RememberMeBeanDefinitionParser implements BeanDefinitionParser {
 
 	static final String ATT_TOKEN_VALIDITY = "token-validity-seconds";
 
+	static final String ATT_HASHING_ALGORITHM = "hashing-algorithm";
+
 	static final String ATT_SECURE_COOKIE = "use-secure-cookie";
 
 	static final String ATT_FORM_REMEMBERME_PARAMETER = "remember-me-parameter";
@@ -88,6 +90,7 @@ class RememberMeBeanDefinitionParser implements BeanDefinitionParser {
 		String successHandlerRef = element.getAttribute(ATT_SUCCESS_HANDLER_REF);
 		String rememberMeServicesRef = element.getAttribute(ATT_SERVICES_REF);
 		String tokenValiditySeconds = element.getAttribute(ATT_TOKEN_VALIDITY);
+		String hashingAlgorithm = element.getAttribute(ATT_HASHING_ALGORITHM);
 		String useSecureCookie = element.getAttribute(ATT_SECURE_COOKIE);
 		String remembermeParameter = element.getAttribute(ATT_FORM_REMEMBERME_PARAMETER);
 		String remembermeCookie = element.getAttribute(ATT_REMEMBERME_COOKIE);
@@ -99,15 +102,16 @@ class RememberMeBeanDefinitionParser implements BeanDefinitionParser {
 		boolean userServiceSet = StringUtils.hasText(userServiceRef);
 		boolean useSecureCookieSet = StringUtils.hasText(useSecureCookie);
 		boolean tokenValiditySet = StringUtils.hasText(tokenValiditySeconds);
+		boolean hashingAlgorithmSet = StringUtils.hasText(hashingAlgorithm);
 		boolean remembermeParameterSet = StringUtils.hasText(remembermeParameter);
 		boolean remembermeCookieSet = StringUtils.hasText(remembermeCookie);
 		if (servicesRefSet && (dataSourceSet || tokenRepoSet || userServiceSet || tokenValiditySet || useSecureCookieSet
-				|| remembermeParameterSet || remembermeCookieSet)) {
+				|| remembermeParameterSet || remembermeCookieSet || hashingAlgorithmSet)) {
 			pc.getReaderContext()
 					.error(ATT_SERVICES_REF + " can't be used in combination with attributes " + ATT_TOKEN_REPOSITORY
 							+ "," + ATT_DATA_SOURCE + ", " + ATT_USER_SERVICE_REF + ", " + ATT_TOKEN_VALIDITY + ", "
-							+ ATT_SECURE_COOKIE + ", " + ATT_FORM_REMEMBERME_PARAMETER + " or " + ATT_REMEMBERME_COOKIE,
-							source);
+							+ ATT_SECURE_COOKIE + ", " + ATT_FORM_REMEMBERME_PARAMETER + ", " + ATT_HASHING_ALGORITHM
+							+ " or " + ATT_REMEMBERME_COOKIE, source);
 		}
 		if (dataSourceSet && tokenRepoSet) {
 			pc.getReaderContext().error("Specify " + ATT_TOKEN_REPOSITORY + " or " + ATT_DATA_SOURCE + " but not both",
@@ -129,6 +133,9 @@ class RememberMeBeanDefinitionParser implements BeanDefinitionParser {
 		}
 		else if (!servicesRefSet) {
 			services = new RootBeanDefinition(TokenBasedRememberMeServices.class);
+			if (hashingAlgorithmSet) {
+				services.getConstructorArgumentValues().addIndexedArgumentValue(2, hashingAlgorithm);
+			}
 		}
 		String servicesName;
 		if (services != null) {

--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.5.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.5.rnc
@@ -758,6 +758,10 @@ remember-me.attlist &=
 	attribute token-validity-seconds {xsd:string}?
 
 remember-me.attlist &=
+	## The algorithm of cookie which store the token for remember-me authentication.
+	attribute hashing-algorithm {"UNSET" | "MD5" | "SHA256"}?
+
+remember-me.attlist &=
 	## Reference to an AuthenticationSuccessHandler bean which should be used to handle a successful remember-me authentication.
 	attribute authentication-success-handler-ref {xsd:token}?
 remember-me.attlist &=
@@ -776,6 +780,7 @@ remember-me-services-ref =
 remember-me-data-source-ref =
 	## DataSource bean for the database that contains the token repository schema.
 	data-source-ref
+
 
 anonymous =
 	## Adds support for automatically granting all anonymous web requests a particular principal identity and a corresponding granted authority.

--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.5.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.5.xsd
@@ -2257,6 +2257,19 @@
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="hashing-algorithm">
+         <xs:annotation>
+            <xs:documentation>The algorithm of cookie which store the token for remember-me authentication.
+                </xs:documentation>
+         </xs:annotation>
+         <xs:simpleType>
+            <xs:restriction base="xs:token">
+               <xs:enumeration value="UNSET"/>
+               <xs:enumeration value="MD5"/>
+               <xs:enumeration value="SHA256"/>
+            </xs:restriction>
+         </xs:simpleType>
+      </xs:attribute>
       <xs:attribute name="authentication-success-handler-ref" type="xs:token">
          <xs:annotation>
             <xs:documentation>Reference to an AuthenticationSuccessHandler bean which should be used to handle a

--- a/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-Sha256Config.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/RememberMeConfigTests-Sha256Config.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2021 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<b:beans xmlns:b="http://www.springframework.org/schema/beans"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xmlns="http://www.springframework.org/schema/security"
+		xsi:schemaLocation="
+			http://www.springframework.org/schema/security
+			https://www.springframework.org/schema/security/spring-security.xsd
+			http://www.springframework.org/schema/beans
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<http auto-config="true">
+		<intercept-url pattern="/authenticated" access="authenticated"/>
+		<remember-me hashing-algorithm="SHA256" />
+	</http>
+
+	<b:bean
+		name="basicController"
+		class="org.springframework.security.config.http.RememberMeConfigTests.BasicController"/>
+
+	<b:import resource="userservice.xml"/>
+</b:beans>

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/appendix/namespace.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/appendix/namespace.adoc
@@ -1708,6 +1708,11 @@ Specifies the period in seconds for which the remember-me cookie should be valid
 By default it will be valid for 14 days.
 
 
+[[nsa-remember-me-hashing-algorithm]]
+* **hashing-algorithm**
+Maps to the `hashingAlgorithm` property of `TokenBasedRememberMeServices`.
+Specifies the algorithm used for the digital signature within generated cookies. The supported algorithms are *SHA256* or *MD5*.
+
 [[nsa-remember-me-use-secure-cookie]]
 * **use-secure-cookie**
 It is recommended that remember-me cookies are only submitted over HTTPS and thus should be flagged as "secure".

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/authentication/rememberme.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/authentication/rememberme.adoc
@@ -22,7 +22,16 @@ In essence a cookie is sent to the browser upon successful interactive authentic
 ----
 base64(username + ":" + expirationTime + ":" +
 md5Hex(username + ":" + expirationTime + ":" password + ":" + key))
-
+----
+or, if a specific hashing algorithm is specified:
+[source,txt]
+----
+base64(username + ":" + expirationTime + ":" + algorithmName +
+":" + hashingAlgorithm(username + ":" + expirationTime + ":" password + ":" + key))
+----
+where:
+[source,txt]
+----
 username:          As identifiable to the UserDetailsService
 password:          That matches the one in the retrieved UserDetails
 expirationTime:    The date and time when the remember-me token expires, expressed in milliseconds
@@ -42,7 +51,7 @@ If you are familiar with the topics discussed in the chapter on <<ns-config,name
 ----
 <http>
 ...
-<remember-me key="myAppKey"/>
+<remember-me key="myAppKey" hashing-algorithm="SHA256"/>
 </http>
 ----
 

--- a/web/src/main/java/org/springframework/security/web/authentication/rememberme/RememberMeHashingAlgorithm.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/rememberme/RememberMeHashingAlgorithm.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication.rememberme;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * Hashing algorithms supported by {@link TokenBasedRememberMeServices}
+ *
+ * @since 5.5
+ */
+public enum RememberMeHashingAlgorithm {
+
+	UNSET("", ""), MD5("MD5", "MD5"), SHA256("SHA256", "SHA-256");
+
+	private final String identifier;
+
+	private final String digestAlgorithm;
+
+	RememberMeHashingAlgorithm(String identifier, String digestAlgorithm) {
+		this.identifier = identifier;
+		this.digestAlgorithm = digestAlgorithm;
+	}
+
+	/**
+	 * The identifier to use in cookies created by {@link TokenBasedRememberMeServices} to
+	 * signify this algorithm is being used.
+	 *
+	 * If empty, then no algorithm will be specified in the resulting cookie.
+	 */
+	public String getIdentifier() {
+		return this.identifier;
+	}
+
+	/**
+	 * The name of the algorithm to use
+	 *
+	 * The output should be acceptable for being passed to
+	 * {@link java.security.MessageDigest#getInstance(String)}.
+	 */
+	public String getDigestAlgorithm() {
+		return this.digestAlgorithm;
+	}
+
+	static Optional<RememberMeHashingAlgorithm> findByIdentifier(String identifier) {
+		return Arrays.stream(values()).filter((algorithm) -> algorithm.getIdentifier().equals(identifier)).findAny();
+	}
+
+}


### PR DESCRIPTION
This pull requests addresses #8549 by allowing for the use of SHA-256 when generating the cookies used in Remember Me cookies, as well as enabling `TokenBasedRememberMeServices` to accept such cookies. This allows for the use of a cryptographically secure algorithm for encoding the password and key, making it harder for an attacker to potentially obtain these even from an older cookie.

There are a few existing alternatives that provide a more secure implementation of the Remember Me functionality: `PersistentTokenBasedRememberMeServices` (which uses random strings), or Spring Session's `SpringSessionRememberMeServices`. This PR helps secure the "simple" implementation that is suggested first in the documentation, so it likely appears as more approach to users and does not require a database. Alternatively, users can subclass `TokenBasedRememberMeServices` to provide a more secure hashing algorithm, and this PR seeks not to break any code that is doing so.

This PR extends the cookie format used by `TokenBasedRememberMeServices` to have an optional component before the hashed-string containing the algorithm used. Existing cookies are still accepted, and the existing (and overridable) `makeTokenSignature(long,String,password)` is used if no algorithm is specified in the cookie, or when generating cookies without any hashing algorithm specified. The breaking change to remove support for cookies that do not have a hashing algorithm specified, potentially in Spring Security 6, would allow for the default hashing algorithm to be changed in the future without breaking existing Remember Me cookies.

Unlike previous pull requests from last May (PR #8580 and #8591), this is designed to preserve existing functionality unless the user explicitly chooses an algorithm (currently MD5 and SHA256).

This has one test failure I know of - `XsdDocumentedTests.countWhenReviewingDocumentationThenAllElementsDocumented`. I added documentation to `namespace.adoc` and updated the schema in `spring-security-5.5.rnc`, but the test class is still referring to `spring-security-5.4.rnc`. If I switch the test class to use `spring-security-5.5.rnc`, then there are two test failures that look related to the lack of documentation in `namespace.adoc` for https://github.com/spring-projects/spring-security/commit/54d3839f63a41f81aff43e88f1acd57e5a138838 .
