### PR TITLE
Add setMetadataFilename method to Saml2MetadataFilter

### DIFF
--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/Saml2MetadataFilter.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/Saml2MetadataFilter.java
@@ -17,6 +17,8 @@
 package org.springframework.security.saml2.provider.service.web;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -83,8 +85,9 @@ public final class Saml2MetadataFilter extends OncePerRequestFilter {
 			throws IOException {
 		response.setContentType(MediaType.APPLICATION_XML_VALUE);
 		String fileName = this.metadataFilename.replace("{registrationId}", registrationId);
-		String format = "attachment; filename=\"%s\"";
-		response.setHeader(HttpHeaders.CONTENT_DISPOSITION, String.format(format, fileName));
+		String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8.name());
+		String format = "attachment; filename=\"%s\"; filename*=UTF-8''%s";
+		response.setHeader(HttpHeaders.CONTENT_DISPOSITION, String.format(format, fileName, encodedFileName));
 		response.setContentLength(metadata.length());
 		response.getWriter().write(metadata);
 	}

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/web/Saml2MetadataFilterTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/web/Saml2MetadataFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,15 @@
 
 package org.springframework.security.saml2.provider.service.web;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 import javax.servlet.FilterChain;
 
 import org.junit.Before;
 import org.junit.Test;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.saml2.core.TestSaml2X509Credentials;
@@ -31,6 +35,7 @@ import org.springframework.security.saml2.provider.service.registration.TestRely
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -118,6 +123,45 @@ public class Saml2MetadataFilterTests {
 	@Test
 	public void setRequestMatcherWhenNullThenIllegalArgument() {
 		assertThatIllegalArgumentException().isThrownBy(() -> this.filter.setRequestMatcher(null));
+	}
+
+	@Test
+	public void setMetadataFilenameWhenEmptyThenThrowsException() {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> this.filter.setMetadataFilename(" "))
+				.withMessage("metadataFilename cannot be empty");
+	}
+
+	@Test
+	public void setMetadataFilenameWhenMissingRegistrationIdVariableThenThrowsException() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> this.filter.setMetadataFilename("metadata-filename.xml"))
+				.withMessage("metadataFilename must contain a {registrationId} match variable");
+	}
+
+	@Test
+	public void doFilterWhenSetMetadataFilenameThenUses() throws Exception {
+		String testMetadataFilename = "test-{registrationId}-metadata.xml";
+		this.request.setPathInfo("/saml2/service-provider-metadata/validRegistration");
+		RelyingPartyRegistration validRegistration = TestRelyingPartyRegistrations.noCredentials()
+				.assertingPartyDetails((party) -> party.verificationX509Credentials(
+						(c) -> c.add(TestSaml2X509Credentials.relyingPartyVerifyingCredential())))
+				.build();
+		String generatedMetadata = "<xml>test</xml>";
+		given(this.resolver.resolve(validRegistration)).willReturn(generatedMetadata);
+
+		this.filter = new Saml2MetadataFilter((request) -> validRegistration, this.resolver);
+		this.filter.setMetadataFilename(testMetadataFilename);
+		this.filter.doFilter(this.request, this.response, this.chain);
+
+		verifyNoInteractions(this.chain);
+		assertThat(this.response.getStatus()).isEqualTo(200);
+		assertThat(this.response.getContentAsString()).isEqualTo(generatedMetadata);
+
+		String fileName = testMetadataFilename.replace("{registrationId}", validRegistration.getRegistrationId());
+		String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8.name());
+		assertThat(this.response.getHeaderValue(HttpHeaders.CONTENT_DISPOSITION)).asString()
+				.isEqualTo("attachment; filename=\"%s\"; filename*=UTF-8''%s", fileName, encodedFileName);
+		verify(this.resolver).resolve(validRegistration);
 	}
 
 }


### PR DESCRIPTION
Add setMetadataFilename method to Saml2MetadataFilter

Populated shared objects RelyingPartyRegistrationRepository and DefaultRelyingPartyRegistrationResolver in Saml2LoginConfigurer class

Closes gh-9317

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
