### PR TITLE
Saml2AuthenticationTokenConverter gh-9310

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LoginConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LoginConfigurerTests.java
@@ -19,7 +19,6 @@ package org.springframework.security.config.annotation.web.configurers.saml2;
 import java.io.IOException;
 import java.net.URLDecoder;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
@@ -107,10 +106,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class Saml2LoginConfigurerTests {
 
 	private static final Converter<Assertion, Collection<? extends GrantedAuthority>> AUTHORITIES_EXTRACTOR = (
-			a) -> Arrays.asList(new SimpleGrantedAuthority("TEST"));
+			a) -> Collections.singletonList(new SimpleGrantedAuthority("TEST"));
 
-	private static final GrantedAuthoritiesMapper AUTHORITIES_MAPPER = (authorities) -> Arrays
-			.asList(new SimpleGrantedAuthority("TEST CONVERTED"));
+	private static final GrantedAuthoritiesMapper AUTHORITIES_MAPPER = (authorities) -> Collections
+			.singletonList(new SimpleGrantedAuthority("TEST CONVERTED"));
 
 	private static final Duration RESPONSE_TIME_VALIDATION_SKEW = Duration.ZERO;
 

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/Saml2AuthenticationTokenConverter.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/Saml2AuthenticationTokenConverter.java
@@ -100,7 +100,7 @@ public final class Saml2AuthenticationTokenConverter implements AuthenticationCo
 			InflaterOutputStream inflaterOutputStream = new InflaterOutputStream(out, new Inflater(true));
 			inflaterOutputStream.write(b);
 			inflaterOutputStream.finish();
-			return new String(out.toByteArray(), StandardCharsets.UTF_8);
+			return out.toString(StandardCharsets.UTF_8.name());
 		}
 		catch (IOException ex) {
 			throw new Saml2AuthenticationException(

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/core/Saml2Utils.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/core/Saml2Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@ import org.apache.commons.codec.binary.Base64;
 import org.springframework.security.saml2.Saml2Exception;
 
 public final class Saml2Utils {
+
+	public static final String INVALID_BASE64 = "cmVzcG9 \n\t\r uc2U9+/";
 
 	private static Base64 BASE64 = new Base64(0, new byte[] { '\n' });
 
@@ -67,6 +69,20 @@ public final class Saml2Utils {
 		}
 		catch (IOException ex) {
 			throw new Saml2Exception("Unable to inflate string", ex);
+		}
+	}
+
+	public static byte[] invalidSamlDeflate(String s) {
+		try {
+			ByteArrayOutputStream out = new ByteArrayOutputStream();
+			DeflaterOutputStream deflaterOutputStream = new DeflaterOutputStream(out,
+					new Deflater(Deflater.DEFLATED, false));
+			deflaterOutputStream.write(s.getBytes(StandardCharsets.UTF_8));
+			deflaterOutputStream.finish();
+			return out.toByteArray();
+		}
+		catch (IOException ex) {
+			throw new Saml2Exception("Unable to deflate string", ex);
 		}
 	}
 

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/core/Saml2Utils.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/core/Saml2Utils.java
@@ -65,7 +65,7 @@ public final class Saml2Utils {
 			InflaterOutputStream inflaterOutputStream = new InflaterOutputStream(out, new Inflater(true));
 			inflaterOutputStream.write(b);
 			inflaterOutputStream.finish();
-			return new String(out.toByteArray(), StandardCharsets.UTF_8);
+			return out.toString(StandardCharsets.UTF_8.name());
 		}
 		catch (IOException ex) {
 			throw new Saml2Exception("Unable to inflate string", ex);

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/web/Saml2AuthenticationTokenConverterTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/web/Saml2AuthenticationTokenConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.saml2.core.Saml2ErrorCodes;
 import org.springframework.security.saml2.core.Saml2Utils;
+import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticationException;
 import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticationToken;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.security.saml2.provider.service.registration.TestRelyingPartyRegistrations;
@@ -37,6 +39,7 @@ import org.springframework.util.StreamUtils;
 import org.springframework.web.util.UriUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -62,6 +65,22 @@ public class Saml2AuthenticationTokenConverterTests {
 		assertThat(token.getSaml2Response()).isEqualTo("response");
 		assertThat(token.getRelyingPartyRegistration().getRegistrationId())
 				.isEqualTo(this.relyingPartyRegistration.getRegistrationId());
+	}
+
+	@Test
+	public void convertWhenSamlResponseInvalidBase64ThenSaml2AuthenticationException() {
+		Saml2AuthenticationTokenConverter converter = new Saml2AuthenticationTokenConverter(
+				this.relyingPartyRegistrationResolver);
+		given(this.relyingPartyRegistrationResolver.convert(any(HttpServletRequest.class)))
+				.willReturn(this.relyingPartyRegistration);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setParameter("SAMLResponse", Saml2Utils.INVALID_BASE64);
+		assertThatExceptionOfType(Saml2AuthenticationException.class).isThrownBy(() -> converter.convert(request))
+				.withCauseInstanceOf(IllegalArgumentException.class)
+				.satisfies((ex) -> assertThat(ex.getSaml2Error().getErrorCode())
+						.isEqualTo(Saml2ErrorCodes.INVALID_RESPONSE))
+				.satisfies((ex) -> assertThat(ex.getSaml2Error().getDescription())
+						.isEqualTo("Failed to decode SAMLResponse"));
 	}
 
 	@Test
@@ -98,6 +117,25 @@ public class Saml2AuthenticationTokenConverterTests {
 		assertThat(token.getSaml2Response()).isEqualTo("response");
 		assertThat(token.getRelyingPartyRegistration().getRegistrationId())
 				.isEqualTo(this.relyingPartyRegistration.getRegistrationId());
+	}
+
+	@Test
+	public void convertWhenGetRequestInvalidDeflatedThenSaml2AuthenticationException() {
+		Saml2AuthenticationTokenConverter converter = new Saml2AuthenticationTokenConverter(
+				this.relyingPartyRegistrationResolver);
+		given(this.relyingPartyRegistrationResolver.convert(any(HttpServletRequest.class)))
+				.willReturn(this.relyingPartyRegistration);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("GET");
+		byte[] invalidDeflated = Saml2Utils.invalidSamlDeflate("response");
+		String encoded = Saml2Utils.samlEncode(invalidDeflated);
+		request.setParameter("SAMLResponse", encoded);
+		assertThatExceptionOfType(Saml2AuthenticationException.class).isThrownBy(() -> converter.convert(request))
+				.withCauseInstanceOf(IOException.class)
+				.satisfies((ex) -> assertThat(ex.getSaml2Error().getErrorCode())
+						.isEqualTo(Saml2ErrorCodes.INVALID_RESPONSE))
+				.satisfies(
+						(ex) -> assertThat(ex.getSaml2Error().getDescription()).isEqualTo("Unable to inflate string"));
 	}
 
 	@Test


### PR DESCRIPTION
 Saml2AuthenticationTokenConverter wrap SAMLResponse Base64 decode exception and inflate exception to Saml2AuthenticationException
    
Closes gh-9310


<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
