### PR TITLE
Fix interaction between basic auth and "switch user"

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilter.java
@@ -193,11 +193,12 @@ public class BasicAuthenticationFilter extends OncePerRequestFilter {
 			// check if we are switched - if so we only need to authenticate now
 			// if the current basic auth username is different from the one we
 			// switched from
-			for(GrantedAuthority ga : existingAuth.getAuthorities()) {
-				if(ga instanceof SwitchUserGrantedAuthority) {
+			for (GrantedAuthority ga : existingAuth.getAuthorities()) {
+				if (ga instanceof SwitchUserGrantedAuthority) {
 					Authentication origAuth = ((SwitchUserGrantedAuthority) ga).getSource();
-					return origAuth == null || !origAuth.isAuthenticated() ||
-						(origAuth instanceof UsernamePasswordAuthenticationToken && !origAuth.getName().equals(username));
+					return origAuth == null || !origAuth.isAuthenticated()
+							|| (origAuth instanceof UsernamePasswordAuthenticationToken
+									&& !origAuth.getName().equals(username));
 				}
 			}
 


### PR DESCRIPTION
As per gh-9027, the "switch user" mechanism and the basic authentication filter do not currently work well together.  When impersonating another user, the basic authentication username will be that of the administrator (the one doing the impersonating) but the username cached in the `Authentication` in the security context will be the user being impersonated.  The basic auth filter checks the basic auth username against the cached username and forces a re-authentication if they differ, which in turn breaks the "switch user" function.

This PR aims to fix this issue by detecting when the cached authentication is a "switch user" case, and then checking the current basic auth username against the original username we switched _from_ (extracted from the `SwitchUserGrantedAuthority`) rather than against the impersonated username we have switched _to_.