### PR TITLE
Consistent username and password parameter handling

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/UsernamePasswordAuthenticationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/UsernamePasswordAuthenticationFilter.java
@@ -76,7 +76,6 @@ public class UsernamePasswordAuthenticationFilter extends AbstractAuthentication
 		}
 		String username = obtainUsername(request);
 		username = (username != null) ? username : "";
-		username = username.trim();
 		String password = obtainPassword(request);
 		password = (password != null) ? password : "";
 		UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(username, password);


### PR DESCRIPTION
Consider consistent username and password parameter processing of trim in `UsernamePasswordAuthenticationFilter`.

The scenario is as follows:
An application registration logic considers that the username with spaces before and after it is legal, then there will be problems using Spring Security's UsernamePasswordAuthenticationFilter.

> The scene is legal but unreasonable

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
