### PR TITLE
Anonymous in ExceptionTranslationWebFilter

### DIFF
--- a/web/src/main/java/org/springframework/security/web/server/authorization/ExceptionTranslationWebFilter.java
+++ b/web/src/main/java/org/springframework/security/web/server/authorization/ExceptionTranslationWebFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,18 @@ package org.springframework.security.web.server.authorization;
 
 import reactor.core.publisher.Mono;
 
+import org.springframework.context.MessageSource;
+import org.springframework.context.MessageSourceAware;
+import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.authentication.AuthenticationTrustResolver;
+import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.SpringSecurityMessageSource;
 import org.springframework.security.web.server.ServerAuthenticationEntryPoint;
 import org.springframework.security.web.server.authentication.HttpBasicServerAuthenticationEntryPoint;
 import org.springframework.util.Assert;
@@ -30,20 +39,30 @@ import org.springframework.web.server.WebFilterChain;
 
 /**
  * @author Rob Winch
+ * @author César Revert
  * @since 5.0
  */
-public class ExceptionTranslationWebFilter implements WebFilter {
+public class ExceptionTranslationWebFilter implements WebFilter, MessageSourceAware {
 
 	private ServerAuthenticationEntryPoint authenticationEntryPoint = new HttpBasicServerAuthenticationEntryPoint();
 
 	private ServerAccessDeniedHandler accessDeniedHandler = new HttpStatusServerAccessDeniedHandler(
 			HttpStatus.FORBIDDEN);
 
+	private AuthenticationTrustResolver authenticationTrustResolver = new AuthenticationTrustResolverImpl();
+
+	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+
 	@Override
 	public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
-		return chain.filter(exchange).onErrorResume(AccessDeniedException.class,
-				(denied) -> exchange.getPrincipal().switchIfEmpty(commenceAuthentication(exchange, denied))
-						.flatMap((principal) -> this.accessDeniedHandler.handle(exchange, denied)));
+		return chain.filter(exchange).onErrorResume(AccessDeniedException.class, (denied) -> exchange.getPrincipal()
+				.filter((principal) -> (!(principal instanceof Authentication) || (principal instanceof Authentication
+						&& !(this.authenticationTrustResolver.isAnonymous((Authentication) principal)))))
+				.switchIfEmpty(commenceAuthentication(exchange,
+						new InsufficientAuthenticationException(
+								this.messages.getMessage("ExceptionTranslationWebFilter.insufficientAuthentication",
+										"Full authentication is required to access this resource"))))
+				.flatMap((principal) -> this.accessDeniedHandler.handle(exchange, denied)).then());
 	}
 
 	/**
@@ -66,7 +85,28 @@ public class ExceptionTranslationWebFilter implements WebFilter {
 		this.authenticationEntryPoint = authenticationEntryPoint;
 	}
 
-	private <T> Mono<T> commenceAuthentication(ServerWebExchange exchange, AccessDeniedException denied) {
+	/**
+	 * Sets the authentication trust resolver.
+	 * @param authenticationTrustResolver the authentication trust resolver to use.
+	 * Default is {@link AuthenticationTrustResolverImpl}
+	 *
+	 * @since 5.5
+	 */
+	public void setAuthenticationTrustResolver(AuthenticationTrustResolver authenticationTrustResolver) {
+		Assert.notNull(authenticationTrustResolver, "authenticationTrustResolver must not be null");
+		this.authenticationTrustResolver = authenticationTrustResolver;
+	}
+
+	/**
+	 * @since 5.5
+	 */
+	@Override
+	public void setMessageSource(MessageSource messageSource) {
+		Assert.notNull(messageSource, "messageSource cannot be null");
+		this.messages = new MessageSourceAccessor(messageSource);
+	}
+
+	private <T> Mono<T> commenceAuthentication(ServerWebExchange exchange, AuthenticationException denied) {
 		return this.authenticationEntryPoint
 				.commence(exchange, new AuthenticationCredentialsNotFoundException("Not Authenticated", denied))
 				.then(Mono.empty());


### PR DESCRIPTION
The ExceptionTranslationWebFilter does not support correctly when
anonymous authentication is enabled. With this enabled provoked always
the execution of the access denied handler, and with this fix it
behaves like the ExceptionTranslationFilter (servlet), executing the
access denied handler only if the principal is not empty and neither
anonymous.

Closes gh-9130

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
