### PR TITLE
Expire OAuth2AuthorizationRequest when saving to the session

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/HttpSessionOAuth2AuthorizationRequestRepository.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/HttpSessionOAuth2AuthorizationRequestRepository.java
@@ -69,8 +69,8 @@ public final class HttpSessionOAuth2AuthorizationRequestRepository
 			return null;
 		}
 		Map<String, OAuth2AuthorizationRequestReference> authorizationRequests = this.getAuthorizationRequests(request);
-		OAuth2AuthorizationRequestReference wrappedWithCreated = authorizationRequests.get(stateParameter);
-		return (wrappedWithCreated != null) ? wrappedWithCreated.wrapped : null;
+		OAuth2AuthorizationRequestReference authorizationRequestReference = authorizationRequests.get(stateParameter);
+		return (authorizationRequestReference != null) ? authorizationRequestReference.authorizationRequest : null;
 	}
 
 	@Override
@@ -103,7 +103,7 @@ public final class HttpSessionOAuth2AuthorizationRequestRepository
 			return null;
 		}
 		Map<String, OAuth2AuthorizationRequestReference> authorizationRequests = this.getAuthorizationRequests(request);
-		OAuth2AuthorizationRequestReference wrappedWithCreatedOriginalRequest = authorizationRequests
+		OAuth2AuthorizationRequestReference authorizationRequestReference = authorizationRequests
 				.remove(stateParameter);
 		if (!authorizationRequests.isEmpty()) {
 			request.getSession().setAttribute(this.sessionAttributeName, authorizationRequests);
@@ -111,7 +111,7 @@ public final class HttpSessionOAuth2AuthorizationRequestRepository
 		else {
 			request.getSession().removeAttribute(this.sessionAttributeName);
 		}
-		return (wrappedWithCreatedOriginalRequest != null) ? wrappedWithCreatedOriginalRequest.wrapped : null;
+		return (authorizationRequestReference != null) ? authorizationRequestReference.authorizationRequest : null;
 	}
 
 	@Override
@@ -193,12 +193,13 @@ public final class HttpSessionOAuth2AuthorizationRequestRepository
 
 		private final Instant expiresAt;
 
-		private final OAuth2AuthorizationRequest wrapped;
+		private final OAuth2AuthorizationRequest authorizationRequest;
 
-		private OAuth2AuthorizationRequestReference(OAuth2AuthorizationRequest wrapped, Instant created) {
-			Assert.notNull(wrapped, "wrapped cannot be null");
-			this.expiresAt = created;
-			this.wrapped = wrapped;
+		private OAuth2AuthorizationRequestReference(OAuth2AuthorizationRequest authorizationRequest,
+				Instant expiresAt) {
+			Assert.notNull(authorizationRequest, "authorizationRequest cannot be null");
+			this.expiresAt = expiresAt;
+			this.authorizationRequest = authorizationRequest;
 		}
 
 	}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/HttpSessionOAuth2AuthorizationRequestRepository.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/HttpSessionOAuth2AuthorizationRequestRepository.java
@@ -168,7 +168,7 @@ public final class HttpSessionOAuth2AuthorizationRequestRepository
 	 * {@link OAuth2AuthorizationRequest} is considered not expired. Must not be negative.
 	 * @since 5.5
 	 */
-	public void setAuthorizationRequestTimeToLive(Duration authorizationRequestTimeToLive) {
+	void setAuthorizationRequestTimeToLive(Duration authorizationRequestTimeToLive) {
 		Assert.notNull(authorizationRequestTimeToLive, "oAuth2AuthorizationRequestExpiresIn cannot be null");
 		Assert.state(!authorizationRequestTimeToLive.isNegative(),
 				"oAuth2AuthorizationRequestExpiresIn cannot be negative");
@@ -181,7 +181,7 @@ public final class HttpSessionOAuth2AuthorizationRequestRepository
 	 * attempt is made to save another one, then the oldest will be removed.
 	 * @param maxActiveAuthorizationRequests must not be negative.
 	 */
-	public void setMaxActiveAuthorizationRequestsPerSession(int maxActiveAuthorizationRequestsPerSession) {
+	void setMaxActiveAuthorizationRequestsPerSession(int maxActiveAuthorizationRequestsPerSession) {
 		Assert.state(maxActiveAuthorizationRequestsPerSession > 0,
 				"maxActiveAuthorizationRequestsPerSession must be greater than zero");
 		this.maxActiveAuthorizationRequestsPerSession = maxActiveAuthorizationRequestsPerSession;

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/HttpSessionOAuth2AuthorizationRequestRepository.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/HttpSessionOAuth2AuthorizationRequestRepository.java
@@ -179,7 +179,7 @@ public final class HttpSessionOAuth2AuthorizationRequestRepository
 	 * Sets the maximum number of {@link OAuth2AuthorizationRequest} that can be
 	 * stored/active for a session. If the maximum number are present in a session when an
 	 * attempt is made to save another one, then the oldest will be removed.
-	 * @param maxActiveAuthorizationRequests must not be negative.
+	 * @param maxActiveAuthorizationRequestsPerSession must not be negative.
 	 */
 	void setMaxActiveAuthorizationRequestsPerSession(int maxActiveAuthorizationRequestsPerSession) {
 		Assert.state(maxActiveAuthorizationRequestsPerSession > 0,

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/HttpSessionOAuth2AuthorizationRequestRepositoryTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/HttpSessionOAuth2AuthorizationRequestRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -243,9 +243,9 @@ public class HttpSessionOAuth2AuthorizationRequestRepositoryTests {
 	}
 
 	@Test
-	public void testExpiredAuthorizationRequestsRemoved() {
+	public void removeAuthorizationRequestWhenExpired() {
 		final Duration expiresIn = Duration.ofMinutes(2);
-		this.authorizationRequestRepository.setOAuth2AuthorizationRequestExpiresIn(expiresIn);
+		this.authorizationRequestRepository.setAuthorizationRequestTimeToLive(expiresIn);
 		this.authorizationRequestRepository.setClock(Clock.fixed(Instant.ofEpochMilli(0), ZoneId.systemDefault()));
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		MockHttpServletResponse response = new MockHttpServletResponse();

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/HttpSessionOAuth2AuthorizationRequestRepositoryTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/HttpSessionOAuth2AuthorizationRequestRepositoryTests.java
@@ -268,6 +268,36 @@ public class HttpSessionOAuth2AuthorizationRequestRepositoryTests {
 		assertThat(loadedAuthorizationRequest2).isEqualTo(authorizationRequest2);
 	}
 
+	@Test
+	public void removeOldestAuthorizationRequestWhenMoreThanMax() {
+		this.authorizationRequestRepository.setMaxActiveAuthorizationRequestsPerSession(2);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		String state1 = "state-1122";
+		OAuth2AuthorizationRequest authorizationRequest1 = createAuthorizationRequest().state(state1).build();
+		this.authorizationRequestRepository.saveAuthorizationRequest(authorizationRequest1, request, response);
+		String state2 = "state-3344";
+		OAuth2AuthorizationRequest authorizationRequest2 = createAuthorizationRequest().state(state2).build();
+		this.authorizationRequestRepository.saveAuthorizationRequest(authorizationRequest2, request, response);
+		String state3 = "state-4455";
+		OAuth2AuthorizationRequest authorizationRequest3 = createAuthorizationRequest().state(state3).build();
+		this.authorizationRequestRepository.saveAuthorizationRequest(authorizationRequest3, request, response);
+		request.addParameter(OAuth2ParameterNames.STATE, state1);
+		OAuth2AuthorizationRequest loadedAuthorizationRequest1 = this.authorizationRequestRepository
+				.loadAuthorizationRequest(request);
+		assertThat(loadedAuthorizationRequest1).isNull();
+		request.removeParameter(OAuth2ParameterNames.STATE);
+		request.addParameter(OAuth2ParameterNames.STATE, state2);
+		OAuth2AuthorizationRequest loadedAuthorizationRequest2 = this.authorizationRequestRepository
+				.loadAuthorizationRequest(request);
+		assertThat(loadedAuthorizationRequest2).isEqualTo(authorizationRequest2);
+		request.removeParameter(OAuth2ParameterNames.STATE);
+		request.addParameter(OAuth2ParameterNames.STATE, state3);
+		OAuth2AuthorizationRequest loadedAuthorizationRequest3 = this.authorizationRequestRepository
+				.loadAuthorizationRequest(request);
+		assertThat(loadedAuthorizationRequest3).isEqualTo(authorizationRequest3);
+	}
+
 	private OAuth2AuthorizationRequest.Builder createAuthorizationRequest() {
 		return OAuth2AuthorizationRequest.authorizationCode().authorizationUri("https://example.com/oauth2/authorize")
 				.clientId("client-id-1234").state("state-1234");


### PR DESCRIPTION
Closes gh-5145

This straightforward approach cleans up expired `OAuth2AuthorizationRequest`s as they're loaded (and subsequently saved) to the session. It's basically the same approach as https://github.com/spring-projects/spring-security/pull/7381 but storing creation instead of expiration and using a wrapper class instead of modifying `OAuth2AuthorizationRequest`.

This approach introduces no new dependencies or requirements (such as Spring Cache abstraction).

From https://github.com/spring-projects/spring-security/pull/7381#pullrequestreview-295160506

> The expiring capability is really a cross-cutting concern. Can you try the following solution?
> 
>     * Intercept calls to `loadAuthorizationRequest()` and store the information necessary
> 
>     * At a scheduled time (configurable with skew), the component will attempt to `loadAuthorizationRequest()` and if it returns than determine if time has expired and than `removeAuthorizationRequest`
> 
> 
> Please take a look at the [Cache abstraction](https://docs.spring.io/spring/docs/current/spring-framework-reference/integration.html#cache) to see if it would meet our needs.

For `HttpSessionOAuth2AuthorizationRequestRepository`, I don't believe that could work because the session can only be loaded and saved while the request for it is being processed. In other words, the task that runs at the scheduled itme would not be able to call  `loadAuthorizationRequest()` and get the data back, nor would it be able to call `removeAuthorizationRequest` to write it. Even if it could call those methods, they wouldn't work right; session persistence is handed by servlet filters (see Spring Session) and those filters wouldn't be intercepting session use to handle persistence outside of a request.

It make sense to create a new implementation of the `AuthorizationRequestRepository<OAuth2AuthorizationRequest>` interface at some point which uses a database or Spring Cache abstraction for persistence, as that would allow for expiration to run as a scheduled job. However, that's not of interest to me at the moment :)

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->