### PR TITLE
Add support for authorization events in DelegatingAuthorizationManager

### DIFF
--- a/core/src/main/java/org/springframework/security/authorization/AuthorizationEventPublisher.java
+++ b/core/src/main/java/org/springframework/security/authorization/AuthorizationEventPublisher.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authorization;
+
+/**
+ * @author Parikshit Dutta
+ * @since 5.5
+ */
+public interface AuthorizationEventPublisher {
+
+	void publishAuthorizationSuccess(AuthorizationDecision authorizationDecision);
+
+	void publishAuthorizationFailure(AuthorizationDecision authorizationDecision);
+
+}

--- a/core/src/main/java/org/springframework/security/authorization/DefaultAuthorizationEventPublisher.java
+++ b/core/src/main/java/org/springframework/security/authorization/DefaultAuthorizationEventPublisher.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authorization;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.security.authorization.event.AuthorizationFailureEvent;
+import org.springframework.security.authorization.event.AuthorizationSuccessEvent;
+
+/**
+ * Default implementation of {@link AuthorizationEventPublisher}
+ *
+ * @author Parikshit Dutta
+ * @since 5.5
+ */
+public class DefaultAuthorizationEventPublisher implements AuthorizationEventPublisher, ApplicationEventPublisherAware {
+
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	public DefaultAuthorizationEventPublisher() {
+		this(null);
+	}
+
+	public DefaultAuthorizationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+		this.applicationEventPublisher = applicationEventPublisher;
+	}
+
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+		this.applicationEventPublisher = applicationEventPublisher;
+	}
+
+	@Override
+	public void publishAuthorizationSuccess(AuthorizationDecision authorizationDecision) {
+		if (this.applicationEventPublisher != null) {
+			this.applicationEventPublisher.publishEvent(new AuthorizationSuccessEvent(authorizationDecision));
+		}
+	}
+
+	@Override
+	public void publishAuthorizationFailure(AuthorizationDecision authorizationDecision) {
+		if (this.applicationEventPublisher != null) {
+			this.applicationEventPublisher.publishEvent(new AuthorizationFailureEvent(authorizationDecision));
+		}
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/authorization/event/AuthorizationFailureEvent.java
+++ b/core/src/main/java/org/springframework/security/authorization/event/AuthorizationFailureEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authorization.event;
+
+import org.springframework.context.ApplicationEvent;
+import org.springframework.security.authorization.AuthorizationDecision;
+
+/**
+ * An {@link ApplicationEvent} which indicates failed authorization.
+ *
+ * @author Parikshit Dutta
+ * @since 5.5
+ */
+public class AuthorizationFailureEvent extends ApplicationEvent {
+
+	public AuthorizationFailureEvent(AuthorizationDecision authorizationDecision) {
+		super(authorizationDecision);
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/authorization/event/AuthorizationSuccessEvent.java
+++ b/core/src/main/java/org/springframework/security/authorization/event/AuthorizationSuccessEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authorization.event;
+
+import org.springframework.context.ApplicationEvent;
+import org.springframework.security.authorization.AuthorizationDecision;
+
+/**
+ * An {@link ApplicationEvent} which indicates successful authorization.
+ *
+ * @author Parikshit Dutta
+ * @since 5.5
+ */
+public class AuthorizationSuccessEvent extends ApplicationEvent {
+
+	public AuthorizationSuccessEvent(AuthorizationDecision authorizationDecision) {
+		super(authorizationDecision);
+	}
+
+}

--- a/core/src/test/java/org/springframework/security/authorization/DefaultAuthorizationEventPublisherTests.java
+++ b/core/src/test/java/org/springframework/security/authorization/DefaultAuthorizationEventPublisherTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authorization;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.authorization.event.AuthorizationFailureEvent;
+import org.springframework.security.authorization.event.AuthorizationSuccessEvent;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link DefaultAuthorizationEventPublisher}
+ *
+ * @author Parikshit Dutta
+ */
+public class DefaultAuthorizationEventPublisherTests {
+
+	ApplicationEventPublisher applicationEventPublisher;
+
+	DefaultAuthorizationEventPublisher authorizationEventPublisher;
+
+	@Before
+	public void init() {
+		this.applicationEventPublisher = mock(ApplicationEventPublisher.class);
+		this.authorizationEventPublisher = new DefaultAuthorizationEventPublisher();
+		this.authorizationEventPublisher.setApplicationEventPublisher(this.applicationEventPublisher);
+	}
+
+	@Test
+	public void testAuthenticationSuccessIsPublished() {
+		this.authorizationEventPublisher.publishAuthorizationSuccess(mock(AuthorizationDecision.class));
+		verify(this.applicationEventPublisher).publishEvent(isA(AuthorizationSuccessEvent.class));
+	}
+
+	@Test
+	public void testAuthenticationFailureIsPublished() {
+		this.authorizationEventPublisher.publishAuthorizationFailure(mock(AuthorizationDecision.class));
+		verify(this.applicationEventPublisher).publishEvent(isA(AuthorizationFailureEvent.class));
+	}
+
+	@Test
+	public void testNullPublisherNotInvoked() {
+		this.authorizationEventPublisher.setApplicationEventPublisher(null);
+		this.authorizationEventPublisher.publishAuthorizationSuccess(mock(AuthorizationDecision.class));
+		this.authorizationEventPublisher.publishAuthorizationFailure(mock(AuthorizationDecision.class));
+		verify(this.applicationEventPublisher, never()).publishEvent(any());
+	}
+
+}


### PR DESCRIPTION
- added AuthorizationSuccessEvent to represent event for granted AuthorizationDecision
- added AuthorizationFailureEvent to represent event for denied AuthorizationDecision

- added AuthorizationEventPublisher to represent generic publisher for raising authorization events  
- added default implementation [DefaultAuthorizationEventPublisher] for AuthorizationEventPublisher 
- added DefaultAuthorizationEventPublisherTests to handle respective test scenarios

- updated DelegatingAuthorizationManager to add AuthorizationEventPublisher to raise authorization events
- updated DelegatingAuthorizationManagerTests to add respective test scenarios

Closes #9288 and #9286