### PR TITLE
Add SecurityContext to delegating TaskScheduler

### DIFF
--- a/core/src/main/java/org/springframework/security/scheduling/DelegatingSecurityContextTaskScheduler.java
+++ b/core/src/main/java/org/springframework/security/scheduling/DelegatingSecurityContextTaskScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,12 @@ package org.springframework.security.scheduling;
 import java.util.Date;
 import java.util.concurrent.ScheduledFuture;
 
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.Trigger;
+import org.springframework.security.concurrent.DelegatingSecurityContextRunnable;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.Assert;
 
 /**
@@ -32,45 +36,67 @@ import org.springframework.util.Assert;
  */
 public class DelegatingSecurityContextTaskScheduler implements TaskScheduler {
 
-	private final TaskScheduler taskScheduler;
+	private final TaskScheduler delegate;
+
+	private final SecurityContext securityContext;
 
 	/**
-	 * Creates a new {@link DelegatingSecurityContextTaskScheduler}
-	 * @param taskScheduler the {@link TaskScheduler}
+	 * Creates a new {@link DelegatingSecurityContextTaskScheduler} that uses the
+	 * specified {@link SecurityContext}.
+	 * @param delegateTaskScheduler the {@link TaskScheduler} to delegate to. Cannot be
+	 * null.
+	 * @param securityContext the {@link SecurityContext} to use for each
+	 * {@link DelegatingSecurityContextRunnable} or null to default to the current
+	 * {@link SecurityContext}
 	 */
-	public DelegatingSecurityContextTaskScheduler(TaskScheduler taskScheduler) {
-		Assert.notNull(taskScheduler, "Task scheduler must not be null");
-		this.taskScheduler = taskScheduler;
+	public DelegatingSecurityContextTaskScheduler(TaskScheduler delegateTaskScheduler,
+			SecurityContext securityContext) {
+		Assert.notNull(delegateTaskScheduler, "delegateTaskScheduler cannot be null");
+		this.delegate = delegateTaskScheduler;
+		this.securityContext = securityContext;
+	}
+
+	/**
+	 * Creates a new {@link DelegatingSecurityContextTaskScheduler} that uses the current
+	 * {@link SecurityContext} from the {@link SecurityContextHolder}.
+	 * @param delegate the {@link TaskExecutor} to delegate to. Cannot be null.
+	 */
+	public DelegatingSecurityContextTaskScheduler(TaskScheduler delegate) {
+		this(delegate, null);
 	}
 
 	@Override
 	public ScheduledFuture<?> schedule(Runnable task, Trigger trigger) {
-		return this.taskScheduler.schedule(task, trigger);
+		return this.delegate.schedule(wrap(task), trigger);
 	}
 
 	@Override
 	public ScheduledFuture<?> schedule(Runnable task, Date startTime) {
-		return this.taskScheduler.schedule(task, startTime);
+		return this.delegate.schedule(wrap(task), startTime);
 	}
 
 	@Override
 	public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, Date startTime, long period) {
-		return this.taskScheduler.scheduleAtFixedRate(task, startTime, period);
+		return this.delegate.scheduleAtFixedRate(wrap(task), startTime, period);
 	}
 
 	@Override
 	public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, long period) {
-		return this.taskScheduler.scheduleAtFixedRate(task, period);
+		return this.delegate.scheduleAtFixedRate(wrap(task), period);
 	}
 
 	@Override
 	public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, Date startTime, long delay) {
-		return this.taskScheduler.scheduleWithFixedDelay(task, startTime, delay);
+		return this.delegate.scheduleWithFixedDelay(wrap(task), startTime, delay);
 	}
 
 	@Override
 	public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, long delay) {
-		return this.taskScheduler.scheduleWithFixedDelay(task, delay);
+		return this.delegate.scheduleWithFixedDelay(wrap(task), delay);
+	}
+
+	private Runnable wrap(Runnable delegate) {
+		return DelegatingSecurityContextRunnable.create(delegate, this.securityContext);
 	}
 
 }


### PR DESCRIPTION
Wrap DelegatingSecurityContextTaskScheduler's Runnable tasks in
DelegatingSecurityContextRunnables, allowing to specify a
SecurityContext to use for tasks execution.

Closes gh-9514
