### PR TITLE
OAuth2 should not login redirect non-user-browser requests

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2LoginConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2LoginConfigurerTests.java
@@ -355,7 +355,9 @@ public class OAuth2LoginConfigurerTests {
 		String requestUri = "/";
 		this.request = new MockHttpServletRequest("GET", requestUri);
 		this.request.setServletPath(requestUri);
+		this.request.addHeader("Accept", MediaType.TEXT_HTML);
 		this.springSecurityFilterChain.doFilter(this.request, this.response, this.filterChain);
+		assertThat(this.response.getStatus()).isEqualTo(302);
 		assertThat(this.response.getRedirectedUrl()).matches("http://localhost/oauth2/authorization/google");
 	}
 
@@ -369,7 +371,8 @@ public class OAuth2LoginConfigurerTests {
 		this.request.setServletPath(requestUri);
 		this.request.addHeader(HttpHeaders.ACCEPT, new MediaType("image", "*").toString());
 		this.springSecurityFilterChain.doFilter(this.request, this.response, this.filterChain);
-		assertThat(this.response.getRedirectedUrl()).matches("http://localhost/login");
+		assertThat(this.response.getStatus()).isEqualTo(302);
+		assertThat(this.response.getRedirectedUrl()).matches("http://localhost/oauth2/authorization/google");
 	}
 
 	// gh-5347
@@ -393,7 +396,19 @@ public class OAuth2LoginConfigurerTests {
 		this.request.setServletPath(requestUri);
 		this.request.addHeader("X-Requested-With", "XMLHttpRequest");
 		this.springSecurityFilterChain.doFilter(this.request, this.response, this.filterChain);
-		assertThat(this.response.getRedirectedUrl()).doesNotMatch("http://localhost/oauth2/authorization/google");
+		assertThat(this.response.getStatus()).isEqualTo(401);
+	}
+
+	@Test
+	public void oauth2LoginWithOneClientConfiguredAndRequestAcceptJSONNotAuthenticatedThenDoesNotRedirectForAuthorization()
+			throws Exception {
+		loadConfig(OAuth2LoginConfig.class);
+		String requestUri = "/";
+		this.request = new MockHttpServletRequest("GET", requestUri);
+		this.request.setServletPath(requestUri);
+		this.request.addHeader("Accept", MediaType.APPLICATION_JSON);
+		this.springSecurityFilterChain.doFilter(this.request, this.response, this.filterChain);
+		assertThat(this.response.getStatus()).isEqualTo(401);
 	}
 
 	@Test


### PR DESCRIPTION
Requests with an Accept indicating a request didn't originating as a
user browsing a URL shouldn't redirect to the login page. For example,
requests with `Accept: application/json` or `X-Requested-With:
XMLHttpRequest` shouldn't go to the login page; they should result an
HTTP 401 error.

Closes: gh-9548

This change brings oauth2 into alignment with the intent expressed in this commit:
https://github.com/spring-projects/spring-security/commit/66858e22ad381c83b47d373296a4cafbdb1a2615

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
