### PR TITLE
Add null check in CsrfFilter and CsrfWebFilter

### DIFF
--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -174,15 +174,16 @@ public final class CsrfFilter extends OncePerRequestFilter {
 	 * @return
 	 */
 	private static boolean equalsConstantTime(String expected, String actual) {
-		byte[] expectedBytes = bytesUtf8(expected);
-		byte[] actualBytes = bytesUtf8(actual);
+		if (expected == actual) {
+			return true;
+		}
+		if (expected == null || actual == null) {
+			return false;
+		}
+		// Encode after ensure that the string is not null
+		byte[] expectedBytes = Utf8.encode(expected);
+		byte[] actualBytes = Utf8.encode(actual);
 		return MessageDigest.isEqual(expectedBytes, actualBytes);
-	}
-
-	private static byte[] bytesUtf8(String s) {
-		// need to check if Utf8.encode() runs in constant time (probably not).
-		// This may leak length of string.
-		return (s != null) ? Utf8.encode(s) : null;
 	}
 
 	private static final class DefaultRequiresCsrfMatcher implements RequestMatcher {

--- a/web/src/main/java/org/springframework/security/web/server/csrf/CsrfWebFilter.java
+++ b/web/src/main/java/org/springframework/security/web/server/csrf/CsrfWebFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -177,15 +177,16 @@ public class CsrfWebFilter implements WebFilter {
 	 * @return
 	 */
 	private static boolean equalsConstantTime(String expected, String actual) {
-		byte[] expectedBytes = bytesUtf8(expected);
-		byte[] actualBytes = bytesUtf8(actual);
+		if (expected == actual) {
+			return true;
+		}
+		if (expected == null || actual == null) {
+			return false;
+		}
+		// Encode after ensure that the string is not null
+		byte[] expectedBytes = Utf8.encode(expected);
+		byte[] actualBytes = Utf8.encode(actual);
 		return MessageDigest.isEqual(expectedBytes, actualBytes);
-	}
-
-	private static byte[] bytesUtf8(String s) {
-		// need to check if Utf8.encode() runs in constant time (probably not).
-		// This may leak length of string.
-		return (s != null) ? Utf8.encode(s) : null;
 	}
 
 	private Mono<CsrfToken> generateToken(ServerWebExchange exchange) {

--- a/web/src/test/java/org/springframework/security/web/csrf/CsrfFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CsrfFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.security.web.csrf;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 
 import javax.servlet.FilterChain;
@@ -94,6 +95,18 @@ public class CsrfFilterTests {
 	private void resetRequestResponse() {
 		this.request = new MockHttpServletRequest();
 		this.response = new MockHttpServletResponse();
+	}
+
+	@Test
+	public void nullConstantTimeEquals() throws Exception {
+		Method method = CsrfFilter.class.getDeclaredMethod("equalsConstantTime", String.class, String.class);
+		method.setAccessible(true);
+		assertThat(method.invoke(CsrfFilter.class, null, null)).isEqualTo(true);
+		String expectedToken = "Hello—World";
+		String actualToken = new String("Hello—World");
+		assertThat(method.invoke(CsrfFilter.class, expectedToken, null)).isEqualTo(false);
+		assertThat(method.invoke(CsrfFilter.class, expectedToken, "hello-world")).isEqualTo(false);
+		assertThat(method.invoke(CsrfFilter.class, expectedToken, actualToken)).isEqualTo(true);
 	}
 
 	@Test

--- a/web/src/test/java/org/springframework/security/web/server/csrf/CsrfWebFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/csrf/CsrfWebFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.springframework.security.web.server.csrf;
+
+import java.lang.reflect.Method;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -64,6 +66,18 @@ public class CsrfWebFilterTests {
 	private MockServerWebExchange get = MockServerWebExchange.from(MockServerHttpRequest.get("/"));
 
 	private MockServerWebExchange post = MockServerWebExchange.from(MockServerHttpRequest.post("/"));
+
+	@Test
+	public void nullConstantTimeEquals() throws Exception {
+		Method method = CsrfWebFilter.class.getDeclaredMethod("equalsConstantTime", String.class, String.class);
+		method.setAccessible(true);
+		assertThat(method.invoke(CsrfWebFilter.class, null, null)).isEqualTo(true);
+		String expectedToken = "Hello—World";
+		String actualToken = new String("Hello—World");
+		assertThat(method.invoke(CsrfWebFilter.class, expectedToken, null)).isEqualTo(false);
+		assertThat(method.invoke(CsrfWebFilter.class, expectedToken, "hello-world")).isEqualTo(false);
+		assertThat(method.invoke(CsrfWebFilter.class, expectedToken, actualToken)).isEqualTo(true);
+	}
 
 	@Test
 	public void filterWhenGetThenSessionNotCreatedAndChainContinues() {


### PR DESCRIPTION
Solve the problem that CsrfFilter and CsrfWebFilter throws NPE exception when comparing two byte array is equal in low JDK version.
When JDK version is lower than 1.8.0_45,method java.security.MessageDigest#isEqual does not verify whether the two arrays are null.
And the above two class call this method without null judgment.

ZiQiang Zhao  <1694392889@qq.com>
Because I'm not familiar with git, I mistakenly closed the old pr #9524 . @jzheaux 

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
