### PR TITLE
Set 'details' on authentication token created by HttpServlet3RequestFactory

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ServletApiConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ServletApiConfigurer.java
@@ -91,7 +91,8 @@ public final class ServletApiConfigurer<H extends HttpSecurityBuilder<H>>
 		if (trustResolver != null) {
 			this.securityContextRequestFilter.setTrustResolver(trustResolver);
 		}
-		AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource = http.getSharedObject(AuthenticationDetailsSource.class);
+		AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource = http
+				.getSharedObject(AuthenticationDetailsSource.class);
 		if (authenticationDetailsSource != null) {
 			this.securityContextRequestFilter.setAuthenticationDetailsSource(authenticationDetailsSource);
 		}

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ServletApiConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ServletApiConfigurer.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.context.ApplicationContext;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationTrustResolver;
 import org.springframework.security.config.annotation.web.HttpSecurityBuilder;
@@ -89,6 +90,10 @@ public final class ServletApiConfigurer<H extends HttpSecurityBuilder<H>>
 		AuthenticationTrustResolver trustResolver = http.getSharedObject(AuthenticationTrustResolver.class);
 		if (trustResolver != null) {
 			this.securityContextRequestFilter.setTrustResolver(trustResolver);
+		}
+		AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource = http.getSharedObject(AuthenticationDetailsSource.class);
+		if (authenticationDetailsSource != null) {
+			this.securityContextRequestFilter.setAuthenticationDetailsSource(authenticationDetailsSource);
 		}
 		ApplicationContext context = http.getSharedObject(ApplicationContext.class);
 		if (context != null) {

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ServletApiConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ServletApiConfigurerTests.java
@@ -150,10 +150,12 @@ public class ServletApiConfigurerTests {
 	}
 
 	@Test
-	public void configureWhenSharedObjectAuthenticationDetailsSourceThenAuthenticationDetailsSourceUsed() throws Exception {
+	public void configureWhenSharedObjectAuthenticationDetailsSourceThenAuthenticationDetailsSourceUsed() {
 		this.spring.register(SharedAuthenticationDetailsSourceConfig.class).autowire();
-		this.mvc.perform(get("/"));
-		verify(SharedAuthenticationDetailsSourceConfig.ADS, atLeastOnce()).buildDetails(any());
+		SecurityContextHolderAwareRequestFilter scaFilter = getFilter(SecurityContextHolderAwareRequestFilter.class);
+		AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource =
+				getFieldValue(scaFilter, "authenticationDetailsSource");
+		assertThat(authenticationDetailsSource).isEqualTo(SharedAuthenticationDetailsSourceConfig.ADS);
 	}
 
 	@Test

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ServletApiConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ServletApiConfigurerTests.java
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationTrustResolver;
 import org.springframework.security.authentication.TestingAuthenticationToken;
@@ -146,6 +147,13 @@ public class ServletApiConfigurerTests {
 		this.spring.register(SharedTrustResolverConfig.class).autowire();
 		this.mvc.perform(get("/"));
 		verify(SharedTrustResolverConfig.TR, atLeastOnce()).isAnonymous(any());
+	}
+
+	@Test
+	public void configureWhenSharedObjectAuthenticationDetailsSourceThenAuthenticationDetailsSourceUsed() throws Exception {
+		this.spring.register(SharedAuthenticationDetailsSourceConfig.class).autowire();
+		this.mvc.perform(get("/"));
+		verify(SharedAuthenticationDetailsSourceConfig.ADS, atLeastOnce()).buildDetails(any());
 	}
 
 	@Test
@@ -315,6 +323,22 @@ public class ServletApiConfigurerTests {
 			// @formatter:off
 			http
 				.setSharedObject(AuthenticationTrustResolver.class, TR);
+			// @formatter:on
+		}
+
+	}
+
+	@EnableWebSecurity
+	static class SharedAuthenticationDetailsSourceConfig extends WebSecurityConfigurerAdapter {
+
+		@SuppressWarnings("unchecked")
+		static AuthenticationDetailsSource<HttpServletRequest, ?> ADS = spy(AuthenticationDetailsSource.class);
+
+		@Override
+		protected void configure(HttpSecurity http) {
+			// @formatter:off
+			http
+				.setSharedObject(AuthenticationDetailsSource.class, ADS);
 			// @formatter:on
 		}
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ServletApiConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ServletApiConfigurerTests.java
@@ -153,8 +153,8 @@ public class ServletApiConfigurerTests {
 	public void configureWhenSharedObjectAuthenticationDetailsSourceThenAuthenticationDetailsSourceUsed() {
 		this.spring.register(SharedAuthenticationDetailsSourceConfig.class).autowire();
 		SecurityContextHolderAwareRequestFilter scaFilter = getFilter(SecurityContextHolderAwareRequestFilter.class);
-		AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource =
-				getFieldValue(scaFilter, "authenticationDetailsSource");
+		AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource = getFieldValue(scaFilter,
+				"authenticationDetailsSource");
 		assertThat(authenticationDetailsSource).isEqualTo(SharedAuthenticationDetailsSourceConfig.ADS);
 	}
 

--- a/web/src/main/java/org/springframework/security/web/servletapi/HttpServlet3RequestFactory.java
+++ b/web/src/main/java/org/springframework/security/web/servletapi/HttpServlet3RequestFactory.java
@@ -165,8 +165,8 @@ final class HttpServlet3RequestFactory implements HttpServletRequestFactory {
 	/**
 	 * Sets the {@link AuthenticationDetailsSource} to be used. The default is
 	 * {@link WebAuthenticationDetailsSource}.
-	 * @param authenticationDetailsSource the {@link AuthenticationDetailsSource} to use. Cannot be
-	 * null.
+	 * @param authenticationDetailsSource the {@link AuthenticationDetailsSource} to use.
+	 * Cannot be null.
 	 */
 	void setAuthenticationDetailsSource(
 			AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource) {
@@ -247,8 +247,10 @@ final class HttpServlet3RequestFactory implements HttpServletRequestFactory {
 		private Authentication getAuthentication(AuthenticationManager authManager, String username, String password)
 				throws ServletException {
 			try {
-				UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(username, password);
-				authentication.setDetails(authenticationDetailsSource.buildDetails(this));
+				UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(username,
+						password);
+				Object details = HttpServlet3RequestFactory.this.authenticationDetailsSource.buildDetails(this);
+				authentication.setDetails(details);
 				return authManager.authenticate(authentication);
 			}
 			catch (AuthenticationException ex) {

--- a/web/src/main/java/org/springframework/security/web/servletapi/SecurityContextHolderAwareRequestFilter.java
+++ b/web/src/main/java/org/springframework/security/web/servletapi/SecurityContextHolderAwareRequestFilter.java
@@ -179,8 +179,8 @@ public class SecurityContextHolderAwareRequestFilter extends GenericFilterBean {
 	/**
 	 * Sets the {@link AuthenticationDetailsSource} to be used. The default is
 	 * {@link WebAuthenticationDetailsSource}.
-	 * @param authenticationDetailsSource the {@link AuthenticationDetailsSource} to use. Cannot be
-	 * null.
+	 * @param authenticationDetailsSource the {@link AuthenticationDetailsSource} to use.
+	 * Cannot be null.
 	 */
 	public void setAuthenticationDetailsSource(
 			AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource) {

--- a/web/src/main/java/org/springframework/security/web/servletapi/SecurityContextHolderAwareRequestFilter.java
+++ b/web/src/main/java/org/springframework/security/web/servletapi/SecurityContextHolderAwareRequestFilter.java
@@ -27,12 +27,14 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationTrustResolver;
 import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.util.Assert;
 import org.springframework.web.filter.GenericFilterBean;
@@ -79,6 +81,8 @@ public class SecurityContextHolderAwareRequestFilter extends GenericFilterBean {
 	private List<LogoutHandler> logoutHandlers;
 
 	private AuthenticationTrustResolver trustResolver = new AuthenticationTrustResolverImpl();
+
+	private AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource = new WebAuthenticationDetailsSource();
 
 	public void setRolePrefix(String rolePrefix) {
 		Assert.notNull(rolePrefix, "Role prefix must not be null");
@@ -172,9 +176,23 @@ public class SecurityContextHolderAwareRequestFilter extends GenericFilterBean {
 		updateFactory();
 	}
 
+	/**
+	 * Sets the {@link AuthenticationDetailsSource} to be used. The default is
+	 * {@link WebAuthenticationDetailsSource}.
+	 * @param authenticationDetailsSource the {@link AuthenticationDetailsSource} to use. Cannot be
+	 * null.
+	 */
+	public void setAuthenticationDetailsSource(
+			AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource) {
+		Assert.notNull(authenticationDetailsSource, "authenticationDetailsSource cannot be null");
+		this.authenticationDetailsSource = authenticationDetailsSource;
+		updateFactory();
+	}
+
 	private HttpServletRequestFactory createServlet3Factory(String rolePrefix) {
 		HttpServlet3RequestFactory factory = new HttpServlet3RequestFactory(rolePrefix);
 		factory.setTrustResolver(this.trustResolver);
+		factory.setAuthenticationDetailsSource(this.authenticationDetailsSource);
 		factory.setAuthenticationEntryPoint(this.authenticationEntryPoint);
 		factory.setAuthenticationManager(this.authenticationManager);
 		factory.setLogoutHandlers(this.logoutHandlers);


### PR DESCRIPTION
Currently the login mechanism when triggered by executing HttpServlet3RequestFactory#login does not set any details on the underlying authentication token that is authenticated.

This change adds support for setting an AuthenticationDetailsSource on the HttpServlet3RequestFactory, which defaults to a WebAuthenticationDetailsSource. The instance used can be overridden by the ServletApiConfigurer if a shared object of type AuthenticationDetailsSource has been registered.

Closes gh-9579