### PR TITLE
Add guard around logger.debug statement

### DIFF
--- a/web/src/main/java/org/springframework/security/web/session/SimpleRedirectInvalidSessionStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/session/SimpleRedirectInvalidSessionStrategy.java
@@ -52,7 +52,9 @@ public final class SimpleRedirectInvalidSessionStrategy implements InvalidSessio
 
 	@Override
 	public void onInvalidSessionDetected(HttpServletRequest request, HttpServletResponse response) throws IOException {
-		this.logger.debug("Starting new session (if required) and redirecting to '" + this.destinationUrl + "'");
+		if (this.logger.isDebugEnabled()) {
+			this.logger.debug("Starting new session (if required) and redirecting to '" + this.destinationUrl + "'");
+		}
 		if (this.createNewSession) {
 			request.getSession();
 		}


### PR DESCRIPTION
The log message involves string concatenation, the cost of which should only be incurred if debug logging is enabled

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
