### PR TITLE
Allow plugins to adjust the postLogoutRedirectUri

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/web/logout/NoPostLogoutRedirectUriProvider.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/web/logout/NoPostLogoutRedirectUriProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.oidc.web.logout;
+
+import java.net.URI;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * A provider to provide no URI during OIDC logout flow.
+ *
+ * @author Sebastian Sprenger
+ * @since 5.4
+ **/
+class NoPostLogoutRedirectUriProvider implements PostLogoutRedirectUriProvider {
+
+	@Override
+	public URI postLogoutRedirectUri(HttpServletRequest request) {
+		return null;
+	}
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/web/logout/PostLogoutRedirectUriProvider.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/web/logout/PostLogoutRedirectUriProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.oidc.web.logout;
+
+import java.net.URI;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Strategy to create a post logout redirect URI during the OIDC logout flow.
+ *
+ * @author Sebastian Sprenger
+ * @since 5.4
+ * @see org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler
+ **/
+public interface PostLogoutRedirectUriProvider {
+
+	URI postLogoutRedirectUri(HttpServletRequest request);
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/web/logout/StaticLogoutRedirectUriProvider.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/web/logout/StaticLogoutRedirectUriProvider.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.oidc.web.logout;
+
+import java.net.URI;
+import java.util.Collections;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.security.web.util.UrlUtils;
+import org.springframework.util.Assert;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * A provider to statically provide a configured redirect URI during OIDC logout flow.
+ *
+ * @author Josh Cummings
+ * @author Sebastian Sprenger
+ * @since 5.4
+ **/
+public class StaticLogoutRedirectUriProvider implements PostLogoutRedirectUriProvider {
+
+	private final String postLogoutRedirectUri;
+
+	/**
+	 * Set the post logout redirect uri template to use. Supports the {@code "{baseUrl}"}
+	 * placeholder, for example:
+	 *
+	 * <pre>
+	 * 	new StaticLogoutRedirectUriProvider("{baseUrl}");
+	 * </pre>
+	 *
+	 * will make so that {@code post_logout_redirect_uri} will be set to the base url for
+	 * the client application.
+	 * @param postLogoutRedirectUri - A template for creating the
+	 * {@code post_logout_redirect_uri} query parameter
+	 *
+	 * @since 5.4
+	 **/
+	public StaticLogoutRedirectUriProvider(String postLogoutRedirectUri) {
+		Assert.notNull(postLogoutRedirectUri, "postLogoutRedirectUri cannot be null");
+		this.postLogoutRedirectUri = postLogoutRedirectUri;
+	}
+
+	@Override
+	public URI postLogoutRedirectUri(HttpServletRequest request) {
+		// @formatter:off
+		UriComponents uriComponents = UriComponentsBuilder
+				.fromHttpUrl(UrlUtils.buildFullRequestUrl(request))
+				.replacePath(request.getContextPath())
+				.replaceQuery(null)
+				.fragment(null)
+				.build();
+		return UriComponentsBuilder.fromUriString(this.postLogoutRedirectUri)
+				.buildAndExpand(Collections.singletonMap("baseUrl", uriComponents.toUriString()))
+				.toUri();
+		// @formatter:on
+	}
+
+}


### PR DESCRIPTION
OidcClientInitiatedLogoutSuccessHandler only allowed a static redirect URI
during OIDC logout. Now there is an interface which allows more flexibility
as it has access to the request object.

Closes gh-9653
