### PR TITLE
Allow Creating RelyingPartyRegistration from Metadata InputStream

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/servlet/saml2/saml2-login.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/saml2/saml2-login.adoc
@@ -536,7 +536,6 @@ RelyingPartyRegistration relyingPartyRegistration = RelyingPartyRegistrations
         .registrationId("my-id")
         .build();
 ----
-
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
@@ -546,6 +545,20 @@ val relyingPartyRegistration = RelyingPartyRegistrations
     .build()
 ----
 ====
+
+Note that you can also create a `RelyingPartyRegistration` from an arbitrary `InputStream` source.
+One such example is when the metadata is stored in a database:
+
+[source,java]
+----
+String xml = fromDatabase();
+try (InputStream source = new ByteArrayInputStream(xml.getBytes())) {
+    RelyingPartyRegistration relyingPartyRegistration = RelyingPartyRegistrations
+            .fromMetadata(source)
+            .registrationId("my-id")
+            .build();
+}
+----
 
 Though a more sophisticated setup is also possible, like so:
 


### PR DESCRIPTION
Update SAML2 Login reference documentation to reflect the changes

Closes gh-9558

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
