### PR TITLE
Update Documentation to point to spring-security-samples

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -80,6 +80,7 @@ dependencies {
 	implementation 'io.spring.gradle:propdeps-plugin:0.0.10.RELEASE'
 	implementation 'io.spring.javaformat:spring-javaformat-gradle-plugin:0.0.15'
 	implementation 'io.spring.nohttp:nohttp-gradle:0.0.8'
+	implementation 'org.aim42:htmlSanityCheck:1.1.6'
 	implementation 'org.asciidoctor:asciidoctor-gradle-jvm:3.1.0'
 	implementation 'org.asciidoctor:asciidoctor-gradle-jvm-pdf:3.1.0'
 	implementation 'org.hidetake:gradle-ssh-plugin:2.10.1'

--- a/docs/guides/spring-security-docs-guides.gradle
+++ b/docs/guides/spring-security-docs-guides.gradle
@@ -17,7 +17,6 @@ asciidoctor {
 			idseparator: '-',
 			doctype: 'book',
 			'spring-security-version' : project.version,
-			'download-url' : getDownloadUrl(),
 			'include-maven-repository' : getMavenRepositoryInclude(),
 			revnumber : project.version,
 			'gh-samples-url': ghSamplesUrl,
@@ -30,11 +29,6 @@ ext.spec = copySpec {
 		exclude 'build', 'Guardfile'
 	}
 }
-
-def getDownloadUrl() {
-	snapshotBuild ? "https://github.com/spring-projects/spring-security/archive/main.zip" : "https://github.com/spring-projects/spring-security/archive/${project.version}.zip"
-}
-
 
 def getMavenRepositoryInclude() {
 	if(snapshotBuild) {

--- a/docs/guides/spring-security-docs-guides.gradle
+++ b/docs/guides/spring-security-docs-guides.gradle
@@ -5,6 +5,8 @@ asciidoctor {
 	baseDir = file('src/docs/asciidoc')
 	options eruby: 'erubis'
 
+	def ghTag = snapshotBuild ? 'main' : project.version
+	def ghSamplesUrl = "https://github.com/spring-projects/spring-security-samples/tree/$ghTag"
 	attributes copycss : '',
 			icons : 'font',
 			'source-highlighter': 'prettify',
@@ -17,7 +19,9 @@ asciidoctor {
 			'spring-security-version' : project.version,
 			'download-url' : getDownloadUrl(),
 			'include-maven-repository' : getMavenRepositoryInclude(),
-			revnumber : project.version
+			revnumber : project.version,
+			'gh-samples-url': ghSamplesUrl,
+			'gh-old-samples-url': "https://github.com/spring-projects/spring-security/tree/5.4.x/samples"
 }
 
 ext.spec = copySpec {

--- a/docs/guides/src/docs/asciidoc/_includes/setting-up-the-sample-boot.asc
+++ b/docs/guides/src/docs/asciidoc/_includes/setting-up-the-sample-boot.asc
@@ -12,7 +12,7 @@ download-url: the URL to download the Spring Security distribution
 
 == Setting up the sample
 
-This section outlines how to setup a workspace within https://spring.io/tools/sts[Spring Tool Suite (STS)] so that you can follow along with this guide. The next section outlines generic steps for how to apply Spring Security to your existing application. While you could simply apply the steps to your existing application, we encourage you to follow along with this guide in order to reduce the complexity.
+This section outlines how to setup a workspace within https://spring.io/tools[Eclipse IDE with Spring Tools] so that you can follow along with this guide. The next section outlines generic steps for how to apply Spring Security to your existing application. While you could simply apply the steps to your existing application, we encourage you to follow along with this guide in order to reduce the complexity.
 
 === Obtaining the sample project
 

--- a/docs/guides/src/docs/asciidoc/_includes/setting-up-the-sample-boot.asc
+++ b/docs/guides/src/docs/asciidoc/_includes/setting-up-the-sample-boot.asc
@@ -16,7 +16,12 @@ This section outlines how to setup a workspace within https://spring.io/tools/st
 
 === Obtaining the sample project
 
-Extract the {download-url}[Spring Security Distribution] to a known location and remember it as _SPRING_SECURITY_HOME_.
+Clone the {gh-samples-url}[Spring Security Samples project] to a known location and remember it as _SPRING_SECURITY_HOME_.
+[NOTE]
+====
+These samples are being migrated to a separate project, however, you can still find
+the not migrated samples in an older branch of the {gh-old-samples-url}[Spring Security repository].
+====
 
 === Import the {starter-appname} sample application
 

--- a/docs/guides/src/docs/asciidoc/_includes/setting-up-the-sample.asc
+++ b/docs/guides/src/docs/asciidoc/_includes/setting-up-the-sample.asc
@@ -12,7 +12,7 @@ download-url: the URL to download the Spring Security distribution
 
 == Setting up the sample
 
-This section outlines how to setup a workspace within https://spring.io/tools/sts[Spring Tool Suite (STS)] so that you can follow along with this guide. The next section outlines generic steps for how to apply Spring Security to your existing application. While you could simply apply the steps to your existing application, we encourage you to follow along with this guide in order to reduce the complexity.
+This section outlines how to setup a workspace within https://spring.io/tools[Eclipse IDE with Spring Tools] so that you can follow along with this guide. The next section outlines generic steps for how to apply Spring Security to your existing application. While you could simply apply the steps to your existing application, we encourage you to follow along with this guide in order to reduce the complexity.
 
 === Obtaining the sample project
 

--- a/docs/guides/src/docs/asciidoc/_includes/setting-up-the-sample.asc
+++ b/docs/guides/src/docs/asciidoc/_includes/setting-up-the-sample.asc
@@ -16,7 +16,12 @@ This section outlines how to setup a workspace within https://spring.io/tools/st
 
 === Obtaining the sample project
 
-Extract the {download-url}[Spring Security Distribution] to a known location and remember it as _SPRING_SECURITY_HOME_.
+Clone the {gh-samples-url}[Spring Security Samples project] to a known location and remember it as _SPRING_SECURITY_HOME_.
+[NOTE]
+====
+These samples are being migrated to a separate project, however, you can still find
+the not migrated samples in an older branch of the {gh-old-samples-url}[Spring Security repository].
+====
 
 === Import the {starter-appname} sample application
 

--- a/docs/manual/spring-security-docs-manual.gradle
+++ b/docs/manual/spring-security-docs-manual.gradle
@@ -16,11 +16,14 @@ asciidoctor {
 asciidoctorj {
 	def ghTag = snapshotBuild ? 'main' : project.version
 	def ghUrl = "https://github.com/spring-projects/spring-security/tree/$ghTag"
+	def ghOldSamplesUrl = "https://github.com/spring-projects/spring-security/tree/5.4.x/samples"
+	def ghSamplesUrl = "https://github.com/spring-projects/spring-security-samples/tree/$ghTag"
 	attributes 'spring-security-version' : project.version,
 		'spring-boot-version' : springBootVersion,
 		revnumber : project.version,
 		'gh-url': ghUrl,
-		'gh-samples-url': "$ghUrl/samples"
+		'gh-samples-url': ghSamplesUrl,
+		'gh-old-samples-url': ghOldSamplesUrl
 	attributeProvider resolvedVersions(project.configurations.testRuntimeClasspath)
 }
 

--- a/docs/manual/spring-security-docs-manual.gradle
+++ b/docs/manual/spring-security-docs-manual.gradle
@@ -14,16 +14,27 @@ asciidoctor {
 }
 
 asciidoctorj {
+	def docsTag = snapshotBuild ? 'current' : project.version
 	def ghTag = snapshotBuild ? 'main' : project.version
 	def ghUrl = "https://github.com/spring-projects/spring-security/tree/$ghTag"
 	def ghOldSamplesUrl = "https://github.com/spring-projects/spring-security/tree/5.4.x/samples"
 	def ghSamplesUrl = "https://github.com/spring-projects/spring-security-samples/tree/$ghTag"
+	def securityDocsUrl = "https://docs.spring.io/spring-security/site/docs/$docsTag"
+	def oldSecurityApiUrl = "https://docs.spring.io/spring-security/site/docs/5.4.x/api/"
+	def springVersion = "5.3.x"
+	def securityApiUrl = "$securityDocsUrl/api/"
+	def securityReferenceUrl = "$securityDocsUrl/reference/html5/"
+	def springFrameworkApiUrl = "https://docs.spring.io/spring-framework/docs/$springVersion/javadoc-api/"
 	attributes 'spring-security-version' : project.version,
 		'spring-boot-version' : springBootVersion,
 		revnumber : project.version,
 		'gh-url': ghUrl,
 		'gh-samples-url': ghSamplesUrl,
-		'gh-old-samples-url': ghOldSamplesUrl
+		'gh-old-samples-url': ghOldSamplesUrl,
+		'old-security-api-url': oldSecurityApiUrl,
+		'security-api-url': securityApiUrl,
+		'security-reference-url': securityReferenceUrl,
+		'spring-framework-api-url': springFrameworkApiUrl
 	attributeProvider resolvedVersions(project.configurations.testRuntimeClasspath)
 }
 

--- a/docs/manual/src/docs/asciidoc/_includes/about/exploits/csrf.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/about/exploits/csrf.adoc
@@ -114,7 +114,7 @@ This means that requests with the HTTP method `GET`, `HEAD`, `OPTIONS`, and `TRA
 
 [[csrf-protection-stp]]
 === Synchronizer Token Pattern
-The predominant and most comprehensive way to protect against CSRF attacks is to use the https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#General_Recommendation:_Synchronizer_Token_Pattern[Synchronizer Token Pattern].
+The predominant and most comprehensive way to protect against CSRF attacks is to use the https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#synchronizer-token-pattern[Synchronizer Token Pattern].
 This solution is to ensure that each HTTP request requires, in addition to our session cookie, a secure random generated value called a CSRF token must be present in the HTTP request.
 
 When an HTTP request is submitted, the server must look up the expected CSRF token and compare it against the actual CSRF token in the HTTP request.
@@ -348,7 +348,7 @@ This allows the expected CSRF token to outlive the session.
 One might ask why the expected CSRF token isn't stored in a cookie by default.
 This is because there are known exploits in which headers (for example, to specify the cookies) can be set by another domain.
 This is the same reason Ruby on Rails https://weblog.rubyonrails.org/2011/2/8/csrf-protection-bypass-in-ruby-on-rails/[no longer skips CSRF checks when the header X-Requested-With is present].
-See http://lists.webappsec.org/pipermail/websecurity_lists.webappsec.org/2011-February/007533.html[this webappsec.org thread] for details on how to perform the exploit.
+See https://web.archive.org/web/20210221120355/https://lists.webappsec.org/pipermail/websecurity_lists.webappsec.org/2011-February/007533.html[this webappsec.org thread] for details on how to perform the exploit.
 Another disadvantage is that by removing the state (that is, the timeout), you lose the ability to forcibly invalidate the token if it is compromised.
 
 // FIXME: Document timeout with lengthy form expire. We do not want to automatically replay that request because it can lead to exploit

--- a/docs/manual/src/docs/asciidoc/_includes/about/exploits/headers.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/about/exploits/headers.adoc
@@ -7,7 +7,7 @@ This portion of the documentation discusses the general topic of Security HTTP R
 Refer to the relevant sections for specific information on Security HTTP Response Headers <<servlet-headers,servlet>> and <<webflux-headers,WebFlux>> based applications.
 ====
 
-There are many https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#tab=Headers[HTTP response headers] that can be used to increase the security of web applications.
+There are many https://owasp.org/www-project-secure-headers/#div-headers[HTTP response headers] that can be used to increase the security of web applications.
 This section is dedicated to the various HTTP response headers that Spring Security provides explicit support for.
 If necessary, Spring Security can also be configured to provide <<headers-custom,custom headers>>.
 
@@ -267,7 +267,7 @@ Content-Security-Policy: script-src https://trustedscripts.example.com; report-u
 ----
 ====
 
-https://www.w3.org/TR/CSP2/#violation-reports[Violation reports] are standard JSON structures that can be captured either by the web application's own API or by a publicly hosted CSP violation reporting service, such as, https://report-uri.io/.
+https://www.w3.org/TR/CSP2/#violation-reports[Violation reports] are standard JSON structures that can be captured either by the web application's own API or by a publicly hosted CSP violation reporting service, such as, https://report-uri.com/.
 
 The `Content-Security-Policy-Report-Only` header provides the capability for web application authors and administrators to monitor security policies, rather than enforce them.
 This header is typically used when experimenting and/or developing security policies for a site.

--- a/docs/manual/src/docs/asciidoc/_includes/about/exploits/http.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/about/exploits/http.adoc
@@ -25,7 +25,7 @@ Without proper configuration, the application server will not know that the load
 
 To fix this you can use https://tools.ietf.org/html/rfc7239[RFC 7239] to specify that a load balancer is being used.
 To make the application aware of this, you need to either configure your application server aware of the X-Forwarded headers.
-For example Tomcat uses the https://tomcat.apache.org/tomcat-8.0-doc/api/org/apache/catalina/valves/RemoteIpValve.html[RemoteIpValve] and Jetty uses https://download.eclipse.org/jetty/stable-9/apidocs/org/eclipse/jetty/server/ForwardedRequestCustomizer.html[ForwardedRequestCustomizer].
+For example Tomcat uses the https://tomcat.apache.org/tomcat-8.0-doc/api/org/apache/catalina/valves/RemoteIpValve.html[RemoteIpValve] and Jetty uses https://www.eclipse.org/jetty/javadoc/jetty-9/org/eclipse/jetty/server/ForwardedRequestCustomizer.html[ForwardedRequestCustomizer].
 Alternatively, Spring users can leverage https://github.com/spring-projects/spring-framework/blob/v4.3.3.RELEASE/spring-web/src/main/java/org/springframework/web/filter/ForwardedHeaderFilter.java[ForwardedHeaderFilter].
 
 Spring Boot users may use the `server.use-forward-headers` property to configure the application.

--- a/docs/manual/src/docs/asciidoc/_includes/about/getting-spring-security.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/about/getting-spring-security.adoc
@@ -24,7 +24,7 @@ The topics in this section provide detail on how to consume Spring Security when
 === Spring Boot with Maven
 
 Spring Boot provides a `spring-boot-starter-security` starter that aggregates Spring Security-related dependencies together.
-The simplest and preferred way to use the starter is to use https://docs.spring.io/initializr/docs/current/reference/htmlsingle/[Spring Initializr] by using an IDE integration (https://joshlong.com/jl/blogPost/tech_tip_geting_started_with_spring_boot.html[Eclipse], https://www.jetbrains.com/help/idea/spring-boot.html#d1489567e2[IntelliJ], https://github.com/AlexFalappa/nb-springboot/wiki/Quick-Tour[NetBeans]) or through https://start.spring.io.
+The simplest and preferred way to use the starter is to use https://docs.spring.io/initializr/docs/current/reference/html/[Spring Initializr] by using an IDE integration (https://joshlong.com/jl/blogPost/tech_tip_geting_started_with_spring_boot.html[Eclipse], https://www.jetbrains.com/help/idea/spring-boot.html#d1489567e2[IntelliJ], https://github.com/AlexFalappa/nb-springboot/wiki/Quick-Tour[NetBeans]) or through https://start.spring.io.
 
 Alternatively, you can manually add the starter, as the following example shows:
 
@@ -196,7 +196,7 @@ The following topics provide detail on how to consume Spring Security when using
 === Spring Boot with Gradle
 
 Spring Boot provides a `spring-boot-starter-security` starter that aggregates Spring Security related dependencies together.
-The simplest and preferred method to use the starter is to use https://docs.spring.io/initializr/docs/current/reference/htmlsingle/[Spring Initializr] by using an IDE integration (https://joshlong.com/jl/blogPost/tech_tip_geting_started_with_spring_boot.html[Eclipse], https://www.jetbrains.com/help/idea/spring-boot.html#d1489567e2[IntelliJ], https://github.com/AlexFalappa/nb-springboot/wiki/Quick-Tour[NetBeans]) or through https://start.spring.io.
+The simplest and preferred method to use the starter is to use https://docs.spring.io/initializr/docs/current/reference/html/[Spring Initializr] by using an IDE integration (https://joshlong.com/jl/blogPost/tech_tip_geting_started_with_spring_boot.html[Eclipse], https://www.jetbrains.com/help/idea/spring-boot.html#d1489567e2[IntelliJ], https://github.com/AlexFalappa/nb-springboot/wiki/Quick-Tour[NetBeans]) or through https://start.spring.io.
 
 Alternatively, you can manually add the starter, as the following example shows:
 

--- a/docs/manual/src/docs/asciidoc/_includes/about/samples.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/about/samples.adoc
@@ -2,3 +2,9 @@
 = Samples
 
 Spring Security includes many {gh-samples-url}[samples] applications.
+
+[NOTE]
+====
+These samples are being migrated to a separate project, however, you can still find
+the not migrated samples in an older branch of the {gh-old-samples-url}[Spring Security repository].
+====

--- a/docs/manual/src/docs/asciidoc/_includes/reactive/method.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/reactive/method.adoc
@@ -234,4 +234,4 @@ class SecurityConfig {
 ----
 ====
 
-You can find a complete sample in {gh-samples-url}/javaconfig/hellowebflux-method[hellowebflux-method]
+You can find a complete sample in {gh-samples-url}/reactive/webflux/java/method[hellowebflux-method]

--- a/docs/manual/src/docs/asciidoc/_includes/reactive/oauth2/login.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/reactive/oauth2/login.adoc
@@ -12,7 +12,7 @@ NOTE: OAuth 2.0 Login is implemented by using the *Authorization Code Grant*, as
 
 Spring Boot 2.0 brings full auto-configuration capabilities for OAuth 2.0 Login.
 
-This section shows how to configure the {gh-samples-url}/boot/oauth2login-webflux[*OAuth 2.0 Login WebFlux sample*] using _Google_ as the _Authentication Provider_ and covers the following topics:
+This section shows how to configure the {gh-samples-url}/reactive/webflux/java/oauth2/login[*OAuth 2.0 Login WebFlux sample*] using _Google_ as the _Authentication Provider_ and covers the following topics:
 
 * <<webflux-oauth2-login-sample-setup,Initial setup>>
 * <<webflux-oauth2-login-sample-redirect,Setting the redirect URI>>

--- a/docs/manual/src/docs/asciidoc/_includes/reactive/oauth2/resource-server.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/reactive/oauth2/resource-server.adoc
@@ -11,7 +11,7 @@ This authorization server can be consulted by resource servers to authorize requ
 
 [NOTE]
 ====
-A complete working example for {gh-samples-url}/boot/oauth2resourceserver-webflux[*JWTs*]  is available in the {gh-samples-url}[Spring Security repository].
+A complete working example for {gh-samples-url}/reactive/webflux/java/oauth2/resource-server[*JWTs*]  is available in the {gh-samples-url}[Spring Security repository].
 ====
 
 [[webflux-oauth2resourceserver-jwt-minimaldependencies]]

--- a/docs/manual/src/docs/asciidoc/_includes/reactive/registered-oauth2-authorized-client.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/reactive/registered-oauth2-authorized-client.adoc
@@ -5,7 +5,7 @@ Spring Security allows resolving an access token using `@RegisteredOAuth2Authori
 
 [NOTE]
 ====
-A working example can be found in {gh-samples-url}/boot/oauth2webclient-webflux[*OAuth 2.0 WebClient WebFlux sample*].
+A working example can be found in {gh-samples-url}/reactive/webflux/java/oauth2/webclient[*OAuth 2.0 WebClient WebFlux sample*].
 ====
 
 After configuring Spring Security for <<webflux-oauth2-login,OAuth2 Login>> or as an <<webflux-oauth2-client,OAuth2 Client>>, an `OAuth2AuthorizedClient` can be resolved using the following:

--- a/docs/manual/src/docs/asciidoc/_includes/reactive/rsocket.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/reactive/rsocket.adoc
@@ -6,7 +6,7 @@ The main entry point into security is found in the `PayloadSocketAcceptorInterce
 
 You can find a few sample applications that demonstrate the code below:
 
-* Hello RSocket {gh-samples-url}/boot/hellorsocket[hellorsocket]
+* Hello RSocket {gh-samples-url}/reactive/rsocket/hello-security[hellorsocket]
 * https://github.com/rwinch/spring-flights/tree/security[Spring Flights]
 
 

--- a/docs/manual/src/docs/asciidoc/_includes/reactive/webflux.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/reactive/webflux.adoc
@@ -4,9 +4,9 @@
 Spring Security's WebFlux support relies on a `WebFilter` and works the same for Spring WebFlux and Spring WebFlux.Fn.
 You can find a few sample applications that demonstrate the code below:
 
-* Hello WebFlux {gh-samples-url}/boot/hellowebflux[hellowebflux]
-* Hello WebFlux.Fn {gh-samples-url}/boot/hellowebfluxfn[hellowebfluxfn]
-* Hello WebFlux Method {gh-samples-url}/boot/hellowebflux-method[hellowebflux-method]
+* Hello WebFlux {gh-samples-url}/reactive/webflux/java/hello-security[hellowebflux]
+* Hello WebFlux.Fn {gh-samples-url}/reactive/webflux-fn/hello-security[hellowebfluxfn]
+* Hello WebFlux Method {gh-samples-url}/reactive/webflux/java/method[hellowebflux-method]
 
 
 == Minimal WebFlux Security Configuration

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/appendix/faq.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/appendix/faq.adoc
@@ -275,7 +275,7 @@ To get around this, you can disable session fixation protection, but in newer Se
 Note that switching between HTTP and HTTPS is not a good idea in general, as any application which uses HTTP at all is vulnerable to man-in-the-middle attacks.
 To be truly secure, the user should begin accessing your site in HTTPS and continue using it until they log out.
 Even clicking on an HTTPS link from a page accessed over HTTP is potentially risky.
-If you need more convincing, check out a tool like https://www.thoughtcrime.org/software/sslstrip/[sslstrip].
+If you need more convincing, check out a tool like https://github.com/moxie0/sslstrip/[sslstrip].
 
 
 ==== I'm not switching between HTTP and HTTPS but my session is still getting lost
@@ -396,7 +396,7 @@ For third-party jars the situation isn't always quite so obvious.
 A good starting point is to copy those from one of the pre-built sample applications WEB-INF/lib directories.
 For a basic application, you can start with the tutorial sample.
 If you want to use LDAP, with an embedded test server, then use the LDAP sample as a starting point.
-The reference manual also includes https://static.springsource.org/spring-security/site/docs/3.1.x/reference/springsecurity-single.html#appendix-dependencies[an appendix] listing the first-level dependencies for each Spring Security module with some information on whether they are optional and what they are required for.
+The reference manual also includes {security-reference-url}#modules[an appendix] listing the first-level dependencies for each Spring Security module with some information on whether they are optional and what they are required for.
 
 If you are building your project with maven, then adding the appropriate Spring Security modules as dependencies to your pom.xml will automatically pull in the core jars that the framework requires.
 Any which are marked as "optional" in the Spring Security POM files will have to be added to your own pom.xml file if you need them.

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/appendix/proxy-server.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/appendix/proxy-server.adoc
@@ -7,7 +7,7 @@ Without proper configuration, the application server will not know that the load
 
 To fix this you can use https://tools.ietf.org/html/rfc7239[RFC 7239] to specify that a load balancer is being used.
 To make the application aware of this, you need to either configure your application server aware of the X-Forwarded headers.
-For example Tomcat uses the https://tomcat.apache.org/tomcat-8.0-doc/api/org/apache/catalina/valves/RemoteIpValve.html[RemoteIpValve] and Jetty uses https://download.eclipse.org/jetty/stable-9/apidocs/org/eclipse/jetty/server/ForwardedRequestCustomizer.html[ForwardedRequestCustomizer].
+For example Tomcat uses the https://tomcat.apache.org/tomcat-8.0-doc/api/org/apache/catalina/valves/RemoteIpValve.html[RemoteIpValve] and Jetty uses https://www.eclipse.org/jetty/javadoc/jetty-9/org/eclipse/jetty/server/ForwardedRequestCustomizer.html[ForwardedRequestCustomizer].
 Alternatively, Spring 4.3+ users can leverage https://github.com/spring-projects/spring-framework/blob/v4.3.3.RELEASE/spring-web/src/main/java/org/springframework/web/filter/ForwardedHeaderFilter.java[ForwardedHeaderFilter].
 
 Spring Boot users may use the `server.use-forward-headers` property to configure the application.

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/architecture/delegating-filter-proxy.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/architecture/delegating-filter-proxy.adoc
@@ -1,7 +1,7 @@
 [[servlet-delegatingfilterproxy]]
 = DelegatingFilterProxy
 
-Spring provides a `Filter` implementation named {security-api-url}org/springframework/web/filter/DelegatingFilterProxy.html/[`DelegatingFilterProxy`] that allows bridging between the Servlet container's lifecycle and Spring's `ApplicationContext`.
+Spring provides a `Filter` implementation named {spring-framework-api-url}org/springframework/web/filter/DelegatingFilterProxy.html[`DelegatingFilterProxy`] that allows bridging between the Servlet container's lifecycle and Spring's `ApplicationContext`.
 The Servlet container allows registering ``Filter``s using its own standards, but it is not aware of Spring defined Beans.
 `DelegatingFilterProxy` can be registered via standard Servlet container mechanisms, but delegate all the work to a Spring Bean that implements `Filter`.
 

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/authentication/jaas.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/authentication/jaas.adoc
@@ -117,7 +117,7 @@ class="org.springframework.security.authentication.jaas.DefaultJaasAuthenticatio
 
 [[jaas-jaasauthenticationprovider]]
 === JaasAuthenticationProvider
-The `JaasAuthenticationProvider` assumes the default `Configuration` is an instance of https://download.oracle.com/javase/1.4.2/docs/guide/security/jaas/spec/com/sun/security/auth/login/ConfigFile.html[ ConfigFile].
+The `JaasAuthenticationProvider` assumes the default `Configuration` is an instance of https://docs.oracle.com/javase/8/docs/jre/api/security/jaas/spec/com/sun/security/auth/login/ConfigFile.html[ ConfigFile].
 This assumption is made in order to attempt to update the `Configuration`.
 The `JaasAuthenticationProvider` then uses the default `Configuration` to create the `LoginContext`.
 

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/authentication/preauth.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/authentication/preauth.adoc
@@ -147,5 +147,4 @@ It's also assumed that you have added a `UserDetailsService` (called "userDetail
 The class `J2eePreAuthenticatedProcessingFilter` will extract the username from the `userPrincipal` property of the `HttpServletRequest`.
 Use of this filter would usually be combined with the use of Java EE roles as described above in <<j2ee-preauth-details>>.
 
-There is a sample application in the codebase which uses this approach, so get hold of the code from github and have a look at the application context file if you are interested.
-The code is in the `samples/xml/preauth` directory.
+There is a {gh-old-samples-url}/xml/preauth[sample application] in the samples project which uses this approach, so get hold of the code from GitHub and have a look at the application context file if you are interested.

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/authentication/rememberme.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/authentication/rememberme.adoc
@@ -51,7 +51,7 @@ If you have more than one in your application context, you need to specify which
 
 [[remember-me-persistent-token]]
 === Persistent Token Approach
-This approach is based on the article http://jaspan.com/improved_persistent_login_cookie_best_practice[http://jaspan.com/improved_persistent_login_cookie_best_practice] with some minor modifications  footnote:[Essentially, the username is not included in the cookie, to prevent exposing a valid login name unecessarily.
+This approach is based on the article https://web.archive.org/web/20180819014446/http://jaspan.com/improved_persistent_login_cookie_best_practice[http://jaspan.com/improved_persistent_login_cookie_best_practice] with some minor modifications  footnote:[Essentially, the username is not included in the cookie, to prevent exposing a valid login name unecessarily.
 There is a discussion on this in the comments section of this article.].
 To use the this approach with namespace configuration, you would supply a datasource reference:
 

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/authentication/x509.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/authentication/x509.adoc
@@ -52,7 +52,7 @@ This means that you can easily use X.509 authentication with other options such 
 
 [[x509-ssl-config]]
 === Setting up SSL in Tomcat
-There are some pre-generated certificates in the `samples/certificate` directory in the Spring Security project.
+There are some pre-generated certificates in the {gh-samples-url}/servlet/java-configuration/authentication/x509/server[Spring Security Samples repository].
 You can use these to enable SSL for testing if you don't want to generate your own.
 The file `server.jks` contains the server certificate, private key and the issuing certificate authority certificate.
 There are also some client certificate files for the users from the sample applications.

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/exploits/csrf.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/exploits/csrf.adoc
@@ -375,7 +375,7 @@ For details, refer to the <<servlet-csrf-configure-custom-repository>> section.
 
 If a token does expire, you might want to customize how it is handled by specifying a custom `AccessDeniedHandler`.
 The custom `AccessDeniedHandler` can process the `InvalidCsrfTokenException` any way you like.
-For an example of how to customize the `AccessDeniedHandler` refer to the provided links for both <<nsa-access-denied-handler,xml>> and https://github.com/spring-projects/spring-security/blob/3.2.0.RC1/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpAccessDeniedHandlerTests.java#L64[Java configuration].
+For an example of how to customize the `AccessDeniedHandler` refer to the provided links for both <<nsa-access-denied-handler,xml>> and {gh-url}/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpServerAccessDeniedHandlerTests.java#L64[Java configuration].
 // FIXME: We should add a custom AccessDeniedHandler section in the reference and update the links above
 
 

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/exploits/firewall.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/exploits/firewall.adoc
@@ -80,7 +80,7 @@ fun httpFirewall(): StrictHttpFirewall {
 ----
 ====
 
-The `StrictHttpFirewall` provides an allowed list of valid HTTP methods that are allowed to protect against https://www.owasp.org/index.php/Cross_Site_Tracing[Cross Site Tracing (XST)] and https://www.owasp.org/index.php/Test_HTTP_Methods_(OTG-CONFIG-006)[HTTP Verb Tampering].
+The `StrictHttpFirewall` provides an allowed list of valid HTTP methods that are allowed to protect against https://owasp.org/www-community/attacks/Cross_Site_Tracing[Cross Site Tracing (XST)] and https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/06-Test_HTTP_Methods[HTTP Verb Tampering].
 The default valid methods are "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", and "PUT".
 If your application needs to modify the valid methods, you can configure a custom `StrictHttpFirewall` bean.
 For example, the following will only allow HTTP "GET" and "POST" methods:

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/hello/index.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/hello/index.adoc
@@ -5,7 +5,7 @@ This section covers the minimum setup for how to use Spring Security with Spring
 
 [NOTE]
 ====
-The completed application can be found at {gh-samples-url}/boot/helloworld[samples/boot/helloworld]
+The completed application can be found {gh-samples-url}/servlet/spring-boot/java/hello-security[in our samples repository].
 For your convenience, you can download a minimal Spring Boot + Spring Security application by https://start.spring.io/starter.zip?type=maven-project&language=java&packaging=jar&jvmVersion=1.8&groupId=example&artifactId=hello-security&name=hello-security&description=Hello%20Security&packageName=example.hello-security&dependencies=web,security[clicking here].
 ====
 

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/integrations/websocket.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/integrations/websocket.adoc
@@ -241,7 +241,7 @@ This means developers need to explicitly protect their applications from externa
 ==== Spring WebSocket Allowed Origin
 
 Fortunately, since Spring 4.1.5 Spring's WebSocket and SockJS support restricts access to the https://docs.spring.io/spring/docs/current/spring-framework-reference/html/websocket.html#websocket-server-allowed-origins[current domain].
-Spring Security adds an additional layer of protection to provide https://en.wikipedia.org/wiki/Defense_in_depth_%2528computing%2529[defence in depth].
+Spring Security adds an additional layer of protection to provide https://en.wikipedia.org/wiki/Defense_in_depth_(computing)[defence in depth].
 
 [[websocket-sameorigin-csrf]]
 ==== Adding CSRF to Stomp Headers

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/namespace/index.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/namespace/index.adoc
@@ -20,7 +20,7 @@ This is much simpler than wiring up the equivalent Apache Directory Server beans
 The most common alternative configuration requirements are supported by attributes on the `ldap-server` element and the user is isolated from worrying about which beans they need to create and what the bean property names are.
 footnote:[You can find out more about the use of the `ldap-server` element in the chapter on pass:specialcharacters,macros[<<servlet-authentication-ldap>>].].
 Use of a good XML editor while editing the application context file should provide information on the attributes and elements that are available.
-We would recommend that you try out the https://spring.io/tools/sts[Spring Tool Suite] as it has special features for working with standard Spring namespaces.
+We would recommend that you try out the https://spring.io/tools[Eclipse IDE with Spring Tools] as it has special features for working with standard Spring namespaces.
 
 
 To start using the security namespace in your application context, you need to have the `spring-security-config` jar on your classpath.

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/oauth2/oauth2-login.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/oauth2/oauth2-login.adoc
@@ -12,7 +12,7 @@ NOTE: OAuth 2.0 Login is implemented by using the *Authorization Code Grant*, as
 
 Spring Boot 2.x brings full auto-configuration capabilities for OAuth 2.0 Login.
 
-This section shows how to configure the {gh-samples-url}/boot/oauth2login[*OAuth 2.0 Login sample*] using _Google_ as the _Authentication Provider_ and covers the following topics:
+This section shows how to configure the {gh-samples-url}/servlet/spring-boot/java/oauth2/login[*OAuth 2.0 Login sample*] using _Google_ as the _Authentication Provider_ and covers the following topics:
 
 * <<oauth2login-sample-initial-setup,Initial setup>>
 * <<oauth2login-sample-redirect-uri,Setting the redirect URI>>

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/oauth2/oauth2-resourceserver.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/oauth2/oauth2-resourceserver.adoc
@@ -31,7 +31,7 @@ image:{icondir}/number_1.png[] First, a user makes an unauthenticated request to
 image:{icondir}/number_2.png[] Spring Security's <<servlet-authorization-filtersecurityinterceptor,`FilterSecurityInterceptor`>> indicates that the unauthenticated request is __Denied__ by throwing an `AccessDeniedException`.
 
 image:{icondir}/number_3.png[] Since the user is not authenticated, <<servlet-exceptiontranslationfilter,`ExceptionTranslationFilter`>> initiates __Start Authentication__.
-The configured <<servlet-authentication-authenticationentrypoint,`AuthenticationEntryPoint`>> is an instance of {security-api-url}org/springframework/security/oauth2/server/resource/authentication/BearerTokenAuthenticationEntryPoint.html[`BearerTokenAuthenticationEntryPoint`] which sends a WWW-Authenticate header.
+The configured <<servlet-authentication-authenticationentrypoint,`AuthenticationEntryPoint`>> is an instance of {security-api-url}org/springframework/security/oauth2/server/resource/web/BearerTokenAuthenticationEntryPoint.html[`BearerTokenAuthenticationEntryPoint`] which sends a WWW-Authenticate header.
 The `RequestCache` is typically a `NullRequestCache` that does not save the request since the client is capable of replaying the requests it originally requested.
 
 When a client receives the `WWW-Authenticate: Bearer` header, it knows it should retry with a bearer token.

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/oauth2/oauth2-resourceserver.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/oauth2/oauth2-resourceserver.adoc
@@ -15,7 +15,7 @@ This section provides details on how Spring Security provides support for OAuth 
 
 [NOTE]
 ====
-Working samples for both {gh-samples-url}/boot/oauth2resourceserver[JWTs] and {gh-samples-url}/boot/oauth2resourceserver-opaque[Opaque Tokens] are available in the {gh-samples-url}[Spring Security repository].
+Working samples for both {gh-samples-url}/servlet/spring-boot/java/oauth2/resource-server/jwe[JWTs] and {gh-samples-url}/servlet/spring-boot/java/oauth2/resource-server/opaque[Opaque Tokens] are available in the {gh-samples-url}[Spring Security Samples repository].
 ====
 
 Let's take a look at how Bearer Token Authentication works within Spring Security.

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/saml2/saml2-login.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/saml2/saml2-login.adoc
@@ -16,7 +16,7 @@ This process is similar to the one started in 2017 for <<oauth2,Spring Security'
 
 [NOTE]
 ====
-A working sample for {gh-samples-url}/boot/saml2login[SAML 2.0 Login] is available in the {gh-samples-url}[Spring Security repository].
+A working sample for {gh-samples-url}/servlet/spring-boot/java/saml2-login[SAML 2.0 Login] is available in the {gh-samples-url}[Spring Security Samples repository].
 ====
 
 Let's take a look at how SAML 2.0 Relying Party Authentication works within Spring Security.

--- a/docs/manual/src/docs/asciidoc/_includes/servlet/saml2/saml2-login.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/servlet/saml2/saml2-login.adoc
@@ -363,7 +363,7 @@ class MyCustomSecurityConfiguration : WebSecurityConfigurerAdapter() {
 The above requires the role of `USER` for any URL that starts with `/messages/`.
 
 [[servlet-saml2login-relyingpartyregistrationrepository]]
-The second `@Bean` Spring Boot creates is a {security-api-url}org/springframework/security/saml2/provider/service/registration/RelyingPartyRegistrationRepository.html[`RelyingPartyRegistrationRepository`], which represents the asserting party and relying party metadata.
+The second `@Bean` Spring Boot creates is a {old-security-api-url}org/springframework/security/saml2/provider/service/registration/RelyingPartyRegistrationRepository.html[`RelyingPartyRegistrationRepository`], which represents the asserting party and relying party metadata.
 This includes things like the location of the SSO endpoint the relying party should use when requesting authentication from the asserting party.
 
 You can override the default by publishing your own `RelyingPartyRegistrationRepository` bean.
@@ -512,7 +512,7 @@ A relying party can be multi-tenant by registering more than one relying party i
 
 [[servlet-saml2login-relyingpartyregistration]]
 === RelyingPartyRegistration
-A {security-api-url}org/springframework/security/saml2/provider/service/registration/RelyingPartyRegistration.html[`RelyingPartyRegistration`]
+A {old-security-api-url}org/springframework/security/saml2/provider/service/registration/RelyingPartyRegistration.html[`RelyingPartyRegistration`]
 instance represents a link between an relying party and assering party's metadata.
 
 In a `RelyingPartyRegistration`, you can provide relying party metadata like its `Issuer` value, where it expects SAML Responses to be sent to, and any credentials that it owns for the purposes of signing or decrypting payloads.

--- a/docs/manual/src/docs/asciidoc/index.adoc
+++ b/docs/manual/src/docs/asciidoc/index.adoc
@@ -1,7 +1,6 @@
 = Spring Security Reference
 Ben Alex; Luke Taylor; Rob Winch; Gunnar Hillert; Joe Grandja; Jay Bryant; Eddú Meléndez; Josh Cummings; Dave Syer; Eleftheria Stein
 :include-dir: _includes
-:security-api-url: https://docs.spring.io/spring-security/site/docs/current/api/
 :source-indent: 0
 :tabsize: 4
 :toc: left


### PR DESCRIPTION
Update the docs to point to the new Spring Security Samples project.
Fix some broken links not related to the samples as well.
Add a link checker that can be used by running the `htmlSanityCheck` gradle task

Closes gh-9815, gh-9816, gh-9817, gh-9818, gh-9869

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
