### PR TITLE
CSRF Support with SameSite cookie

### DIFF
--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
@@ -117,10 +117,7 @@ public final class CsrfFilter extends OncePerRequestFilter {
 			filterChain.doFilter(request, response);
 			return;
 		}
-		String actualToken = request.getHeader(csrfToken.getHeaderName());
-		if (actualToken == null) {
-			actualToken = request.getParameter(csrfToken.getParameterName());
-		}
+		String actualToken = this.tokenRepository.readActualToken(request, csrfToken);
 		if (!equalsConstantTime(csrfToken.getToken(), actualToken)) {
 			this.logger.debug(
 					LogMessage.of(() -> "Invalid CSRF token found for " + UrlUtils.buildFullRequestUrl(request)));

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRepository.java
@@ -26,8 +26,8 @@ import javax.servlet.http.HttpSession;
  * {@link HttpSession}.
  *
  * @author Rob Winch
- * @see HttpSessionCsrfTokenRepository
  * @since 3.2
+ * @see HttpSessionCsrfTokenRepository
  */
 public interface CsrfTokenRepository {
 

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRepository.java
@@ -26,13 +26,14 @@ import javax.servlet.http.HttpSession;
  * {@link HttpSession}.
  *
  * @author Rob Winch
- * @since 3.2
  * @see HttpSessionCsrfTokenRepository
+ * @since 3.2
  */
 public interface CsrfTokenRepository {
 
 	/**
 	 * Generates a {@link CsrfToken}
+	 *
 	 * @param request the {@link HttpServletRequest} to use
 	 * @return the {@link CsrfToken} that was generated. Cannot be null.
 	 */
@@ -42,17 +43,34 @@ public interface CsrfTokenRepository {
 	 * Saves the {@link CsrfToken} using the {@link HttpServletRequest} and
 	 * {@link HttpServletResponse}. If the {@link CsrfToken} is null, it is the same as
 	 * deleting it.
-	 * @param token the {@link CsrfToken} to save or null to delete
-	 * @param request the {@link HttpServletRequest} to use
+	 *
+	 * @param token    the {@link CsrfToken} to save or null to delete
+	 * @param request  the {@link HttpServletRequest} to use
 	 * @param response the {@link HttpServletResponse} to use
 	 */
 	void saveToken(CsrfToken token, HttpServletRequest request, HttpServletResponse response);
 
 	/**
 	 * Loads the expected {@link CsrfToken} from the {@link HttpServletRequest}
+	 *
 	 * @param request the {@link HttpServletRequest} to use
 	 * @return the {@link CsrfToken} or null if none exists
 	 */
 	CsrfToken loadToken(HttpServletRequest request);
+
+	/**
+	 * reads actual token from request, by default this method will read header and parameter for token value
+	 *
+	 * @param request
+	 * @param csrfToken
+	 * @return
+	 */
+	default String readActualToken(HttpServletRequest request, CsrfToken csrfToken) {
+		String actualToken = request.getHeader(csrfToken.getHeaderName());
+		if (actualToken == null) {
+			actualToken = request.getParameter(csrfToken.getParameterName());
+		}
+		return actualToken;
+	}
 
 }

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRepository.java
@@ -33,7 +33,6 @@ public interface CsrfTokenRepository {
 
 	/**
 	 * Generates a {@link CsrfToken}
-	 *
 	 * @param request the {@link HttpServletRequest} to use
 	 * @return the {@link CsrfToken} that was generated. Cannot be null.
 	 */
@@ -43,24 +42,22 @@ public interface CsrfTokenRepository {
 	 * Saves the {@link CsrfToken} using the {@link HttpServletRequest} and
 	 * {@link HttpServletResponse}. If the {@link CsrfToken} is null, it is the same as
 	 * deleting it.
-	 *
-	 * @param token    the {@link CsrfToken} to save or null to delete
-	 * @param request  the {@link HttpServletRequest} to use
+	 * @param token the {@link CsrfToken} to save or null to delete
+	 * @param request the {@link HttpServletRequest} to use
 	 * @param response the {@link HttpServletResponse} to use
 	 */
 	void saveToken(CsrfToken token, HttpServletRequest request, HttpServletResponse response);
 
 	/**
 	 * Loads the expected {@link CsrfToken} from the {@link HttpServletRequest}
-	 *
 	 * @param request the {@link HttpServletRequest} to use
 	 * @return the {@link CsrfToken} or null if none exists
 	 */
 	CsrfToken loadToken(HttpServletRequest request);
 
 	/**
-	 * reads actual token from request, by default this method will read header and parameter for token value
-	 *
+	 * reads actual token from request, by default this method will read header and
+	 * parameter for token value
 	 * @param request
 	 * @param csrfToken
 	 * @return

--- a/web/src/main/java/org/springframework/security/web/csrf/SameSiteCookieCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/SameSiteCookieCsrfTokenRepository.java
@@ -28,11 +28,10 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.web.util.WebUtils;
 
-
 /**
  * A {@link CsrfTokenRepository} that persists the CSRF token in a cookie named
- * "XSRF-TOKEN" which has sameSite attribute and reads the same cookie. SameSite
- * prevents the browser from sending this cookie along with cross-site requests.
+ * "XSRF-TOKEN" which has sameSite attribute and reads the same cookie. SameSite prevents
+ * the browser from sending this cookie along with cross-site requests.
  *
  * @author gajendra.jatav
  */
@@ -78,11 +77,9 @@ public class SameSiteCookieCsrfTokenRepository implements CsrfTokenRepository {
 	public void saveToken(CsrfToken token, HttpServletRequest request, HttpServletResponse response) {
 		String tokenValue = (token != null) ? token.getToken() : "";
 		ResponseCookie.ResponseCookieBuilder cookieBuilder = ResponseCookie.from(this.cookieName, tokenValue)
-				.sameSite(this.sameSite)
-				.secure((this.secure != null) ? this.secure : request.isSecure())
+				.sameSite(this.sameSite).secure((this.secure != null) ? this.secure : request.isSecure())
 				.path(StringUtils.hasLength(this.cookiePath) ? this.cookiePath : this.getRequestContext(request))
-				.maxAge((token != null) ? this.cookieMaxAge : 0)
-				.httpOnly(this.cookieHttpOnly);
+				.maxAge((token != null) ? this.cookieMaxAge : 0).httpOnly(this.cookieHttpOnly);
 
 		if (StringUtils.hasLength(this.cookieDomain)) {
 			cookieBuilder.domain(this.cookieDomain);
@@ -116,12 +113,10 @@ public class SameSiteCookieCsrfTokenRepository implements CsrfTokenRepository {
 		return token;
 	}
 
-
 	/**
 	 * Sets the name of the HTTP request parameter that should be used to provide a token.
-	 *
 	 * @param parameterName the name of the HTTP request parameter that should be used to
-	 *                      provide a token
+	 * provide a token
 	 */
 	public void setParameterName(String parameterName) {
 		Assert.notNull(parameterName, "parameterName cannot be null");
@@ -130,9 +125,8 @@ public class SameSiteCookieCsrfTokenRepository implements CsrfTokenRepository {
 
 	/**
 	 * Sets the name of the HTTP header that should be used to provide the token.
-	 *
 	 * @param headerName the name of the HTTP header that should be used to provide the
-	 *                   token
+	 * token
 	 */
 	public void setHeaderName(String headerName) {
 		Assert.notNull(headerName, "headerName cannot be null");
@@ -141,9 +135,8 @@ public class SameSiteCookieCsrfTokenRepository implements CsrfTokenRepository {
 
 	/**
 	 * Sets the name of the cookie that the expected CSRF token is saved to and read from.
-	 *
 	 * @param cookieName the name of the cookie that the expected CSRF token is saved to
-	 *                   and read from
+	 * and read from
 	 */
 	public void setCookieName(String cookieName) {
 		Assert.notNull(cookieName, "cookieName cannot be null");
@@ -153,9 +146,8 @@ public class SameSiteCookieCsrfTokenRepository implements CsrfTokenRepository {
 	/**
 	 * Sets the HttpOnly attribute on the cookie containing the CSRF token. Defaults to
 	 * <code>true</code>.
-	 *
 	 * @param cookieHttpOnly <code>true</code> sets the HttpOnly attribute,
-	 *                       <code>false</code> does not set it
+	 * <code>false</code> does not set it
 	 */
 	public void setCookieHttpOnly(boolean cookieHttpOnly) {
 		this.cookieHttpOnly = cookieHttpOnly;
@@ -169,7 +161,6 @@ public class SameSiteCookieCsrfTokenRepository implements CsrfTokenRepository {
 	/**
 	 * Sets the SameSite attribute on the cookie containing the CSRF token. Defaults to
 	 * <code>Lax</code>.
-	 *
 	 * @param sameSite
 	 */
 	public void setSameSite(String sameSite) {
@@ -186,7 +177,6 @@ public class SameSiteCookieCsrfTokenRepository implements CsrfTokenRepository {
 	/**
 	 * Set the path that the Cookie will be created with. This will override the default
 	 * functionality which uses the request context as the path.
-	 *
 	 * @param path the path to use
 	 */
 	public void setCookiePath(String path) {
@@ -195,7 +185,6 @@ public class SameSiteCookieCsrfTokenRepository implements CsrfTokenRepository {
 
 	/**
 	 * Get the path that the CSRF cookie will be set to.
-	 *
 	 * @return the path to be used.
 	 */
 	public String getCookiePath() {
@@ -205,9 +194,8 @@ public class SameSiteCookieCsrfTokenRepository implements CsrfTokenRepository {
 	/**
 	 * Sets the domain of the cookie that the expected CSRF token is saved to and read
 	 * from.
-	 *
 	 * @param cookieDomain the domain of the cookie that the expected CSRF token is saved
-	 *                     to and read from
+	 * to and read from
 	 * @since 5.2
 	 */
 	public void setCookieDomain(String cookieDomain) {
@@ -217,9 +205,8 @@ public class SameSiteCookieCsrfTokenRepository implements CsrfTokenRepository {
 	/**
 	 * Sets secure flag of the cookie that the expected CSRF token is saved to and read
 	 * from. By default secure flag depends on {@link ServletRequest#isSecure()}
-	 *
 	 * @param secure the secure flag of the cookie that the expected CSRF token is saved
-	 *               to and read from
+	 * to and read from
 	 * @since 5.4
 	 */
 	public void setSecure(Boolean secure) {
@@ -242,10 +229,9 @@ public class SameSiteCookieCsrfTokenRepository implements CsrfTokenRepository {
 	 * <p>
 	 * A zero value causes the cookie to be deleted immediately therefore it is not a
 	 * valid value and in that case an {@link IllegalArgumentException} will be thrown.
-	 *
 	 * @param cookieMaxAge an integer specifying the maximum age of the cookie in seconds;
-	 *                     if negative, means the cookie is not stored; if zero, the method throws an
-	 *                     {@link IllegalArgumentException}
+	 * if negative, means the cookie is not stored; if zero, the method throws an
+	 * {@link IllegalArgumentException}
 	 * @since 5.5
 	 */
 	public void setCookieMaxAge(int cookieMaxAge) {

--- a/web/src/main/java/org/springframework/security/web/csrf/SameSiteCookieCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/SameSiteCookieCsrfTokenRepository.java
@@ -1,15 +1,33 @@
+/*
+ * Copyright 2012-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.security.web.csrf;
+
+import java.util.UUID;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.http.ResponseCookie;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.web.util.WebUtils;
 
-import javax.servlet.ServletRequest;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.util.UUID;
 
 /**
  * A {@link CsrfTokenRepository} that persists the CSRF token in a cookie named
@@ -155,7 +173,7 @@ public class SameSiteCookieCsrfTokenRepository implements CsrfTokenRepository {
 	 * @param sameSite
 	 */
 	public void setSameSite(String sameSite) {
-		Assert.notNull(cookieName, "sameSite cannot be null");
+		Assert.notNull(sameSite, "sameSite cannot be null");
 		Assert.isTrue(sameSite.equals(SAME_SITE_LAX) || sameSite.equals(SAME_SITE_STRICT),
 				"sameSite should be either set to Lax or Strict");
 		this.sameSite = sameSite;

--- a/web/src/main/java/org/springframework/security/web/csrf/SameSiteCookieCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/SameSiteCookieCsrfTokenRepository.java
@@ -1,0 +1,238 @@
+package org.springframework.security.web.csrf;
+
+import org.springframework.http.ResponseCookie;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.WebUtils;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.UUID;
+
+/**
+ * A {@link CsrfTokenRepository} that persists the CSRF token in a cookie named
+ * "XSRF-TOKEN" which has sameSite attribute and reads the same cookie. SameSite
+ * prevents the browser from sending this cookie along with cross-site requests.
+ *
+ * @author gajendra.jatav
+ */
+public class SameSiteCookieCsrfTokenRepository implements CsrfTokenRepository {
+
+	static final String DEFAULT_CSRF_COOKIE_NAME = "XSRF-TOKEN";
+
+	static final String DEFAULT_CSRF_PARAMETER_NAME = "_csrf";
+
+	static final String DEFAULT_CSRF_HEADER_NAME = "X-XSRF-TOKEN";
+
+	static final String SAME_SITE_LAX = "Lax";
+
+	static final String SAME_SITE_STRICT = "Strict";
+
+	private String parameterName = DEFAULT_CSRF_PARAMETER_NAME;
+
+	private String headerName = DEFAULT_CSRF_HEADER_NAME;
+
+	private String cookieName = DEFAULT_CSRF_COOKIE_NAME;
+
+	private boolean cookieHttpOnly = true;
+
+	private String cookiePath;
+
+	private String cookieDomain;
+
+	private Boolean secure;
+
+	private int cookieMaxAge = -1;
+
+	private String sameSite = SAME_SITE_LAX;
+
+	public SameSiteCookieCsrfTokenRepository() {
+	}
+
+	@Override
+	public CsrfToken generateToken(HttpServletRequest request) {
+		return new DefaultCsrfToken(this.headerName, this.parameterName, createNewToken());
+	}
+
+	@Override
+	public void saveToken(CsrfToken token, HttpServletRequest request, HttpServletResponse response) {
+		String tokenValue = (token != null) ? token.getToken() : "";
+		ResponseCookie.ResponseCookieBuilder cookieBuilder = ResponseCookie.from(this.cookieName, tokenValue)
+				.sameSite(this.sameSite)
+				.secure((this.secure != null) ? this.secure : request.isSecure())
+				.path(StringUtils.hasLength(this.cookiePath) ? this.cookiePath : this.getRequestContext(request))
+				.maxAge((token != null) ? this.cookieMaxAge : 0)
+				.httpOnly(this.cookieHttpOnly);
+
+		if (StringUtils.hasLength(this.cookieDomain)) {
+			cookieBuilder.domain(this.cookieDomain);
+		}
+		response.addHeader("Set-Cookie", cookieBuilder.build().toString());
+	}
+
+	@Override
+	public CsrfToken loadToken(HttpServletRequest request) {
+		Cookie cookie = WebUtils.getCookie(request, this.cookieName);
+		if (cookie == null) {
+			return null;
+		}
+		String token = cookie.getValue();
+		if (!StringUtils.hasLength(token)) {
+			return null;
+		}
+		return new DefaultCsrfToken(this.headerName, this.parameterName, token);
+	}
+
+	@Override
+	public String readActualToken(HttpServletRequest request, CsrfToken csrfToken) {
+		Cookie cookie = WebUtils.getCookie(request, this.cookieName);
+		if (cookie == null) {
+			return null;
+		}
+		String token = cookie.getValue();
+		if (!StringUtils.hasLength(token)) {
+			return null;
+		}
+		return token;
+	}
+
+
+	/**
+	 * Sets the name of the HTTP request parameter that should be used to provide a token.
+	 *
+	 * @param parameterName the name of the HTTP request parameter that should be used to
+	 *                      provide a token
+	 */
+	public void setParameterName(String parameterName) {
+		Assert.notNull(parameterName, "parameterName cannot be null");
+		this.parameterName = parameterName;
+	}
+
+	/**
+	 * Sets the name of the HTTP header that should be used to provide the token.
+	 *
+	 * @param headerName the name of the HTTP header that should be used to provide the
+	 *                   token
+	 */
+	public void setHeaderName(String headerName) {
+		Assert.notNull(headerName, "headerName cannot be null");
+		this.headerName = headerName;
+	}
+
+	/**
+	 * Sets the name of the cookie that the expected CSRF token is saved to and read from.
+	 *
+	 * @param cookieName the name of the cookie that the expected CSRF token is saved to
+	 *                   and read from
+	 */
+	public void setCookieName(String cookieName) {
+		Assert.notNull(cookieName, "cookieName cannot be null");
+		this.cookieName = cookieName;
+	}
+
+	/**
+	 * Sets the HttpOnly attribute on the cookie containing the CSRF token. Defaults to
+	 * <code>true</code>.
+	 *
+	 * @param cookieHttpOnly <code>true</code> sets the HttpOnly attribute,
+	 *                       <code>false</code> does not set it
+	 */
+	public void setCookieHttpOnly(boolean cookieHttpOnly) {
+		this.cookieHttpOnly = cookieHttpOnly;
+	}
+
+	private String getRequestContext(HttpServletRequest request) {
+		String contextPath = request.getContextPath();
+		return (contextPath.length() > 0) ? contextPath : "/";
+	}
+
+	/**
+	 * Sets the SameSite attribute on the cookie containing the CSRF token. Defaults to
+	 * <code>Lax</code>.
+	 *
+	 * @param sameSite
+	 */
+	public void setSameSite(String sameSite) {
+		Assert.notNull(cookieName, "sameSite cannot be null");
+		Assert.isTrue(sameSite.equals(SAME_SITE_LAX) || sameSite.equals(SAME_SITE_STRICT),
+				"sameSite should be either set to Lax or Strict");
+		this.sameSite = sameSite;
+	}
+
+	private String createNewToken() {
+		return UUID.randomUUID().toString();
+	}
+
+	/**
+	 * Set the path that the Cookie will be created with. This will override the default
+	 * functionality which uses the request context as the path.
+	 *
+	 * @param path the path to use
+	 */
+	public void setCookiePath(String path) {
+		this.cookiePath = path;
+	}
+
+	/**
+	 * Get the path that the CSRF cookie will be set to.
+	 *
+	 * @return the path to be used.
+	 */
+	public String getCookiePath() {
+		return this.cookiePath;
+	}
+
+	/**
+	 * Sets the domain of the cookie that the expected CSRF token is saved to and read
+	 * from.
+	 *
+	 * @param cookieDomain the domain of the cookie that the expected CSRF token is saved
+	 *                     to and read from
+	 * @since 5.2
+	 */
+	public void setCookieDomain(String cookieDomain) {
+		this.cookieDomain = cookieDomain;
+	}
+
+	/**
+	 * Sets secure flag of the cookie that the expected CSRF token is saved to and read
+	 * from. By default secure flag depends on {@link ServletRequest#isSecure()}
+	 *
+	 * @param secure the secure flag of the cookie that the expected CSRF token is saved
+	 *               to and read from
+	 * @since 5.4
+	 */
+	public void setSecure(Boolean secure) {
+		this.secure = secure;
+	}
+
+	/**
+	 * Sets maximum age in seconds for the cookie that the expected CSRF token is saved to
+	 * and read from. By default maximum age value is -1.
+	 *
+	 * <p>
+	 * A positive value indicates that the cookie will expire after that many seconds have
+	 * passed. Note that the value is the <i>maximum</i> age when the cookie will expire,
+	 * not the cookie's current age.
+	 *
+	 * <p>
+	 * A negative value means that the cookie is not stored persistently and will be
+	 * deleted when the Web browser exits.
+	 *
+	 * <p>
+	 * A zero value causes the cookie to be deleted immediately therefore it is not a
+	 * valid value and in that case an {@link IllegalArgumentException} will be thrown.
+	 *
+	 * @param cookieMaxAge an integer specifying the maximum age of the cookie in seconds;
+	 *                     if negative, means the cookie is not stored; if zero, the method throws an
+	 *                     {@link IllegalArgumentException}
+	 * @since 5.5
+	 */
+	public void setCookieMaxAge(int cookieMaxAge) {
+		Assert.isTrue(cookieMaxAge != 0, "cookieMaxAge cannot be zero");
+		this.cookieMaxAge = cookieMaxAge;
+	}
+
+}

--- a/web/src/test/java/org/springframework/security/web/csrf/CsrfFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CsrfFilterTests.java
@@ -195,7 +195,7 @@ public class CsrfFilterTests {
 	public void doFilterIsCsrfRequestExistingTokenHeader() throws ServletException, IOException {
 		given(this.requestMatcher.matches(this.request)).willReturn(true);
 		given(this.tokenRepository.loadToken(this.request)).willReturn(this.token);
-		given(this.tokenRepository.readActualToken(this.request, this.token)).willReturn(this.token.getToken());
+		given(this.tokenRepository.readActualToken(this.request, this.token)).willCallRealMethod();
 		this.request.addHeader(this.token.getHeaderName(), this.token.getToken());
 		this.filter.doFilter(this.request, this.response, this.filterChain);
 		assertThat(this.request.getAttribute(this.token.getParameterName())).isEqualTo(this.token);
@@ -209,7 +209,7 @@ public class CsrfFilterTests {
 			throws ServletException, IOException {
 		given(this.requestMatcher.matches(this.request)).willReturn(true);
 		given(this.tokenRepository.loadToken(this.request)).willReturn(this.token);
-		given(this.tokenRepository.readActualToken(this.request, this.token)).willReturn(this.token.getToken());
+		given(this.tokenRepository.readActualToken(this.request, this.token)).willCallRealMethod();
 		this.request.setParameter(this.token.getParameterName(), this.token.getToken() + " INVALID");
 		this.request.addHeader(this.token.getHeaderName(), this.token.getToken());
 		this.filter.doFilter(this.request, this.response, this.filterChain);
@@ -223,7 +223,7 @@ public class CsrfFilterTests {
 	public void doFilterIsCsrfRequestExistingToken() throws ServletException, IOException {
 		given(this.requestMatcher.matches(this.request)).willReturn(true);
 		given(this.tokenRepository.loadToken(this.request)).willReturn(this.token);
-		given(this.tokenRepository.readActualToken(this.request, this.token)).willReturn(this.token.getToken());
+		given(this.tokenRepository.readActualToken(this.request, this.token)).willCallRealMethod();
 		this.request.setParameter(this.token.getParameterName(), this.token.getToken());
 		this.filter.doFilter(this.request, this.response, this.filterChain);
 		assertThat(this.request.getAttribute(this.token.getParameterName())).isEqualTo(this.token);
@@ -238,7 +238,7 @@ public class CsrfFilterTests {
 	public void doFilterIsCsrfRequestGenerateToken() throws ServletException, IOException {
 		given(this.requestMatcher.matches(this.request)).willReturn(true);
 		given(this.tokenRepository.generateToken(this.request)).willReturn(this.token);
-		given(this.tokenRepository.readActualToken(this.request, this.token)).willReturn(this.token.getToken());
+		given(this.tokenRepository.readActualToken(this.request, this.token)).willCallRealMethod();
 		this.request.setParameter(this.token.getParameterName(), this.token.getToken());
 		this.filter.doFilter(this.request, this.response, this.filterChain);
 		assertToken(this.request.getAttribute(this.token.getParameterName())).isEqualTo(this.token);
@@ -333,6 +333,7 @@ public class CsrfFilterTests {
 		given(token.getHeaderName()).willReturn(this.token.getHeaderName());
 		given(token.getParameterName()).willReturn(this.token.getParameterName());
 		given(this.tokenRepository.loadToken(this.request)).willReturn(token);
+		given(this.tokenRepository.readActualToken(this.request, token)).willCallRealMethod();
 		given(this.requestMatcher.matches(this.request)).willReturn(true);
 		filter.doFilterInternal(this.request, this.response, this.filterChain);
 		assertThat(this.response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);

--- a/web/src/test/java/org/springframework/security/web/csrf/CsrfFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CsrfFilterTests.java
@@ -195,6 +195,7 @@ public class CsrfFilterTests {
 	public void doFilterIsCsrfRequestExistingTokenHeader() throws ServletException, IOException {
 		given(this.requestMatcher.matches(this.request)).willReturn(true);
 		given(this.tokenRepository.loadToken(this.request)).willReturn(this.token);
+		given(this.tokenRepository.readActualToken(this.request, this.token)).willReturn(this.token.getToken());
 		this.request.addHeader(this.token.getHeaderName(), this.token.getToken());
 		this.filter.doFilter(this.request, this.response, this.filterChain);
 		assertThat(this.request.getAttribute(this.token.getParameterName())).isEqualTo(this.token);
@@ -208,6 +209,7 @@ public class CsrfFilterTests {
 			throws ServletException, IOException {
 		given(this.requestMatcher.matches(this.request)).willReturn(true);
 		given(this.tokenRepository.loadToken(this.request)).willReturn(this.token);
+		given(this.tokenRepository.readActualToken(this.request, this.token)).willReturn(this.token.getToken());
 		this.request.setParameter(this.token.getParameterName(), this.token.getToken() + " INVALID");
 		this.request.addHeader(this.token.getHeaderName(), this.token.getToken());
 		this.filter.doFilter(this.request, this.response, this.filterChain);
@@ -221,6 +223,7 @@ public class CsrfFilterTests {
 	public void doFilterIsCsrfRequestExistingToken() throws ServletException, IOException {
 		given(this.requestMatcher.matches(this.request)).willReturn(true);
 		given(this.tokenRepository.loadToken(this.request)).willReturn(this.token);
+		given(this.tokenRepository.readActualToken(this.request, this.token)).willReturn(this.token.getToken());
 		this.request.setParameter(this.token.getParameterName(), this.token.getToken());
 		this.filter.doFilter(this.request, this.response, this.filterChain);
 		assertThat(this.request.getAttribute(this.token.getParameterName())).isEqualTo(this.token);
@@ -235,6 +238,7 @@ public class CsrfFilterTests {
 	public void doFilterIsCsrfRequestGenerateToken() throws ServletException, IOException {
 		given(this.requestMatcher.matches(this.request)).willReturn(true);
 		given(this.tokenRepository.generateToken(this.request)).willReturn(this.token);
+		given(this.tokenRepository.readActualToken(this.request, this.token)).willReturn(this.token.getToken());
 		this.request.setParameter(this.token.getParameterName(), this.token.getToken());
 		this.filter.doFilter(this.request, this.response, this.filterChain);
 		assertToken(this.request.getAttribute(this.token.getParameterName())).isEqualTo(this.token);

--- a/web/src/test/java/org/springframework/security/web/csrf/SameSiteCookieCsrfTokenRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/SameSiteCookieCsrfTokenRepositoryTests.java
@@ -1,0 +1,244 @@
+package org.springframework.security.web.csrf;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockCookie;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.servlet.http.Cookie;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * @author gajendra.jatav
+ */
+public class SameSiteCookieCsrfTokenRepositoryTests {
+
+	SameSiteCookieCsrfTokenRepository repository;
+
+	MockHttpServletResponse response;
+
+	MockHttpServletRequest request;
+
+	@Before
+	public void setup() {
+		this.repository = new SameSiteCookieCsrfTokenRepository();
+		this.request = new MockHttpServletRequest();
+		this.response = new MockHttpServletResponse();
+		this.request.setContextPath("/context");
+	}
+
+	@Test
+	public void generateToken() {
+		CsrfToken generateToken = this.repository.generateToken(this.request);
+		assertThat(generateToken).isNotNull();
+		assertThat(generateToken.getHeaderName()).isEqualTo(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_HEADER_NAME);
+		assertThat(generateToken.getParameterName()).isEqualTo(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_PARAMETER_NAME);
+		assertThat(generateToken.getToken()).isNotEmpty();
+	}
+
+	@Test
+	public void generateTokenCustom() {
+		String headerName = "headerName";
+		String parameterName = "paramName";
+		this.repository.setHeaderName(headerName);
+		this.repository.setParameterName(parameterName);
+		CsrfToken generateToken = this.repository.generateToken(this.request);
+		assertThat(generateToken).isNotNull();
+		assertThat(generateToken.getHeaderName()).isEqualTo(headerName);
+		assertThat(generateToken.getParameterName()).isEqualTo(parameterName);
+		assertThat(generateToken.getToken()).isNotEmpty();
+	}
+
+	@Test
+	public void saveToken() {
+		CsrfToken token = this.repository.generateToken(this.request);
+		this.repository.saveToken(token, this.request, this.response);
+		MockCookie tokenCookie = (MockCookie) this.response.getCookie(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+		assertThat(tokenCookie.getSameSite()).isEqualTo(SameSiteCookieCsrfTokenRepository.SAME_SITE_LAX);
+		assertThat(tokenCookie.getMaxAge()).isEqualTo(-1);
+		assertThat(tokenCookie.getName()).isEqualTo(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+		assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
+		assertThat(tokenCookie.getSecure()).isEqualTo(this.request.isSecure());
+		assertThat(tokenCookie.getValue()).isEqualTo(token.getToken());
+		assertThat(tokenCookie.isHttpOnly()).isTrue();
+	}
+
+	@Test
+	public void saveTokenSecure() {
+		this.request.setSecure(true);
+		CsrfToken token = this.repository.generateToken(this.request);
+		this.repository.saveToken(token, this.request, this.response);
+		Cookie tokenCookie = this.response.getCookie(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+		assertThat(tokenCookie.getSecure()).isTrue();
+	}
+
+	@Test
+	public void saveTokenSecureFlagTrue() {
+		this.request.setSecure(false);
+		this.repository.setSecure(Boolean.TRUE);
+		CsrfToken token = this.repository.generateToken(this.request);
+		this.repository.saveToken(token, this.request, this.response);
+		Cookie tokenCookie = this.response.getCookie(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+		assertThat(tokenCookie.getSecure()).isTrue();
+	}
+
+	@Test
+	public void saveTokenSecureFlagFalse() {
+		this.request.setSecure(true);
+		this.repository.setSecure(Boolean.FALSE);
+		CsrfToken token = this.repository.generateToken(this.request);
+		this.repository.saveToken(token, this.request, this.response);
+		Cookie tokenCookie = this.response.getCookie(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+		assertThat(tokenCookie.getSecure()).isFalse();
+	}
+
+	@Test
+	public void saveTokenNull() {
+		this.request.setSecure(true);
+		this.repository.saveToken(null, this.request, this.response);
+		MockCookie tokenCookie = (MockCookie) this.response.getCookie(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+		assertThat(tokenCookie.getSameSite()).isEqualTo(SameSiteCookieCsrfTokenRepository.SAME_SITE_LAX);
+		assertThat(tokenCookie.getMaxAge()).isZero();
+		assertThat(tokenCookie.getName()).isEqualTo(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+		assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
+		assertThat(tokenCookie.getSecure()).isEqualTo(this.request.isSecure());
+		assertThat(tokenCookie.getValue()).isEmpty();
+	}
+
+	@Test
+	public void saveTokenHttpOnlyTrue() {
+		this.repository.setCookieHttpOnly(true);
+		CsrfToken token = this.repository.generateToken(this.request);
+		this.repository.saveToken(token, this.request, this.response);
+		Cookie tokenCookie = this.response.getCookie(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+		assertThat(tokenCookie.isHttpOnly()).isTrue();
+	}
+
+	@Test
+	public void saveTokenHttpOnlyFalse() {
+		this.repository.setCookieHttpOnly(false);
+		CsrfToken token = this.repository.generateToken(this.request);
+		this.repository.saveToken(token, this.request, this.response);
+		Cookie tokenCookie = this.response.getCookie(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+		assertThat(tokenCookie.isHttpOnly()).isFalse();
+	}
+
+	@Test
+	public void saveTokenCustomPath() {
+		String customPath = "/custompath";
+		this.repository.setCookiePath(customPath);
+		CsrfToken token = this.repository.generateToken(this.request);
+		this.repository.saveToken(token, this.request, this.response);
+		Cookie tokenCookie = this.response.getCookie(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+		assertThat(tokenCookie.getPath()).isEqualTo(this.repository.getCookiePath());
+	}
+
+	@Test
+	public void saveTokenEmptyCustomPath() {
+		String customPath = "";
+		this.repository.setCookiePath(customPath);
+		CsrfToken token = this.repository.generateToken(this.request);
+		this.repository.saveToken(token, this.request, this.response);
+		Cookie tokenCookie = this.response.getCookie(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+		assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
+	}
+
+	@Test
+	public void saveTokenNullCustomPath() {
+		String customPath = null;
+		this.repository.setCookiePath(customPath);
+		CsrfToken token = this.repository.generateToken(this.request);
+		this.repository.saveToken(token, this.request, this.response);
+		Cookie tokenCookie = this.response.getCookie(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+		assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
+	}
+
+	@Test
+	public void saveTokenWithCookieDomain() {
+		String domainName = "example.com";
+		this.repository.setCookieDomain(domainName);
+		CsrfToken token = this.repository.generateToken(this.request);
+		this.repository.saveToken(token, this.request, this.response);
+		Cookie tokenCookie = this.response.getCookie(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+		assertThat(tokenCookie.getDomain()).isEqualTo(domainName);
+	}
+
+	@Test
+	public void saveTokenWithCookieMaxAge() {
+		int maxAge = 1200;
+		this.repository.setCookieMaxAge(maxAge);
+		CsrfToken token = this.repository.generateToken(this.request);
+		this.repository.saveToken(token, this.request, this.response);
+		Cookie tokenCookie = this.response.getCookie(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+		assertThat(tokenCookie.getMaxAge()).isEqualTo(maxAge);
+	}
+
+	@Test
+	public void loadTokenNoCookiesNull() {
+		assertThat(this.repository.loadToken(this.request)).isNull();
+	}
+
+	@Test
+	public void loadTokenCookieIncorrectNameNull() {
+		this.request.setCookies(new Cookie("other", "name"));
+		assertThat(this.repository.loadToken(this.request)).isNull();
+	}
+
+	@Test
+	public void loadTokenCookieValueEmptyString() {
+		this.request.setCookies(new Cookie(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME, ""));
+		assertThat(this.repository.loadToken(this.request)).isNull();
+	}
+
+	@Test
+	public void loadToken() {
+		CsrfToken generateToken = this.repository.generateToken(this.request);
+		this.request
+				.setCookies(new Cookie(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME, generateToken.getToken()));
+		CsrfToken loadToken = this.repository.loadToken(this.request);
+		assertThat(loadToken).isNotNull();
+		assertThat(loadToken.getHeaderName()).isEqualTo(generateToken.getHeaderName());
+		assertThat(loadToken.getParameterName()).isEqualTo(generateToken.getParameterName());
+		assertThat(loadToken.getToken()).isNotEmpty();
+	}
+
+	@Test
+	public void loadTokenCustom() {
+		String cookieName = "cookieName";
+		String value = "value";
+		String headerName = "headerName";
+		String parameterName = "paramName";
+		this.repository.setHeaderName(headerName);
+		this.repository.setParameterName(parameterName);
+		this.repository.setCookieName(cookieName);
+		this.request.setCookies(new Cookie(cookieName, value));
+		CsrfToken loadToken = this.repository.loadToken(this.request);
+		assertThat(loadToken).isNotNull();
+		assertThat(loadToken.getHeaderName()).isEqualTo(headerName);
+		assertThat(loadToken.getParameterName()).isEqualTo(parameterName);
+		assertThat(loadToken.getToken()).isEqualTo(value);
+	}
+
+	@Test
+	public void setCookieNameNullIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.repository.setCookieName(null));
+	}
+
+	@Test
+	public void setParameterNameNullIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.repository.setParameterName(null));
+	}
+
+	@Test
+	public void setHeaderNameNullIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.repository.setHeaderName(null));
+	}
+
+	@Test
+	public void setCookieMaxAgeZeroIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.repository.setCookieMaxAge(0));
+	}
+}

--- a/web/src/test/java/org/springframework/security/web/csrf/SameSiteCookieCsrfTokenRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/SameSiteCookieCsrfTokenRepositoryTests.java
@@ -52,7 +52,8 @@ public class SameSiteCookieCsrfTokenRepositoryTests {
 		CsrfToken generateToken = this.repository.generateToken(this.request);
 		assertThat(generateToken).isNotNull();
 		assertThat(generateToken.getHeaderName()).isEqualTo(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_HEADER_NAME);
-		assertThat(generateToken.getParameterName()).isEqualTo(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_PARAMETER_NAME);
+		assertThat(generateToken.getParameterName())
+				.isEqualTo(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_PARAMETER_NAME);
 		assertThat(generateToken.getToken()).isNotEmpty();
 	}
 
@@ -73,7 +74,8 @@ public class SameSiteCookieCsrfTokenRepositoryTests {
 	public void saveToken() {
 		CsrfToken token = this.repository.generateToken(this.request);
 		this.repository.saveToken(token, this.request, this.response);
-		MockCookie tokenCookie = (MockCookie) this.response.getCookie(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+		MockCookie tokenCookie = (MockCookie) this.response
+				.getCookie(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
 		assertThat(tokenCookie.getSameSite()).isEqualTo(SameSiteCookieCsrfTokenRepository.SAME_SITE_LAX);
 		assertThat(tokenCookie.getMaxAge()).isEqualTo(-1);
 		assertThat(tokenCookie.getName()).isEqualTo(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
@@ -116,7 +118,8 @@ public class SameSiteCookieCsrfTokenRepositoryTests {
 	public void saveTokenNull() {
 		this.request.setSecure(true);
 		this.repository.saveToken(null, this.request, this.response);
-		MockCookie tokenCookie = (MockCookie) this.response.getCookie(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
+		MockCookie tokenCookie = (MockCookie) this.response
+				.getCookie(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
 		assertThat(tokenCookie.getSameSite()).isEqualTo(SameSiteCookieCsrfTokenRepository.SAME_SITE_LAX);
 		assertThat(tokenCookie.getMaxAge()).isZero();
 		assertThat(tokenCookie.getName()).isEqualTo(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
@@ -213,8 +216,8 @@ public class SameSiteCookieCsrfTokenRepositoryTests {
 	@Test
 	public void loadToken() {
 		CsrfToken generateToken = this.repository.generateToken(this.request);
-		this.request
-				.setCookies(new Cookie(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME, generateToken.getToken()));
+		this.request.setCookies(
+				new Cookie(SameSiteCookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME, generateToken.getToken()));
 		CsrfToken loadToken = this.repository.loadToken(this.request);
 		assertThat(loadToken).isNotNull();
 		assertThat(loadToken.getHeaderName()).isEqualTo(generateToken.getHeaderName());
@@ -258,4 +261,5 @@ public class SameSiteCookieCsrfTokenRepositoryTests {
 	public void setCookieMaxAgeZeroIllegalArgumentException() {
 		assertThatIllegalArgumentException().isThrownBy(() -> this.repository.setCookieMaxAge(0));
 	}
+
 }

--- a/web/src/test/java/org/springframework/security/web/csrf/SameSiteCookieCsrfTokenRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/SameSiteCookieCsrfTokenRepositoryTests.java
@@ -1,12 +1,29 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.security.web.csrf;
+
+import javax.servlet.http.Cookie;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.mock.web.MockCookie;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-
-import javax.servlet.http.Cookie;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;


### PR DESCRIPTION
Fix for  #7537
I've added CsrfTokenRepository SameSiteCookieCsrfTokenRepository that persists the CSRF token in a cookie named "XSRF-TOKEN" which has sameSite attribute and reads the same cookie. SameSite prevents the browser from sending this cookie along with cross-site requests.  