### PR TITLE
Add insufficient authentication message for French

### DIFF
--- a/core/src/main/resources/org/springframework/security/messages_fr.properties
+++ b/core/src/main/resources/org/springframework/security/messages_fr.properties
@@ -49,3 +49,4 @@ RunAsImplAuthenticationProvider.incorrectKey=Le RunAsUserToken pr\u00E9sent\u00E
 SubjectDnX509PrincipalExtractor.noMatching=Aucun motif concordant n''a \u00E9t\u00E9 trouv\u00E9 dans le subjectDN\: {0}
 SwitchUserFilter.noCurrentUser=Aucun utilisateur n''est associ\u00E9 \u00E0 la requ\u00EAte en cours
 SwitchUserFilter.noOriginalAuthentication=L''objet Authentication original n''a pas \u00E9t\u00E9 trouv\u00E9
+ExceptionTranslationFilter.insufficientAuthentication=Une authentification compl\u00E8te est requise pour acc\u00E9der \u00E0 cette ressource


### PR DESCRIPTION
Partially fix gh-9315

This PR add french translation missing for ExceptionTranslationFilter.insufficientAuthentication in messages_fr.properties
