### PR TITLE
Added support for the CAS gateway feature.

### DIFF
--- a/cas/src/main/java/org/springframework/security/cas/authentication/TriggerCasGatewayException.java
+++ b/cas/src/main/java/org/springframework/security/cas/authentication/TriggerCasGatewayException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.cas.authentication;
+
+import org.springframework.security.cas.web.CasAuthenticationEntryPoint;
+import org.springframework.security.core.AuthenticationException;
+
+/**
+ * Exception used to indicate the {@link CasAuthenticationEntryPoint} to make a CAS gateway authentication request.
+ *
+ * @author Michael Remond
+ *
+ */
+public class TriggerCasGatewayException extends AuthenticationException {
+ 
+
+	private static final long serialVersionUID = 4864856111227081697L;
+
+	//~ Constructors ===================================================================================================
+
+	/**
+     * Constructs an {@code InitiateCasGatewayAuthenticationException} with the specified message and no root cause.
+     *
+     * @param msg the detail message
+     */
+    public TriggerCasGatewayException(String msg) {
+        super(msg);
+    }
+
+    /**
+     * Constructs an {@code InitiateCasGatewayAuthenticationException} with the specified message and root cause.
+     *
+     * @param msg the detail message
+     * @param t the root cause
+     */
+    public TriggerCasGatewayException(String msg, Throwable t) {
+        super(msg, t);
+    }
+
+}

--- a/cas/src/main/java/org/springframework/security/cas/web/CasCookieGatewayRequestMatcher.java
+++ b/cas/src/main/java/org/springframework/security/cas/web/CasCookieGatewayRequestMatcher.java
@@ -1,0 +1,131 @@
+package org.springframework.security.cas.web;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+import org.jasig.cas.client.authentication.DefaultGatewayResolverImpl;
+import org.jasig.cas.client.authentication.GatewayResolver;
+import org.springframework.security.cas.ServiceProperties;
+import org.springframework.security.cas.authentication.CasAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Default RequestMatcher implementation for the {@link TriggerCasGatewayFilter}.
+ * 
+ * This RequestMatcher returns <code>true</code> iff :
+ * <ul>
+ * <li>
+ * User is not already authenticated (see {@link #isAuthenticated})</li>
+ * <li>
+ * The request was not previously gatewayed</li>
+ * <li>
+ * The request matches additional criteria (see {@link #performGatewayAuthentication})</li>
+ * </ul>
+ * 
+ * Implementors can override this class to customize the authentication check and the gateway criteria.
+ * <p>
+ * The request is marked as "gatewayed" using the configured {@link GatewayResolver} to avoid infinite loop.
+ * 
+ * @author Michael Remond
+ * 
+ */
+public class CasCookieGatewayRequestMatcher implements RequestMatcher {
+
+    // ~ Instance fields
+    // ================================================================================================
+
+    private ServiceProperties serviceProperties;
+
+	private String cookieName;
+	
+    private GatewayResolver gatewayStorage = new DefaultGatewayResolverImpl();
+
+    // ~ Constructors
+    // ===================================================================================================
+
+    public CasCookieGatewayRequestMatcher(ServiceProperties serviceProperties, final String cookieName) {
+        Assert.notNull(serviceProperties, "serviceProperties cannot be null");
+        this.serviceProperties = serviceProperties;
+        this.cookieName = cookieName;
+    }
+
+    public final boolean matches(HttpServletRequest request) {
+
+        // Test if we are already authenticated
+        if (isAuthenticated(request)) {
+            return false;
+        }
+
+        // Test if the request was already gatewayed to avoid infinite loop
+        final boolean wasGatewayed = this.gatewayStorage.hasGatewayedAlready(request, serviceProperties.getService());
+
+        if (wasGatewayed) {
+            return false;
+        }
+
+        // If request matches gateway criteria, we mark the request as gatewayed and return true to trigger a CAS
+        // gateway authentication
+        if (performGatewayAuthentication(request)) {
+            gatewayStorage.storeGatewayInformation(request, serviceProperties.getService());
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Test if the user is authenticated in Spring Security. Default implementation test if the user is CAS
+     * authenticated.
+     * 
+     * @param request
+     * @return true if the user is authenticated
+     */
+    protected boolean isAuthenticated(HttpServletRequest request) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication instanceof CasAuthenticationToken;
+    }
+
+    /**
+     * Method that determines if the current request triggers a CAS gateway authentication.
+     * This implementation returns <code>true</code> only if a {@link Cookie} with the configured
+	 * name is present at the request
+     * 
+     * @param request
+     * @return true if the request must trigger a CAS gateway authentication
+     */
+	protected boolean performGatewayAuthentication(HttpServletRequest request) {
+		if (!StringUtils.hasText(this.cookieName)) {
+			return true;
+		}
+    	
+    	Cookie[] cookies = request.getCookies();
+		if (cookies == null || cookies.length == 0) {
+			return false;
+		}
+        
+        for (Cookie cookie: cookies) {
+            // Check the cookie name. If it matches the configured cookie name, return true
+            if (this.cookieName.equalsIgnoreCase(cookie.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void setGatewayStorage(GatewayResolver gatewayStorage) {
+        Assert.notNull(gatewayStorage, "gatewayStorage cannot be null");
+        this.gatewayStorage = gatewayStorage;
+    }
+    
+	public String getCookieName() {
+		return cookieName;
+	}
+
+	public void setCookieName(String cookieName) {
+		this.cookieName = cookieName;
+	}
+}

--- a/cas/src/main/java/org/springframework/security/cas/web/TriggerCasGatewayFilter.java
+++ b/cas/src/main/java/org/springframework/security/cas/web/TriggerCasGatewayFilter.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2013-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.cas.web;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.cas.authentication.TriggerCasGatewayException;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.util.Assert;
+import org.springframework.web.filter.GenericFilterBean;
+
+/**
+ * Triggers a CAS gateway authentication attempt.
+ * <p>
+ * This filter must be placed after the <code>ExceptionTranslationFilter</code> in the filter chain in order to start
+ * the authentication process. Throws a {@link TriggerCasGatewayException} when the current request matches against the
+ * configured {@link RequestMatcher}.
+ * <p>
+ * The default implementation you can use is {@link DefaultCasGatewayRequestMatcher}.
+ * 
+ * @author Michael Remond
+ */
+public class TriggerCasGatewayFilter extends GenericFilterBean {
+
+    // ~ Instance fields
+    // ================================================================================================
+
+    private RequestMatcher requestMatcher;
+
+    // ~ Constructors
+    // ===================================================================================================
+
+    public TriggerCasGatewayFilter(RequestMatcher requestMatcher) {
+        Assert.notNull(requestMatcher, "requestMatcher cannot be null");
+        this.requestMatcher = requestMatcher;
+    }
+
+    public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException,
+            ServletException {
+
+        HttpServletRequest request = (HttpServletRequest) req;
+        HttpServletResponse response = (HttpServletResponse) res;
+
+        if (requestMatcher.matches(request)) {
+            throw new TriggerCasGatewayException("Try a CAS gateway authentication");
+        } else {
+            // Continue in the chain
+            chain.doFilter(request, response);
+        }
+
+    }
+
+    public void setRequestMatcher(RequestMatcher requestMatcher) {
+        this.requestMatcher = requestMatcher;
+    }
+
+}

--- a/cas/src/test/java/org/springframework/security/cas/web/CasAuthenticationEntryPointTests.java
+++ b/cas/src/test/java/org/springframework/security/cas/web/CasAuthenticationEntryPointTests.java
@@ -16,16 +16,16 @@
 
 package org.springframework.security.cas.web;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
 import java.net.URLEncoder;
 
 import org.junit.Test;
-
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.cas.ServiceProperties;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import org.springframework.security.cas.authentication.TriggerCasGatewayException;
 
 /**
  * Tests {@link CasAuthenticationEntryPoint}.
@@ -95,4 +95,46 @@ public class CasAuthenticationEntryPointTests {
 						.isEqualTo(response.getRedirectedUrl());
 	}
 
+	 public void testNormalOperationWithRenewFalseAndGateway() throws Exception {
+	        ServiceProperties sp = new ServiceProperties();
+	        sp.setSendRenew(false);
+	        sp.setService("https://mycompany.com/bigWebApp/j_spring_cas_security_check");
+
+	        CasAuthenticationEntryPoint ep = new CasAuthenticationEntryPoint();
+	        ep.setLoginUrl("https://cas/login");
+	        ep.setServiceProperties(sp);
+
+	        MockHttpServletRequest request = new MockHttpServletRequest();
+	        request.setRequestURI("/some_path");
+
+	        MockHttpServletResponse response = new MockHttpServletResponse();
+
+	        ep.afterPropertiesSet();
+	        ep.commence(request, response, new TriggerCasGatewayException(""));
+			assertThat("https://cas/login?service="
+					+ URLEncoder.encode("https://mycompany.com/bigWebApp/j_spring_cas_security_check", "UTF-8")
+					+ "&gateway=true").isEqualTo(response.getRedirectedUrl());
+	    }
+
+	    public void testNormalOperationWithRenewTrueAndGateway() throws Exception {
+	        ServiceProperties sp = new ServiceProperties();
+	        sp.setSendRenew(true);
+	        sp.setService("https://mycompany.com/bigWebApp/j_spring_cas_security_check");
+
+	        CasAuthenticationEntryPoint ep = new CasAuthenticationEntryPoint();
+	        ep.setLoginUrl("https://cas/login");
+	        ep.setServiceProperties(sp);
+
+	        MockHttpServletRequest request = new MockHttpServletRequest();
+	        request.setRequestURI("/some_path");
+
+	        MockHttpServletResponse response = new MockHttpServletResponse();
+
+	        ep.afterPropertiesSet();
+	        ep.commence(request, response, new TriggerCasGatewayException(""));
+			assertThat("https://cas/login?service="
+					+ URLEncoder.encode("https://mycompany.com/bigWebApp/j_spring_cas_security_check", "UTF-8")
+					+ "&renew=true&gateway=true").isEqualTo(response.getRedirectedUrl());
+	    }
+	
 }

--- a/cas/src/test/java/org/springframework/security/cas/web/CasCookieGatewayRequestMatcherTests.java
+++ b/cas/src/test/java/org/springframework/security/cas/web/CasCookieGatewayRequestMatcherTests.java
@@ -1,0 +1,97 @@
+package org.springframework.security.cas.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+import org.jasig.cas.client.authentication.DefaultGatewayResolverImpl;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.cas.ServiceProperties;
+import org.springframework.security.cas.authentication.CasAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class CasCookieGatewayRequestMatcherTests {
+
+    @Test
+    public void testNullServiceProperties() throws Exception {
+        try {
+            new CasCookieGatewayRequestMatcher(null, null);
+            fail("Should have thrown IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+        	assertEquals("serviceProperties cannot be null", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void testNormalOperationWithNoSSOSession() throws IOException, ServletException {
+    	SecurityContextHolder.getContext().setAuthentication(null);
+        ServiceProperties serviceProperties = new ServiceProperties();
+        serviceProperties.setService("http://localhost/j_spring_cas_security_check");
+        CasCookieGatewayRequestMatcher rm = new CasCookieGatewayRequestMatcher(serviceProperties, null);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/some_path");
+
+        // First request
+        assertTrue(rm.matches(request));
+        assertNotNull(request.getSession(false).getAttribute(DefaultGatewayResolverImpl.CONST_CAS_GATEWAY));
+        // Second request
+        assertFalse(rm.matches(request));
+        assertNotNull(request.getSession(false).getAttribute(DefaultGatewayResolverImpl.CONST_CAS_GATEWAY));
+    }
+
+
+    @Test
+    public void testGatewayWhenCasAuthenticated() throws IOException, ServletException {
+    	SecurityContextHolder.getContext().setAuthentication(null);
+        ServiceProperties serviceProperties = new ServiceProperties();
+        serviceProperties.setService("http://localhost/j_spring_cas_security_check");
+        CasCookieGatewayRequestMatcher rm = new CasCookieGatewayRequestMatcher(serviceProperties, "CAS_TGT_COOKIE_TEST_NAME");
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/some_path");
+        request.setCookies(new Cookie("CAS_TGT_COOKIE_TEST_NAME", "casTGCookieValue"));
+        
+        assertTrue(rm.matches(request));
+        
+        MockHttpServletRequest requestWithoutCasCookie = new MockHttpServletRequest("GET", "/some_path");
+        requestWithoutCasCookie.setCookies(new Cookie("WRONG_CAS_TGT_COOKIE_TEST_NAME", "casTGCookieValue"));
+        
+        assertFalse(rm.matches(requestWithoutCasCookie));
+    }
+    
+    @Test
+    public void testGatewayWhenAlreadySessionCreated() throws IOException, ServletException {
+        SecurityContextHolder.getContext().setAuthentication(mock(CasAuthenticationToken.class));
+
+        ServiceProperties serviceProperties = new ServiceProperties();
+        serviceProperties.setService("http://localhost/j_spring_cas_security_check");
+        CasCookieGatewayRequestMatcher rm = new CasCookieGatewayRequestMatcher(serviceProperties, "CAS_TGT_COOKIE_TEST_NAME");
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/some_path");
+        assertFalse(rm.matches(request));
+    }
+
+    
+    @Test
+    public void testGatewayWithNoMatchingRequest() throws IOException, ServletException {
+    	SecurityContextHolder.getContext().setAuthentication(null);
+        ServiceProperties serviceProperties = new ServiceProperties();
+        serviceProperties.setService("http://localhost/j_spring_cas_security_check");
+        CasCookieGatewayRequestMatcher rm = new CasCookieGatewayRequestMatcher(serviceProperties, "CAS_TGT_COOKIE_TEST_NAME") {
+            @Override
+            protected boolean performGatewayAuthentication(HttpServletRequest request) {
+                return false;
+            }
+        };
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/some_path");
+
+        assertFalse(rm.matches(request));
+    }
+
+}


### PR DESCRIPTION
This is the CAS gateway feature.
This is a implementation based on the following discussion (PR): https://github.com/spring-projects/spring-security/pull/40#

I did some modifications in order to perform the CAS gateway redirection only if the CAS cookie is present on the client application request. Of course this will not fit in all situations (where CAS domain is different from client applications won't work), but for many of situations this is a pretty good approach.

Regards.
