### PR TITLE
Fix Adding Filter Relative to Custom Filter

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/FilterOrderRegistration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/FilterOrderRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,8 +114,18 @@ final class FilterOrderRegistration {
 		put(SwitchUserFilter.class, order.next());
 	}
 
-	private void put(Class<? extends Filter> filter, int position) {
+	/**
+	 * Register a {@link Filter} with its specific position. If the {@link Filter} was
+	 * already registered before, the position previously defined is not going to be
+	 * overriden
+	 * @param filter the {@link Filter} to register
+	 * @param position the position to associate with the {@link Filter}
+	 */
+	void put(Class<? extends Filter> filter, int position) {
 		String className = filter.getName();
+		if (this.filterToOrder.containsKey(className)) {
+			return;
+		}
 		this.filterToOrder.put(className, position);
 	}
 

--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
@@ -2653,6 +2653,7 @@ public final class HttpSecurity extends AbstractConfiguredSecurityBuilder<Defaul
 	private HttpSecurity addFilterAtOffsetOf(Filter filter, int offset, Class<? extends Filter> registeredFilter) {
 		int order = this.filterOrders.getOrder(registeredFilter) + offset;
 		this.filters.add(new OrderedFilter(filter, order));
+		this.filterOrders.put(filter.getClass(), order);
 		return this;
 	}
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/builders/FilterOrderRegistrationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/builders/FilterOrderRegistrationTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.config.annotation.web.builders;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.junit.Test;
+
+import org.springframework.security.web.access.channel.ChannelProcessingFilter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FilterOrderRegistrationTests {
+
+	private final FilterOrderRegistration filterOrderRegistration = new FilterOrderRegistration();
+
+	@Test
+	public void putWhenNewFilterThenInsertCorrect() {
+		int position = 153;
+		this.filterOrderRegistration.put(MyFilter.class, position);
+		Integer order = this.filterOrderRegistration.getOrder(MyFilter.class);
+		assertThat(order).isEqualTo(position);
+	}
+
+	@Test
+	public void putWhenCustomFilterAlreadyExistsThenDoesNotOverride() {
+		int position = 160;
+		this.filterOrderRegistration.put(MyFilter.class, position);
+		this.filterOrderRegistration.put(MyFilter.class, 173);
+		Integer order = this.filterOrderRegistration.getOrder(MyFilter.class);
+		assertThat(order).isEqualTo(position);
+	}
+
+	@Test
+	public void putWhenPredefinedFilterThenDoesNotOverride() {
+		int position = 100;
+		Integer predefinedFilterOrderBefore = this.filterOrderRegistration.getOrder(ChannelProcessingFilter.class);
+		this.filterOrderRegistration.put(MyFilter.class, position);
+		Integer myFilterOrder = this.filterOrderRegistration.getOrder(MyFilter.class);
+		Integer predefinedFilterOrderAfter = this.filterOrderRegistration.getOrder(ChannelProcessingFilter.class);
+		assertThat(myFilterOrder).isEqualTo(position);
+		assertThat(predefinedFilterOrderAfter).isEqualTo(predefinedFilterOrderBefore).isEqualTo(position);
+	}
+
+	static class MyFilter implements Filter {
+
+		@Override
+		public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+				throws IOException, ServletException {
+			filterChain.doFilter(servletRequest, servletResponse);
+		}
+
+	}
+
+}


### PR DESCRIPTION
- Prevent already defined filter's positions to be overriden

Closes gh-9787

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
