### PR TITLE
fix typo preventing full exception to be  displayed in log

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/OAuth2AuthorizationRequestRedirectFilter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/OAuth2AuthorizationRequestRedirectFilter.java
@@ -221,7 +221,7 @@ public class OAuth2AuthorizationRequestRedirectFilter extends OncePerRequestFilt
 
 	private void unsuccessfulRedirectForAuthorization(HttpServletRequest request, HttpServletResponse response,
 			Exception ex) throws IOException {
-		this.logger.error(LogMessage.format("Authorization Request failed: %s", ex, ex));
+		this.logger.error(LogMessage.format("Authorization Request failed: %s", ex), ex);
 		response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value(),
 				HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase());
 	}


### PR DESCRIPTION
closes gh-9901

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
