### PR TITLE
Improve Error Message for Invalid Properties in InMemoryUserDetailsManager 

### DIFF
--- a/core/src/main/java/org/springframework/security/provisioning/InMemoryUserDetailsManager.java
+++ b/core/src/main/java/org/springframework/security/provisioning/InMemoryUserDetailsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,6 +79,7 @@ public class InMemoryUserDetailsManager implements UserDetailsManager, UserDetai
 			String name = (String) names.nextElement();
 			editor.setAsText(users.getProperty(name));
 			UserAttribute attr = (UserAttribute) editor.getValue();
+			Assert.notNull(attr, "The entry with username '" + name + "' could not be converted to an UserDetails");
 			createUser(createUserDetails(name, attr));
 		}
 	}

--- a/core/src/test/java/org/springframework/security/provisioning/InMemoryUserDetailsManagerTests.java
+++ b/core/src/test/java/org/springframework/security/provisioning/InMemoryUserDetailsManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.security.provisioning;
 
+import java.util.Properties;
+
 import org.junit.Test;
 
 import org.springframework.security.core.userdetails.PasswordEncodedUser;
@@ -23,6 +25,7 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 /**
  * @author Rob Winch
@@ -48,6 +51,32 @@ public class InMemoryUserDetailsManagerTests {
 		this.manager.updatePassword(userNotLowerCase, newPassword);
 		assertThat(this.manager.loadUserByUsername(userNotLowerCase.getUsername()).getPassword())
 				.isEqualTo(newPassword);
+	}
+
+	@Test
+	public void constructorWhenUserPropertiesThenCreate() {
+		Properties properties = new Properties();
+		properties.setProperty("joe", "{noop}joespassword,ROLE_A");
+		properties.setProperty("bob", "{noop}bobspassword,ROLE_A,ROLE_B");
+		InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager(properties);
+		assertThat(manager.userExists("joe")).isTrue();
+		assertThat(manager.userExists("bob")).isTrue();
+	}
+
+	@Test
+	public void constructorWhenUserPropertiesWithEmptyValueThenException() {
+		Properties properties = new Properties();
+		properties.setProperty("joe", "");
+		assertThatIllegalArgumentException().isThrownBy(() -> new InMemoryUserDetailsManager(properties))
+				.withMessage("The entry with username 'joe' could not be converted to an UserDetails");
+	}
+
+	@Test
+	public void constructorWhenUserPropertiesNoRolesThenException() {
+		Properties properties = new Properties();
+		properties.setProperty("joe", "{noop}joespassword");
+		assertThatIllegalArgumentException().isThrownBy(() -> new InMemoryUserDetailsManager(properties))
+				.withMessage("The entry with username 'joe' could not be converted to an UserDetails");
 	}
 
 }


### PR DESCRIPTION
Check if the UserAttribute is null when instantiating the InMemoryUserDetailsManager using the Properties argument's constructor

Closes gh-3403

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
