### PR TITLE
Assert Error-Messages already includes dashes

### DIFF
--- a/core/src/main/java/org/springframework/security/converter/RsaKeyConverters.java
+++ b/core/src/main/java/org/springframework/security/converter/RsaKeyConverters.java
@@ -72,8 +72,8 @@ public final class RsaKeyConverters {
 		return (source) -> {
 			List<String> lines = readAllLines(source);
 			Assert.isTrue(!lines.isEmpty() && lines.get(0).startsWith(PKCS8_PEM_HEADER),
-					"Key is not in PEM-encoded PKCS#8 format, please check that the header begins with -----"
-							+ PKCS8_PEM_HEADER + "-----");
+					"Key is not in PEM-encoded PKCS#8 format, please check that the header begins with "
+							+ PKCS8_PEM_HEADER);
 			StringBuilder base64Encoded = new StringBuilder();
 			for (String line : lines) {
 				if (RsaKeyConverters.isNotPkcs8Wrapper(line)) {
@@ -104,8 +104,8 @@ public final class RsaKeyConverters {
 		return (source) -> {
 			List<String> lines = readAllLines(source);
 			Assert.isTrue(!lines.isEmpty() && lines.get(0).startsWith(X509_PEM_HEADER),
-					"Key is not in PEM-encoded X.509 format, please check that the header begins with -----"
-							+ X509_PEM_HEADER + "-----");
+					"Key is not in PEM-encoded X.509 format, please check that the header begins with "
+							+ X509_PEM_HEADER);
 			StringBuilder base64Encoded = new StringBuilder();
 			for (String line : lines) {
 				if (RsaKeyConverters.isNotX509Wrapper(line)) {


### PR DESCRIPTION
When the cert-content is not valid, the assert output message is not correct.
Because it outputs too many dashes .The const X509- and PKCS8-PEM_HEADER already includes the dashes.

I took the output message via copy and paste, but it was still not valid ;-(

Only the output is affected, the checks itself is correct.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
