### PR TITLE
Accept predicate in constructor for JwtIssuerAuthenticationManagerRes…

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
@@ -86,6 +86,16 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 				new TrustedIssuerJwtAuthenticationManagerResolver(
 						Collections.unmodifiableCollection(trustedIssuers)::contains));
 	}
+	
+	/**
+     * Construct a {@link JwtIssuerAuthenticationManagerResolver} using the provided
+     * parameters
+     * @param trustedIssuer a predicate to determine whether the issuer should be trusted or not
+     */
+    public JwtIssuerAuthenticationManagerResolver(Predicate<String> trustedIssuer) {
+        this.authenticationManager = new ResolvingAuthenticationManager(
+                new TrustedIssuerJwtAuthenticationManagerResolver(trustedIssuer));
+    }
 
 	/**
 	 * Construct a {@link JwtIssuerAuthenticationManagerResolver} using the provided


### PR DESCRIPTION
Add a constructor to JwtIssuerAuthenticationManagerResolver to allow it to accept a Predicate<String> to determine whether an issuer should be trusted or not. This allows for cases where the trusted issuers are not necessarily known at application startup. Since JwtIssuerAuthenticationManagerResolver is final and internal classes are private, this is not possible to extend it to support this use case without duplicating the whole class.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
