### PR TITLE
Fix Saml2WebSsoAuthenticationRequestFilter javadoc

### DIFF
--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/servlet/filter/Saml2WebSsoAuthenticationRequestFilter.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/servlet/filter/Saml2WebSsoAuthenticationRequestFilter.java
@@ -62,7 +62,7 @@ import org.springframework.web.util.UriUtils;
  *
  * <p>
  * By default, this {@code Filter} responds to authentication requests at the {@code URI}
- * {@code /oauth2/authorization/{registrationId}}. The {@code URI} template variable
+ * {@code /saml2/authenticate/{registrationId}}. The {@code URI} template variable
  * {@code {registrationId}} represents the
  * {@link RelyingPartyRegistration#getRegistrationId() registration identifier} of the
  * relying party that is used for initiating the authentication request.


### PR DESCRIPTION
Fix (maybe copy-paste?) error in Saml2WebSsoAuthenticationRequestFilter. It responds to requests on `/saml2/authenticate/{registrationId}`.