### PR TITLE
Allow extending the authentication provider

### DIFF
--- a/saml2/saml2-service-provider/src/opensaml3Main/java/org/springframework/security/saml2/provider/service/authentication/OpenSamlAuthenticationProvider.java
+++ b/saml2/saml2-service-provider/src/opensaml3Main/java/org/springframework/security/saml2/provider/service/authentication/OpenSamlAuthenticationProvider.java
@@ -135,7 +135,7 @@ import org.springframework.util.StringUtils;
  * @deprecated Because OpenSAML 3 has reached End-of-Life, please update to
  * {@code OpenSaml4AuthenticationProvider}
  */
-public final class OpenSamlAuthenticationProvider implements AuthenticationProvider {
+public class OpenSamlAuthenticationProvider implements AuthenticationProvider {
 
 	static {
 		OpenSamlInitializationService.initialize();

--- a/saml2/saml2-service-provider/src/opensaml4Main/java/org/springframework/security/saml2/provider/service/authentication/OpenSaml4AuthenticationProvider.java
+++ b/saml2/saml2-service-provider/src/opensaml4Main/java/org/springframework/security/saml2/provider/service/authentication/OpenSaml4AuthenticationProvider.java
@@ -129,7 +129,7 @@ import org.springframework.util.StringUtils;
  * StatusResponse</a>
  * @see <a href="https://wiki.shibboleth.net/confluence/display/OS30/Home">OpenSAML 3</a>
  */
-public final class OpenSaml4AuthenticationProvider implements AuthenticationProvider {
+public class OpenSaml4AuthenticationProvider implements AuthenticationProvider {
 
 	static {
 		OpenSamlInitializationService.initialize();


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->

I want to extend the authentication provider classes to add some extra logic, but I couldn't because they are final classes.

Seems that there are no direct reasons for making them `final`. So can we remove the `final` keyword?
