### PR TITLE
Allow configure cusomized Authentication Filter

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/AbstractAuthenticationFilterConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/AbstractAuthenticationFilterConfigurer.java
@@ -59,6 +59,7 @@ import org.springframework.web.accept.HeaderContentNegotiationStrategy;
  * @see FormLoginConfigurer
  * @see OpenIDLoginConfigurer
  */
+@SuppressWarnings("deprecation")
 public abstract class AbstractAuthenticationFilterConfigurer<B extends HttpSecurityBuilder<B>, T extends AbstractAuthenticationFilterConfigurer<B, T, F>, F extends AbstractAuthenticationProcessingFilter>
 		extends AbstractHttpConfigurer<T, B> {
 
@@ -104,6 +105,15 @@ public abstract class AbstractAuthenticationFilterConfigurer<B extends HttpSecur
 		if (defaultLoginProcessingUrl != null) {
 			loginProcessingUrl(defaultLoginProcessingUrl);
 		}
+	}
+
+	/**
+	 * Sets the customized Authentication Filter if needed
+	 * @param authenticationFilter the Authentication Filter
+	 */
+	public T authenticationFilter(F authenticationFilter) {
+		setAuthenticationFilter(authenticationFilter);
+		return getSelf();
 	}
 
 	/**
@@ -233,7 +243,6 @@ public abstract class AbstractAuthenticationFilterConfigurer<B extends HttpSecur
 		registerDefaultAuthenticationEntryPoint(http);
 	}
 
-	@SuppressWarnings("unchecked")
 	protected final void registerDefaultAuthenticationEntryPoint(B http) {
 		registerAuthenticationEntryPoint(http, this.authenticationEntryPoint);
 	}
@@ -371,6 +380,7 @@ public abstract class AbstractAuthenticationFilterConfigurer<B extends HttpSecur
 	 * Updates the default values for authentication.
 	 * @throws Exception
 	 */
+	@SuppressWarnings("unchecked")
 	protected final void updateAuthenticationDefaults() {
 		if (this.loginProcessingUrl == null) {
 			loginProcessingUrl(this.loginPage);


### PR DESCRIPTION
After this commit, user can replace built-in AuthenticationFilter with their own. for example, obtain username and password from request body instead of parameters.
```java
http.formLogin().authenticationFilter(new RestfulUsernamePasswordAuthenticationFilter(authenticationManager(), objectMapper))
```
```java
public class RestfulUsernamePasswordAuthenticationFilter extends UsernamePasswordAuthenticationFilter {

	private static final String ATTR_NAME_REQUEST_BODY = "_REQUEST_BODY";

	private final ObjectMapper objectMapper;

	public RestfulUsernamePasswordAuthenticationFilter(AuthenticationManager authenticationManager,
			ObjectMapper objectMapper) {
		super(authenticationManager);
		this.objectMapper = objectMapper;
	}

	@Nullable
	protected String obtainUsername(HttpServletRequest request) {
		Map<String, String> requestBody = body(request);
		if (requestBody != null) {
			request.setAttribute(ATTR_NAME_REQUEST_BODY, requestBody);
			return requestBody.get(getUsernameParameter());
		}
		return super.obtainUsername(request);
	}

	@Nullable
	protected String obtainPassword(HttpServletRequest request) {
		@SuppressWarnings("unchecked")
		Map<String, String> requestBody = (Map<String, String>) request.getAttribute(ATTR_NAME_REQUEST_BODY);
		if (requestBody != null) {
			request.removeAttribute(ATTR_NAME_REQUEST_BODY);
			return requestBody.get(getPasswordParameter());
		}
		return super.obtainPassword(request);
	}

	@Nullable
	private Map<String, String> body(HttpServletRequest request) {
		String contentType = request.getContentType();
		if (contentType != null) {
			if (MediaType.parseMediaType(contentType).isCompatibleWith(APPLICATION_JSON)) {
				try {
					return objectMapper.readValue(request.getInputStream(), new TypeReference<Map<String, String>>() {
					});
				} catch (Exception e) {
					log.error(e.getMessage(), e);
				}
			}
		}
		return null;
	}
}
```