### PR TITLE
OpenSAML Version null-pointer exception check

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LoginConfigurer.java
@@ -261,7 +261,7 @@ public final class Saml2LoginConfigurer<B extends HttpSecurityBuilder<B>>
 	}
 
 	private void registerDefaultAuthenticationProvider(B http) {
-		if (Version.getVersion().startsWith("4")) {
+		if (version().startsWith("4")) {
 			http.authenticationProvider(postProcess(new OpenSaml4AuthenticationProvider()));
 		}
 		else {
@@ -346,7 +346,7 @@ public final class Saml2LoginConfigurer<B extends HttpSecurityBuilder<B>>
 		private Saml2AuthenticationRequestFactory getResolver(B http) {
 			Saml2AuthenticationRequestFactory resolver = getSharedOrBean(http, Saml2AuthenticationRequestFactory.class);
 			if (resolver == null) {
-				if (Version.getVersion().startsWith("4")) {
+				if (version().startsWith("4")) {
 					return new OpenSaml4AuthenticationRequestFactory();
 				}
 				return new OpenSamlAuthenticationRequestFactory();
@@ -364,6 +364,16 @@ public final class Saml2LoginConfigurer<B extends HttpSecurityBuilder<B>>
 			return resolver;
 		}
 
+	}
+
+	private String version() {
+		String version = Version.getVersion();
+		if (version != null) {
+			return version;
+		}
+		return Version.class.getModule().getDescriptor().version()
+				.map(Object::toString)
+				.orElseThrow(() -> new IllegalStateException("cannot determine OpenSAML version"));
 	}
 
 }

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LoginConfigurer.java
@@ -260,6 +260,15 @@ public final class Saml2LoginConfigurer<B extends HttpSecurityBuilder<B>>
 		return this.authenticationConverter;
 	}
 
+	private String version() {
+		String version = Version.getVersion();
+		if (version != null) {
+			return version;
+		}
+		return Version.class.getModule().getDescriptor().version().map(Object::toString)
+				.orElseThrow(() -> new IllegalStateException("cannot determine OpenSAML version"));
+	}
+
 	private void registerDefaultAuthenticationProvider(B http) {
 		if (version().startsWith("4")) {
 			http.authenticationProvider(postProcess(new OpenSaml4AuthenticationProvider()));
@@ -366,14 +375,5 @@ public final class Saml2LoginConfigurer<B extends HttpSecurityBuilder<B>>
 
 	}
 
-	private String version() {
-		String version = Version.getVersion();
-		if (version != null) {
-			return version;
-		}
-		return Version.class.getModule().getDescriptor().version()
-				.map(Object::toString)
-				.orElseThrow(() -> new IllegalStateException("cannot determine OpenSAML version"));
-	}
 
 }


### PR DESCRIPTION
This will enable the app to check for the version using both classpath and module-path (java 9+) when using modules. 

This issue has been discussed in this ticket: https://github.com/spring-projects/spring-security/issues/10077 and followed recommendation of @jzheaux on how to handle this. 