### PR TITLE
For convenience added convertToUperCase on LdapAuthenticationProviderConfigurer

### DIFF
--- a/config/src/integration-test/java/org/springframework/security/config/annotation/authentication/ldap/LdapAuthenticationProviderConfigurerTests.java
+++ b/config/src/integration-test/java/org/springframework/security/config/annotation/authentication/ldap/LdapAuthenticationProviderConfigurerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,6 +114,22 @@ public class LdapAuthenticationProviderConfigurerTests {
 		this.mockMvc.perform(request).andExpect(expectedUser);
 	}
 
+	@Test
+	public void authenticationManagerWhenNotConvertToUpperCaseThen() throws Exception {
+		this.spring.register(NotConvertToUpperCaseConfig.class).autowire();
+
+		// @formatter:off
+		SecurityMockMvcRequestBuilders.FormLoginRequestBuilder request = formLogin()
+				.user("ben")
+				.password("benspassword");
+		SecurityMockMvcResultMatchers.AuthenticatedMatcher expectedUser = authenticated()
+				.withUsername("ben")
+				.withAuthorities(
+						AuthorityUtils.createAuthorityList("role_managers", "role_developers"));
+		// @formatter:on
+		this.mockMvc.perform(request).andExpect(expectedUser);
+	}
+
 	@EnableWebSecurity
 	static class MultiLdapAuthenticationProvidersConfig extends WebSecurityConfigurerAdapter {
 
@@ -188,6 +204,23 @@ public class LdapAuthenticationProviderConfigurerTests {
 					.groupSearchFilter("(member={0})")
 					.groupSearchSubtree(true)
 					.userDnPatterns("uid={0},ou=people");
+			// @formatter:on
+		}
+
+	}
+
+	@EnableWebSecurity
+	static class NotConvertToUpperCaseConfig extends BaseLdapProviderConfig {
+
+		@Override
+		protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+			// @formatter:off
+			auth
+				.ldapAuthentication()
+					.groupSearchBase("ou=groups")
+					.groupSearchFilter("(member={0})")
+					.userDnPatterns("uid={0},ou=people")
+					.convertToUpperCase(false);
 			// @formatter:on
 		}
 

--- a/config/src/integration-test/java/org/springframework/security/config/annotation/authentication/ldap/LdapAuthenticationProviderConfigurerTests.java
+++ b/config/src/integration-test/java/org/springframework/security/config/annotation/authentication/ldap/LdapAuthenticationProviderConfigurerTests.java
@@ -115,7 +115,7 @@ public class LdapAuthenticationProviderConfigurerTests {
 	}
 
 	@Test
-	public void authenticationManagerWhenNotConvertToUpperCaseThen() throws Exception {
+	public void authenticationManagerWhenNotConvertToUpperCaseThenRolesAreLowerCased() throws Exception {
 		this.spring.register(NotConvertToUpperCaseConfig.class).autowire();
 
 		// @formatter:off

--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/ldap/LdapAuthenticationProviderConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/ldap/LdapAuthenticationProviderConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,8 @@ public class LdapAuthenticationProviderConfigurer<B extends ProviderManagerBuild
 	private String groupSearchFilter = "(uniqueMember={0})";
 
 	private String rolePrefix = "ROLE_";
+
+	private boolean convertToUpperCase = true;
 
 	private String userSearchBase = ""; // only for search
 
@@ -140,6 +142,7 @@ public class LdapAuthenticationProviderConfigurer<B extends ProviderManagerBuild
 		defaultAuthoritiesPopulator.setGroupSearchFilter(this.groupSearchFilter);
 		defaultAuthoritiesPopulator.setSearchSubtree(this.groupSearchSubtree);
 		defaultAuthoritiesPopulator.setRolePrefix(this.rolePrefix);
+		defaultAuthoritiesPopulator.setConvertToUpperCase(this.convertToUpperCase);
 		this.ldapAuthoritiesPopulator = defaultAuthoritiesPopulator;
 		return defaultAuthoritiesPopulator;
 	}
@@ -344,6 +347,17 @@ public class LdapAuthenticationProviderConfigurer<B extends ProviderManagerBuild
 	 */
 	public LdapAuthenticationProviderConfigurer<B> rolePrefix(String rolePrefix) {
 		this.rolePrefix = rolePrefix;
+		return this;
+	}
+
+	/**
+	 * If true, the role names are converted to uppercase letters. If false, the role
+	 * names remain untouched.
+	 * @param convertToUpperCase set to true to convert the role name to uppercase.
+	 * @return the {@link LdapAuthenticationProviderConfigurer} for further customizations
+	 */
+	public LdapAuthenticationProviderConfigurer<B> convertToUpperCase(boolean convertToUpperCase) {
+		this.convertToUpperCase = convertToUpperCase;
 		return this;
 	}
 


### PR DESCRIPTION
Since LdapAuthenticationProviderConfigurer currently does not offer the possibility to pass the flag convertToUpperCase to the DefaultLdapAuthoritiesPopulator, I have extended this feature on the LdapAuthenticationProviderConfigurer accordingly. Previously, if you only wanted to set convertToUpperCase to 'false', you had to initialize the DefaultLdapAuthoritiesPopulator yourself and set all values accordingly.


Until now:
```
protected void configure(AuthenticationManagerBuilder auth) throws Exception {
  final var ldapAuth = auth.ldapAuthentication();

  final var authoritiesPopulator = new DefaultLdapAuthoritiesPopulator(contextSource, groupSearchBase);
  authoritiesPopulator.setGroupRoleAttribute(groupRoleAttribute);
  authoritiesPopulator.setGroupSearchFilter(groupSearchFilter);
  authoritiesPopulator.setSearchSubtree(groupSearchSubtree);
  authoritiesPopulator.setRolePrefix(rolePrefix);
  authoritiesPopulator.setConvertToUpperCase(false);
  ldapAuth.ldapAuthoritiesPopulator(authoritiesPopulator);
}
```
New:
```
protected void configure(AuthenticationManagerBuilder auth) throws Exception {
  final var ldapAuth = auth.ldapAuthentication();
  ldapAuth.convertToUpperCase(false);
}
```