### PR TITLE
Make AuthorizationGrantTypeConverter support custom grant type

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/StdConverters.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/StdConverters.java
@@ -83,7 +83,7 @@ abstract class StdConverters {
 			if (AuthorizationGrantType.PASSWORD.getValue().equalsIgnoreCase(value)) {
 				return AuthorizationGrantType.PASSWORD;
 			}
-			return null;
+			return new AuthorizationGrantType(value);
 		}
 
 	}

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthorizedClientMixinTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthorizedClientMixinTests.java
@@ -32,6 +32,7 @@ import org.springframework.security.jackson2.SecurityJackson2Modules;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.TestClientRegistrations;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.security.oauth2.core.TestOAuth2AccessTokens;
@@ -69,6 +70,7 @@ public class OAuth2AuthorizedClientMixinTests {
 		providerConfigurationMetadata.put("config2", "value2");
 		// @formatter:off
 		this.clientRegistrationBuilder = TestClientRegistrations.clientRegistration()
+                .authorizationGrantType(new AuthorizationGrantType("self-defined"))
 				.scope("read", "write")
 				.providerConfigurationMetadata(providerConfigurationMetadata);
 		// @formatter:on


### PR DESCRIPTION
Now we have requirement to support self-defined `AuthorizationGrantType`.
But the `AuthorizationGrantTypeConverter`  does not support self-defined `AuthorizationGrantType`.
So I created this PR.

Here is our code bout self-defined `AuthorizationGrantType`: https://github.com/Azure/azure-sdk-for-java/blob/c822f9da53ef9796e0ae302ade875f8ba7668998/sdk/spring/azure-spring-boot/src/main/java/com/azure/spring/aad/AADAuthorizationGrantType.java#L14-L15
