### PR TITLE
Add cause to opaque token introspection failures

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OpaqueTokenAuthenticationProvider.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OpaqueTokenAuthenticationProvider.java
@@ -104,10 +104,10 @@ public final class OpaqueTokenAuthenticationProvider implements AuthenticationPr
 		}
 		catch (BadOpaqueTokenException failed) {
 			this.logger.debug("Failed to authenticate since token was invalid");
-			throw new InvalidBearerTokenException(failed.getMessage());
+			throw new InvalidBearerTokenException(failed.getMessage(), failed);
 		}
 		catch (OAuth2IntrospectionException failed) {
-			throw new AuthenticationServiceException(failed.getMessage());
+			throw new AuthenticationServiceException(failed.getMessage(), failed);
 		}
 	}
 


### PR DESCRIPTION
This adds the cause of opaque OAuth2 introspection failures to the exception thrown by Spring Security, which aids in debugging authentication issues using OAuth2.
