### PR TITLE
Bugfix/oauth2 issuer treatment and exception handling

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/reactive/exploits/headers.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/reactive/exploits/headers.adoc
@@ -90,7 +90,7 @@ Spring Security includes <<headers-cache-control,Cache Control>> headers by defa
 However, if you actually want to cache specific responses, your application can selectively add them to the https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/server/reactive/ServerHttpResponse.html[ServerHttpResponse] to override the header set by Spring Security.
 This is useful to ensure things like CSS, JavaScript, and images are properly cached.
 
-When using Spring WebFluxZz, this is typically done within your configuration.
+When using Spring WebFlux, this is typically done within your configuration.
 Details on how to do this can be found in the https://docs.spring.io/spring/docs/5.0.0.RELEASE/spring-framework-reference/web-reactive.html#webflux-config-static-resources[Static Resources] portion of the Spring Reference documentation
 
 If necessary, you can also disable Spring Security's cache control HTTP response headers.

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OpaqueTokenAuthenticationProvider.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OpaqueTokenAuthenticationProvider.java
@@ -66,7 +66,7 @@ public final class OpaqueTokenAuthenticationProvider implements AuthenticationPr
 
 	private final Log logger = LogFactory.getLog(getClass());
 
-	private OpaqueTokenIntrospector introspector;
+	private final OpaqueTokenIntrospector introspector;
 
 	/**
 	 * Creates a {@code OpaqueTokenAuthenticationProvider} with the provided parameters
@@ -104,10 +104,10 @@ public final class OpaqueTokenAuthenticationProvider implements AuthenticationPr
 		}
 		catch (BadOpaqueTokenException failed) {
 			this.logger.debug("Failed to authenticate since token was invalid");
-			throw new InvalidBearerTokenException(failed.getMessage());
+			throw new InvalidBearerTokenException(failed.getMessage(), failed);
 		}
 		catch (OAuth2IntrospectionException failed) {
-			throw new AuthenticationServiceException(failed.getMessage());
+			throw new AuthenticationServiceException(failed.getMessage(), failed);
 		}
 	}
 

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OpaqueTokenReactiveAuthenticationManager.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/OpaqueTokenReactiveAuthenticationManager.java
@@ -61,7 +61,7 @@ import org.springframework.util.Assert;
  */
 public class OpaqueTokenReactiveAuthenticationManager implements ReactiveAuthenticationManager {
 
-	private ReactiveOpaqueTokenIntrospector introspector;
+	private final ReactiveOpaqueTokenIntrospector introspector;
 
 	/**
 	 * Creates a {@code OpaqueTokenReactiveAuthenticationManager} with the provided

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/NimbusOpaqueTokenIntrospector.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/NimbusOpaqueTokenIntrospector.java
@@ -17,7 +17,6 @@
 package org.springframework.security.oauth2.server.resource.introspection;
 
 import java.net.URI;
-import java.net.URL;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -207,7 +206,25 @@ public class NimbusOpaqueTokenIntrospector implements OpaqueTokenIntrospector {
 			claims.put(OAuth2TokenIntrospectionClaimNames.IAT, iat);
 		}
 		if (response.getIssuer() != null) {
-			claims.put(OAuth2TokenIntrospectionClaimNames.ISS, issuer(response.getIssuer().getValue()));
+			// RFC-7662 page 7 directs users to RFC-7519 for defining the values of these
+			// issuer fields.
+			// https://datatracker.ietf.org/doc/html/rfc7662#page-7
+			//
+			// RFC-7519 page 9 defines issuer fields as being 'case-sensitive' strings
+			// containing
+			// a 'StringOrURI', which is defined on page 5 as being any string, but
+			// strings containing ':'
+			// should be treated as valid URIs.
+			// https://datatracker.ietf.org/doc/html/rfc7519#section-2
+			//
+			// It is not defined however as to whether-or-not normalized URIs should be
+			// treated as the same literal
+			// value. It only defines validation itself, so to avoid potential ambiguity
+			// or unwanted side effects that
+			// may be awkward to debug, we do not want to manipulate this value. Previous
+			// versions of Spring Security
+			// would *only* allow valid URLs, which is not what we wish to achieve here.
+			claims.put(OAuth2TokenIntrospectionClaimNames.ISS, response.getIssuer().getValue());
 		}
 		if (response.getNotBeforeTime() != null) {
 			claims.put(OAuth2TokenIntrospectionClaimNames.NBF, response.getNotBeforeTime().toInstant());
@@ -220,16 +237,6 @@ public class NimbusOpaqueTokenIntrospector implements OpaqueTokenIntrospector {
 			}
 		}
 		return new OAuth2IntrospectionAuthenticatedPrincipal(claims, authorities);
-	}
-
-	private URL issuer(String uri) {
-		try {
-			return new URL(uri);
-		}
-		catch (Exception ex) {
-			throw new OAuth2IntrospectionException(
-					"Invalid " + OAuth2TokenIntrospectionClaimNames.ISS + " value: " + uri);
-		}
 	}
 
 }

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/NimbusOpaqueTokenIntrospector.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/NimbusOpaqueTokenIntrospector.java
@@ -61,13 +61,13 @@ import org.springframework.web.client.RestTemplate;
  */
 public class NimbusOpaqueTokenIntrospector implements OpaqueTokenIntrospector {
 
+	private static final String AUTHORITY_PREFIX = "SCOPE_";
+
 	private final Log logger = LogFactory.getLog(getClass());
 
+	private final RestOperations restOperations;
+
 	private Converter<String, RequestEntity<?>> requestEntityConverter;
-
-	private RestOperations restOperations;
-
-	private final String authorityPrefix = "SCOPE_";
 
 	/**
 	 * Creates a {@code OpaqueTokenAuthenticationProvider} with the provided parameters
@@ -258,7 +258,7 @@ public class NimbusOpaqueTokenIntrospector implements OpaqueTokenIntrospector {
 			List<String> scopes = Collections.unmodifiableList(response.getScope().toStringList());
 			claims.put(OAuth2TokenIntrospectionClaimNames.SCOPE, scopes);
 			for (String scope : scopes) {
-				authorities.add(new SimpleGrantedAuthority(this.authorityPrefix + scope));
+				authorities.add(new SimpleGrantedAuthority(AUTHORITY_PREFIX + scope));
 			}
 		}
 		return new OAuth2IntrospectionAuthenticatedPrincipal(claims, authorities);

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/NimbusReactiveOpaqueTokenIntrospector.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/NimbusReactiveOpaqueTokenIntrospector.java
@@ -121,7 +121,7 @@ public class NimbusReactiveOpaqueTokenIntrospector implements ReactiveOpaqueToke
 		MediaType contentType = responseEntity.headers().contentType().orElseThrow(() -> {
 			this.logger.trace("Did not receive Content-Type from introspection endpoint in response");
 
-			throw new OAuth2IntrospectionException(
+			return new OAuth2IntrospectionException(
 					"Introspection endpoint response was invalid, as no Content-Type header was provided");
 		});
 

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/NimbusReactiveOpaqueTokenIntrospector.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/NimbusReactiveOpaqueTokenIntrospector.java
@@ -17,7 +17,6 @@
 package org.springframework.security.oauth2.server.resource.introspection;
 
 import java.net.URI;
-import java.net.URL;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -174,7 +173,25 @@ public class NimbusReactiveOpaqueTokenIntrospector implements ReactiveOpaqueToke
 			claims.put(OAuth2TokenIntrospectionClaimNames.IAT, iat);
 		}
 		if (response.getIssuer() != null) {
-			claims.put(OAuth2TokenIntrospectionClaimNames.ISS, issuer(response.getIssuer().getValue()));
+			// RFC-7662 page 7 directs users to RFC-7519 for defining the values of these
+			// issuer fields.
+			// https://datatracker.ietf.org/doc/html/rfc7662#page-7
+			//
+			// RFC-7519 page 9 defines issuer fields as being 'case-sensitive' strings
+			// containing
+			// a 'StringOrURI', which is defined on page 5 as being any string, but
+			// strings containing ':'
+			// should be treated as valid URIs.
+			// https://datatracker.ietf.org/doc/html/rfc7519#section-2
+			//
+			// It is not defined however as to whether-or-not normalized URIs should be
+			// treated as the same literal
+			// value. It only defines validation itself, so to avoid potential ambiguity
+			// or unwanted side effects that
+			// may be awkward to debug, we do not want to manipulate this value. Previous
+			// versions of Spring Security
+			// would *only* allow valid URLs, which is not what we wish to achieve here.
+			claims.put(OAuth2TokenIntrospectionClaimNames.ISS, response.getIssuer().getValue());
 		}
 		if (response.getNotBeforeTime() != null) {
 			claims.put(OAuth2TokenIntrospectionClaimNames.NBF, response.getNotBeforeTime().toInstant());
@@ -188,16 +205,6 @@ public class NimbusReactiveOpaqueTokenIntrospector implements ReactiveOpaqueToke
 			}
 		}
 		return new OAuth2IntrospectionAuthenticatedPrincipal(claims, authorities);
-	}
-
-	private URL issuer(String uri) {
-		try {
-			return new URL(uri);
-		}
-		catch (Exception ex) {
-			throw new OAuth2IntrospectionException(
-					"Invalid " + OAuth2TokenIntrospectionClaimNames.ISS + " value: " + uri);
-		}
 	}
 
 	private OAuth2IntrospectionException onError(Throwable ex) {

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/NimbusReactiveOpaqueTokenIntrospector.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/NimbusReactiveOpaqueTokenIntrospector.java
@@ -57,13 +57,13 @@ import org.springframework.web.reactive.function.client.WebClient;
  */
 public class NimbusReactiveOpaqueTokenIntrospector implements ReactiveOpaqueTokenIntrospector {
 
+	private static final String AUTHORITY_PREFIX = "SCOPE_";
+
 	private final Log logger = LogFactory.getLog(getClass());
 
 	private final URI introspectionUri;
 
 	private final WebClient webClient;
-
-	private String authorityPrefix = "SCOPE_";
 
 	/**
 	 * Creates a {@code OpaqueTokenReactiveAuthenticationManager} with the provided
@@ -227,7 +227,7 @@ public class NimbusReactiveOpaqueTokenIntrospector implements ReactiveOpaqueToke
 			claims.put(OAuth2TokenIntrospectionClaimNames.SCOPE, scopes);
 
 			for (String scope : scopes) {
-				authorities.add(new SimpleGrantedAuthority(this.authorityPrefix + scope));
+				authorities.add(new SimpleGrantedAuthority(AUTHORITY_PREFIX + scope));
 			}
 		}
 		return new OAuth2IntrospectionAuthenticatedPrincipal(claims, authorities);

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/SpringOpaqueTokenIntrospector.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/SpringOpaqueTokenIntrospector.java
@@ -158,6 +158,10 @@ public class SpringOpaqueTokenIntrospector implements OpaqueTokenIntrospector {
 		Map<String, Object> claims = responseEntity.getBody();
 		// relying solely on the authorization server to validate this token (not checking
 		// 'exp', for example)
+		if (claims == null) {
+			return Collections.emptyMap();
+		}
+
 		boolean active = (boolean) claims.compute(OAuth2TokenIntrospectionClaimNames.ACTIVE, (k, v) -> {
 			if (v instanceof String) {
 				return Boolean.parseBoolean((String) v);

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/SpringOpaqueTokenIntrospector.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/SpringOpaqueTokenIntrospector.java
@@ -57,16 +57,16 @@ import org.springframework.web.client.RestTemplate;
  */
 public class SpringOpaqueTokenIntrospector implements OpaqueTokenIntrospector {
 
-	private final Log logger = LogFactory.getLog(getClass());
+	private static final String AUTHORITY_PREFIX = "SCOPE_";
 
 	private static final ParameterizedTypeReference<Map<String, Object>> STRING_OBJECT_MAP = new ParameterizedTypeReference<Map<String, Object>>() {
 	};
 
+	private final Log logger = LogFactory.getLog(getClass());
+
+	private final RestOperations restOperations;
+
 	private Converter<String, RequestEntity<?>> requestEntityConverter;
-
-	private RestOperations restOperations;
-
-	private final String authorityPrefix = "SCOPE_";
 
 	/**
 	 * Creates a {@code OpaqueTokenAuthenticationProvider} with the provided parameters
@@ -216,7 +216,7 @@ public class SpringOpaqueTokenIntrospector implements OpaqueTokenIntrospector {
 			if (v instanceof String) {
 				Collection<String> scopes = Arrays.asList(((String) v).split(" "));
 				for (String scope : scopes) {
-					authorities.add(new SimpleGrantedAuthority(this.authorityPrefix + scope));
+					authorities.add(new SimpleGrantedAuthority(AUTHORITY_PREFIX + scope));
 				}
 				return scopes;
 			}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/SpringOpaqueTokenIntrospector.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/SpringOpaqueTokenIntrospector.java
@@ -17,7 +17,6 @@
 package org.springframework.security.oauth2.server.resource.introspection;
 
 import java.net.URI;
-import java.net.URL;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -187,7 +186,25 @@ public class SpringOpaqueTokenIntrospector implements OpaqueTokenIntrospector {
 				(k, v) -> Instant.ofEpochSecond(((Number) v).longValue()));
 		claims.computeIfPresent(OAuth2TokenIntrospectionClaimNames.IAT,
 				(k, v) -> Instant.ofEpochSecond(((Number) v).longValue()));
-		claims.computeIfPresent(OAuth2TokenIntrospectionClaimNames.ISS, (k, v) -> issuer(v.toString()));
+		// RFC-7662 page 7 directs users to RFC-7519 for defining the values of these
+		// issuer fields.
+		// https://datatracker.ietf.org/doc/html/rfc7662#page-7
+		//
+		// RFC-7519 page 9 defines issuer fields as being 'case-sensitive' strings
+		// containing
+		// a 'StringOrURI', which is defined on page 5 as being any string, but strings
+		// containing ':'
+		// should be treated as valid URIs.
+		// https://datatracker.ietf.org/doc/html/rfc7519#section-2
+		//
+		// It is not defined however as to whether-or-not normalized URIs should be
+		// treated as the same literal
+		// value. It only defines validation itself, so to avoid potential ambiguity or
+		// unwanted side effects that
+		// may be awkward to debug, we do not want to manipulate this value. Previous
+		// versions of Spring Security
+		// would *only* allow valid URLs, which is not what we wish to achieve here.
+		claims.computeIfPresent(OAuth2TokenIntrospectionClaimNames.ISS, (k, v) -> v.toString());
 		claims.computeIfPresent(OAuth2TokenIntrospectionClaimNames.NBF,
 				(k, v) -> Instant.ofEpochSecond(((Number) v).longValue()));
 		Collection<GrantedAuthority> authorities = new ArrayList<>();
@@ -202,16 +219,6 @@ public class SpringOpaqueTokenIntrospector implements OpaqueTokenIntrospector {
 			return v;
 		});
 		return new OAuth2IntrospectionAuthenticatedPrincipal(claims, authorities);
-	}
-
-	private URL issuer(String uri) {
-		try {
-			return new URL(uri);
-		}
-		catch (Exception ex) {
-			throw new OAuth2IntrospectionException(
-					"Invalid " + OAuth2TokenIntrospectionClaimNames.ISS + " value: " + uri);
-		}
 	}
 
 }

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/SpringReactiveOpaqueTokenIntrospector.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/SpringReactiveOpaqueTokenIntrospector.java
@@ -35,6 +35,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.security.oauth2.core.OAuth2TokenIntrospectionClaimNames;
 import org.springframework.util.Assert;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.ClientResponse;
@@ -122,7 +123,7 @@ public class SpringReactiveOpaqueTokenIntrospector implements ReactiveOpaqueToke
 		// relying solely on the authorization server to validate this token (not checking
 		// 'exp', for example)
 		return responseEntity.bodyToMono(STRING_OBJECT_MAP)
-				.filter((body) -> (boolean) body.compute(OAuth2IntrospectionClaimNames.ACTIVE, (k, v) -> {
+				.filter((body) -> (boolean) body.compute(OAuth2TokenIntrospectionClaimNames.ACTIVE, (k, v) -> {
 					if (v instanceof String) {
 						return Boolean.parseBoolean((String) v);
 					}
@@ -134,16 +135,16 @@ public class SpringReactiveOpaqueTokenIntrospector implements ReactiveOpaqueToke
 	}
 
 	private OAuth2AuthenticatedPrincipal convertClaimsSet(Map<String, Object> claims) {
-		claims.computeIfPresent(OAuth2IntrospectionClaimNames.AUDIENCE, (k, v) -> {
+		claims.computeIfPresent(OAuth2TokenIntrospectionClaimNames.AUD, (k, v) -> {
 			if (v instanceof String) {
 				return Collections.singletonList(v);
 			}
 			return v;
 		});
-		claims.computeIfPresent(OAuth2IntrospectionClaimNames.CLIENT_ID, (k, v) -> v.toString());
-		claims.computeIfPresent(OAuth2IntrospectionClaimNames.EXPIRES_AT,
+		claims.computeIfPresent(OAuth2TokenIntrospectionClaimNames.CLIENT_ID, (k, v) -> v.toString());
+		claims.computeIfPresent(OAuth2TokenIntrospectionClaimNames.EXP,
 				(k, v) -> Instant.ofEpochSecond(((Number) v).longValue()));
-		claims.computeIfPresent(OAuth2IntrospectionClaimNames.ISSUED_AT,
+		claims.computeIfPresent(OAuth2TokenIntrospectionClaimNames.IAT,
 				(k, v) -> Instant.ofEpochSecond(((Number) v).longValue()));
 		// RFC-7662 page 7 directs users to RFC-7519 for defining the values of these
 		// issuer fields.
@@ -163,11 +164,11 @@ public class SpringReactiveOpaqueTokenIntrospector implements ReactiveOpaqueToke
 		// may be awkward to debug, we do not want to manipulate this value. Previous
 		// versions of Spring Security
 		// would *only* allow valid URLs, which is not what we wish to achieve here.
-		claims.computeIfPresent(OAuth2IntrospectionClaimNames.ISSUER, (k, v) -> v.toString());
-		claims.computeIfPresent(OAuth2IntrospectionClaimNames.NOT_BEFORE,
+		claims.computeIfPresent(OAuth2TokenIntrospectionClaimNames.ISS, (k, v) -> v.toString());
+		claims.computeIfPresent(OAuth2TokenIntrospectionClaimNames.NBF,
 				(k, v) -> Instant.ofEpochSecond(((Number) v).longValue()));
 		Collection<GrantedAuthority> authorities = new ArrayList<>();
-		claims.computeIfPresent(OAuth2IntrospectionClaimNames.SCOPE, (k, v) -> {
+		claims.computeIfPresent(OAuth2TokenIntrospectionClaimNames.SCOPE, (k, v) -> {
 			if (v instanceof String) {
 				Collection<String> scopes = Arrays.asList(((String) v).split(" "));
 				for (String scope : scopes) {

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/SpringReactiveOpaqueTokenIntrospector.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/SpringReactiveOpaqueTokenIntrospector.java
@@ -51,14 +51,14 @@ import org.springframework.web.reactive.function.client.WebClient;
  */
 public class SpringReactiveOpaqueTokenIntrospector implements ReactiveOpaqueTokenIntrospector {
 
+	private static final String AUTHORITY_PREFIX = "SCOPE_";
+
 	private static final ParameterizedTypeReference<Map<String, Object>> STRING_OBJECT_MAP = new ParameterizedTypeReference<Map<String, Object>>() {
 	};
 
 	private final URI introspectionUri;
 
 	private final WebClient webClient;
-
-	private String authorityPrefix = "SCOPE_";
 
 	/**
 	 * Creates a {@code OpaqueTokenReactiveAuthenticationManager} with the provided
@@ -171,7 +171,7 @@ public class SpringReactiveOpaqueTokenIntrospector implements ReactiveOpaqueToke
 			if (v instanceof String) {
 				Collection<String> scopes = Arrays.asList(((String) v).split(" "));
 				for (String scope : scopes) {
-					authorities.add(new SimpleGrantedAuthority(this.authorityPrefix + scope));
+					authorities.add(new SimpleGrantedAuthority(AUTHORITY_PREFIX + scope));
 				}
 				return scopes;
 			}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/SpringReactiveOpaqueTokenIntrospector.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/SpringReactiveOpaqueTokenIntrospector.java
@@ -17,7 +17,6 @@
 package org.springframework.security.oauth2.server.resource.introspection;
 
 import java.net.URI;
-import java.net.URL;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -146,7 +145,25 @@ public class SpringReactiveOpaqueTokenIntrospector implements ReactiveOpaqueToke
 				(k, v) -> Instant.ofEpochSecond(((Number) v).longValue()));
 		claims.computeIfPresent(OAuth2IntrospectionClaimNames.ISSUED_AT,
 				(k, v) -> Instant.ofEpochSecond(((Number) v).longValue()));
-		claims.computeIfPresent(OAuth2IntrospectionClaimNames.ISSUER, (k, v) -> issuer(v.toString()));
+		// RFC-7662 page 7 directs users to RFC-7519 for defining the values of these
+		// issuer fields.
+		// https://datatracker.ietf.org/doc/html/rfc7662#page-7
+		//
+		// RFC-7519 page 9 defines issuer fields as being 'case-sensitive' strings
+		// containing
+		// a 'StringOrURI', which is defined on page 5 as being any string, but strings
+		// containing ':'
+		// should be treated as valid URIs.
+		// https://datatracker.ietf.org/doc/html/rfc7519#section-2
+		//
+		// It is not defined however as to whether-or-not normalized URIs should be
+		// treated as the same literal
+		// value. It only defines validation itself, so to avoid potential ambiguity or
+		// unwanted side effects that
+		// may be awkward to debug, we do not want to manipulate this value. Previous
+		// versions of Spring Security
+		// would *only* allow valid URLs, which is not what we wish to achieve here.
+		claims.computeIfPresent(OAuth2IntrospectionClaimNames.ISSUER, (k, v) -> v.toString());
 		claims.computeIfPresent(OAuth2IntrospectionClaimNames.NOT_BEFORE,
 				(k, v) -> Instant.ofEpochSecond(((Number) v).longValue()));
 		Collection<GrantedAuthority> authorities = new ArrayList<>();
@@ -161,16 +178,6 @@ public class SpringReactiveOpaqueTokenIntrospector implements ReactiveOpaqueToke
 			return v;
 		});
 		return new OAuth2IntrospectionAuthenticatedPrincipal(claims, authorities);
-	}
-
-	private URL issuer(String uri) {
-		try {
-			return new URL(uri);
-		}
-		catch (Exception ex) {
-			throw new OAuth2IntrospectionException(
-					"Invalid " + OAuth2IntrospectionClaimNames.ISSUER + " value: " + uri);
-		}
 	}
 
 	private OAuth2IntrospectionException onError(Throwable ex) {

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/introspection/NimbusOpaqueTokenIntrospectorTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/introspection/NimbusOpaqueTokenIntrospectorTests.java
@@ -17,7 +17,6 @@
 package org.springframework.security.oauth2.server.resource.introspection;
 
 import java.io.IOException;
-import java.net.URL;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Base64;
@@ -146,7 +145,7 @@ public class NimbusOpaqueTokenIntrospectorTests {
 							Arrays.asList("https://protected.example.net/resource"))
 					.containsEntry(OAuth2TokenIntrospectionClaimNames.CLIENT_ID, "l238j323ds-23ij4")
 					.containsEntry(OAuth2TokenIntrospectionClaimNames.EXP, Instant.ofEpochSecond(1419356238))
-					.containsEntry(OAuth2TokenIntrospectionClaimNames.ISS, new URL("https://server.example.com/"))
+					.containsEntry(OAuth2TokenIntrospectionClaimNames.ISS, "https://server.example.com/")
 					.containsEntry(OAuth2TokenIntrospectionClaimNames.SCOPE, Arrays.asList("read", "write", "dolphin"))
 					.containsEntry(OAuth2TokenIntrospectionClaimNames.SUB, "Z5O3upPC88QrAjx00dis")
 					.containsEntry(OAuth2TokenIntrospectionClaimNames.USERNAME, "jdoe")

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/introspection/NimbusReactiveOpaqueTokenIntrospectorTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/introspection/NimbusReactiveOpaqueTokenIntrospectorTests.java
@@ -17,7 +17,6 @@
 package org.springframework.security.oauth2.server.resource.introspection;
 
 import java.io.IOException;
-import java.net.URL;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Base64;
@@ -117,7 +116,7 @@ public class NimbusReactiveOpaqueTokenIntrospectorTests {
 							Arrays.asList("https://protected.example.net/resource"))
 					.containsEntry(OAuth2TokenIntrospectionClaimNames.CLIENT_ID, "l238j323ds-23ij4")
 					.containsEntry(OAuth2TokenIntrospectionClaimNames.EXP, Instant.ofEpochSecond(1419356238))
-					.containsEntry(OAuth2TokenIntrospectionClaimNames.ISS, new URL("https://server.example.com/"))
+					.containsEntry(OAuth2TokenIntrospectionClaimNames.ISS, "https://server.example.com/")
 					.containsEntry(OAuth2TokenIntrospectionClaimNames.SCOPE, Arrays.asList("read", "write", "dolphin"))
 					.containsEntry(OAuth2TokenIntrospectionClaimNames.SUB, "Z5O3upPC88QrAjx00dis")
 					.containsEntry(OAuth2TokenIntrospectionClaimNames.USERNAME, "jdoe")

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/introspection/SpringOpaqueTokenIntrospectorTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/introspection/SpringOpaqueTokenIntrospectorTests.java
@@ -17,7 +17,6 @@
 package org.springframework.security.oauth2.server.resource.introspection;
 
 import java.io.IOException;
-import java.net.URL;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Base64;
@@ -150,7 +149,7 @@ public class SpringOpaqueTokenIntrospectorTests {
 							Arrays.asList("https://protected.example.net/resource"))
 					.containsEntry(OAuth2TokenIntrospectionClaimNames.CLIENT_ID, "l238j323ds-23ij4")
 					.containsEntry(OAuth2TokenIntrospectionClaimNames.EXP, Instant.ofEpochSecond(1419356238))
-					.containsEntry(OAuth2TokenIntrospectionClaimNames.ISS, new URL("https://server.example.com/"))
+					.containsEntry(OAuth2TokenIntrospectionClaimNames.ISS, "https://server.example.com/")
 					.containsEntry(OAuth2TokenIntrospectionClaimNames.SCOPE, Arrays.asList("read", "write", "dolphin"))
 					.containsEntry(OAuth2TokenIntrospectionClaimNames.SUB, "Z5O3upPC88QrAjx00dis")
 					.containsEntry(OAuth2TokenIntrospectionClaimNames.USERNAME, "jdoe")

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/introspection/SpringOpaqueTokenIntrospectorTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/introspection/SpringOpaqueTokenIntrospectorTests.java
@@ -102,13 +102,6 @@ public class SpringOpaqueTokenIntrospectorTests {
 	// @formatter:on
 
 	// @formatter:off
-	private static final String MALFORMED_ISSUER_RESPONSE = "{\n"
-			+ "     \"active\" : \"true\",\n"
-			+ "     \"iss\" : \"badissuer\"\n"
-			+ "    }";
-	// @formatter:on
-
-	// @formatter:off
 	private static final String MALFORMED_SCOPE_RESPONSE = "{\n"
 			+ "      \"active\": true,\n"
 			+ "      \"client_id\": \"l238j323ds-23ij4\",\n"
@@ -128,8 +121,6 @@ public class SpringOpaqueTokenIntrospectorTests {
 	private static final ResponseEntity<Map<String, Object>> INACTIVE = response(INACTIVE_RESPONSE);
 
 	private static final ResponseEntity<Map<String, Object>> INVALID = response(INVALID_RESPONSE);
-
-	private static final ResponseEntity<Map<String, Object>> MALFORMED_ISSUER = response(MALFORMED_ISSUER_RESPONSE);
 
 	private static final ResponseEntity<Map<String, Object>> MALFORMED_SCOPE = response(MALFORMED_SCOPE_RESPONSE);
 
@@ -236,16 +227,6 @@ public class SpringOpaqueTokenIntrospectorTests {
 		OpaqueTokenIntrospector introspectionClient = new SpringOpaqueTokenIntrospector(INTROSPECTION_URL,
 				restOperations);
 		given(restOperations.exchange(any(RequestEntity.class), eq(STRING_OBJECT_MAP))).willReturn(INVALID);
-		assertThatExceptionOfType(OAuth2IntrospectionException.class)
-				.isThrownBy(() -> introspectionClient.introspect("token"));
-	}
-
-	@Test
-	public void introspectWhenIntrospectionTokenReturnsMalformedIssuerResponseThenInvalidToken() {
-		RestOperations restOperations = mock(RestOperations.class);
-		OpaqueTokenIntrospector introspectionClient = new SpringOpaqueTokenIntrospector(INTROSPECTION_URL,
-				restOperations);
-		given(restOperations.exchange(any(RequestEntity.class), eq(STRING_OBJECT_MAP))).willReturn(MALFORMED_ISSUER);
 		assertThatExceptionOfType(OAuth2IntrospectionException.class)
 				.isThrownBy(() -> introspectionClient.introspect("token"));
 	}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/introspection/SpringReactiveOpaqueTokenIntrospectorTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/introspection/SpringReactiveOpaqueTokenIntrospectorTests.java
@@ -96,13 +96,6 @@ public class SpringReactiveOpaqueTokenIntrospectorTests {
 			+ "     }";
 	// @formatter:on
 
-	// @formatter:off
-	private static final String MALFORMED_ISSUER_RESPONSE = "{\n"
-			+ "     \"active\" : \"true\",\n"
-			+ "     \"iss\" : \"badissuer\"\n"
-			+ "    }";
-	// @formatter:on
-
 	private final ObjectMapper mapper = new ObjectMapper();
 
 	@Test
@@ -195,15 +188,6 @@ public class SpringReactiveOpaqueTokenIntrospectorTests {
 		assertThatExceptionOfType(OAuth2IntrospectionException.class)
 				.isThrownBy(() -> introspectionClient.introspect("token").block());
 		// @formatter:on
-	}
-
-	@Test
-	public void authenticateWhenIntrospectionTokenReturnsMalformedIssuerResponseThenInvalidToken() {
-		WebClient webClient = mockResponse(MALFORMED_ISSUER_RESPONSE);
-		SpringReactiveOpaqueTokenIntrospector introspectionClient = new SpringReactiveOpaqueTokenIntrospector(
-				INTROSPECTION_URL, webClient);
-		assertThatExceptionOfType(OAuth2IntrospectionException.class)
-				.isThrownBy(() -> introspectionClient.introspect("token").block());
 	}
 
 	@Test

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/introspection/SpringReactiveOpaqueTokenIntrospectorTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/introspection/SpringReactiveOpaqueTokenIntrospectorTests.java
@@ -17,7 +17,6 @@
 package org.springframework.security.oauth2.server.resource.introspection;
 
 import java.io.IOException;
-import java.net.URL;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Base64;
@@ -122,7 +121,7 @@ public class SpringReactiveOpaqueTokenIntrospectorTests {
 							Arrays.asList("https://protected.example.net/resource"))
 					.containsEntry(OAuth2IntrospectionClaimNames.CLIENT_ID, "l238j323ds-23ij4")
 					.containsEntry(OAuth2IntrospectionClaimNames.EXPIRES_AT, Instant.ofEpochSecond(1419356238))
-					.containsEntry(OAuth2IntrospectionClaimNames.ISSUER, new URL("https://server.example.com/"))
+					.containsEntry(OAuth2IntrospectionClaimNames.ISSUER, "https://server.example.com/")
 					.containsEntry(OAuth2IntrospectionClaimNames.SCOPE, Arrays.asList("read", "write", "dolphin"))
 					.containsEntry(OAuth2IntrospectionClaimNames.SUBJECT, "Z5O3upPC88QrAjx00dis")
 					.containsEntry(OAuth2IntrospectionClaimNames.USERNAME, "jdoe")

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/introspection/SpringReactiveOpaqueTokenIntrospectorTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/introspection/SpringReactiveOpaqueTokenIntrospectorTests.java
@@ -37,6 +37,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.security.oauth2.core.OAuth2TokenIntrospectionClaimNames;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -106,18 +107,19 @@ public class SpringReactiveOpaqueTokenIntrospectorTests {
 			SpringReactiveOpaqueTokenIntrospector introspectionClient = new SpringReactiveOpaqueTokenIntrospector(
 					introspectUri, CLIENT_ID, CLIENT_SECRET);
 			OAuth2AuthenticatedPrincipal authority = introspectionClient.introspect("token").block();
+			assertThat(authority).isNotNull();
 			// @formatter:off
 			assertThat(authority.getAttributes())
 					.isNotNull()
-					.containsEntry(OAuth2IntrospectionClaimNames.ACTIVE, true)
-					.containsEntry(OAuth2IntrospectionClaimNames.AUDIENCE,
+					.containsEntry(OAuth2TokenIntrospectionClaimNames.ACTIVE, true)
+					.containsEntry(OAuth2TokenIntrospectionClaimNames.AUD,
 							Arrays.asList("https://protected.example.net/resource"))
-					.containsEntry(OAuth2IntrospectionClaimNames.CLIENT_ID, "l238j323ds-23ij4")
-					.containsEntry(OAuth2IntrospectionClaimNames.EXPIRES_AT, Instant.ofEpochSecond(1419356238))
-					.containsEntry(OAuth2IntrospectionClaimNames.ISSUER, "https://server.example.com/")
-					.containsEntry(OAuth2IntrospectionClaimNames.SCOPE, Arrays.asList("read", "write", "dolphin"))
-					.containsEntry(OAuth2IntrospectionClaimNames.SUBJECT, "Z5O3upPC88QrAjx00dis")
-					.containsEntry(OAuth2IntrospectionClaimNames.USERNAME, "jdoe")
+					.containsEntry(OAuth2TokenIntrospectionClaimNames.CLIENT_ID, "l238j323ds-23ij4")
+					.containsEntry(OAuth2TokenIntrospectionClaimNames.EXP, Instant.ofEpochSecond(1419356238))
+					.containsEntry(OAuth2TokenIntrospectionClaimNames.ISS, "https://server.example.com/")
+					.containsEntry(OAuth2TokenIntrospectionClaimNames.SCOPE, Arrays.asList("read", "write", "dolphin"))
+					.containsEntry(OAuth2TokenIntrospectionClaimNames.SUB, "Z5O3upPC88QrAjx00dis")
+					.containsEntry(OAuth2TokenIntrospectionClaimNames.USERNAME, "jdoe")
 					.containsEntry("extension_field", "twenty-seven");
 			// @formatter:on
 		}
@@ -149,21 +151,22 @@ public class SpringReactiveOpaqueTokenIntrospectorTests {
 	@Test
 	public void authenticateWhenActiveTokenThenParsesValuesInResponse() {
 		Map<String, Object> introspectedValues = new HashMap<>();
-		introspectedValues.put(OAuth2IntrospectionClaimNames.ACTIVE, true);
-		introspectedValues.put(OAuth2IntrospectionClaimNames.AUDIENCE, Arrays.asList("aud"));
-		introspectedValues.put(OAuth2IntrospectionClaimNames.NOT_BEFORE, 29348723984L);
+		introspectedValues.put(OAuth2TokenIntrospectionClaimNames.ACTIVE, true);
+		introspectedValues.put(OAuth2TokenIntrospectionClaimNames.AUD, Arrays.asList("aud"));
+		introspectedValues.put(OAuth2TokenIntrospectionClaimNames.NBF, 29348723984L);
 		WebClient webClient = mockResponse(introspectedValues);
 		SpringReactiveOpaqueTokenIntrospector introspectionClient = new SpringReactiveOpaqueTokenIntrospector(
 				INTROSPECTION_URL, webClient);
 		OAuth2AuthenticatedPrincipal authority = introspectionClient.introspect("token").block();
+		assertThat(authority).isNotNull();
 		// @formatter:off
 		assertThat(authority.getAttributes())
 				.isNotNull()
-				.containsEntry(OAuth2IntrospectionClaimNames.ACTIVE, true)
-				.containsEntry(OAuth2IntrospectionClaimNames.AUDIENCE, Arrays.asList("aud"))
-				.containsEntry(OAuth2IntrospectionClaimNames.NOT_BEFORE, Instant.ofEpochSecond(29348723984L))
-				.doesNotContainKey(OAuth2IntrospectionClaimNames.CLIENT_ID)
-				.doesNotContainKey(OAuth2IntrospectionClaimNames.SCOPE);
+				.containsEntry(OAuth2TokenIntrospectionClaimNames.ACTIVE, true)
+				.containsEntry(OAuth2TokenIntrospectionClaimNames.AUD, Arrays.asList("aud"))
+				.containsEntry(OAuth2TokenIntrospectionClaimNames.NBF, Instant.ofEpochSecond(29348723984L))
+				.doesNotContainKey(OAuth2TokenIntrospectionClaimNames.CLIENT_ID)
+				.doesNotContainKey(OAuth2TokenIntrospectionClaimNames.SCOPE);
 		// @formatter:on
 	}
 
@@ -234,6 +237,7 @@ public class SpringReactiveOpaqueTokenIntrospectorTests {
 		return webClient;
 	}
 
+	@SuppressWarnings("unchecked")
 	private Map<String, Object> toMap(String string) {
 		try {
 			return this.mapper.readValue(string, Map.class);


### PR DESCRIPTION
----
Bug fixes:

Fixes to OAuth2 introspection processing, fixing a couple of misinterpretations of
the implementation spec, and amending logging to aid in debugging.

-   Amended treatment of OAuth2 'iss' claim
    
    Prior to this commit, the OAuth2 resource server code is failing any issuer
    that is not a valid URL. This does not correspond to
    https://datatracker.ietf.org/doc/html/rfc7662#page-7 which redirects to
    https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1, defining an
    issuer as being a "StringOrURI", which is defined at
    https://datatracker.ietf.org/doc/html/rfc7519#page-5 as being
    an "arbitrary string value" that "MUST be a URI" only for
    "any value containing a ':'". 

    While OIDC does require this field to be a valid URL, the use of the resource
    server itself should not require all integrations to be using OIDC under the
    hood, since that is irrelevant implementation detail as far as a REST API
    using OAuth2 resource server introspection for authentication and authorization
    is concerned.
    
    The issue currently is that an issuer that is not a valid URL may be
    provided, which will automatically result in the request being aborted
    due to being invalid.
    
    I have removed the check entirely, since while the claim could be invalid,
    it is still a response that the OAuth2 introspection endpoint has provided.
    In the liklihood that interpretations of this behaviour are different for
    the OAuth2 server implementation in use, this currently stops Spring
    Security from being able to be used at all without implementing a custom
    introspector from scratch.
    
    It is also worth noting that the spec does not specify whether it is
    valid to normalize issuers or not if they are valid URLs. This may cause
    other unintended side effects as a result of this change, so it is
    safer to disable it entirely. Best practises such as those outlined at
    https://curity.io/resources/learn/jwt-best-practices/#4-always-check-the-issuer always suggest
    that issuers must "match _exactly_ the value you expect it to be" which
    is not necessarily guaranteed by converting to java.net.URL (since there is no
    concrete specification to say that the URL class must conform to JWT semantics).

    

    **This issue is currently causing issues in existing applications we have that use this library**, 
    which is what has sparked the change to update this. The change itself may be
    considered breaking if the documentation refers to the issuer as being stored
    as a URL object. However, if the documentation only implies that .toString can be performed,
    then the underlying logic of this change would likely just be considered implementation
    detail instead.

----
Minor fixes and improvements:

-   Fixed potential NullPointerException in opaque token introspection
    
    It appears Nimbus does not check the presence of the Content-Type
    header before parsing it in some versions, and since prior to this
    commit, the code is .toString()-ing the result, a malformed response
    (such as that from a misbehaving cloud gateway) that does not include
    a Content-Type would currently throw a NullPointerException.
    
    In addition to this, I have added a little more information to the
    log output for this module on the standard and reactive implementations
    to aid in debugging authorization/authentication issues much more
    easily. A failed introspection will now log the reason to debug logs
    to make this simpler to debug.

- Fix typo in headers asciidoc. Would have opened a separate PR for
  this but it felt like a little bit of an overkill to remove two characters!

- Fixed final field warnings in opaque token introspectors

-   Ensuring consistency in error handling of opaque providers/managers
    
    The OpaqueTokenAuthenticationProvider now propagates the cause of
    introspection exceptions in the same way that the reactive
    OpaqueTokenReactiveAuthenticationManager does.
    
    Fixed a final field warning on both OpaqueTokenAuthenticationProvider
    and OpaqueTokenReactiveAuthenticationManager.

-   Replace usages of deprecated OAuth2IntrospectionClaimNames
    
    Replace all usages of OAuth2IntrospectionClaimNames with
    the suggested OAuth2TokenIntrospectionClaimNames.
    
    There does not appear to be any further usages of OAuth2IntrospectionClaimNames,
    so it should be suitable for removal when appropriate in accordance with the
    deprecation policy.

