### PR TITLE
Document AuthenticationPrincipal type cannot be primitive

### DIFF
--- a/core/src/main/java/org/springframework/security/core/annotation/AuthenticationPrincipal.java
+++ b/core/src/main/java/org/springframework/security/core/annotation/AuthenticationPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,12 @@ import org.springframework.security.core.Authentication;
 /**
  * Annotation that is used to resolve {@link Authentication#getPrincipal()} to a method
  * argument.
+ *
+ * If the {@link Authentication} or {@link Authentication#getPrincipal()} is null, it will
+ * return null. For that reason, the argument type cannot be a primitive. If the types do
+ * not match, null will be returned unless
+ * {@link AuthenticationPrincipal#errorOnInvalidType()} is true in which case a
+ * {@link ClassCastException} will be thrown.
  *
  * @author Rob Winch
  * @since 4.0


### PR DESCRIPTION
Closes gh-10172

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
