### PR TITLE
Update `DefaultWebInvocationPrivilegeEvaluator` to use current `ServletContext`

### DIFF
--- a/web/src/main/java/org/springframework/security/web/FilterInvocation.java
+++ b/web/src/main/java/org/springframework/security/web/FilterInvocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import javax.servlet.FilterChain;
+import javax.servlet.ServletContext;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
@@ -78,10 +79,19 @@ public class FilterInvocation {
 	}
 
 	public FilterInvocation(String contextPath, String servletPath, String method) {
-		this(contextPath, servletPath, null, null, method);
+		this(contextPath, servletPath, method, null);
+	}
+
+	public FilterInvocation(String contextPath, String servletPath, String method, ServletContext servletContext) {
+		this(contextPath, servletPath, null, null, method, servletContext);
 	}
 
 	public FilterInvocation(String contextPath, String servletPath, String pathInfo, String query, String method) {
+		this(contextPath, servletPath, pathInfo, query, method, null);
+	}
+
+	public FilterInvocation(String contextPath, String servletPath, String pathInfo, String query, String method,
+			ServletContext servletContext) {
 		DummyRequest request = new DummyRequest();
 		contextPath = (contextPath != null) ? contextPath : "/cp";
 		request.setContextPath(contextPath);
@@ -90,6 +100,7 @@ public class FilterInvocation {
 		request.setPathInfo(pathInfo);
 		request.setQueryString(query);
 		request.setMethod(method);
+		request.setServletContext(servletContext);
 		this.request = request;
 	}
 
@@ -159,6 +170,8 @@ public class FilterInvocation {
 		private String queryString;
 
 		private String method;
+
+		private ServletContext servletContext;
 
 		private final HttpHeaders headers = new HttpHeaders();
 
@@ -288,6 +301,15 @@ public class FilterInvocation {
 
 		void setParameter(String name, String... values) {
 			this.parameters.put(name, values);
+		}
+
+		@Override
+		public ServletContext getServletContext() {
+			return this.servletContext;
+		}
+
+		void setServletContext(ServletContext servletContext) {
+			this.servletContext = servletContext;
 		}
 
 	}

--- a/web/src/main/java/org/springframework/security/web/access/DefaultWebInvocationPrivilegeEvaluator.java
+++ b/web/src/main/java/org/springframework/security/web/access/DefaultWebInvocationPrivilegeEvaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package org.springframework.security.web.access;
 
 import java.util.Collection;
 
+import javax.servlet.ServletContext;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -28,6 +30,7 @@ import org.springframework.security.access.intercept.AbstractSecurityInterceptor
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.FilterInvocation;
 import org.springframework.util.Assert;
+import org.springframework.web.context.ServletContextAware;
 
 /**
  * Allows users to determine whether they have privileges for a given web URI.
@@ -36,11 +39,13 @@ import org.springframework.util.Assert;
  * @author Luke Taylor
  * @since 3.0
  */
-public class DefaultWebInvocationPrivilegeEvaluator implements WebInvocationPrivilegeEvaluator {
+public class DefaultWebInvocationPrivilegeEvaluator implements WebInvocationPrivilegeEvaluator, ServletContextAware {
 
 	protected static final Log logger = LogFactory.getLog(DefaultWebInvocationPrivilegeEvaluator.class);
 
 	private final AbstractSecurityInterceptor securityInterceptor;
+
+	private ServletContext servletContext;
 
 	public DefaultWebInvocationPrivilegeEvaluator(AbstractSecurityInterceptor securityInterceptor) {
 		Assert.notNull(securityInterceptor, "SecurityInterceptor cannot be null");
@@ -82,7 +87,7 @@ public class DefaultWebInvocationPrivilegeEvaluator implements WebInvocationPriv
 	@Override
 	public boolean isAllowed(String contextPath, String uri, String method, Authentication authentication) {
 		Assert.notNull(uri, "uri parameter is required");
-		FilterInvocation filterInvocation = new FilterInvocation(contextPath, uri, method);
+		FilterInvocation filterInvocation = new FilterInvocation(contextPath, uri, method, this.servletContext);
 		Collection<ConfigAttribute> attributes = this.securityInterceptor.obtainSecurityMetadataSource()
 				.getAttributes(filterInvocation);
 		if (attributes == null) {
@@ -99,6 +104,11 @@ public class DefaultWebInvocationPrivilegeEvaluator implements WebInvocationPriv
 			logger.debug(LogMessage.format("%s denied for %s", filterInvocation, authentication), ex);
 			return false;
 		}
+	}
+
+	@Override
+	public void setServletContext(ServletContext servletContext) {
+		this.servletContext = servletContext;
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/FilterInvocationTests.java
+++ b/web/src/test/java/org/springframework/security/web/FilterInvocationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletContext;
 import org.springframework.security.web.FilterInvocation.DummyRequest;
 import org.springframework.security.web.util.UrlUtils;
 
@@ -129,6 +130,16 @@ public class FilterInvocationTests {
 		request.setContextPath("");
 		request.setRequestURI("/something");
 		UrlUtils.buildRequestUrl(request);
+	}
+
+	@Test
+	public void constructorWhenServletContextProvidedThenSetServletContextInRequest() {
+		String contextPath = "";
+		String servletPath = "/path";
+		String method = "";
+		MockServletContext mockServletContext = new MockServletContext();
+		FilterInvocation filterInvocation = new FilterInvocation(contextPath, servletPath, method, mockServletContext);
+		assertThat(filterInvocation.getRequest().getServletContext()).isSameAs(mockServletContext);
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/access/DefaultWebInvocationPrivilegeEvaluatorTests.java
+++ b/web/src/test/java/org/springframework/security/web/access/DefaultWebInvocationPrivilegeEvaluatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,10 @@ package org.springframework.security.web.access;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.mock.web.MockServletContext;
 import org.springframework.security.access.AccessDecisionManager;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.intercept.RunAsManager;
@@ -27,6 +29,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.FilterInvocation;
 import org.springframework.security.web.access.intercept.FilterInvocationSecurityMetadataSource;
 import org.springframework.security.web.access.intercept.FilterSecurityInterceptor;
 
@@ -34,9 +37,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * Tests
@@ -104,6 +109,19 @@ public class DefaultWebInvocationPrivilegeEvaluatorTests {
 		willThrow(new AccessDeniedException("")).given(this.adm).decide(any(Authentication.class), anyObject(),
 				anyList());
 		assertThat(wipe.isAllowed("/foo/index.jsp", token)).isFalse();
+	}
+
+	@Test
+	public void isAllowedWhenServletContextIsSetThenPassedFilterInvocationHasServletContext() {
+		Authentication token = new TestingAuthenticationToken("test", "Password", "MOCK_INDEX");
+		MockServletContext servletContext = new MockServletContext();
+		ArgumentCaptor<FilterInvocation> filterInvocationArgumentCaptor = ArgumentCaptor
+				.forClass(FilterInvocation.class);
+		DefaultWebInvocationPrivilegeEvaluator wipe = new DefaultWebInvocationPrivilegeEvaluator(this.interceptor);
+		wipe.setServletContext(servletContext);
+		wipe.isAllowed("/foo/index.jsp", token);
+		verify(this.adm).decide(eq(token), filterInvocationArgumentCaptor.capture(), any());
+		assertThat(filterInvocationArgumentCaptor.getValue().getRequest().getServletContext()).isNotNull();
 	}
 
 }


### PR DESCRIPTION
Closes gh-10208

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
