### PR TITLE
Introduce @OverrideMethodSecurity to avoid boilerplate code

### DIFF
--- a/core/src/main/java/org/springframework/security/access/annotation/OverrideMethodSecurity.java
+++ b/core/src/main/java/org/springframework/security/access/annotation/OverrideMethodSecurity.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.access.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation combined with secure annotations such as <code>@Secured</code> for
+ * overriding method's declaring class level security attributes.
+ *
+ * For example:
+ *
+ * <pre>
+ * public class CrudRepository&lt;T&gt; {
+ *
+ *   public void create(T entity) {
+ *
+ *   }
+ *   public void update(T entity) {
+ *
+ *   }
+ *   public void delete(T entity) {
+ *
+ *   }
+ *
+ * }
+ *
+ * &#064;Secured({ &quot;ROLE_USER&quot; })
+ * &#064;OverrideMethodSecurity
+ * public class ContractRepository extends CrudRepository&lt;Contract&gt; {
+ *
+ * }
+ * </pre> Otherwise you need redeclare methods without this annotation: <pre>
+ * &#064;Secured({ &quot;ROLE_USER&quot; })
+ * public class ContractRepository extends CrudRepository&lt;Contract&gt; {
+ *
+ *   &#064;Override
+ *   public void create(Contract contract) {
+ *     super.create(contract);
+ *   }
+ *
+ *   &#064;Override
+ *   public void update(Contract contract) {
+ *     super.update(contract);
+ *   }
+ *
+ *   &#064;Override
+ *   public void delete(Contract contract) {
+ *     super.delete(contract);
+ *   }
+ *
+ * }
+ * </pre>
+ *
+ * @author Yanming Zhou
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface OverrideMethodSecurity {
+
+}

--- a/core/src/main/java/org/springframework/security/access/method/AbstractFallbackMethodSecurityMetadataSource.java
+++ b/core/src/main/java/org/springframework/security/access/method/AbstractFallbackMethodSecurityMetadataSource.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 
 import org.springframework.aop.support.AopUtils;
 import org.springframework.security.access.ConfigAttribute;
+import org.springframework.security.access.annotation.OverrideMethodSecurity;
 
 /**
  * Abstract implementation of {@link MethodSecurityMetadataSource} that supports both
@@ -42,6 +43,7 @@ import org.springframework.security.access.ConfigAttribute;
  *
  * @author Ben Alex
  * @author Luke taylor
+ * @author Yanming Zhou
  * @since 2.0
  */
 public abstract class AbstractFallbackMethodSecurityMetadataSource extends AbstractMethodSecurityMetadataSource {
@@ -56,6 +58,9 @@ public abstract class AbstractFallbackMethodSecurityMetadataSource extends Abstr
 		Collection<ConfigAttribute> attr = findAttributes(specificMethod, targetClass);
 		if (attr != null) {
 			return attr;
+		}
+		if (targetClass != null && targetClass.isAnnotationPresent(OverrideMethodSecurity.class)) {
+			return findAttributes(targetClass);
 		}
 		// Second try is the config attribute on the target class.
 		attr = findAttributes(specificMethod.getDeclaringClass());

--- a/core/src/test/java/org/springframework/security/access/annotation/SecuredAnnotationSecurityMetadataSourceTests.java
+++ b/core/src/test/java/org/springframework/security/access/annotation/SecuredAnnotationSecurityMetadataSourceTests.java
@@ -46,6 +46,7 @@ import static org.assertj.core.api.Assertions.fail;
  * @author Joe Scalise
  * @author Ben Alex
  * @author Luke Taylor
+ * @author Yanming Zhou
  */
 public class SecuredAnnotationSecurityMetadataSourceTests {
 
@@ -169,6 +170,28 @@ public class SecuredAnnotationSecurityMetadataSourceTests {
 		assertThat(attributes).extracting("attribute").containsOnly("ROLE_PERSON");
 	}
 
+	@Test
+	public void annotatedAnnotationAtClassLevelWithOverrideMethodSecurityIsDetected() throws Exception {
+		MockMethodInvocation annotatedAtClassLevel = new MockMethodInvocation(
+				new AnnotatedAnnotationAtClassLevelWithOverrideMethodSecurity(), ReturnVoidClass.class, "doSomething",
+				List.class);
+		ConfigAttribute[] attrs = this.mds.getAttributes(annotatedAtClassLevel).toArray(new ConfigAttribute[0]);
+		assertThat(attrs).hasSize(1);
+		assertThat(attrs).extracting("attribute").containsOnly("CUSTOM");
+		annotatedAtClassLevel = new MockMethodInvocation(
+				new AnnotatedAnnotationAtClassLevelWithOverrideMethodSecurity(), ReturnVoidClass.class,
+				"doSomethingElse", List.class);
+		attrs = this.mds.getAttributes(annotatedAtClassLevel).toArray(new ConfigAttribute[0]);
+		assertThat(attrs).hasSize(1);
+		assertThat(attrs).extracting("attribute").containsOnly("ELSE");
+		annotatedAtClassLevel = new MockMethodInvocation(
+				new AnnotatedAnnotationAtClassLevelWithOverrideMethodSecurity(),
+				AnnotatedAnnotationAtClassLevelWithOverrideMethodSecurity.class, "doOtherThing", List.class);
+		attrs = this.mds.getAttributes(annotatedAtClassLevel).toArray(new ConfigAttribute[0]);
+		assertThat(attrs).hasSize(1);
+		assertThat(attrs).extracting("attribute").containsOnly("OTHER");
+	}
+
 	// Inner classes
 	class Department extends Entity {
 
@@ -283,6 +306,27 @@ public class SecuredAnnotationSecurityMetadataSourceTests {
 		@Override
 		@AnnotatedAnnotation
 		public void doSomething(List<?> param) {
+		}
+
+	}
+
+	public static class ReturnVoidClass {
+
+		public void doSomething(List<?> param) {
+		}
+
+		@Secured("ELSE")
+		public void doSomethingElse(List<?> param) {
+		}
+
+	}
+
+	@AnnotatedAnnotation
+	@OverrideMethodSecurity
+	public static class AnnotatedAnnotationAtClassLevelWithOverrideMethodSecurity extends ReturnVoidClass {
+
+		@Secured("OTHER")
+		public void doOtherThing(List<?> param) {
 		}
 
 	}


### PR DESCRIPTION
```java
public class CrudRepository<T> {

  public void create(T entity) {

  }
  public void update(T entity) {

  }
  public void delete(T entity) {

  }

}
```
Before this commit:
```java
@Secured({ "ROLE_USER" })
public class ContractRepository extends CrudRepository<Contract> {

  @Override
  public void create(Contract contract) {
    super.create(contract);
  }

  @Override
  public void update(Contract contract) {
    super.update(contract);
  }

  @Override
  public void delete(Contract contract) {
    super.delete(contract);
  }

}
```
After this commit:
```java
@Secured({ "ROLE_USER" })
@OverrideMethodSecurity
public class ContractRepository extends CrudRepository<Contract> {

}
```