### PR TITLE
Use SpringSecurityMessageSource as international information back message source.

### DIFF
--- a/acl/src/main/java/org/springframework/security/acls/afterinvocation/AclEntryAfterInvocationProvider.java
+++ b/acl/src/main/java/org/springframework/security/acls/afterinvocation/AclEntryAfterInvocationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ * Copyright 2004, 2005, 2006, 2021 Acegi Technology Pty Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.springframework.security.access.ConfigAttribute;
 import org.springframework.security.acls.model.AclService;
 import org.springframework.security.acls.model.Permission;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 
 /**
  * Given a domain object instance returned from a secure object invocation, ensures the
@@ -64,7 +64,7 @@ public class AclEntryAfterInvocationProvider extends AbstractAclProvider impleme
 
 	protected static final Log logger = LogFactory.getLog(AclEntryAfterInvocationProvider.class);
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	public AclEntryAfterInvocationProvider(AclService aclService, List<Permission> requirePermission) {
 		this(aclService, "AFTER_ACL_READ", requirePermission);
@@ -112,7 +112,7 @@ public class AclEntryAfterInvocationProvider extends AbstractAclProvider impleme
 
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 }

--- a/cas/src/main/java/org/springframework/security/cas/authentication/CasAuthenticationProvider.java
+++ b/cas/src/main/java/org/springframework/security/cas/authentication/CasAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ * Copyright 2004, 2005, 2006, 2021 Acegi Technology Pty Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import org.springframework.security.cas.web.CasAuthenticationFilter;
 import org.springframework.security.cas.web.authentication.ServiceAuthenticationDetails;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
 import org.springframework.security.core.userdetails.AuthenticationUserDetailsService;
@@ -68,7 +68,7 @@ public class CasAuthenticationProvider implements AuthenticationProvider, Initia
 
 	private final UserDetailsChecker userDetailsChecker = new AccountStatusUserDetailsChecker();
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	private StatelessTicketCache statelessTicketCache = new NullStatelessTicketCache();
 
@@ -219,7 +219,7 @@ public class CasAuthenticationProvider implements AuthenticationProvider, Initia
 
 	@Override
 	public void setMessageSource(final MessageSource messageSource) {
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 	public void setStatelessTicketCache(final StatelessTicketCache statelessTicketCache) {

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/DefaultLoginPageConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/DefaultLoginPageConfigurerTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.security.config.annotation.web.configurers;
 
+import java.util.Locale;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -69,6 +72,14 @@ public class DefaultLoginPageConfigurerTests {
 
 	@Autowired
 	MockMvc mvc;
+
+	/**
+	 * Ensure that the default Locale for testing in different environments is EN
+	 */
+	@BeforeEach
+	public void setDefaultLocal() {
+		Locale.setDefault(new Locale("en"));
+	}
 
 	@Test
 	public void getWhenFormLoginEnabledThenRedirectsToLoginPage() throws Exception {

--- a/core/src/main/java/org/springframework/security/access/intercept/AbstractSecurityInterceptor.java
+++ b/core/src/main/java/org/springframework/security/access/intercept/AbstractSecurityInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ * Copyright 2004, 2005, 2006, 2021 Acegi Technology Pty Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.Assert;
@@ -109,7 +109,7 @@ public abstract class AbstractSecurityInterceptor
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	private ApplicationEventPublisher eventPublisher;
 
@@ -412,7 +412,7 @@ public abstract class AbstractSecurityInterceptor
 
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 	/**

--- a/core/src/main/java/org/springframework/security/access/intercept/RunAsImplAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/access/intercept/RunAsImplAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ * Copyright 2004, 2005, 2006, 2021 Acegi Technology Pty Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.util.Assert;
 
 /**
@@ -42,7 +42,7 @@ import org.springframework.util.Assert;
  */
 public class RunAsImplAuthenticationProvider implements InitializingBean, AuthenticationProvider, MessageSourceAware {
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	private String key;
 
@@ -71,7 +71,7 @@ public class RunAsImplAuthenticationProvider implements InitializingBean, Authen
 
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 	@Override

--- a/core/src/main/java/org/springframework/security/access/vote/AbstractAccessDecisionManager.java
+++ b/core/src/main/java/org/springframework/security/access/vote/AbstractAccessDecisionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ * Copyright 2004, 2005, 2006, 2021 Acegi Technology Pty Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.springframework.security.access.AccessDecisionManager;
 import org.springframework.security.access.AccessDecisionVoter;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.ConfigAttribute;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.util.Assert;
 
 /**
@@ -47,7 +47,7 @@ public abstract class AbstractAccessDecisionManager
 
 	private List<AccessDecisionVoter<?>> decisionVoters;
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	private boolean allowIfAllAbstainDecisions = false;
 
@@ -83,7 +83,7 @@ public abstract class AbstractAccessDecisionManager
 
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 	@Override

--- a/core/src/main/java/org/springframework/security/authentication/AbstractUserDetailsReactiveAuthenticationManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/AbstractUserDetailsReactiveAuthenticationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.springframework.context.MessageSource;
 import org.springframework.context.MessageSourceAware;
 import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.security.core.userdetails.ReactiveUserDetailsPasswordService;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsChecker;
@@ -52,7 +52,7 @@ public abstract class AbstractUserDetailsReactiveAuthenticationManager
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	private PasswordEncoder passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
 
@@ -173,7 +173,7 @@ public abstract class AbstractUserDetailsReactiveAuthenticationManager
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
 		Assert.notNull(messageSource, "messageSource cannot be null");
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 	/**

--- a/core/src/main/java/org/springframework/security/authentication/AccountStatusUserDetailsChecker.java
+++ b/core/src/main/java/org/springframework/security/authentication/AccountStatusUserDetailsChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.context.MessageSource;
 import org.springframework.context.MessageSourceAware;
 import org.springframework.context.support.MessageSourceAccessor;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsChecker;
 import org.springframework.util.Assert;
@@ -34,7 +34,7 @@ public class AccountStatusUserDetailsChecker implements UserDetailsChecker, Mess
 
 	private final Log logger = LogFactory.getLog(getClass());
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	@Override
 	public void check(UserDetails user) {
@@ -66,7 +66,7 @@ public class AccountStatusUserDetailsChecker implements UserDetailsChecker, Mess
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
 		Assert.notNull(messageSource, "messageSource cannot be null");
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 }

--- a/core/src/main/java/org/springframework/security/authentication/AnonymousAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/AnonymousAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ * Copyright 2004, 2005, 2006, 2021 Acegi Technology Pty Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import org.springframework.context.MessageSourceAware;
 import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.util.Assert;
 
 /**
@@ -35,7 +35,7 @@ import org.springframework.util.Assert;
  */
 public class AnonymousAuthenticationProvider implements AuthenticationProvider, MessageSourceAware {
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	private String key;
 
@@ -63,7 +63,7 @@ public class AnonymousAuthenticationProvider implements AuthenticationProvider, 
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
 		Assert.notNull(messageSource, "messageSource cannot be null");
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 	@Override

--- a/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import org.springframework.core.log.LogMessage;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.CredentialsContainer;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 
@@ -95,7 +95,7 @@ public class ProviderManager implements AuthenticationManager, MessageSourceAwar
 
 	private List<AuthenticationProvider> providers = Collections.emptyList();
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	private AuthenticationManager parent;
 
@@ -268,7 +268,7 @@ public class ProviderManager implements AuthenticationManager, MessageSourceAwar
 
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 	public void setAuthenticationEventPublisher(AuthenticationEventPublisher eventPublisher) {

--- a/core/src/main/java/org/springframework/security/authentication/RememberMeAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/RememberMeAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ * Copyright 2004, 2005, 2006, 2021 Acegi Technology Pty Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.springframework.context.MessageSourceAware;
 import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.util.Assert;
 
 /**
@@ -34,7 +34,7 @@ import org.springframework.util.Assert;
  */
 public class RememberMeAuthenticationProvider implements AuthenticationProvider, InitializingBean, MessageSourceAware {
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	private String key;
 
@@ -66,7 +66,7 @@ public class RememberMeAuthenticationProvider implements AuthenticationProvider,
 
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 	@Override

--- a/core/src/main/java/org/springframework/security/authentication/dao/AbstractUserDetailsAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/dao/AbstractUserDetailsAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ * Copyright 2004, 2005, 2006, 2021 Acegi Technology Pty Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import org.springframework.security.authentication.LockedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
 import org.springframework.security.core.userdetails.UserCache;
@@ -79,7 +79,7 @@ public abstract class AbstractUserDetailsAuthenticationProvider
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	private UserCache userCache = new NullUserCache();
 
@@ -277,7 +277,7 @@ public abstract class AbstractUserDetailsAuthenticationProvider
 
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 	public void setUserCache(UserCache userCache) {

--- a/core/src/main/java/org/springframework/security/core/SpringSecurityMessageSource.java
+++ b/core/src/main/java/org/springframework/security/core/SpringSecurityMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ * Copyright 2004, 2005, 2006, 2021 Acegi Technology Pty Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.springframework.security.core;
 
-import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.context.support.ResourceBundleMessageSource;
 
 /**
@@ -24,9 +23,9 @@ import org.springframework.context.support.ResourceBundleMessageSource;
  * <p>
  * All Spring Security classes requiring message localization will by default use this
  * class. However, all such classes will also implement <code>MessageSourceAware</code> so
- * that the application context can inject an alternative message source. Therefore this
- * class is only used when the deployment environment has not specified an alternative
- * message source.
+ * that the application context can inject an alternative message source. When message
+ * source is specified in the deployment environment, it is used as the rollback message
+ * source
  * </p>
  *
  * @author Ben Alex
@@ -35,10 +34,6 @@ public class SpringSecurityMessageSource extends ResourceBundleMessageSource {
 
 	public SpringSecurityMessageSource() {
 		setBasename("org.springframework.security.messages");
-	}
-
-	public static MessageSourceAccessor getAccessor() {
-		return new MessageSourceAccessor(new SpringSecurityMessageSource());
 	}
 
 }

--- a/core/src/main/java/org/springframework/security/core/SpringSecurityMessageSourceAccessor.java
+++ b/core/src/main/java/org/springframework/security/core/SpringSecurityMessageSourceAccessor.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.core;
+
+import java.util.Locale;
+
+import org.springframework.context.MessageSource;
+import org.springframework.context.MessageSourceResolvable;
+import org.springframework.context.NoSuchMessageException;
+import org.springframework.context.support.MessageSourceAccessor;
+import org.springframework.lang.Nullable;
+
+/**
+ * Like {@link MessageSourceAccessor}, this is a helper class for easy access to message
+ * from a MessageSource, providing various overloaded getMessage methods.
+ *
+ * <p>
+ * Unlike MessageSourceAccessor, it sets the SpringSecurityMessageSource to fallback
+ * messageSource. When a user provides messageSource cannot find information, will make
+ * SpringSecurityMessageSource out looking.
+ *
+ * @author Hccake
+ * @since 5.6.0
+ * @see MessageSourceAccessor
+ */
+public class SpringSecurityMessageSourceAccessor extends MessageSourceAccessor {
+
+	private final MessageSource messageSource;
+
+	/**
+	 * Create a new MessageSourceAccessor, using LocaleContextHolder's locale as default
+	 * locale, and always use SpringSecurityMessageSource to get the message
+	 * @see org.springframework.context.i18n.LocaleContextHolder#getLocale()
+	 */
+	public SpringSecurityMessageSourceAccessor() {
+		super(new SpringSecurityMessageSource());
+		this.messageSource = null;
+	}
+
+	/**
+	 * Create a new MessageSourceAccessor, using LocaleContextHolder's locale as default
+	 * locale.
+	 * @param messageSource the MessageSource to wrap
+	 * @see org.springframework.context.i18n.LocaleContextHolder#getLocale()
+	 */
+	public SpringSecurityMessageSourceAccessor(MessageSource messageSource) {
+		super(new SpringSecurityMessageSource());
+		this.messageSource = messageSource;
+	}
+
+	/**
+	 * Create a new MessageSourceAccessor, using the given default locale.
+	 * @param messageSource the MessageSource to wrap
+	 * @param defaultLocale the default locale to use for message access
+	 */
+	public SpringSecurityMessageSourceAccessor(MessageSource messageSource, Locale defaultLocale) {
+		super(new SpringSecurityMessageSource(), defaultLocale);
+		this.messageSource = messageSource;
+	}
+
+	/**
+	 * Retrieve the message for the given code and the default Locale.
+	 * @param code the code of the message
+	 * @param defaultMessage the String to return if the lookup fails
+	 * @return the message
+	 */
+	@Override
+	public String getMessage(String code, String defaultMessage) {
+		return this.getMessage(code, defaultMessage, getDefaultLocale());
+	}
+
+	/**
+	 * Retrieve the message for the given code and the given Locale.
+	 * @param code the code of the message
+	 * @param defaultMessage the String to return if the lookup fails
+	 * @param locale the Locale in which to do lookup
+	 * @return the message
+	 */
+	@Override
+	public String getMessage(String code, String defaultMessage, Locale locale) {
+		return this.getMessage(code, null, defaultMessage, locale);
+	}
+
+	/**
+	 * Retrieve the message for the given code and the default Locale.
+	 * @param code the code of the message
+	 * @param args arguments for the message, or {@code null} if none
+	 * @param defaultMessage the String to return if the lookup fails
+	 * @return the message
+	 */
+	@Override
+	public String getMessage(String code, @Nullable Object[] args, String defaultMessage) {
+		return this.getMessage(code, args, defaultMessage, getDefaultLocale());
+	}
+
+	/**
+	 * Retrieve the message for the given code and the given Locale.
+	 * @param code the code of the message
+	 * @param args arguments for the message, or {@code null} if none
+	 * @param defaultMessage the String to return if the lookup fails
+	 * @param locale the Locale in which to do lookup
+	 * @return the message
+	 */
+	@Override
+	public String getMessage(String code, @Nullable Object[] args, String defaultMessage, Locale locale) {
+		String msg;
+		if (this.messageSource != null) {
+			try {
+				msg = this.messageSource.getMessage(code, args, locale);
+			}
+			catch (NoSuchMessageException ex) {
+				msg = super.getMessage(code, args, defaultMessage, locale);
+			}
+		}
+		else {
+			msg = super.getMessage(code, args, defaultMessage, locale);
+		}
+		return msg;
+	}
+
+	/**
+	 * Retrieve the message for the given code and the default Locale.
+	 * @param code the code of the message
+	 * @return the message
+	 * @throws org.springframework.context.NoSuchMessageException if not found
+	 */
+	@Override
+	public String getMessage(String code) throws NoSuchMessageException {
+		return this.getMessage(code, getDefaultLocale());
+	}
+
+	/**
+	 * Retrieve the message for the given code and the given Locale.
+	 * @param code the code of the message
+	 * @param locale the Locale in which to do lookup
+	 * @return the message
+	 * @throws org.springframework.context.NoSuchMessageException if not found
+	 */
+	@Override
+	public String getMessage(String code, Locale locale) throws NoSuchMessageException {
+		return this.getMessage(code, new Object[] {}, locale);
+	}
+
+	/**
+	 * Retrieve the message for the given code and the default Locale.
+	 * @param code the code of the message
+	 * @param args arguments for the message, or {@code null} if none
+	 * @return the message
+	 * @throws org.springframework.context.NoSuchMessageException if not found
+	 */
+	@Override
+	public String getMessage(String code, @Nullable Object[] args) throws NoSuchMessageException {
+		return this.getMessage(code, args, getDefaultLocale());
+	}
+
+	/**
+	 * Retrieve the message for the given code and the given Locale.
+	 * @param code the code of the message
+	 * @param args arguments for the message, or {@code null} if none
+	 * @param locale the Locale in which to do lookup
+	 * @return the message
+	 * @throws org.springframework.context.NoSuchMessageException if not found
+	 */
+	@Override
+	public String getMessage(String code, @Nullable Object[] args, Locale locale) throws NoSuchMessageException {
+		String msg;
+		if (this.messageSource != null) {
+			try {
+				msg = this.messageSource.getMessage(code, args, locale);
+			}
+			catch (NoSuchMessageException ex) {
+				msg = super.getMessage(code, args, locale);
+			}
+		}
+		else {
+			msg = super.getMessage(code, args, locale);
+		}
+		return msg;
+	}
+
+	/**
+	 * Retrieve the given MessageSourceResolvable (e.g. an ObjectError instance) in the
+	 * default Locale.
+	 * @param resolvable the MessageSourceResolvable
+	 * @return the message
+	 * @throws org.springframework.context.NoSuchMessageException if not found
+	 */
+	@Override
+	public String getMessage(MessageSourceResolvable resolvable) throws NoSuchMessageException {
+		return this.getMessage(resolvable, getDefaultLocale());
+	}
+
+	/**
+	 * Retrieve the given MessageSourceResolvable (e.g. an ObjectError instance) in the
+	 * given Locale.
+	 * @param resolvable the MessageSourceResolvable
+	 * @param locale the Locale in which to do lookup
+	 * @return the message
+	 * @throws org.springframework.context.NoSuchMessageException if not found
+	 */
+	@Override
+	public String getMessage(MessageSourceResolvable resolvable, Locale locale) throws NoSuchMessageException {
+		String msg;
+		if (this.messageSource != null) {
+			try {
+				msg = this.messageSource.getMessage(resolvable, locale);
+			}
+			catch (NoSuchMessageException ex) {
+				msg = super.getMessage(resolvable, locale);
+			}
+		}
+		else {
+			msg = super.getMessage(resolvable, locale);
+		}
+		return msg;
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/core/userdetails/jdbc/JdbcDaoImpl.java
+++ b/core/src/main/java/org/springframework/security/core/userdetails/jdbc/JdbcDaoImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ * Copyright 2004, 2005, 2006, 2021 Acegi Technology Pty Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.support.JdbcDaoSupport;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
@@ -128,7 +128,7 @@ public class JdbcDaoImpl extends JdbcDaoSupport implements UserDetailsService, M
 			+ "where gm.username = ? " + "and g.id = ga.group_id " + "and g.id = gm.group_id";
 	// @formatter:on
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	private String authoritiesByUsernameQuery;
 
@@ -370,7 +370,7 @@ public class JdbcDaoImpl extends JdbcDaoSupport implements UserDetailsService, M
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
 		Assert.notNull(messageSource, "messageSource cannot be null");
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 }

--- a/core/src/test/java/org/springframework/security/core/SpringSecurityMessageSourceTests.java
+++ b/core/src/test/java/org/springframework/security/core/SpringSecurityMessageSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ * Copyright 2004, 2005, 2006, 2021 Acegi Technology Pty Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ public class SpringSecurityMessageSourceTests {
 		Locale before = LocaleContextHolder.getLocale();
 		LocaleContextHolder.setLocale(Locale.FRENCH);
 		// Cause a message to be generated
-		MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+		MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 		assertThat("Le jeton nonce est compromis FOOBAR").isEqualTo(messages.getMessage(
 				"DigestAuthenticationFilter.nonceCompromised", new Object[] { "FOOBAR" }, "ERROR - FAILED TO LOOKUP"));
 		// Revert to original Locale
@@ -57,7 +57,7 @@ public class SpringSecurityMessageSourceTests {
 		Locale.setDefault(Locale.GERMAN);
 		Locale beforeHolder = LocaleContextHolder.getLocale();
 		LocaleContextHolder.setLocale(Locale.US);
-		MessageSourceAccessor msgs = SpringSecurityMessageSource.getAccessor();
+		MessageSourceAccessor msgs = new SpringSecurityMessageSourceAccessor();
 		assertThat("Access is denied")
 				.isEqualTo(msgs.getMessage("AbstractAccessDecisionManager.accessDenied", "Ooops"));
 		// Revert to original Locale

--- a/itest/web/src/integration-test/java/org/springframework/security/integration/ConcurrentSessionManagementTests.java
+++ b/itest/web/src/integration-test/java/org/springframework/security/integration/ConcurrentSessionManagementTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.security.integration;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 
@@ -44,6 +45,8 @@ public class ConcurrentSessionManagementTests extends AbstractWebServerIntegrati
 
 	@Test
 	public void maxConcurrentLoginsValueIsRespected() throws Exception {
+		Locale.setDefault(new Locale("en"));
+
 		final MockHttpSession session1 = new MockHttpSession();
 		final MockHttpSession session2 = new MockHttpSession();
 

--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/AbstractLdapAuthenticationProvider.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/AbstractLdapAuthenticationProvider.java
@@ -32,7 +32,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -52,7 +52,7 @@ public abstract class AbstractLdapAuthenticationProvider implements Authenticati
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	private boolean useAuthenticationRequestCredentials = true;
 
@@ -126,7 +126,7 @@ public abstract class AbstractLdapAuthenticationProvider implements Authenticati
 
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 	/**

--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/AbstractLdapAuthenticator.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/AbstractLdapAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ * Copyright 2004, 2005, 2006, 2021 Acegi Technology Pty Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.springframework.context.MessageSource;
 import org.springframework.context.MessageSourceAware;
 import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.ldap.core.ContextSource;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.security.ldap.search.LdapUserSearch;
 import org.springframework.util.Assert;
 
@@ -45,7 +45,7 @@ public abstract class AbstractLdapAuthenticator implements LdapAuthenticator, In
 	 */
 	private LdapUserSearch userSearch;
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	/**
 	 * The attributes which will be retrieved from the directory. Null means all
@@ -108,7 +108,7 @@ public abstract class AbstractLdapAuthenticator implements LdapAuthenticator, In
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
 		Assert.notNull(messageSource, "Message source must not be null");
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 	/**

--- a/web/src/main/java/org/springframework/security/web/access/ExceptionTranslationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/access/ExceptionTranslationFilter.java
@@ -35,7 +35,7 @@ import org.springframework.security.authentication.AuthenticationTrustResolverIm
 import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -92,7 +92,7 @@ public class ExceptionTranslationFilter extends GenericFilterBean implements Mes
 
 	private RequestCache requestCache = new HttpSessionRequestCache();
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	public ExceptionTranslationFilter(AuthenticationEntryPoint authenticationEntryPoint) {
 		this(authenticationEntryPoint, new HttpSessionRequestCache());
@@ -236,7 +236,7 @@ public class ExceptionTranslationFilter extends GenericFilterBean implements Mes
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
 		Assert.notNull(messageSource, "messageSource cannot be null");
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 	/**

--- a/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ * Copyright 2004, 2005, 2006, 2021 Acegi Technology Pty Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import org.springframework.security.authentication.InternalAuthenticationService
 import org.springframework.security.authentication.event.InteractiveAuthenticationSuccessEvent;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.session.NullAuthenticatedSessionStrategy;
@@ -118,7 +118,7 @@ public abstract class AbstractAuthenticationProcessingFilter extends GenericFilt
 
 	private AuthenticationManager authenticationManager;
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	private RememberMeServices rememberMeServices = new NullRememberMeServices();
 
@@ -398,7 +398,7 @@ public abstract class AbstractAuthenticationProcessingFilter extends GenericFilt
 
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 	protected boolean getAllowSessionCreation() {

--- a/web/src/main/java/org/springframework/security/web/authentication/preauth/x509/SubjectDnX509PrincipalExtractor.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/preauth/x509/SubjectDnX509PrincipalExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.springframework.context.MessageSourceAware;
 import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.core.log.LogMessage;
 import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.util.Assert;
 
 /**
@@ -48,7 +48,7 @@ public class SubjectDnX509PrincipalExtractor implements X509PrincipalExtractor, 
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	private Pattern subjectDnPattern;
 
@@ -95,7 +95,7 @@ public class SubjectDnX509PrincipalExtractor implements X509PrincipalExtractor, 
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
 		Assert.notNull(messageSource, "messageSource cannot be null");
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 }

--- a/web/src/main/java/org/springframework/security/web/authentication/rememberme/AbstractRememberMeServices.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/rememberme/AbstractRememberMeServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ import org.springframework.security.authentication.AccountStatusUserDetailsCheck
 import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.authentication.RememberMeAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -74,7 +74,7 @@ public abstract class AbstractRememberMeServices
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	private UserDetailsService userDetailsService;
 
@@ -490,7 +490,7 @@ public abstract class AbstractRememberMeServices
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
 		Assert.notNull(messageSource, "messageSource cannot be null");
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 }

--- a/web/src/main/java/org/springframework/security/web/authentication/session/ConcurrentSessionControlAuthenticationStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/session/ConcurrentSessionControlAuthenticationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import org.springframework.context.MessageSource;
 import org.springframework.context.MessageSourceAware;
 import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.security.core.session.SessionInformation;
 import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
@@ -70,7 +70,7 @@ import org.springframework.util.Assert;
 public class ConcurrentSessionControlAuthenticationStrategy
 		implements MessageSourceAware, SessionAuthenticationStrategy {
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	private final SessionRegistry sessionRegistry;
 
@@ -190,7 +190,7 @@ public class ConcurrentSessionControlAuthenticationStrategy
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
 		Assert.notNull(messageSource, "messageSource cannot be null");
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 }

--- a/web/src/main/java/org/springframework/security/web/authentication/switchuser/SwitchUserFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/switchuser/SwitchUserFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ * Copyright 2004, 2005, 2006, 2021 Acegi Technology Pty Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -118,7 +118,7 @@ public class SwitchUserFilter extends GenericFilterBean implements ApplicationEv
 
 	private AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource = new WebAuthenticationDetailsSource();
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	private RequestMatcher exitUserMatcher = createMatcher("/logout/impersonate");
 
@@ -371,7 +371,7 @@ public class SwitchUserFilter extends GenericFilterBean implements ApplicationEv
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
 		Assert.notNull(messageSource, "messageSource cannot be null");
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 	/**

--- a/web/src/main/java/org/springframework/security/web/authentication/www/DigestAuthenticationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/DigestAuthenticationFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006, 2009 Acegi Technology Pty Limited
+ * Copyright 2004, 2005, 2006, 2009, 2021 Acegi Technology Pty Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserCache;
@@ -96,7 +96,7 @@ public class DigestAuthenticationFilter extends GenericFilterBean implements Mes
 
 	private DigestAuthenticationEntryPoint authenticationEntryPoint;
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	private UserCache userCache = new NullUserCache();
 
@@ -240,7 +240,7 @@ public class DigestAuthenticationFilter extends GenericFilterBean implements Mes
 
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 	public void setPasswordAlreadyEncoded(boolean passwordAlreadyEncoded) {

--- a/web/src/main/java/org/springframework/security/web/server/authorization/ExceptionTranslationWebFilter.java
+++ b/web/src/main/java/org/springframework/security/web/server/authorization/ExceptionTranslationWebFilter.java
@@ -29,7 +29,7 @@ import org.springframework.security.authentication.AuthenticationTrustResolverIm
 import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.security.web.server.ServerAuthenticationEntryPoint;
 import org.springframework.security.web.server.authentication.HttpBasicServerAuthenticationEntryPoint;
 import org.springframework.util.Assert;
@@ -51,7 +51,7 @@ public class ExceptionTranslationWebFilter implements WebFilter, MessageSourceAw
 
 	private AuthenticationTrustResolver authenticationTrustResolver = new AuthenticationTrustResolverImpl();
 
-	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	protected MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 
 	@Override
 	public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
@@ -103,7 +103,7 @@ public class ExceptionTranslationWebFilter implements WebFilter, MessageSourceAw
 	@Override
 	public void setMessageSource(MessageSource messageSource) {
 		Assert.notNull(messageSource, "messageSource cannot be null");
-		this.messages = new MessageSourceAccessor(messageSource);
+		this.messages = new SpringSecurityMessageSourceAccessor(messageSource);
 	}
 
 	private <T> Mono<T> commenceAuthentication(ServerWebExchange exchange, AuthenticationException denied) {

--- a/web/src/test/java/org/springframework/security/web/authentication/DefaultLoginPageGeneratingFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/DefaultLoginPageGeneratingFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.security.core.SpringSecurityMessageSourceAccessor;
 import org.springframework.security.web.WebAttributes;
 import org.springframework.security.web.authentication.ui.DefaultLoginPageGeneratingFilter;
 
@@ -144,7 +144,7 @@ public class DefaultLoginPageGeneratingFilterTests {
 				new UsernamePasswordAuthenticationFilter());
 		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/login");
 		request.addParameter("login_error", "true");
-		MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+		MessageSourceAccessor messages = new SpringSecurityMessageSourceAccessor();
 		String message = messages.getMessage("AbstractUserDetailsAuthenticationProvider.badCredentials",
 				"Bad credentials", Locale.KOREA);
 		request.getSession().setAttribute(WebAttributes.AUTHENTICATION_EXCEPTION, new BadCredentialsException(message));


### PR DESCRIPTION
In hibernate-Validation, the default ValidatehiResourceBundle will exist regardless of whether the user has customized the ResourceBundle or not, as the final fallback option  

In spring-security，when the user does not specify the message source, should also be able to use the SpringSecurityMessageSource international configuration.  

Closes [gh-10227](https://github.com/spring-projects/spring-security/issues/10227)
