### PR TITLE
Updated the Reactive Test Support Documentation references for `SecurityMockServerConfigurers`

### DIFF
--- a/docs/manual/src/docs/asciidoc/_includes/reactive/test.adoc
+++ b/docs/manual/src/docs/asciidoc/_includes/reactive/test.adoc
@@ -309,7 +309,7 @@ then Spring Security's test support can come in handy.
 Testing the method above with `WebTestClient` would require simulating some kind of grant flow with an authorization server.
 Certainly this would be a daunting task, which is why Spring Security ships with support for removing this boilerplate.
 
-For example, we can tell Spring Security to include a default `OidcUser` using the `SecurityMockServerConfigurers#oidcLogin` method, like so:
+For example, we can tell Spring Security to include a default `OidcUser` using the `SecurityMockServerConfigurers#mockOidcLogin` method, like so:
 
 ====
 .Java
@@ -544,7 +544,7 @@ fun foo(@AuthenticationPrincipal oauth2User: OAuth2User): Mono<String> {
 ----
 ====
 
-In that case, we can tell Spring Security to include a default `OAuth2User` using the `SecurityMockServerConfigurers#oauth2User` method, like so:
+In that case, we can tell Spring Security to include a default `OAuth2User` using the `SecurityMockServerConfigurers#mockOAuth2Login` method, like so:
 
 ====
 .Java
@@ -769,7 +769,7 @@ fun foo(@RegisteredOAuth2AuthorizedClient("my-app") authorizedClient: OAuth2Auth
 ====
 
 Simulating this handshake with the authorization server could be cumbersome.
-Instead, you can use `SecurityMockServerConfigurers#oauth2Client` to add a `OAuth2AuthorizedClient` into a mock `ServerOAuth2AuthorizedClientRepository`:
+Instead, you can use `SecurityMockServerConfigurers#mockOAuth2Client` to add a `OAuth2AuthorizedClient` into a mock `ServerOAuth2AuthorizedClientRepository`:
 
 ====
 .Java
@@ -973,7 +973,7 @@ We'll look at two of them now:
 ==== `mockJwt() WebTestClientConfigurer`
 
 The first way is via a `WebTestClientConfigurer`.
-The simplest of these would look something like this:
+The simplest of these would be to use the `SecurityMockServerConfigurers#mockJwt` method like the following:
 
 ====
 .Java
@@ -1211,7 +1211,7 @@ fun foo(authentication: BearerTokenAuthentication): Mono<String?> {
 ----
 ====
 
-In that case, we can tell Spring Security to include a default `BearerTokenAuthentication` using the `SecurityMockServerConfigurers#opaqueToken` method, like so:
+In that case, we can tell Spring Security to include a default `BearerTokenAuthentication` using the `SecurityMockServerConfigurers#mockOpaqueToken` method, like so:
 
 ====
 .Java


### PR DESCRIPTION
This PR updates the references to `SecurityMockServerConfigurers` to use the correct method names.  It also adds documentation for `mockJwt()` and includes the reference to `SecurityMockServerConfigurers`.

Closes #10254 