### PR TITLE
Provide a way to customize the token response map before it gets deco…

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractWebClientReactiveOAuth2AccessTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractWebClientReactiveOAuth2AccessTokenResponseClient.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Set;
 
+import org.springframework.security.oauth2.core.web.reactive.function.OAuth2AccessTokenMapCustomizer;
 import reactor.core.publisher.Mono;
 
 import org.springframework.core.convert.converter.Converter;
@@ -62,7 +63,7 @@ import org.springframework.web.reactive.function.client.WebClient;
  * @see WebClientReactiveRefreshTokenTokenResponseClient
  */
 public abstract class AbstractWebClientReactiveOAuth2AccessTokenResponseClient<T extends AbstractOAuth2AuthorizationGrantRequest>
-		implements ReactiveOAuth2AccessTokenResponseClient<T> {
+		implements ReactiveOAuth2AccessTokenResponseClient<T>, OAuth2AccessTokenMapCustomizer {
 
 	private WebClient webClient = WebClient.builder().build();
 
@@ -204,7 +205,7 @@ public abstract class AbstractWebClientReactiveOAuth2AccessTokenResponseClient<T
 	 * @return the token response from the response body.
 	 */
 	private Mono<OAuth2AccessTokenResponse> readTokenResponse(T grantRequest, ClientResponse response) {
-		return response.body(OAuth2BodyExtractors.oauth2AccessTokenResponse())
+		return response.body(OAuth2BodyExtractors.oauth2AccessTokenResponse(this))
 				.map((tokenResponse) -> populateTokenResponse(grantRequest, tokenResponse));
 	}
 

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/web/reactive/function/OAuth2AccessTokenMapCustomizer.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/web/reactive/function/OAuth2AccessTokenMapCustomizer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.core.web.reactive.function;
+
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+
+import java.util.Map;
+
+/**
+ * Provides a way to customize the response {@link Map}
+ * before it gets decoded as {@link OAuth2AccessTokenResponse}
+ *
+ * @author Bishoy Basily
+ * @since 2021-09-13
+ */
+public interface OAuth2AccessTokenMapCustomizer {
+
+	default Map<String, Object> customizeOAuth2AccessTokenMap(Map<String, Object> map) {
+		return map;
+	}
+
+}

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/web/reactive/function/OAuth2AccessTokenResponseBodyExtractor.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/web/reactive/function/OAuth2AccessTokenResponseBodyExtractor.java
@@ -48,15 +48,17 @@ import org.springframework.web.reactive.function.BodyExtractors;
  * @author Rob Winch
  * @since 5.1
  */
-class OAuth2AccessTokenResponseBodyExtractor
-		implements BodyExtractor<Mono<OAuth2AccessTokenResponse>, ReactiveHttpInputMessage> {
+class OAuth2AccessTokenResponseBodyExtractor implements BodyExtractor<Mono<OAuth2AccessTokenResponse>, ReactiveHttpInputMessage>, OAuth2AccessTokenMapCustomizer {
 
 	private static final String INVALID_TOKEN_RESPONSE_ERROR_CODE = "invalid_token_response";
 
 	private static final ParameterizedTypeReference<Map<String, Object>> STRING_OBJECT_MAP = new ParameterizedTypeReference<Map<String, Object>>() {
 	};
 
-	OAuth2AccessTokenResponseBodyExtractor() {
+	private final OAuth2AccessTokenMapCustomizer oAuth2AccessTokenMapCustomizer;
+
+	OAuth2AccessTokenResponseBodyExtractor(OAuth2AccessTokenMapCustomizer oAuth2AccessTokenMapCustomizer) {
+		this.oAuth2AccessTokenMapCustomizer = oAuth2AccessTokenMapCustomizer;
 	}
 
 	@Override
@@ -69,6 +71,7 @@ class OAuth2AccessTokenResponseBodyExtractor
 						ex))
 				.switchIfEmpty(Mono.error(() -> new OAuth2AuthorizationException(
 						invalidTokenResponse("Empty OAuth 2.0 Access Token Response"))))
+				.map(oAuth2AccessTokenMapCustomizer::customizeOAuth2AccessTokenMap)
 				.map(OAuth2AccessTokenResponseBodyExtractor::parse)
 				.flatMap(OAuth2AccessTokenResponseBodyExtractor::oauth2AccessTokenResponse)
 				.map(OAuth2AccessTokenResponseBodyExtractor::oauth2AccessTokenResponse);

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/web/reactive/function/OAuth2BodyExtractors.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/web/reactive/function/OAuth2BodyExtractors.java
@@ -22,6 +22,8 @@ import org.springframework.http.ReactiveHttpInputMessage;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 import org.springframework.web.reactive.function.BodyExtractor;
 
+import java.util.Map;
+
 /**
  * Static factory methods for OAuth2 {@link BodyExtractor} implementations.
  *
@@ -32,10 +34,11 @@ public abstract class OAuth2BodyExtractors {
 
 	/**
 	 * Extractor to decode an {@link OAuth2AccessTokenResponse}
+	 * Customizer to customize the response {@link Map}
 	 * @return a BodyExtractor for {@link OAuth2AccessTokenResponse}
 	 */
-	public static BodyExtractor<Mono<OAuth2AccessTokenResponse>, ReactiveHttpInputMessage> oauth2AccessTokenResponse() {
-		return new OAuth2AccessTokenResponseBodyExtractor();
+	public static BodyExtractor<Mono<OAuth2AccessTokenResponse>, ReactiveHttpInputMessage> oauth2AccessTokenResponse(OAuth2AccessTokenMapCustomizer mapCustomizer) {
+		return new OAuth2AccessTokenResponseBodyExtractor(mapCustomizer);
 	}
 
 	private OAuth2BodyExtractors() {

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/web/reactive/function/OAuth2BodyExtractorsTests.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/web/reactive/function/OAuth2BodyExtractorsTests.java
@@ -56,6 +56,8 @@ public class OAuth2BodyExtractorsTests {
 
 	private Map<String, Object> hints;
 
+	private static class TokenCustomizer implements OAuth2AccessTokenMapCustomizer{ }
+
 	@BeforeEach
 	public void createContext() {
 		final List<HttpMessageReader<?>> messageReaders = new ArrayList<>();
@@ -85,7 +87,7 @@ public class OAuth2BodyExtractorsTests {
 	@Test
 	public void oauth2AccessTokenResponseWhenInvalidJsonThenException() {
 		BodyExtractor<Mono<OAuth2AccessTokenResponse>, ReactiveHttpInputMessage> extractor = OAuth2BodyExtractors
-				.oauth2AccessTokenResponse();
+				.oauth2AccessTokenResponse(new TokenCustomizer());
 		MockClientHttpResponse response = new MockClientHttpResponse(HttpStatus.OK);
 		response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
 		response.setBody("{");
@@ -100,7 +102,7 @@ public class OAuth2BodyExtractorsTests {
 	@Test
 	public void oauth2AccessTokenResponseWhenEmptyThenException() {
 		BodyExtractor<Mono<OAuth2AccessTokenResponse>, ReactiveHttpInputMessage> extractor = OAuth2BodyExtractors
-				.oauth2AccessTokenResponse();
+				.oauth2AccessTokenResponse(new TokenCustomizer());
 		MockClientHttpResponse response = new MockClientHttpResponse(HttpStatus.OK);
 		Mono<OAuth2AccessTokenResponse> result = extractor.extract(response, this.context);
 		// @formatter:off
@@ -113,7 +115,7 @@ public class OAuth2BodyExtractorsTests {
 	@Test
 	public void oauth2AccessTokenResponseWhenValidThenCreated() {
 		BodyExtractor<Mono<OAuth2AccessTokenResponse>, ReactiveHttpInputMessage> extractor = OAuth2BodyExtractors
-				.oauth2AccessTokenResponse();
+				.oauth2AccessTokenResponse(new TokenCustomizer());
 		MockClientHttpResponse response = new MockClientHttpResponse(HttpStatus.OK);
 		response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
 		// @formatter:off
@@ -139,7 +141,7 @@ public class OAuth2BodyExtractorsTests {
 	// gh-6087
 	public void oauth2AccessTokenResponseWhenMultipleAttributeTypesThenCreated() {
 		BodyExtractor<Mono<OAuth2AccessTokenResponse>, ReactiveHttpInputMessage> extractor = OAuth2BodyExtractors
-				.oauth2AccessTokenResponse();
+				.oauth2AccessTokenResponse(new TokenCustomizer());
 		MockClientHttpResponse response = new MockClientHttpResponse(HttpStatus.OK);
 		response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
 		// @formatter:off


### PR DESCRIPTION
**Summary**

Provide a way to customize the token response being extracted by `OAuth2BodyExtractors` before parsing it.

**Current Behavior**
Using `WebClient` to authenticate against a server that returns custom JSON Response, for example: {"Token":"xyz"},
where "xyz" is the token and "bearer" is the type, but since the server doesn't follow the right naming convention,  I can't read the token.

**Desired Behavior**
A way to customize the raw `Map<String, Object>` before it gets decoded by `OAuth2BodyExtractors` as `OAuth2AccessTokenResponse`


#10260 