### PR TITLE
Allow setting custom BodyExtractor to the AbstractWebClientReactiveOAuth2AccessTokenResponseClient

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractWebClientReactiveOAuth2AccessTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractWebClientReactiveOAuth2AccessTokenResponseClient.java
@@ -22,13 +22,12 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Set;
 
-import org.springframework.http.ReactiveHttpInputMessage;
-import org.springframework.web.reactive.function.BodyExtractor;
 import reactor.core.publisher.Mono;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ReactiveHttpInputMessage;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
@@ -40,6 +39,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.BodyExtractor;
 
 /**
  * Abstract base class for all of the {@code WebClientReactive*TokenResponseClient}s that
@@ -207,7 +207,7 @@ public abstract class AbstractWebClientReactiveOAuth2AccessTokenResponseClient<T
 	 * @return the token response from the response body.
 	 */
 	private Mono<OAuth2AccessTokenResponse> readTokenResponse(T grantRequest, ClientResponse response) {
-		return response.body(bodyExtractor)
+		return response.body(this.bodyExtractor)
 				.map((tokenResponse) -> populateTokenResponse(grantRequest, tokenResponse));
 	}
 
@@ -301,6 +301,7 @@ public abstract class AbstractWebClientReactiveOAuth2AccessTokenResponseClient<T
 	 * @since 5.6
 	 */
 	public void setBodyExtractor(BodyExtractor<Mono<OAuth2AccessTokenResponse>, ReactiveHttpInputMessage> bodyExtractor) {
+		Assert.notNull(bodyExtractor, "bodyExtractor cannot be null");
 		this.bodyExtractor = bodyExtractor;
 	}
 

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractWebClientReactiveOAuth2AccessTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractWebClientReactiveOAuth2AccessTokenResponseClient.java
@@ -22,6 +22,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Set;
 
+import org.springframework.http.ReactiveHttpInputMessage;
+import org.springframework.web.reactive.function.BodyExtractor;
 import reactor.core.publisher.Mono;
 
 import org.springframework.core.convert.converter.Converter;
@@ -67,6 +69,7 @@ public abstract class AbstractWebClientReactiveOAuth2AccessTokenResponseClient<T
 	private WebClient webClient = WebClient.builder().build();
 
 	private Converter<T, HttpHeaders> headersConverter = this::populateTokenRequestHeaders;
+	private BodyExtractor<Mono<OAuth2AccessTokenResponse>, ReactiveHttpInputMessage> bodyExtractor = OAuth2BodyExtractors.oauth2AccessTokenResponse();
 
 	AbstractWebClientReactiveOAuth2AccessTokenResponseClient() {
 	}
@@ -204,7 +207,7 @@ public abstract class AbstractWebClientReactiveOAuth2AccessTokenResponseClient<T
 	 * @return the token response from the response body.
 	 */
 	private Mono<OAuth2AccessTokenResponse> readTokenResponse(T grantRequest, ClientResponse response) {
-		return response.body(OAuth2BodyExtractors.oauth2AccessTokenResponse())
+		return response.body(bodyExtractor)
 				.map((tokenResponse) -> populateTokenResponse(grantRequest, tokenResponse));
 	}
 
@@ -289,6 +292,16 @@ public abstract class AbstractWebClientReactiveOAuth2AccessTokenResponseClient<T
 			}
 			return headers;
 		};
+	}
+
+	/**
+	 * Sets the {@link BodyExtractor} that will be used to decode the {@link OAuth2AccessTokenResponse}
+	 *
+	 * @param bodyExtractor the {@link BodyExtractor} that will be used to decode the {@link OAuth2AccessTokenResponse}
+	 * @since 5.6
+	 */
+	public void setBodyExtractor(BodyExtractor<Mono<OAuth2AccessTokenResponse>, ReactiveHttpInputMessage> bodyExtractor) {
+		this.bodyExtractor = bodyExtractor;
 	}
 
 }

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractWebClientReactiveOAuth2AccessTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractWebClientReactiveOAuth2AccessTokenResponseClient.java
@@ -36,10 +36,10 @@ import org.springframework.security.oauth2.core.web.reactive.function.OAuth2Body
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.BodyExtractor;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.BodyExtractor;
 
 /**
  * Abstract base class for all of the {@code WebClientReactive*TokenResponseClient}s that
@@ -69,7 +69,9 @@ public abstract class AbstractWebClientReactiveOAuth2AccessTokenResponseClient<T
 	private WebClient webClient = WebClient.builder().build();
 
 	private Converter<T, HttpHeaders> headersConverter = this::populateTokenRequestHeaders;
-	private BodyExtractor<Mono<OAuth2AccessTokenResponse>, ReactiveHttpInputMessage> bodyExtractor = OAuth2BodyExtractors.oauth2AccessTokenResponse();
+
+	private BodyExtractor<Mono<OAuth2AccessTokenResponse>, ReactiveHttpInputMessage> bodyExtractor = OAuth2BodyExtractors
+			.oauth2AccessTokenResponse();
 
 	AbstractWebClientReactiveOAuth2AccessTokenResponseClient() {
 	}
@@ -295,12 +297,14 @@ public abstract class AbstractWebClientReactiveOAuth2AccessTokenResponseClient<T
 	}
 
 	/**
-	 * Sets the {@link BodyExtractor} that will be used to decode the {@link OAuth2AccessTokenResponse}
-	 *
-	 * @param bodyExtractor the {@link BodyExtractor} that will be used to decode the {@link OAuth2AccessTokenResponse}
+	 * Sets the {@link BodyExtractor} that will be used to decode the
+	 * {@link OAuth2AccessTokenResponse}
+	 * @param bodyExtractor the {@link BodyExtractor} that will be used to decode the
+	 * {@link OAuth2AccessTokenResponse}
 	 * @since 5.6
 	 */
-	public void setBodyExtractor(BodyExtractor<Mono<OAuth2AccessTokenResponse>, ReactiveHttpInputMessage> bodyExtractor) {
+	public void setBodyExtractor(
+			BodyExtractor<Mono<OAuth2AccessTokenResponse>, ReactiveHttpInputMessage> bodyExtractor) {
 		Assert.notNull(bodyExtractor, "bodyExtractor cannot be null");
 		this.bodyExtractor = bodyExtractor;
 	}

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveAuthorizationCodeTokenResponseClientTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveAuthorizationCodeTokenResponseClientTests.java
@@ -27,6 +27,7 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpHeaders;
@@ -45,7 +46,6 @@ import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
 import org.springframework.security.oauth2.core.endpoint.TestOAuth2AccessTokenResponses;
 import org.springframework.web.reactive.function.BodyExtractor;
 import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveClientCredentialsTokenResponseClientTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveClientCredentialsTokenResponseClientTests.java
@@ -18,13 +18,9 @@ package org.springframework.security.oauth2.client.endpoint;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.util.*;
+import java.util.Base64;
+import java.util.Collections;
 
-import com.nimbusds.oauth2.sdk.AccessTokenResponse;
-import com.nimbusds.oauth2.sdk.TokenResponse;
-import com.nimbusds.oauth2.sdk.token.AccessToken;
-import net.minidev.json.JSONObject;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -32,7 +28,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -40,11 +35,10 @@ import org.springframework.http.ReactiveHttpInputMessage;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.TestClientRegistrations;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
-import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.security.oauth2.core.endpoint.TestOAuth2AccessTokenResponses;
 import org.springframework.web.reactive.function.BodyExtractor;
-import org.springframework.web.reactive.function.BodyExtractors;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
@@ -52,6 +46,7 @@ import reactor.core.publisher.Mono;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -294,79 +289,21 @@ public class WebClientReactiveClientCredentialsTokenResponseClientTests {
 	@Test
 	public void getTokenResponseWhenSuccessCustomResponseThenReturnAccessTokenResponse() {
 
-		// @formatter:off
-		enqueueJson("{\n"
-				+ "   \"Token\": \"access-token-1234\",\n"
-				+ "   \"expires_in\": \"3600\",\n"
-				+ "   \"scope\": \"openid profile\",\n"
-				+ "   \"refresh_token\": \"refresh-token-1234\",\n"
-				+ "   \"custom_parameter_1\": \"custom-value-1\",\n"
-				+ "   \"custom_parameter_2\": \"custom-value-2\"\n"
-				+ "}\n");
-		// @formatter:on
+		enqueueJson("{}");
 
 		WebClientReactiveClientCredentialsTokenResponseClient customClient = new WebClientReactiveClientCredentialsTokenResponseClient();
-		customClient.setBodyExtractor((inputMessage, context) -> {
 
-			BodyExtractor<Mono<Map<String, Object>>, ReactiveHttpInputMessage> delegate = BodyExtractors
-					.toMono(new ParameterizedTypeReference<Map<String, Object>>() {});
+		BodyExtractor<Mono<OAuth2AccessTokenResponse>, ReactiveHttpInputMessage> extractor = mock(BodyExtractor.class);
+		OAuth2AccessTokenResponse response = TestOAuth2AccessTokenResponses.accessTokenResponse().build();
+		given(extractor.extract(any(), any())).willReturn(Mono.just(response));
 
-			return delegate.extract(inputMessage, context)
-					.flatMap(it -> {
-
-						return Mono.fromCallable(() -> {
-
-							it.put("access_token", it.get("Token"));
-							it.put("token_type", "bearer");
-
-							AccessTokenResponse accessTokenResponse =
-									(AccessTokenResponse) TokenResponse.parse(new JSONObject(it));
-
-							AccessToken accessToken = accessTokenResponse.getTokens().getAccessToken();
-							OAuth2AccessToken.TokenType accessTokenType = null;
-							if (OAuth2AccessToken.TokenType.BEARER.getValue().equalsIgnoreCase(accessToken.getType().getValue())) {
-								accessTokenType = OAuth2AccessToken.TokenType.BEARER;
-							}
-							long expiresIn = accessToken.getLifetime();
-							Set<String> scopes = (accessToken.getScope() != null) ?
-									new LinkedHashSet<>(accessToken.getScope().toStringList()) : Collections.emptySet();
-
-							String refreshToken = null;
-							if (accessTokenResponse.getTokens().getRefreshToken() != null) {
-								refreshToken = accessTokenResponse.getTokens().getRefreshToken().getValue();
-							}
-							Map<String, Object> additionalParameters = new LinkedHashMap<>(accessTokenResponse.getCustomParameters());
-
-							// @formatter:off
-							return OAuth2AccessTokenResponse.withToken(accessToken.getValue())
-									.tokenType(accessTokenType)
-									.expiresIn(expiresIn)
-									.scopes(scopes)
-									.refreshToken(refreshToken)
-									.additionalParameters(additionalParameters)
-									.build();
-							// @formatter:on
-
-						});
-
-					});
-
-		});
+		customClient.setBodyExtractor(extractor);
 
 		OAuth2ClientCredentialsGrantRequest request = new OAuth2ClientCredentialsGrantRequest(
 				this.clientRegistration.build());
 
-		Instant expiresAtBefore = Instant.now().plusSeconds(3600);
 		OAuth2AccessTokenResponse accessTokenResponse = customClient.getTokenResponse(request).block();
-		Instant expiresAtAfter = Instant.now().plusSeconds(3600);
-		assertThat(accessTokenResponse.getAccessToken().getTokenValue()).isEqualTo("access-token-1234");
-		assertThat(accessTokenResponse.getAccessToken().getTokenType()).isEqualTo(OAuth2AccessToken.TokenType.BEARER);
-		assertThat(accessTokenResponse.getAccessToken().getExpiresAt()).isBetween(expiresAtBefore, expiresAtAfter);
-		assertThat(accessTokenResponse.getAccessToken().getScopes()).containsExactly("openid", "profile");
-		assertThat(accessTokenResponse.getRefreshToken().getTokenValue()).isEqualTo("refresh-token-1234");
-		assertThat(accessTokenResponse.getAdditionalParameters().size()).isEqualTo(2);
-		assertThat(accessTokenResponse.getAdditionalParameters()).containsEntry("custom_parameter_1", "custom-value-1");
-		assertThat(accessTokenResponse.getAdditionalParameters()).containsEntry("custom_parameter_2", "custom-value-2");
+		assertThat(accessTokenResponse.getAccessToken()).isNotNull();
 
 	}
 

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveClientCredentialsTokenResponseClientTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveClientCredentialsTokenResponseClientTests.java
@@ -18,9 +18,13 @@ package org.springframework.security.oauth2.client.endpoint;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.Collections;
+import java.time.Instant;
+import java.util.*;
 
+import com.nimbusds.oauth2.sdk.AccessTokenResponse;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import net.minidev.json.JSONObject;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -28,16 +32,22 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ReactiveHttpInputMessage;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.TestClientRegistrations;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.web.reactive.function.BodyExtractor;
+import org.springframework.web.reactive.function.BodyExtractors;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -278,6 +288,86 @@ public class WebClientReactiveClientCredentialsTokenResponseClientTests {
 		RecordedRequest actualRequest = this.server.takeRequest();
 		assertThat(actualRequest.getHeader(HttpHeaders.AUTHORIZATION))
 				.isEqualTo("Basic Y2xpZW50LWlkOmNsaWVudC1zZWNyZXQ=");
+	}
+
+	// gh-10260
+	@Test
+	public void getTokenResponseWhenSuccessCustomResponseThenReturnAccessTokenResponse() {
+
+		// @formatter:off
+		enqueueJson("{\n"
+				+ "   \"Token\": \"access-token-1234\",\n"
+				+ "   \"expires_in\": \"3600\",\n"
+				+ "   \"scope\": \"openid profile\",\n"
+				+ "   \"refresh_token\": \"refresh-token-1234\",\n"
+				+ "   \"custom_parameter_1\": \"custom-value-1\",\n"
+				+ "   \"custom_parameter_2\": \"custom-value-2\"\n"
+				+ "}\n");
+		// @formatter:on
+
+		WebClientReactiveClientCredentialsTokenResponseClient customClient = new WebClientReactiveClientCredentialsTokenResponseClient();
+		customClient.setBodyExtractor((inputMessage, context) -> {
+
+			BodyExtractor<Mono<Map<String, Object>>, ReactiveHttpInputMessage> delegate = BodyExtractors
+					.toMono(new ParameterizedTypeReference<Map<String, Object>>() {});
+
+			return delegate.extract(inputMessage, context)
+					.flatMap(it -> {
+
+						return Mono.fromCallable(() -> {
+
+							it.put("access_token", it.get("Token"));
+							it.put("token_type", "bearer");
+
+							AccessTokenResponse accessTokenResponse =
+									(AccessTokenResponse) TokenResponse.parse(new JSONObject(it));
+
+							AccessToken accessToken = accessTokenResponse.getTokens().getAccessToken();
+							OAuth2AccessToken.TokenType accessTokenType = null;
+							if (OAuth2AccessToken.TokenType.BEARER.getValue().equalsIgnoreCase(accessToken.getType().getValue())) {
+								accessTokenType = OAuth2AccessToken.TokenType.BEARER;
+							}
+							long expiresIn = accessToken.getLifetime();
+							Set<String> scopes = (accessToken.getScope() != null) ?
+									new LinkedHashSet<>(accessToken.getScope().toStringList()) : Collections.emptySet();
+
+							String refreshToken = null;
+							if (accessTokenResponse.getTokens().getRefreshToken() != null) {
+								refreshToken = accessTokenResponse.getTokens().getRefreshToken().getValue();
+							}
+							Map<String, Object> additionalParameters = new LinkedHashMap<>(accessTokenResponse.getCustomParameters());
+
+							// @formatter:off
+							return OAuth2AccessTokenResponse.withToken(accessToken.getValue())
+									.tokenType(accessTokenType)
+									.expiresIn(expiresIn)
+									.scopes(scopes)
+									.refreshToken(refreshToken)
+									.additionalParameters(additionalParameters)
+									.build();
+							// @formatter:on
+
+						});
+
+					});
+
+		});
+
+		OAuth2ClientCredentialsGrantRequest request = new OAuth2ClientCredentialsGrantRequest(
+				this.clientRegistration.build());
+
+		Instant expiresAtBefore = Instant.now().plusSeconds(3600);
+		OAuth2AccessTokenResponse accessTokenResponse = customClient.getTokenResponse(request).block();
+		Instant expiresAtAfter = Instant.now().plusSeconds(3600);
+		assertThat(accessTokenResponse.getAccessToken().getTokenValue()).isEqualTo("access-token-1234");
+		assertThat(accessTokenResponse.getAccessToken().getTokenType()).isEqualTo(OAuth2AccessToken.TokenType.BEARER);
+		assertThat(accessTokenResponse.getAccessToken().getExpiresAt()).isBetween(expiresAtBefore, expiresAtAfter);
+		assertThat(accessTokenResponse.getAccessToken().getScopes()).containsExactly("openid", "profile");
+		assertThat(accessTokenResponse.getRefreshToken().getTokenValue()).isEqualTo("refresh-token-1234");
+		assertThat(accessTokenResponse.getAdditionalParameters().size()).isEqualTo(2);
+		assertThat(accessTokenResponse.getAdditionalParameters()).containsEntry("custom_parameter_1", "custom-value-1");
+		assertThat(accessTokenResponse.getAdditionalParameters()).containsEntry("custom_parameter_2", "custom-value-2");
+
 	}
 
 }

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveClientCredentialsTokenResponseClientTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveClientCredentialsTokenResponseClientTests.java
@@ -27,6 +27,7 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpHeaders;
@@ -41,7 +42,6 @@ import org.springframework.security.oauth2.core.endpoint.TestOAuth2AccessTokenRe
 import org.springframework.web.reactive.function.BodyExtractor;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
-import reactor.core.publisher.Mono;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactivePasswordTokenResponseClientTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactivePasswordTokenResponseClientTests.java
@@ -25,6 +25,7 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpHeaders;
@@ -39,7 +40,6 @@ import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 import org.springframework.security.oauth2.core.endpoint.TestOAuth2AccessTokenResponses;
 import org.springframework.web.reactive.function.BodyExtractor;
-import reactor.core.publisher.Mono;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactivePasswordTokenResponseClientTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactivePasswordTokenResponseClientTests.java
@@ -17,12 +17,8 @@
 package org.springframework.security.oauth2.client.endpoint;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.Collections;
 
-import com.nimbusds.oauth2.sdk.AccessTokenResponse;
-import com.nimbusds.oauth2.sdk.TokenResponse;
-import com.nimbusds.oauth2.sdk.token.AccessToken;
-import net.minidev.json.JSONObject;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -30,7 +26,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -42,13 +37,14 @@ import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.security.oauth2.core.endpoint.TestOAuth2AccessTokenResponses;
 import org.springframework.web.reactive.function.BodyExtractor;
-import org.springframework.web.reactive.function.BodyExtractors;
 import reactor.core.publisher.Mono;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -299,81 +295,24 @@ public class WebClientReactivePasswordTokenResponseClientTests {
 	@Test
 	public void getTokenResponseWhenSuccessCustomResponseThenReturnAccessTokenResponse() {
 
-		// @formatter:off
-		String accessTokenSuccessResponse = "{\n"
-				+ "   \"Token\": \"access-token-1234\",\n"
-				+ "   \"expires_in\": \"3600\",\n"
-				+ "   \"scope\": \"openid profile\",\n"
-				+ "   \"refresh_token\": \"refresh-token-1234\",\n"
-				+ "   \"custom_parameter_1\": \"custom-value-1\",\n"
-				+ "   \"custom_parameter_2\": \"custom-value-2\"\n"
-				+ "}\n";
-		// @formatter:on
+		String accessTokenSuccessResponse = "{}";
 
 		WebClientReactivePasswordTokenResponseClient customClient = new WebClientReactivePasswordTokenResponseClient();
-		customClient.setBodyExtractor((inputMessage, context) -> {
 
-			BodyExtractor<Mono<Map<String, Object>>, ReactiveHttpInputMessage> delegate = BodyExtractors
-					.toMono(new ParameterizedTypeReference<Map<String, Object>>() {});
+		BodyExtractor<Mono<OAuth2AccessTokenResponse>, ReactiveHttpInputMessage> extractor = mock(BodyExtractor.class);
+		OAuth2AccessTokenResponse response = TestOAuth2AccessTokenResponses.accessTokenResponse().build();
+		given(extractor.extract(any(), any())).willReturn(Mono.just(response));
 
-			return delegate.extract(inputMessage, context)
-					.flatMap(it -> {
-
-						return Mono.fromCallable(() -> {
-
-							it.put("access_token", it.get("Token"));
-							it.put("token_type", "bearer");
-
-							AccessTokenResponse accessTokenResponse =
-									(AccessTokenResponse) TokenResponse.parse(new JSONObject(it));
-
-							AccessToken accessToken = accessTokenResponse.getTokens().getAccessToken();
-							OAuth2AccessToken.TokenType accessTokenType = null;
-							if (OAuth2AccessToken.TokenType.BEARER.getValue().equalsIgnoreCase(accessToken.getType().getValue())) {
-								accessTokenType = OAuth2AccessToken.TokenType.BEARER;
-							}
-							long expiresIn = accessToken.getLifetime();
-							Set<String> scopes = (accessToken.getScope() != null) ?
-									new LinkedHashSet<>(accessToken.getScope().toStringList()) : Collections.emptySet();
-
-							String refreshToken = null;
-							if (accessTokenResponse.getTokens().getRefreshToken() != null) {
-								refreshToken = accessTokenResponse.getTokens().getRefreshToken().getValue();
-							}
-							Map<String, Object> additionalParameters = new LinkedHashMap<>(accessTokenResponse.getCustomParameters());
-
-							// @formatter:off
-							return OAuth2AccessTokenResponse.withToken(accessToken.getValue())
-									.tokenType(accessTokenType)
-									.expiresIn(expiresIn)
-									.scopes(scopes)
-									.refreshToken(refreshToken)
-									.additionalParameters(additionalParameters)
-									.build();
-							// @formatter:on
-
-						});
-
-					});
-
-		});
+		customClient.setBodyExtractor(extractor);
 
 		ClientRegistration clientRegistration = this.clientRegistrationBuilder.build();
 		OAuth2PasswordGrantRequest passwordGrantRequest = new OAuth2PasswordGrantRequest(clientRegistration,
 				this.username, this.password);
 
 		this.server.enqueue(jsonResponse(accessTokenSuccessResponse));
-		Instant expiresAtBefore = Instant.now().plusSeconds(3600);
+
 		OAuth2AccessTokenResponse accessTokenResponse = customClient.getTokenResponse(passwordGrantRequest).block();
-		Instant expiresAtAfter = Instant.now().plusSeconds(3600);
-		assertThat(accessTokenResponse.getAccessToken().getTokenValue()).isEqualTo("access-token-1234");
-		assertThat(accessTokenResponse.getAccessToken().getTokenType()).isEqualTo(OAuth2AccessToken.TokenType.BEARER);
-		assertThat(accessTokenResponse.getAccessToken().getExpiresAt()).isBetween(expiresAtBefore, expiresAtAfter);
-		assertThat(accessTokenResponse.getAccessToken().getScopes()).containsExactly("openid", "profile");
-		assertThat(accessTokenResponse.getRefreshToken().getTokenValue()).isEqualTo("refresh-token-1234");
-		assertThat(accessTokenResponse.getAdditionalParameters().size()).isEqualTo(2);
-		assertThat(accessTokenResponse.getAdditionalParameters()).containsEntry("custom_parameter_1", "custom-value-1");
-		assertThat(accessTokenResponse.getAdditionalParameters()).containsEntry("custom_parameter_2", "custom-value-2");
+		assertThat(accessTokenResponse.getAccessToken()).isNotNull();
 
 	}
 

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactivePasswordTokenResponseClientTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactivePasswordTokenResponseClientTests.java
@@ -17,8 +17,12 @@
 package org.springframework.security.oauth2.client.endpoint;
 
 import java.time.Instant;
-import java.util.Collections;
+import java.util.*;
 
+import com.nimbusds.oauth2.sdk.AccessTokenResponse;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import net.minidev.json.JSONObject;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -26,16 +30,21 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.http.ReactiveHttpInputMessage;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.TestClientRegistrations;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.web.reactive.function.BodyExtractor;
+import org.springframework.web.reactive.function.BodyExtractors;
+import reactor.core.publisher.Mono;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -284,6 +293,88 @@ public class WebClientReactivePasswordTokenResponseClientTests {
 		RecordedRequest actualRequest = this.server.takeRequest();
 		assertThat(actualRequest.getHeader(HttpHeaders.AUTHORIZATION))
 				.isEqualTo("Basic Y2xpZW50LWlkOmNsaWVudC1zZWNyZXQ=");
+	}
+
+	// gh-10260
+	@Test
+	public void getTokenResponseWhenSuccessCustomResponseThenReturnAccessTokenResponse() {
+
+		// @formatter:off
+		String accessTokenSuccessResponse = "{\n"
+				+ "   \"Token\": \"access-token-1234\",\n"
+				+ "   \"expires_in\": \"3600\",\n"
+				+ "   \"scope\": \"openid profile\",\n"
+				+ "   \"refresh_token\": \"refresh-token-1234\",\n"
+				+ "   \"custom_parameter_1\": \"custom-value-1\",\n"
+				+ "   \"custom_parameter_2\": \"custom-value-2\"\n"
+				+ "}\n";
+		// @formatter:on
+
+		WebClientReactivePasswordTokenResponseClient customClient = new WebClientReactivePasswordTokenResponseClient();
+		customClient.setBodyExtractor((inputMessage, context) -> {
+
+			BodyExtractor<Mono<Map<String, Object>>, ReactiveHttpInputMessage> delegate = BodyExtractors
+					.toMono(new ParameterizedTypeReference<Map<String, Object>>() {});
+
+			return delegate.extract(inputMessage, context)
+					.flatMap(it -> {
+
+						return Mono.fromCallable(() -> {
+
+							it.put("access_token", it.get("Token"));
+							it.put("token_type", "bearer");
+
+							AccessTokenResponse accessTokenResponse =
+									(AccessTokenResponse) TokenResponse.parse(new JSONObject(it));
+
+							AccessToken accessToken = accessTokenResponse.getTokens().getAccessToken();
+							OAuth2AccessToken.TokenType accessTokenType = null;
+							if (OAuth2AccessToken.TokenType.BEARER.getValue().equalsIgnoreCase(accessToken.getType().getValue())) {
+								accessTokenType = OAuth2AccessToken.TokenType.BEARER;
+							}
+							long expiresIn = accessToken.getLifetime();
+							Set<String> scopes = (accessToken.getScope() != null) ?
+									new LinkedHashSet<>(accessToken.getScope().toStringList()) : Collections.emptySet();
+
+							String refreshToken = null;
+							if (accessTokenResponse.getTokens().getRefreshToken() != null) {
+								refreshToken = accessTokenResponse.getTokens().getRefreshToken().getValue();
+							}
+							Map<String, Object> additionalParameters = new LinkedHashMap<>(accessTokenResponse.getCustomParameters());
+
+							// @formatter:off
+							return OAuth2AccessTokenResponse.withToken(accessToken.getValue())
+									.tokenType(accessTokenType)
+									.expiresIn(expiresIn)
+									.scopes(scopes)
+									.refreshToken(refreshToken)
+									.additionalParameters(additionalParameters)
+									.build();
+							// @formatter:on
+
+						});
+
+					});
+
+		});
+
+		ClientRegistration clientRegistration = this.clientRegistrationBuilder.build();
+		OAuth2PasswordGrantRequest passwordGrantRequest = new OAuth2PasswordGrantRequest(clientRegistration,
+				this.username, this.password);
+
+		this.server.enqueue(jsonResponse(accessTokenSuccessResponse));
+		Instant expiresAtBefore = Instant.now().plusSeconds(3600);
+		OAuth2AccessTokenResponse accessTokenResponse = customClient.getTokenResponse(passwordGrantRequest).block();
+		Instant expiresAtAfter = Instant.now().plusSeconds(3600);
+		assertThat(accessTokenResponse.getAccessToken().getTokenValue()).isEqualTo("access-token-1234");
+		assertThat(accessTokenResponse.getAccessToken().getTokenType()).isEqualTo(OAuth2AccessToken.TokenType.BEARER);
+		assertThat(accessTokenResponse.getAccessToken().getExpiresAt()).isBetween(expiresAtBefore, expiresAtAfter);
+		assertThat(accessTokenResponse.getAccessToken().getScopes()).containsExactly("openid", "profile");
+		assertThat(accessTokenResponse.getRefreshToken().getTokenValue()).isEqualTo("refresh-token-1234");
+		assertThat(accessTokenResponse.getAdditionalParameters().size()).isEqualTo(2);
+		assertThat(accessTokenResponse.getAdditionalParameters()).containsEntry("custom_parameter_1", "custom-value-1");
+		assertThat(accessTokenResponse.getAdditionalParameters()).containsEntry("custom_parameter_2", "custom-value-2");
+
 	}
 
 }

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveRefreshTokenTokenResponseClientTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveRefreshTokenTokenResponseClientTests.java
@@ -17,12 +17,8 @@
 package org.springframework.security.oauth2.client.endpoint;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.Collections;
 
-import com.nimbusds.oauth2.sdk.AccessTokenResponse;
-import com.nimbusds.oauth2.sdk.TokenResponse;
-import com.nimbusds.oauth2.sdk.token.AccessToken;
-import net.minidev.json.JSONObject;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -30,7 +26,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -45,13 +40,14 @@ import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.security.oauth2.core.TestOAuth2AccessTokens;
 import org.springframework.security.oauth2.core.TestOAuth2RefreshTokens;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.security.oauth2.core.endpoint.TestOAuth2AccessTokenResponses;
 import org.springframework.web.reactive.function.BodyExtractor;
-import org.springframework.web.reactive.function.BodyExtractors;
 import reactor.core.publisher.Mono;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -302,80 +298,22 @@ public class WebClientReactiveRefreshTokenTokenResponseClientTests {
 	@Test
 	public void getTokenResponseWhenSuccessCustomResponseThenReturnAccessTokenResponse() {
 
-		// @formatter:off
-		String accessTokenSuccessResponse = "{\n"
-				+ "   \"Token\": \"access-token-1234\",\n"
-				+ "   \"expires_in\": \"3600\",\n"
-				+ "   \"scope\": \"openid profile\",\n"
-				+ "   \"refresh_token\": \"refresh-token-1234\",\n"
-				+ "   \"custom_parameter_1\": \"custom-value-1\",\n"
-				+ "   \"custom_parameter_2\": \"custom-value-2\"\n"
-				+ "}\n";
-		// @formatter:on
+		String accessTokenSuccessResponse = "{}";
 
 		WebClientReactiveRefreshTokenTokenResponseClient customClient = new WebClientReactiveRefreshTokenTokenResponseClient();
-		customClient.setBodyExtractor((inputMessage, context) -> {
 
-			BodyExtractor<Mono<Map<String, Object>>, ReactiveHttpInputMessage> delegate = BodyExtractors
-					.toMono(new ParameterizedTypeReference<Map<String, Object>>() {});
+		BodyExtractor<Mono<OAuth2AccessTokenResponse>, ReactiveHttpInputMessage> extractor = mock(BodyExtractor.class);
+		OAuth2AccessTokenResponse response = TestOAuth2AccessTokenResponses.accessTokenResponse().build();
+		given(extractor.extract(any(), any())).willReturn(Mono.just(response));
 
-			return delegate.extract(inputMessage, context)
-					.flatMap(it -> {
-
-						return Mono.fromCallable(() -> {
-
-							it.put("access_token", it.get("Token"));
-							it.put("token_type", "bearer");
-
-							AccessTokenResponse accessTokenResponse =
-									(AccessTokenResponse) TokenResponse.parse(new JSONObject(it));
-
-							AccessToken accessToken = accessTokenResponse.getTokens().getAccessToken();
-							OAuth2AccessToken.TokenType accessTokenType = null;
-							if (OAuth2AccessToken.TokenType.BEARER.getValue().equalsIgnoreCase(accessToken.getType().getValue())) {
-								accessTokenType = OAuth2AccessToken.TokenType.BEARER;
-							}
-							long expiresIn = accessToken.getLifetime();
-							Set<String> scopes = (accessToken.getScope() != null) ?
-									new LinkedHashSet<>(accessToken.getScope().toStringList()) : Collections.emptySet();
-
-							String refreshToken = null;
-							if (accessTokenResponse.getTokens().getRefreshToken() != null) {
-								refreshToken = accessTokenResponse.getTokens().getRefreshToken().getValue();
-							}
-							Map<String, Object> additionalParameters = new LinkedHashMap<>(accessTokenResponse.getCustomParameters());
-
-							// @formatter:off
-							return OAuth2AccessTokenResponse.withToken(accessToken.getValue())
-									.tokenType(accessTokenType)
-									.expiresIn(expiresIn)
-									.scopes(scopes)
-									.refreshToken(refreshToken)
-									.additionalParameters(additionalParameters)
-									.build();
-							// @formatter:on
-
-						});
-
-					});
-
-		});
+		customClient.setBodyExtractor(extractor);
 
 		OAuth2RefreshTokenGrantRequest refreshTokenGrantRequest = new OAuth2RefreshTokenGrantRequest(
 				this.clientRegistrationBuilder.build(), this.accessToken, this.refreshToken);
 
 		this.server.enqueue(jsonResponse(accessTokenSuccessResponse));
-		Instant expiresAtBefore = Instant.now().plusSeconds(3600);
 		OAuth2AccessTokenResponse accessTokenResponse = customClient.getTokenResponse(refreshTokenGrantRequest).block();
-		Instant expiresAtAfter = Instant.now().plusSeconds(3600);
-		assertThat(accessTokenResponse.getAccessToken().getTokenValue()).isEqualTo("access-token-1234");
-		assertThat(accessTokenResponse.getAccessToken().getTokenType()).isEqualTo(OAuth2AccessToken.TokenType.BEARER);
-		assertThat(accessTokenResponse.getAccessToken().getExpiresAt()).isBetween(expiresAtBefore, expiresAtAfter);
-		assertThat(accessTokenResponse.getAccessToken().getScopes()).containsExactly("openid", "profile");
-		assertThat(accessTokenResponse.getRefreshToken().getTokenValue()).isEqualTo("refresh-token-1234");
-		assertThat(accessTokenResponse.getAdditionalParameters().size()).isEqualTo(2);
-		assertThat(accessTokenResponse.getAdditionalParameters()).containsEntry("custom_parameter_1", "custom-value-1");
-		assertThat(accessTokenResponse.getAdditionalParameters()).containsEntry("custom_parameter_2", "custom-value-2");
+		assertThat(accessTokenResponse.getAccessToken()).isNotNull();
 
 	}
 

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveRefreshTokenTokenResponseClientTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveRefreshTokenTokenResponseClientTests.java
@@ -25,6 +25,7 @@ import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpHeaders;
@@ -42,7 +43,6 @@ import org.springframework.security.oauth2.core.TestOAuth2RefreshTokens;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 import org.springframework.security.oauth2.core.endpoint.TestOAuth2AccessTokenResponses;
 import org.springframework.web.reactive.function.BodyExtractor;
-import reactor.core.publisher.Mono;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;


### PR DESCRIPTION
A setter added to set the `BodyExtractor` inside the `AbstractWebClientReactiveOAuth2AccessTokenResponseClient`
Closes gh-10260
