### PR TITLE
Update Saml2LoginConfigurer to pick up Saml2AuthenticationTokenConverter bean

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LoginConfigurer.java
@@ -268,12 +268,17 @@ public final class Saml2LoginConfigurer<B extends HttpSecurityBuilder<B>>
 	}
 
 	private AuthenticationConverter getAuthenticationConverter(B http) {
-		if (this.authenticationConverter == null) {
+		if (this.authenticationConverter != null) {
+			return this.authenticationConverter;
+		}
+		AuthenticationConverter authenticationConverterBean = getBeanOrNull(http,
+				Saml2AuthenticationTokenConverter.class);
+		if (authenticationConverterBean == null) {
 			return new Saml2AuthenticationTokenConverter(
 					(RelyingPartyRegistrationResolver) new DefaultRelyingPartyRegistrationResolver(
 							this.relyingPartyRegistrationRepository));
 		}
-		return this.authenticationConverter;
+		return authenticationConverterBean;
 	}
 
 	private String version() {


### PR DESCRIPTION
Closes gh-10268

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
