### PR TITLE
Support for changing prefix and suffix in `DelegatingPasswordEncoder`

### DIFF
--- a/crypto/src/test/java/org/springframework/security/crypto/password/DelegatingPasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/password/DelegatingPasswordEncoderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 /**
  * @author Rob Winch
  * @author Michael Simons
+ * @author heowc
  * @since 5.0
  */
 @ExtendWith(MockitoExtension.class)
@@ -64,12 +65,16 @@ public class DelegatingPasswordEncoderTests {
 
 	private DelegatingPasswordEncoder passwordEncoder;
 
+	private DelegatingPasswordEncoder onlySuffixPasswordEncoder;
+
 	@BeforeEach
 	public void setup() {
 		this.delegates = new HashMap<>();
 		this.delegates.put(this.bcryptId, this.bcrypt);
 		this.delegates.put("noop", this.noop);
 		this.passwordEncoder = new DelegatingPasswordEncoder(this.bcryptId, this.delegates);
+
+		this.onlySuffixPasswordEncoder = new DelegatingPasswordEncoder(this.bcryptId, this.delegates, "", "$");
 	}
 
 	@Test
@@ -81,6 +86,49 @@ public class DelegatingPasswordEncoderTests {
 	public void constructorWhenIdForEncodeDoesNotExistThenIllegalArgumentException() {
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> new DelegatingPasswordEncoder(this.bcryptId + "INVALID", this.delegates));
+	}
+
+	@Test
+	public void constructorWhenPrefixIsNull() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> new DelegatingPasswordEncoder(this.bcryptId, this.delegates, null, "$"));
+	}
+
+	@Test
+	public void constructorWhenSuffixIsNull() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> new DelegatingPasswordEncoder(this.bcryptId, this.delegates, "$", null));
+	}
+
+	@Test
+	public void constructorWhenPrefixIsEmpty() {
+		assertThat(new DelegatingPasswordEncoder(this.bcryptId, this.delegates, "", "$")).isNotNull();
+	}
+
+	@Test
+	public void constructorWhenSuffixIsEmpty() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> new DelegatingPasswordEncoder(this.bcryptId, this.delegates, "$", ""));
+	}
+
+	@Test
+	public void constructorWhenPrefixAndSuffixAreEmpty() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> new DelegatingPasswordEncoder(this.bcryptId, this.delegates, "", ""));
+	}
+
+	@Test
+	public void constructorWhenIdContainsPrefixThenIllegalArgumentException() {
+		this.delegates.put('$' + this.bcryptId, this.bcrypt);
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> new DelegatingPasswordEncoder(this.bcryptId, this.delegates, "$", "$"));
+	}
+
+	@Test
+	public void constructorWhenIdContainsSuffixThenIllegalArgumentException() {
+		this.delegates.put(this.bcryptId + '$', this.bcrypt);
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> new DelegatingPasswordEncoder(this.bcryptId, this.delegates, "", "$"));
 	}
 
 	@Test
@@ -105,9 +153,23 @@ public class DelegatingPasswordEncoderTests {
 	}
 
 	@Test
+	public void encodeWhenValidBySpecifyDelegatingPasswordEncoderThenUsesIdForEncode() {
+		given(this.bcrypt.encode(this.rawPassword)).willReturn(this.encodedPassword);
+		assertThat(this.onlySuffixPasswordEncoder.encode(this.rawPassword)).isEqualTo("bcrypt$" + this.encodedPassword);
+	}
+
+	@Test
 	public void matchesWhenBCryptThenDelegatesToBCrypt() {
 		given(this.bcrypt.matches(this.rawPassword, this.encodedPassword)).willReturn(true);
 		assertThat(this.passwordEncoder.matches(this.rawPassword, this.bcryptEncodedPassword)).isTrue();
+		verify(this.bcrypt).matches(this.rawPassword, this.encodedPassword);
+		verifyZeroInteractions(this.noop);
+	}
+
+	@Test
+	public void matchesWhenBCryptBySpecifyDelegatingPasswordEncoderThenDelegatesToBCrypt() {
+		given(this.bcrypt.matches(this.rawPassword, this.encodedPassword)).willReturn(true);
+		assertThat(this.onlySuffixPasswordEncoder.matches(this.rawPassword, "bcrypt$" + this.encodedPassword)).isTrue();
 		verify(this.bcrypt).matches(this.rawPassword, this.encodedPassword);
 		verifyZeroInteractions(this.noop);
 	}


### PR DESCRIPTION
Closes gh-10273

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
