### PR TITLE
if there is no mapped port, just use the original

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/LoginUrlAuthenticationEntryPoint.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/LoginUrlAuthenticationEntryPoint.java
@@ -158,15 +158,10 @@ public class LoginUrlAuthenticationEntryPoint implements AuthenticationEntryPoin
 		urlBuilder.setPathInfo(loginForm);
 		if (this.forceHttps && "http".equals(scheme)) {
 			Integer httpsPort = this.portMapper.lookupHttpsPort(serverPort);
-			if (httpsPort != null) {
-				// Overwrite scheme and port in the redirect URL
-				urlBuilder.setScheme("https");
-				urlBuilder.setPort(httpsPort);
-			}
-			else {
-				logger.warn(LogMessage.format("Unable to redirect to HTTPS as no port mapping found for HTTP port %s",
-						serverPort));
-			}
+			if (httpsPort == null) httpsPort = serverPort; //if there is no mapped port, just use the original
+			// Overwrite scheme and port in the redirect URL
+			urlBuilder.setScheme("https");
+			urlBuilder.setPort(httpsPort);
 		}
 		return urlBuilder.getUrl();
 	}
@@ -178,21 +173,16 @@ public class LoginUrlAuthenticationEntryPoint implements AuthenticationEntryPoin
 	protected String buildHttpsRedirectUrlForRequest(HttpServletRequest request) throws IOException, ServletException {
 		int serverPort = this.portResolver.getServerPort(request);
 		Integer httpsPort = this.portMapper.lookupHttpsPort(serverPort);
-		if (httpsPort != null) {
-			RedirectUrlBuilder urlBuilder = new RedirectUrlBuilder();
-			urlBuilder.setScheme("https");
-			urlBuilder.setServerName(request.getServerName());
-			urlBuilder.setPort(httpsPort);
-			urlBuilder.setContextPath(request.getContextPath());
-			urlBuilder.setServletPath(request.getServletPath());
-			urlBuilder.setPathInfo(request.getPathInfo());
-			urlBuilder.setQuery(request.getQueryString());
-			return urlBuilder.getUrl();
-		}
-		// Fall through to server-side forward with warning message
-		logger.warn(
-				LogMessage.format("Unable to redirect to HTTPS as no port mapping found for HTTP port %s", serverPort));
-		return null;
+		if (httpsPort == null) httpsPort = serverPort; //if there is no mapped port, just use the original
+		RedirectUrlBuilder urlBuilder = new RedirectUrlBuilder();
+		urlBuilder.setScheme("https");
+		urlBuilder.setServerName(request.getServerName());
+		urlBuilder.setPort(httpsPort);
+		urlBuilder.setContextPath(request.getContextPath());
+		urlBuilder.setServletPath(request.getServletPath());
+		urlBuilder.setPathInfo(request.getPathInfo());
+		urlBuilder.setQuery(request.getQueryString());
+		return urlBuilder.getUrl();
 	}
 
 	/**


### PR DESCRIPTION
If there is no mapped port configured just use the original port, but switch to the https scheme. This is helpful for services running on http that are behind a proxy running on https - there is no need to setup mapping in that case, just keep the incoming port and don't change it.

If there is mapping setup (for example the default of 80 -> 443) then this commit changes nothing.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
