### PR TITLE
Fixed link in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 # EditorConfig for Spring Security
-# see https://github.com/spring-projects/spring-security/blob/master/CONTRIBUTING.md#mind-the-whitespace
+# see https://github.com/spring-projects/spring-security/blob/master/CONTRIBUTING.adoc#mind-the-whitespace
 
 root = true
 


### PR DESCRIPTION
Simple link fix in `.editorconfig` for fellow developers, .md -> .adoc