### PR TITLE
DaoAuthenticationProviderTests#avg function doesn't return fraction

### DIFF
--- a/core/src/test/java/org/springframework/security/authentication/dao/DaoAuthenticationProviderTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/dao/DaoAuthenticationProviderTests.java
@@ -462,11 +462,7 @@ public class DaoAuthenticationProviderTests {
 	}
 
 	private double avg(List<Long> counts) {
-		long sum = 0;
-		for (Long time : counts) {
-			sum += time;
-		}
-		return sum / counts.size();
+		return counts.stream().mapToLong(Long::longValue).average().orElse(0);
 	}
 
 	@Test


### PR DESCRIPTION
`DaoAuthenticationProviderTests#avg` function returns double, but because of lack of a cast to double at one point in return statement it will always return number without fraction (long casted to double). This works in tests now, but it may be broken in the future.

I've change manual counting of avg for a steam and avg from Java standard libs.
