### PR TITLE
Fix Gradle Deprecation Warnings

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -8,7 +8,6 @@ plugins {
 sourceCompatibility = JavaVersion.VERSION_11
 
 repositories {
-	jcenter()
 	gradlePluginPortal()
 	mavenCentral()
 	maven { url 'https://repo.spring.io/plugins-release/' }

--- a/buildSrc/src/main/groovy/io/spring/gradle/convention/DocsPlugin.groovy
+++ b/buildSrc/src/main/groovy/io/spring/gradle/convention/DocsPlugin.groovy
@@ -25,7 +25,7 @@ public class DocsPlugin implements Plugin<Project> {
 			group = 'Distribution'
 			archiveBaseName = project.rootProject.name
 			archiveClassifier = 'docs'
-			description = "Builds -${classifier} archive containing all " +
+			description = "Builds -${archiveClassifier.get()} archive containing all " +
 				"Docs for deployment at docs.spring.io"
 
 			from(project.tasks.api.outputs) {

--- a/buildSrc/src/main/groovy/io/spring/gradle/convention/RepositoryConventionPlugin.groovy
+++ b/buildSrc/src/main/groovy/io/spring/gradle/convention/RepositoryConventionPlugin.groovy
@@ -35,11 +35,6 @@ class RepositoryConventionPlugin implements Plugin<Project> {
 				mavenLocal()
 			}
 			mavenCentral()
-			jcenter() {
-				content {
-					includeGroup "org.gretty"
-				}
-			}
 			if (isSnapshot) {
 				maven {
 					name = 'artifactory-snapshot'

--- a/buildSrc/src/test/java/io/spring/gradle/convention/RepositoryConventionPluginTests.java
+++ b/buildSrc/src/test/java/io/spring/gradle/convention/RepositoryConventionPluginTests.java
@@ -107,7 +107,7 @@ public class RepositoryConventionPluginTests {
 		this.project.getPluginManager().apply(RepositoryConventionPlugin.class);
 
 		RepositoryHandler repositories = this.project.getRepositories();
-		assertThat(repositories).hasSize(5);
+		assertThat(repositories).hasSize(4);
 		assertThat((repositories.get(0)).getName()).isEqualTo("MavenLocal");
 	}
 
@@ -119,39 +119,33 @@ public class RepositoryConventionPluginTests {
 		this.project.getPluginManager().apply(RepositoryConventionPlugin.class);
 
 		RepositoryHandler repositories = this.project.getRepositories();
-		assertThat(repositories).hasSize(6);
+		assertThat(repositories).hasSize(5);
 		assertThat((repositories.get(0)).getName()).isEqualTo("MavenLocal");
 	}
 
 	private void assertSnapshotRepository(RepositoryHandler repositories) {
-		assertThat(repositories).extracting(ArtifactRepository::getName).hasSize(6);
-		assertThat(((MavenArtifactRepository) repositories.get(0)).getUrl().toString())
-				.isEqualTo("https://repo.maven.apache.org/maven2/");
-		assertThat(((MavenArtifactRepository) repositories.get(1)).getUrl().toString())
-				.isEqualTo("https://jcenter.bintray.com/");
-		assertThat(((MavenArtifactRepository) repositories.get(2)).getUrl().toString())
-				.isEqualTo("https://repo.spring.io/snapshot/");
-		assertThat(((MavenArtifactRepository) repositories.get(3)).getUrl().toString())
-				.isEqualTo("https://repo.spring.io/milestone/");
-	}
-
-	private void assertMilestoneRepository(RepositoryHandler repositories) {
 		assertThat(repositories).extracting(ArtifactRepository::getName).hasSize(5);
 		assertThat(((MavenArtifactRepository) repositories.get(0)).getUrl().toString())
 				.isEqualTo("https://repo.maven.apache.org/maven2/");
 		assertThat(((MavenArtifactRepository) repositories.get(1)).getUrl().toString())
-				.isEqualTo("https://jcenter.bintray.com/");
+				.isEqualTo("https://repo.spring.io/snapshot/");
 		assertThat(((MavenArtifactRepository) repositories.get(2)).getUrl().toString())
 				.isEqualTo("https://repo.spring.io/milestone/");
 	}
 
-	private void assertReleaseRepository(RepositoryHandler repositories) {
+	private void assertMilestoneRepository(RepositoryHandler repositories) {
 		assertThat(repositories).extracting(ArtifactRepository::getName).hasSize(4);
 		assertThat(((MavenArtifactRepository) repositories.get(0)).getUrl().toString())
 				.isEqualTo("https://repo.maven.apache.org/maven2/");
 		assertThat(((MavenArtifactRepository) repositories.get(1)).getUrl().toString())
-				.isEqualTo("https://jcenter.bintray.com/");
-		assertThat(((MavenArtifactRepository) repositories.get(2)).getUrl().toString())
+				.isEqualTo("https://repo.spring.io/milestone/");
+	}
+
+	private void assertReleaseRepository(RepositoryHandler repositories) {
+		assertThat(repositories).extracting(ArtifactRepository::getName).hasSize(3);
+		assertThat(((MavenArtifactRepository) repositories.get(0)).getUrl().toString())
+				.isEqualTo("https://repo.maven.apache.org/maven2/");
+		assertThat(((MavenArtifactRepository) repositories.get(1)).getUrl().toString())
 				.isEqualTo("https://repo.spring.io/release/");
 	}
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,8 +10,6 @@ plugins {
 	id "io.spring.ge.conventions" version "0.0.7"
 }
 
-enableFeaturePreview("VERSION_ORDERING_V2")
-
 dependencyResolutionManagement {
 	repositories {
 		mavenCentral()


### PR DESCRIPTION
This fixes the deprecation warnings emitted by Gradle 7.2:

```
enableFeaturePreview('VERSION_ORDERING_V2') has been deprecated. This is scheduled to be removed in Gradle 8.0. The feature flag is no longer relevant, please remove it from your settings file. See https://docs.gradle.org/7.2/userguide/feature_lifecycle.html#feature_preview for more details.
        at settings_dfhlxatnqhe7e8c2fo902wxnx.run(/Users/larsgrefer/git/spring-projects/spring-security/settings.gradle:13)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

> Configure project :buildSrc
The RepositoryHandler.jcenter() method has been deprecated. This is scheduled to be removed in Gradle 8.0. JFrog announced JCenter's sunset in February 2021. Use mavenCentral() instead. Consult the upgrading guide for further information: https://docs.gradle.org/7.2/userguide/upgrading_version_6.html#jcenter_deprecation
        at build_2oqrf2tvjxex1kq4ulionehg0$_run_closure1.doCall(/Users/larsgrefer/git/spring-projects/spring-security/buildSrc/build.gradle:12)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

> Configure project :spring-security-acl
The RepositoryHandler.jcenter(Action<MavenArtifactRepository>) method has been deprecated. This is scheduled to be removed in Gradle 8.0. JFrog announced JCenter's sunset in February 2021. Use mavenCentral(Action<MavenArtifactRepository> instead. Consult the upgrading guide for further information: https://docs.gradle.org/7.2/userguide/upgrading_version_6.html#jcenter_deprecation
        at spring_security_acl_l5qa57wyb10vbea3v27lro5o.run(/Users/larsgrefer/git/spring-projects/spring-security/acl/spring-security-acl.gradle:1)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

> Configure project :spring-security-docs
The AbstractArchiveTask.classifier property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the archiveClassifier property instead. See https://docs.gradle.org/7.2/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:classifier for more details.
        at spring_security_docs_eaofagogpzk25sj6rr36s6lyk.run(/Users/larsgrefer/git/spring-projects/spring-security/docs/spring-security-docs.gradle:1)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```