### PR TITLE
 Adding keyInfo section to LogoutRequest from RP side

### DIFF
--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/OpenSamlSigningUtils.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/OpenSamlSigningUtils.java
@@ -42,6 +42,9 @@ import org.opensaml.xmlsec.SignatureSigningParametersResolver;
 import org.opensaml.xmlsec.criterion.SignatureSigningConfigurationCriterion;
 import org.opensaml.xmlsec.crypto.XMLSigningUtil;
 import org.opensaml.xmlsec.impl.BasicSignatureSigningConfiguration;
+import org.opensaml.xmlsec.keyinfo.KeyInfoGeneratorManager;
+import org.opensaml.xmlsec.keyinfo.NamedKeyInfoGeneratorManager;
+import org.opensaml.xmlsec.keyinfo.impl.X509KeyInfoGeneratorFactory;
 import org.opensaml.xmlsec.signature.SignableXMLObject;
 import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import org.opensaml.xmlsec.signature.support.SignatureSupport;
@@ -103,6 +106,7 @@ final class OpenSamlSigningUtils {
 		signingConfiguration.setSignatureAlgorithms(algorithms);
 		signingConfiguration.setSignatureReferenceDigestMethods(digests);
 		signingConfiguration.setSignatureCanonicalizationAlgorithm(canonicalization);
+		signingConfiguration.setKeyInfoGeneratorManager(buildSignatureKeyInfoGeneratorManager());
 		criteria.add(new SignatureSigningConfigurationCriterion(signingConfiguration));
 		try {
 			SignatureSigningParameters parameters = resolver.resolveSingle(criteria);
@@ -112,6 +116,22 @@ final class OpenSamlSigningUtils {
 		catch (Exception ex) {
 			throw new Saml2Exception(ex);
 		}
+	}
+
+	private static NamedKeyInfoGeneratorManager buildSignatureKeyInfoGeneratorManager() {
+		final NamedKeyInfoGeneratorManager namedManager = new NamedKeyInfoGeneratorManager();
+
+		namedManager.setUseDefaultManager(true);
+		final KeyInfoGeneratorManager defaultManager = namedManager.getDefaultManager();
+
+		// Generator for X509Credentials
+		final X509KeyInfoGeneratorFactory x509Factory = new X509KeyInfoGeneratorFactory();
+		x509Factory.setEmitEntityCertificate(true);
+		x509Factory.setEmitEntityCertificateChain(true);
+
+		defaultManager.registerFactory(x509Factory);
+
+		return namedManager;
 	}
 
 	private static List<Credential> resolveSigningCredentials(RelyingPartyRegistration relyingPartyRegistration) {

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/TestOpenSamlObjects.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/TestOpenSamlObjects.java
@@ -384,6 +384,22 @@ public final class TestOpenSamlObjects {
 		return logoutResponse;
 	}
 
+	public static LogoutRequest relyingPartyLogoutRequest(RelyingPartyRegistration registration) {
+		LogoutRequestBuilder logoutRequestBuilder = new LogoutRequestBuilder();
+		LogoutRequest logoutRequest = logoutRequestBuilder.buildObject();
+		logoutRequest.setID("id");
+		NameIDBuilder nameIdBuilder = new NameIDBuilder();
+		NameID nameId = nameIdBuilder.buildObject();
+		nameId.setValue("user");
+		logoutRequest.setNameID(nameId);
+		IssuerBuilder issuerBuilder = new IssuerBuilder();
+		Issuer issuer = issuerBuilder.buildObject();
+		issuer.setValue(registration.getAssertingPartyDetails().getEntityId());
+		logoutRequest.setIssuer(issuer);
+		logoutRequest.setDestination(registration.getAssertingPartyDetails().getSingleLogoutServiceLocation());
+		return logoutRequest;
+	}
+
 	static <T extends XMLObject> T build(QName qName) {
 		return (T) XMLObjectProviderRegistrySupport.getBuilderFactory().getBuilder(qName).buildObject(qName);
 	}

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/logout/OpenSamlSigningUtils.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/logout/OpenSamlSigningUtils.java
@@ -42,6 +42,9 @@ import org.opensaml.xmlsec.SignatureSigningParametersResolver;
 import org.opensaml.xmlsec.criterion.SignatureSigningConfigurationCriterion;
 import org.opensaml.xmlsec.crypto.XMLSigningUtil;
 import org.opensaml.xmlsec.impl.BasicSignatureSigningConfiguration;
+import org.opensaml.xmlsec.keyinfo.KeyInfoGeneratorManager;
+import org.opensaml.xmlsec.keyinfo.NamedKeyInfoGeneratorManager;
+import org.opensaml.xmlsec.keyinfo.impl.X509KeyInfoGeneratorFactory;
 import org.opensaml.xmlsec.signature.SignableXMLObject;
 import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import org.opensaml.xmlsec.signature.support.SignatureSupport;
@@ -103,6 +106,7 @@ final class OpenSamlSigningUtils {
 		signingConfiguration.setSignatureAlgorithms(algorithms);
 		signingConfiguration.setSignatureReferenceDigestMethods(digests);
 		signingConfiguration.setSignatureCanonicalizationAlgorithm(canonicalization);
+		signingConfiguration.setKeyInfoGeneratorManager(buildSignatureKeyInfoGeneratorManager());
 		criteria.add(new SignatureSigningConfigurationCriterion(signingConfiguration));
 		try {
 			SignatureSigningParameters parameters = resolver.resolveSingle(criteria);
@@ -112,6 +116,22 @@ final class OpenSamlSigningUtils {
 		catch (Exception ex) {
 			throw new Saml2Exception(ex);
 		}
+	}
+
+	private static NamedKeyInfoGeneratorManager buildSignatureKeyInfoGeneratorManager() {
+		final NamedKeyInfoGeneratorManager namedManager = new NamedKeyInfoGeneratorManager();
+
+		namedManager.setUseDefaultManager(true);
+		final KeyInfoGeneratorManager defaultManager = namedManager.getDefaultManager();
+
+		// Generator for X509Credentials
+		final X509KeyInfoGeneratorFactory x509Factory = new X509KeyInfoGeneratorFactory();
+		x509Factory.setEmitEntityCertificate(true);
+		x509Factory.setEmitEntityCertificateChain(true);
+
+		defaultManager.registerFactory(x509Factory);
+
+		return namedManager;
 	}
 
 	private static List<Credential> resolveSigningCredentials(RelyingPartyRegistration relyingPartyRegistration) {

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2LogoutSigningUtilsTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2LogoutSigningUtilsTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.provider.service.web.authentication.logout;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensaml.saml.saml2.core.LogoutRequest;
+import org.opensaml.xmlsec.signature.Signature;
+
+import org.springframework.security.saml2.core.TestSaml2X509Credentials;
+import org.springframework.security.saml2.provider.service.authentication.TestOpenSamlObjects;
+import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test open SAML Logout signatures
+ */
+public class Saml2LogoutSigningUtilsTests {
+
+	private RelyingPartyRegistration registration;
+
+	@BeforeEach
+	public void setup() {
+		this.registration = RelyingPartyRegistration.withRegistrationId("saml-idp")
+				.entityId("https://some.idp.example.com/entity-id").signingX509Credentials((c) -> {
+					c.add(TestSaml2X509Credentials.relyingPartySigningCredential());
+					c.add(TestSaml2X509Credentials.assertingPartySigningCredential());
+				}).assertingPartyDetails((c) -> c.entityId("https://some.idp.example.com/entity-id")
+						.singleSignOnServiceLocation("https://some.idp.example.com/service-location"))
+				.build();
+	}
+
+	@Test
+	public void whenSigningLogoutRequestRPThenKeyInfoIsPartOfTheSignature() {
+		LogoutRequest logoutRequest = TestOpenSamlObjects.relyingPartyLogoutRequest(this.registration);
+		OpenSamlSigningUtils.sign(logoutRequest, this.registration);
+		Signature signature = logoutRequest.getSignature();
+		assertThat(signature).isNotNull();
+		assertThat(signature.getKeyInfo()).isNotNull();
+	}
+
+}


### PR DESCRIPTION
Fixes #10438 

in `org.springframework.security.saml2.provider.service.web.authentication.logout.OpenSamlSigningUtils` was added 
`signingConfiguration.setKeyInfoGeneratorManager(buildSignatureKeyInfoGeneratorManager());` in 'resolveSigningParameters' method and also added method 'buildSignatureKeyInfoGeneratorManager()' 

the same I did in 'org.springframework.security.saml2.provider.service.authentication.logout.OpenSamlSigningUtils'

And now we have all three places 

`org.springframework.security.saml2.provider.service.web.authentication.logout.OpenSamlSigningUtils
org.springframework.security.saml2.provider.service.authentication.logout.OpenSamlSigningUtils
org.springframework.security.saml2.provider.service.authentication.OpenSamlSigningUtils`

with KeyInfo in Signature.

Also I added `org.springframework.security.saml2.provider.service.authentication.TestOpenSamlObjects#relyingPartyLogoutRequest`

to test that RP LogoutRequest has KeyInfo section in `org.springframework.security.saml2.provider.service.web.authentication.logout.Saml2LogoutSigningUtilsTests`






