### PR TITLE
make RestOperations configurable in OidcIdTokenDecoderFactory

### DIFF
--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/authentication/OidcIdTokenDecoderFactoryTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/authentication/OidcIdTokenDecoderFactoryTests.java
@@ -96,6 +96,11 @@ public class OidcIdTokenDecoderFactoryTests {
 	}
 
 	@Test
+	public void setRestOperationsWhenNullThenThrowIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.idTokenDecoderFactory.setRestOperations(null));
+	}
+
+	@Test
 	public void createDecoderWhenClientRegistrationNullThenThrowIllegalArgumentException() {
 		assertThatIllegalArgumentException().isThrownBy(() -> this.idTokenDecoderFactory.createDecoder(null));
 	}


### PR DESCRIPTION
This is a simple fix for #10512 which allows the `RestOperations` used when fetching a JWKs to be configured externally.

closes #10512 