### PR TITLE
Update MapReactiveUserDetailsService.java

### DIFF
--- a/core/src/main/java/org/springframework/security/core/userdetails/MapReactiveUserDetailsService.java
+++ b/core/src/main/java/org/springframework/security/core/userdetails/MapReactiveUserDetailsService.java
@@ -56,7 +56,6 @@ public class MapReactiveUserDetailsService implements ReactiveUserDetailsService
 	 * @param users the {@link UserDetails} to use
 	 */
 	public MapReactiveUserDetailsService(Collection<UserDetails> users) {
-		Assert.notEmpty(users, "users cannot be null or empty");
 		this.users = new ConcurrentHashMap<>();
 		for (UserDetails user : users) {
 			this.users.put(getKey(user.getUsername()), user);


### PR DESCRIPTION
Remove 	Assert.notEmpty(users, "users cannot be null or empty"); because when configuring a application for the first time there wont be any users for it to find which causes errors. Having default users can be a security concern for a application.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
