### PR TITLE
PermitAllSupport supports AuthorizeHttpRequestsConfigurer

### DIFF
--- a/web/src/main/java/org/springframework/security/web/access/intercept/RequestMatcherDelegatingAuthorizationManager.java
+++ b/web/src/main/java/org/springframework/security/web/access/intercept/RequestMatcherDelegatingAuthorizationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.security.web.access.intercept;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -109,6 +110,20 @@ public final class RequestMatcherDelegatingAuthorizationManager implements Autho
 			Assert.notNull(matcher, "matcher cannot be null");
 			Assert.notNull(manager, "manager cannot be null");
 			this.mappings.put(matcher, manager);
+			return this;
+		}
+
+		/**
+		 * Allows to configure the {@link RequestMatcher} to {@link AuthorizationManager}
+		 * mappings.
+		 * @param mappingsConsumer used to configure the {@link RequestMatcher} to
+		 * {@link AuthorizationManager} mappings.
+		 * @return the {@link Builder} for further customizations
+		 */
+		public Builder mappings(
+				Consumer<Map<RequestMatcher, AuthorizationManager<RequestAuthorizationContext>>> mappingsConsumer) {
+			Assert.notNull(mappingsConsumer, "mappingsConsumer cannot be null");
+			mappingsConsumer.accept(this.mappings);
 			return this;
 		}
 

--- a/web/src/test/java/org/springframework/security/web/access/intercept/RequestMatcherDelegatingAuthorizationManagerTests.java
+++ b/web/src/test/java/org/springframework/security/web/access/intercept/RequestMatcherDelegatingAuthorizationManagerTests.java
@@ -22,9 +22,11 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.authorization.AuthorityAuthorizationManager;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
+import org.springframework.security.web.util.matcher.AnyRequestMatcher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -81,6 +83,42 @@ public class RequestMatcherDelegatingAuthorizationManagerTests {
 
 		AuthorizationDecision abstain = manager.check(authentication, new MockHttpServletRequest(null, "/abstain"));
 		assertThat(abstain).isNull();
+	}
+
+	@Test
+	public void checkWhenMultipleMappingsConfiguredWithConsumerThenDelegatesMatchingManager() {
+		RequestMatcherDelegatingAuthorizationManager manager = RequestMatcherDelegatingAuthorizationManager.builder()
+				.mappings((m) -> {
+					m.put(new MvcRequestMatcher(null, "/grant"), (a, o) -> new AuthorizationDecision(true));
+					m.put(AnyRequestMatcher.INSTANCE, AuthorityAuthorizationManager.hasRole("ADMIN"));
+					m.put(new MvcRequestMatcher(null, "/deny"), (a, o) -> new AuthorizationDecision(false));
+					m.put(new MvcRequestMatcher(null, "/afterAny"), (a, o) -> new AuthorizationDecision(true));
+				}).build();
+
+		Supplier<Authentication> authentication = () -> new TestingAuthenticationToken("user", "password", "ROLE_USER");
+
+		AuthorizationDecision grant = manager.check(authentication, new MockHttpServletRequest(null, "/grant"));
+		assertThat(grant).isNotNull();
+		assertThat(grant.isGranted()).isTrue();
+
+		AuthorizationDecision deny = manager.check(authentication, new MockHttpServletRequest(null, "/deny"));
+		assertThat(deny).isNotNull();
+		assertThat(deny.isGranted()).isFalse();
+
+		AuthorizationDecision afterAny = manager.check(authentication, new MockHttpServletRequest(null, "/afterAny"));
+		assertThat(afterAny).isNotNull();
+		assertThat(afterAny.isGranted()).isFalse();
+
+		AuthorizationDecision unmapped = manager.check(authentication, new MockHttpServletRequest(null, "/unmapped"));
+		assertThat(unmapped).isNotNull();
+		assertThat(unmapped.isGranted()).isFalse();
+	}
+
+	@Test
+	public void addWhenMappingsConsumerNullThenException() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> RequestMatcherDelegatingAuthorizationManager.builder().mappings(null).build())
+				.withMessage("mappingsConsumer cannot be null");
 	}
 
 }


### PR DESCRIPTION
PermitAllSupport supports either an ExpressionUrlAuthorizationConfigurer or an AuthorizeHttpRequestsConfigurer. If none or both are configured an error message is thrown.

Closes gh-10482

CLA was submitted.