### PR TITLE
Fix return type for NoOpPasswordEncoder bean in documentation

### DIFF
--- a/docs/modules/ROOT/pages/features/authentication/password-storage.adoc
+++ b/docs/modules/ROOT/pages/features/authentication/password-storage.adoc
@@ -463,7 +463,7 @@ You should instead migrate to using `DelegatingPasswordEncoder` to support secur
 [source,java,role="primary"]
 ----
 @Bean
-public static NoOpPasswordEncoder passwordEncoder() {
+public static PasswordEncoder passwordEncoder() {
     return NoOpPasswordEncoder.getInstance();
 }
 ----


### PR DESCRIPTION
Fixes the return type of the bean factory method for a `NoOpPasswordEncoder` in the reference documentation.

The return type must be `PasswordEncoder` as that is the return type of `NoOpPasswordEncoder::getInstance`. The code snippet for Kotlin is correct.