### PR TITLE
Allow Multipart form POSTs to include access tokens

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
@@ -128,14 +128,18 @@ public final class DefaultBearerTokenResolver implements BearerTokenResolver {
 
 	private boolean isParameterTokenSupportedForRequest(final HttpServletRequest request) {
 		return (("POST".equals(request.getMethod())
-				&& MediaType.APPLICATION_FORM_URLENCODED_VALUE.equals(request.getContentType()))
+				&& isFormRequest(request))
 				|| "GET".equals(request.getMethod()));
 	}
 
 	private boolean isParameterTokenEnabledForRequest(final HttpServletRequest request) {
 		return ((this.allowFormEncodedBodyParameter && "POST".equals(request.getMethod())
-				&& MediaType.APPLICATION_FORM_URLENCODED_VALUE.equals(request.getContentType()))
+				&& isFormRequest(request))
 				|| (this.allowUriQueryParameter && "GET".equals(request.getMethod())));
 	}
 
+	private static boolean isFormRequest(final HttpServletRequest request) {
+		return MediaType.APPLICATION_FORM_URLENCODED_VALUE.equals(request.getContentType())
+				|| MediaType.MULTIPART_FORM_DATA_VALUE.equals(request.getContentType());
+	}
 }


### PR DESCRIPTION
As part of changes in 6db58cbf8a26296a15eb9f9c187176f099acaa77, we
modified the logic for whether an access token could be sent as a
parameter in a request's body.

However, this doesn't account for Multipart POSTs, for instance where an
image and an access token may be provided together.

This isn't called out as an option for RFC 6750, but is being used in
practice, so we should aim to support it.

In use i.e. by the [Micropub standard](https://micropub.spec.indieweb.org/#reserved-properties)