### PR TITLE
Fixed ClientAuthenticationMethod inconsistent equals and hashCode

### DIFF
--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClientAuthenticationMethod.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClientAuthenticationMethod.java
@@ -103,12 +103,12 @@ public final class ClientAuthenticationMethod implements Serializable {
 			return false;
 		}
 		ClientAuthenticationMethod that = (ClientAuthenticationMethod) obj;
-		return this.getValue().toLowerCase(Locale.ROOT).equals(that.getValue().toLowerCase(Locale.ROOT));
+		return this.getValue().equals(that.getValue());
 	}
 
 	@Override
 	public int hashCode() {
-		return this.getValue().toLowerCase(Locale.ROOT).hashCode();
+		return this.getValue().hashCode();
 	}
 
 }

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClientAuthenticationMethod.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClientAuthenticationMethod.java
@@ -17,6 +17,7 @@
 package org.springframework.security.oauth2.core;
 
 import java.io.Serializable;
+import java.util.Locale;
 
 import org.springframework.security.core.SpringSecurityCoreVersion;
 import org.springframework.util.Assert;
@@ -102,12 +103,12 @@ public final class ClientAuthenticationMethod implements Serializable {
 			return false;
 		}
 		ClientAuthenticationMethod that = (ClientAuthenticationMethod) obj;
-		return this.getValue().equalsIgnoreCase(that.getValue());
+		return this.getValue().toLowerCase(Locale.ROOT).equals(that.getValue().toLowerCase(Locale.ROOT));
 	}
 
 	@Override
 	public int hashCode() {
-		return this.getValue().hashCode();
+		return this.getValue().toLowerCase(Locale.ROOT).hashCode();
 	}
 
 }

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClientAuthenticationMethod.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClientAuthenticationMethod.java
@@ -17,7 +17,6 @@
 package org.springframework.security.oauth2.core;
 
 import java.io.Serializable;
-import java.util.Locale;
 
 import org.springframework.security.core.SpringSecurityCoreVersion;
 import org.springframework.util.Assert;


### PR DESCRIPTION
In `org.springframework.security.oauth2.core.ClientAuthenticationMethod` the equals method was comparing the value using `equalsIgnoreCase`, however the `hashCode` was returning the original string's `hashCode`. This meant that if the value was only differing in the case, `equals` would return true, but the `hashCode` wouldn't match, causing all sorts of problems, such as in a Collection calling `contains` returning false. E.g.:

```
ClientAuthenticationMethod foo1 = new ClientAuthenticationMethod("foo")
ClientAuthenticationMethod foo2 = new ClientAuthenticationMethod("FOO")

foo1.equals(foo2);    // This returns true

List<ClientAuthenticationMethod> list = new ArrayList<>();
list.add(foo1);

list.contains(foo2);  // This returns false
```

I fixed the issue by calling an explicit toLowerCase() in both cases.
