### PR TITLE
Prevent using both `authorizeRequests` and `authorizeHttpRequests`

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
@@ -2889,8 +2889,15 @@ public final class HttpSecurity extends AbstractConfiguredSecurityBuilder<Defaul
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	protected DefaultSecurityFilterChain performBuild() {
+		ExpressionUrlAuthorizationConfigurer<?> expressionConfigurer = getConfigurer(
+				ExpressionUrlAuthorizationConfigurer.class);
+		AuthorizeHttpRequestsConfigurer<?> httpConfigurer = getConfigurer(AuthorizeHttpRequestsConfigurer.class);
+		boolean oneConfigurerPresent = expressionConfigurer == null ^ httpConfigurer == null;
+		Assert.state((expressionConfigurer == null && httpConfigurer == null) || oneConfigurerPresent,
+				"authorizeHttpRequests cannot be used in conjunction with authorizeRequests. Please select just one.");
 		this.filters.sort(OrderComparator.INSTANCE);
 		List<Filter> sortedFilters = new ArrayList<>(this.filters.size());
 		for (Filter filter : this.filters) {


### PR DESCRIPTION
Closes gh-10573

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
