### PR TITLE
Make Saml2AuthenticationRequests serializable

### DIFF
--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/AbstractSaml2AuthenticationRequest.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/AbstractSaml2AuthenticationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,10 @@
 
 package org.springframework.security.saml2.provider.service.authentication;
 
+import java.io.Serializable;
 import java.nio.charset.Charset;
 
+import org.springframework.security.core.SpringSecurityCoreVersion;
 import org.springframework.security.saml2.provider.service.registration.Saml2MessageBinding;
 import org.springframework.util.Assert;
 
@@ -34,7 +36,9 @@ import org.springframework.util.Assert;
  * @see Saml2AuthenticationRequestFactory#createPostAuthenticationRequest(Saml2AuthenticationRequestContext)
  * @see Saml2AuthenticationRequestFactory#createRedirectAuthenticationRequest(Saml2AuthenticationRequestContext)
  */
-public abstract class AbstractSaml2AuthenticationRequest {
+public abstract class AbstractSaml2AuthenticationRequest implements Serializable {
+
+	private static final long serialVersionUID = SpringSecurityCoreVersion.SERIAL_VERSION_UID;
 
 	private final String samlRequest;
 

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/Saml2PostAuthenticationRequestTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/Saml2PostAuthenticationRequestTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.provider.service.authentication;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.util.SerializationUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Saml2PostAuthenticationRequestTests {
+
+	private static final String IDP_SSO_URL = "https://sso-url.example.com/IDP/SSO";
+
+	@Test
+	void serializeWhenDeserializeThenSameFields() {
+		Saml2PostAuthenticationRequest authenticationRequest = getAuthenticationRequestBuilder().build();
+		byte[] bytes = SerializationUtils.serialize(authenticationRequest);
+		Saml2PostAuthenticationRequest deserializedAuthenticationRequest = (Saml2PostAuthenticationRequest) SerializationUtils
+				.deserialize(bytes);
+		assertThat(deserializedAuthenticationRequest).usingRecursiveComparison().isEqualTo(authenticationRequest);
+	}
+
+	@Test
+	void serializeWhenDeserializeAndCompareToOtherThenNotSame() {
+		Saml2PostAuthenticationRequest authenticationRequest = getAuthenticationRequestBuilder().build();
+		Saml2PostAuthenticationRequest otherAuthenticationRequest = getAuthenticationRequestBuilder()
+				.relayState("relay").build();
+		byte[] bytes = SerializationUtils.serialize(otherAuthenticationRequest);
+		Saml2PostAuthenticationRequest deserializedAuthenticationRequest = (Saml2PostAuthenticationRequest) SerializationUtils
+				.deserialize(bytes);
+		assertThat(deserializedAuthenticationRequest).usingRecursiveComparison().isNotEqualTo(authenticationRequest);
+	}
+
+	private Saml2PostAuthenticationRequest.Builder getAuthenticationRequestBuilder() {
+		return Saml2PostAuthenticationRequest
+				.withAuthenticationRequestContext(
+						TestSaml2AuthenticationRequestContexts.authenticationRequestContext().build())
+				.samlRequest("request").authenticationRequestUri(IDP_SSO_URL);
+	}
+
+}

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/Saml2RedirectAuthenticationRequestTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/authentication/Saml2RedirectAuthenticationRequestTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.provider.service.authentication;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.util.SerializationUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Saml2RedirectAuthenticationRequestTests {
+
+	private static final String IDP_SSO_URL = "https://sso-url.example.com/IDP/SSO";
+
+	@Test
+	void serializeWhenDeserializeThenSameFields() {
+		Saml2RedirectAuthenticationRequest authenticationRequest = getAuthenticationRequestBuilder().build();
+		byte[] bytes = SerializationUtils.serialize(authenticationRequest);
+		Saml2RedirectAuthenticationRequest deserializedAuthenticationRequest = (Saml2RedirectAuthenticationRequest) SerializationUtils
+				.deserialize(bytes);
+		assertThat(deserializedAuthenticationRequest).usingRecursiveComparison().isEqualTo(authenticationRequest);
+	}
+
+	@Test
+	void serializeWhenDeserializeAndCompareToOtherThenNotSame() {
+		Saml2RedirectAuthenticationRequest authenticationRequest = getAuthenticationRequestBuilder().build();
+		Saml2RedirectAuthenticationRequest otherAuthenticationRequest = getAuthenticationRequestBuilder()
+				.relayState("relay").build();
+		byte[] bytes = SerializationUtils.serialize(otherAuthenticationRequest);
+		Saml2RedirectAuthenticationRequest deserializedAuthenticationRequest = (Saml2RedirectAuthenticationRequest) SerializationUtils
+				.deserialize(bytes);
+		assertThat(deserializedAuthenticationRequest).usingRecursiveComparison().isNotEqualTo(authenticationRequest);
+	}
+
+	private Saml2RedirectAuthenticationRequest.Builder getAuthenticationRequestBuilder() {
+		return Saml2RedirectAuthenticationRequest
+				.withAuthenticationRequestContext(
+						TestSaml2AuthenticationRequestContexts.authenticationRequestContext().build())
+				.samlRequest("request").authenticationRequestUri(IDP_SSO_URL);
+	}
+
+}


### PR DESCRIPTION
Closes gh-10550

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
