### PR TITLE
remove unused code in InitializeUserDetailsBeanManagerConfigurer

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeUserDetailsBeanManagerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeUserDetailsBeanManagerConfigurer.java
@@ -64,7 +64,6 @@ class InitializeUserDetailsBeanManagerConfigurer extends GlobalAuthenticationCon
 				return;
 			}
 			PasswordEncoder passwordEncoder = getBeanOrNull(PasswordEncoder.class);
-			UserDetailsPasswordService passwordManager = getBeanOrNull(UserDetailsPasswordService.class);
 			DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
 			provider.setUserDetailsService(userDetailsService);
 			if (passwordEncoder != null) {


### PR DESCRIPTION
Hi. 
The "UserDetailsPasswordService passwordManager = getBeanOrNull(UserDetailsPasswordService.class);" code seems to be deprecated.
so I remove it.
Thanks for checking it out.