### PR TITLE
Validate that a collection does not contain null values without using the `contains` method

### DIFF
--- a/messaging/src/main/java/org/springframework/security/messaging/util/matcher/AbstractMessageMatcherComposite.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/util/matcher/AbstractMessageMatcherComposite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,9 @@ public abstract class AbstractMessageMatcherComposite<T> implements MessageMatch
 	 */
 	AbstractMessageMatcherComposite(List<MessageMatcher<T>> messageMatchers) {
 		Assert.notEmpty(messageMatchers, "messageMatchers must contain a value");
-		Assert.isTrue(!messageMatchers.contains(null), "messageMatchers cannot contain null values");
+		for (MessageMatcher<T> messageMatcher : messageMatchers) {
+			Assert.notNull(messageMatcher, "messageMatchers cannot contain null values");
+		}
 		this.messageMatchers = messageMatchers;
 
 	}

--- a/web/src/main/java/org/springframework/security/web/server/util/matcher/MediaTypeServerWebExchangeMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/server/util/matcher/MediaTypeServerWebExchangeMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,8 +66,9 @@ public class MediaTypeServerWebExchangeMatcher implements ServerWebExchangeMatch
 	 */
 	public MediaTypeServerWebExchangeMatcher(Collection<MediaType> matchingMediaTypes) {
 		Assert.notEmpty(matchingMediaTypes, "matchingMediaTypes cannot be null");
-		Assert.isTrue(!matchingMediaTypes.contains(null),
-				() -> "matchingMediaTypes cannot contain null. Got " + matchingMediaTypes);
+		for (MediaType mediaType : matchingMediaTypes) {
+			Assert.notNull(mediaType, () -> "matchingMediaTypes cannot contain null. Got " + matchingMediaTypes);
+		}
 		this.matchingMediaTypes = matchingMediaTypes;
 	}
 

--- a/web/src/main/java/org/springframework/security/web/util/matcher/AndRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/AndRequestMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,9 @@ public final class AndRequestMatcher implements RequestMatcher {
 	 */
 	public AndRequestMatcher(List<RequestMatcher> requestMatchers) {
 		Assert.notEmpty(requestMatchers, "requestMatchers must contain a value");
-		Assert.isTrue(!requestMatchers.contains(null), "requestMatchers cannot contain null values");
+		for (RequestMatcher requestMatcher : requestMatchers) {
+			Assert.notNull(requestMatcher, "requestMatchers cannot contain null values");
+		}
 		this.requestMatchers = requestMatchers;
 	}
 

--- a/web/src/main/java/org/springframework/security/web/util/matcher/OrRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/OrRequestMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,9 @@ public final class OrRequestMatcher implements RequestMatcher {
 	 */
 	public OrRequestMatcher(List<RequestMatcher> requestMatchers) {
 		Assert.notEmpty(requestMatchers, "requestMatchers must contain a value");
-		Assert.isTrue(!requestMatchers.contains(null), "requestMatchers cannot contain null values");
+		for (RequestMatcher requestMatcher : requestMatchers) {
+			Assert.notNull(requestMatcher, "requestMatchers cannot contain null values");
+		}
 		this.requestMatchers = requestMatchers;
 	}
 


### PR DESCRIPTION
Closes gh-10703

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
