### PR TITLE
Fix broken link to SAML2 login example

### DIFF
--- a/docs/modules/ROOT/pages/servlet/saml2/login/index.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/login/index.adoc
@@ -17,5 +17,5 @@ This process is similar to the one started in 2017 for xref:servlet/oauth2/index
 
 [NOTE]
 ====
-A working sample for {gh-samples-url}/servlet/spring-boot/java/saml2-login[SAML 2.0 Login] is available in the {gh-samples-url}[Spring Security Samples repository].
+A working sample for {gh-samples-url}/servlet/spring-boot/java/saml2/login[SAML 2.0 Login] is available in the {gh-samples-url}[Spring Security Samples repository].
 ====


### PR DESCRIPTION
Fix this link to point to 
https://github.com/spring-projects/spring-security-samples/tree/5.6.x/servlet/spring-boot/java/saml2/login 
instead of 
https://github.com/spring-projects/spring-security-samples/tree/5.6.x/servlet/spring-boot/java/saml2-login 
