### PR TITLE
Fix typo in role hierarchy document 

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authorization/architecture.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/architecture.adoc
@@ -201,7 +201,7 @@ AccessDecisionVoter hierarchyVoter() {
     hierarchy.setHierarchy("ROLE_ADMIN > ROLE_STAFF\n" +
             "ROLE_STAFF > ROLE_USER\n" +
             "ROLE_USER > ROLE_GUEST");
-    return new RoleHierarcyVoter(hierarchy);
+    return new RoleHierarchyVoter(hierarchy);
 }
 ----
 


### PR DESCRIPTION
This change fixes trivial stuff.