### PR TITLE
Replace StringUtils class of oauth2-oidc-sdk completely

### DIFF
--- a/test/src/main/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessors.java
+++ b/test/src/main/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessors.java
@@ -41,8 +41,6 @@ import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import com.nimbusds.oauth2.sdk.util.StringUtils;
-
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
@@ -102,6 +100,7 @@ import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.DigestUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.WebApplicationContextUtils;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -1206,7 +1205,7 @@ public final class SecurityMockMvcRequestPostProcessors {
 				return getAuthorities((Collection) scope);
 			}
 			String scopes = scope.toString();
-			if (StringUtils.isBlank(scopes)) {
+			if (!StringUtils.hasText(scopes)) {
 				return Collections.emptyList();
 			}
 			return getAuthorities(Arrays.asList(scopes.split(" ")));


### PR DESCRIPTION
origin Issue: #9925

In `spring-security-samples` repo, a sample module uses `com.nimbusds:oauth2-oidc-sdk` dependency.
- [oauth2/resource-server/opaque](https://github.com/spring-projects/spring-security-samples/blob/2ddf0a2fa9b7543ab893884cdfd255a3600b76be/servlet/spring-boot/java/oauth2/resource-server/opaque/build.gradle#L34)
```gradle
dependencies {
	implementation 'com.nimbusds:oauth2-oidc-sdk'
}
```

This change replaces `StringUtils` class of `oauth2-oidc-sdk` completely.
If this pr is accepted, then I am able to remove `oauth2-oidc-sdk` dependency of opaque example.

