### PR TITLE
Change in SimpleGrantedAuthority#equals

### DIFF
--- a/core/src/main/java/org/springframework/security/core/authority/SimpleGrantedAuthority.java
+++ b/core/src/main/java/org/springframework/security/core/authority/SimpleGrantedAuthority.java
@@ -50,6 +50,7 @@ public final class SimpleGrantedAuthority implements GrantedAuthority {
 		if (this == obj) {
 			return true;
 		}
+		if (obj == null) return false;
 		if (obj instanceof SimpleGrantedAuthority) {
 			return this.role.equals(((SimpleGrantedAuthority) obj).role);
 		}


### PR DESCRIPTION
Prevent NPE when calling equals with parameter null

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
