### PR TITLE
Build modules using Java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,6 @@ subprojects {
 	tasks.withType(JavaCompile) {
 		options.encoding = "UTF-8"
 		options.compilerArgs.add("-parameters")
-		options.release = 8
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,13 @@ allprojects {
 			}
 		}
 	}
+
+	tasks.withType(JavaCompile).configureEach {
+		javaCompiler = javaToolchains.compilerFor {
+			languageVersion = JavaLanguageVersion.of(8)
+		}
+	}
+
 }
 
 if (hasProperty('buildScan')) {

--- a/config/spring-security-config.gradle
+++ b/config/spring-security-config.gradle
@@ -113,7 +113,6 @@ dependencies {
 	testRuntimeOnly 'org.hsqldb:hsqldb'
 }
 
-
 rncToXsd {
 	rncDir = file('src/main/resources/org/springframework/security/config/')
 	xsdDir = rncDir
@@ -130,3 +129,33 @@ tasks.withType(KotlinCompile).configureEach {
 }
 
 build.dependsOn rncToXsd
+
+compileTestJava {
+	exclude "org/springframework/security/config/annotation/web/configurers/saml2/**", "org/springframework/security/config/http/Saml2*"
+}
+
+task compileSaml2TestJava(type: JavaCompile) {
+	javaCompiler = javaToolchains.compilerFor {
+		languageVersion = JavaLanguageVersion.of(11)
+	}
+	source = sourceSets.test.java.srcDirs
+	include "org/springframework/security/config/annotation/web/configurers/saml2/**", "org/springframework/security/config/http/Saml2*"
+	classpath = sourceSets.test.compileClasspath
+	destinationDirectory = new File("${buildDir}/classes/java/test")
+	options.sourcepath = sourceSets.test.java.getSourceDirectories()
+}
+
+task saml2Tests(type: Test) {
+	javaLauncher = javaToolchains.launcherFor {
+		languageVersion = JavaLanguageVersion.of(11)
+	}
+	filter {
+		includeTestsMatching "org.springframework.security.config.annotation.web.configurers.saml2.*"
+	}
+	useJUnitPlatform()
+	dependsOn compileSaml2TestJava
+}
+
+tasks.named('test') {
+	finalizedBy 'saml2Tests'
+}

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
@@ -18,6 +18,7 @@ package org.springframework.security.config.annotation.web.configurers.oauth2.se
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -27,6 +28,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationManagerResolver;
@@ -159,12 +161,17 @@ public final class OAuth2ResourceServerConfigurer<H extends HttpSecurityBuilder<
 	private OpaqueTokenConfigurer opaqueTokenConfigurer;
 
 	private AccessDeniedHandler accessDeniedHandler = new DelegatingAccessDeniedHandler(
-			new LinkedHashMap<>(Map.of(CsrfException.class, new AccessDeniedHandlerImpl())),
-			new BearerTokenAccessDeniedHandler());
+			new LinkedHashMap<>(createAccessDeniedHandlers()), new BearerTokenAccessDeniedHandler());
 
 	private AuthenticationEntryPoint authenticationEntryPoint = new BearerTokenAuthenticationEntryPoint();
 
 	private BearerTokenRequestMatcher requestMatcher = new BearerTokenRequestMatcher();
+
+	private static Map<Class<? extends AccessDeniedException>, AccessDeniedHandler> createAccessDeniedHandlers() {
+		Map<Class<? extends AccessDeniedException>, AccessDeniedHandler> handlers = new HashMap<>();
+		handlers.put(CsrfException.class, new AccessDeniedHandlerImpl());
+		return handlers;
+	}
 
 	public OAuth2ResourceServerConfigurer(ApplicationContext context) {
 		Assert.notNull(context, "context cannot be null");

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
@@ -18,7 +18,6 @@ package org.springframework.security.config.annotation.web.configurers.oauth2.se
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -28,7 +27,6 @@ import javax.servlet.http.HttpServletRequest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.MediaType;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationManagerResolver;
@@ -161,17 +159,12 @@ public final class OAuth2ResourceServerConfigurer<H extends HttpSecurityBuilder<
 	private OpaqueTokenConfigurer opaqueTokenConfigurer;
 
 	private AccessDeniedHandler accessDeniedHandler = new DelegatingAccessDeniedHandler(
-			new LinkedHashMap<>(createAccessDeniedHandlers()), new BearerTokenAccessDeniedHandler());
+			new LinkedHashMap<>(Map.of(CsrfException.class, new AccessDeniedHandlerImpl())),
+			new BearerTokenAccessDeniedHandler());
 
 	private AuthenticationEntryPoint authenticationEntryPoint = new BearerTokenAuthenticationEntryPoint();
 
 	private BearerTokenRequestMatcher requestMatcher = new BearerTokenRequestMatcher();
-
-	private static Map<Class<? extends AccessDeniedException>, AccessDeniedHandler> createAccessDeniedHandlers() {
-		Map<Class<? extends AccessDeniedException>, AccessDeniedHandler> handlers = new HashMap<>();
-		handlers.put(CsrfException.class, new AccessDeniedHandlerImpl());
-		return handlers;
-	}
 
 	public OAuth2ResourceServerConfigurer(ApplicationContext context) {
 		Assert.notNull(context, "context cannot be null");

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LoginConfigurer.java
@@ -359,7 +359,8 @@ public final class Saml2LoginConfigurer<B extends HttpSecurityBuilder<B>>
 		if (version != null) {
 			return version;
 		}
-		return Version.getVersion();
+		return Version.class.getModule().getDescriptor().version().map(Object::toString)
+				.orElseThrow(() -> new IllegalStateException("cannot determine OpenSAML version"));
 	}
 
 	private void registerDefaultAuthenticationProvider(B http) {

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurer.java
@@ -319,7 +319,8 @@ public final class Saml2LogoutConfigurer<H extends HttpSecurityBuilder<H>>
 		if (version != null) {
 			return version;
 		}
-		return Version.getVersion();
+		return Version.class.getModule().getDescriptor().version().map(Object::toString)
+				.orElseThrow(() -> new IllegalStateException("cannot determine OpenSAML version"));
 	}
 
 	/**

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpX509Tests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpX509Tests.java
@@ -21,13 +21,11 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 
-import javax.security.auth.x500.X500Principal;
 import javax.servlet.http.HttpServletRequest;
 
-import org.bouncycastle.asn1.x500.X500Name;
-import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import sun.security.x509.X500Name;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -242,8 +240,12 @@ public class NamespaceHttpX509Tests {
 		}
 
 		private String extractCommonName(X509Certificate certificate) {
-			X500Principal principal = certificate.getSubjectX500Principal();
-			return new X500Name(principal.getName()).getRDNs(BCStyle.CN)[0].getFirst().getValue().toString();
+			try {
+				return ((X500Name) certificate.getSubjectDN()).getCommonName();
+			}
+			catch (Exception ex) {
+				throw new IllegalArgumentException(ex);
+			}
 		}
 
 	}

--- a/core/src/test/java/org/springframework/security/core/SpringSecurityCoreVersionTests.java
+++ b/core/src/test/java/org/springframework/security/core/SpringSecurityCoreVersionTests.java
@@ -18,7 +18,6 @@ package org.springframework.security.core;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -61,24 +60,15 @@ public class SpringSecurityCoreVersionTests {
 
 	@BeforeEach
 	public void setup() throws Exception {
-		setFinalStaticField(SpringSecurityCoreVersion.class, "logger", this.logger);
+		Field logger = ReflectionUtils.findField(SpringSecurityCoreVersion.class, "logger");
+		StaticFinalReflectionUtils.setField(logger, this.logger);
 	}
 
 	@AfterEach
 	public void cleanup() throws Exception {
 		System.clearProperty(getDisableChecksProperty());
-		setFinalStaticField(SpringSecurityCoreVersion.class, "logger",
-				LogFactory.getLog(SpringSecurityCoreVersion.class));
-	}
-
-	private static void setFinalStaticField(Class<?> clazz, String fieldName, Object value)
-			throws ReflectiveOperationException {
-		Field field = clazz.getDeclaredField(fieldName);
-		field.setAccessible(true);
-		Field modifiers = Field.class.getDeclaredField("modifiers");
-		modifiers.setAccessible(true);
-		modifiers.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-		field.set(null, value);
+		Field logger = ReflectionUtils.findField(SpringSecurityCoreVersion.class, "logger");
+		StaticFinalReflectionUtils.setField(logger, LogFactory.getLog(SpringSecurityCoreVersion.class));
 	}
 
 	@Test

--- a/core/src/test/java/org/springframework/security/core/StaticFinalReflectionUtils.java
+++ b/core/src/test/java/org/springframework/security/core/StaticFinalReflectionUtils.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2008 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.core;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import sun.misc.Unsafe;
+
+import org.springframework.objenesis.instantiator.util.UnsafeUtils;
+
+/**
+ * Used for setting static variables even if they are private static final.
+ *
+ * The code in this class has been adopted from Powermock's <a href=
+ * "https://github.com/noushadali/powermock/blob/powermock-1.5.4/reflect/src/main/java/org/powermock/reflect/internal/WhiteboxImpl.java#L326">WhiteboxImpl</a>.
+ *
+ * @author Rob Winch
+ */
+final class StaticFinalReflectionUtils {
+
+	/**
+	 * Used to support setting static fields that are final using Java's Unsafe. If the
+	 * field is not static final, use
+	 * {@link org.springframework.test.util.ReflectionTestUtils}.
+	 * @param field the field to set
+	 * @param newValue the new value
+	 */
+	static void setField(final Field field, final Object newValue) {
+		try {
+			field.setAccessible(true);
+			int fieldModifiersMask = field.getModifiers();
+			boolean isFinalModifierPresent = (fieldModifiersMask & Modifier.FINAL) == Modifier.FINAL;
+			if (isFinalModifierPresent) {
+				AccessController.doPrivileged(new PrivilegedAction<Object>() {
+					@Override
+					public Object run() {
+						try {
+							Unsafe unsafe = UnsafeUtils.getUnsafe();
+							long offset = unsafe.staticFieldOffset(field);
+							Object base = unsafe.staticFieldBase(field);
+							setFieldUsingUnsafe(base, field.getType(), offset, newValue, unsafe);
+							return null;
+						}
+						catch (Throwable thrown) {
+							throw new RuntimeException(thrown);
+						}
+					}
+				});
+			}
+			else {
+				field.set(null, newValue);
+			}
+		}
+		catch (SecurityException ex) {
+			throw new RuntimeException(ex);
+		}
+		catch (IllegalAccessException ex) {
+			throw new RuntimeException(ex);
+		}
+		catch (IllegalArgumentException ex) {
+			throw new RuntimeException(ex);
+		}
+	}
+
+	private static void setFieldUsingUnsafe(Object base, Class type, long offset, Object newValue, Unsafe unsafe) {
+		if (type == Integer.TYPE) {
+			unsafe.putInt(base, offset, ((Integer) newValue));
+		}
+		else if (type == Short.TYPE) {
+			unsafe.putShort(base, offset, ((Short) newValue));
+		}
+		else if (type == Long.TYPE) {
+			unsafe.putLong(base, offset, ((Long) newValue));
+		}
+		else if (type == Byte.TYPE) {
+			unsafe.putByte(base, offset, ((Byte) newValue));
+		}
+		else if (type == Boolean.TYPE) {
+			unsafe.putBoolean(base, offset, ((Boolean) newValue));
+		}
+		else if (type == Float.TYPE) {
+			unsafe.putFloat(base, offset, ((Float) newValue));
+		}
+		else if (type == Double.TYPE) {
+			unsafe.putDouble(base, offset, ((Double) newValue));
+		}
+		else if (type == Character.TYPE) {
+			unsafe.putChar(base, offset, ((Character) newValue));
+		}
+		else {
+			unsafe.putObject(base, offset, newValue);
+		}
+	}
+
+	private StaticFinalReflectionUtils() {
+	}
+
+}

--- a/saml2/saml2-service-provider/spring-security-saml2-service-provider.gradle
+++ b/saml2/saml2-service-provider/spring-security-saml2-service-provider.gradle
@@ -36,8 +36,17 @@ configurations {
 }
 
 compileOpensaml4MainJava {
+	javaCompiler = javaToolchains.compilerFor {
+		languageVersion = JavaLanguageVersion.of(11)
+	}
 	sourceCompatibility = '11'
 	targetCompatibility = '11'
+}
+
+compileOpensaml4TestJava {
+	javaCompiler = javaToolchains.compilerFor {
+		languageVersion = JavaLanguageVersion.of(11)
+	}
 }
 
 dependencies {


### PR DESCRIPTION
This PR does the following:

- Revert the commit https://github.com/spring-projects/spring-security/commit/60ed3602f6281d1a34c643484dfcb3440e2243d5 that was used as a workaround;
- Fix https://github.com/spring-projects/spring-security/issues/10695 by creating a `static` method to initialize the handlers;
- Use Java 8 for all modules but OpenSAML4;
- Because the `Saml2Login/LogoutConfigurerTests` are using some OpenSAML4 classes, these tests have to be compiled using Java 11. For this, those tests were removed from the `compileTestJava` task and a new Gradle task `compileSaml2TestJava` is being used to compile them;
- Another task `saml2Tests` is being used to run the tests compiled by `compileSaml2TestJava`.
- Instead of using the `ModuleDescriptor` to retrieve the OpenSAML version, now we are checking if the class `org.opensaml.core.xml.persist.impl.PassthroughSourceStrategy` exists in the classpath. This class was introduced in OpenSAML4.