### PR TITLE
Use utf-8 in ServerHttpBasicAuthenticationConverter

### DIFF
--- a/web/src/main/java/org/springframework/security/web/server/ServerHttpBasicAuthenticationConverter.java
+++ b/web/src/main/java/org/springframework/security/web/server/ServerHttpBasicAuthenticationConverter.java
@@ -16,6 +16,7 @@
 
 package org.springframework.security.web.server;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.function.Function;
 
@@ -51,9 +52,8 @@ public class ServerHttpBasicAuthenticationConverter implements Function<ServerWe
 		if (!StringUtils.startsWithIgnoreCase(authorization, "basic ")) {
 			return Mono.empty();
 		}
-		String credentials = (authorization.length() <= BASIC.length()) ? ""
-				: authorization.substring(BASIC.length(), authorization.length());
-		String decoded = new String(base64Decode(credentials));
+		String credentials = (authorization.length() <= BASIC.length()) ? "" : authorization.substring(BASIC.length());
+		String decoded = new String(base64Decode(credentials), StandardCharsets.UTF_8);
 		String[] parts = decoded.split(":", 2);
 		if (parts.length != 2) {
 			return Mono.empty();

--- a/web/src/test/java/org/springframework/security/web/server/authentication/ServerHttpBasicAuthenticationConverterTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/authentication/ServerHttpBasicAuthenticationConverterTests.java
@@ -62,7 +62,7 @@ public class ServerHttpBasicAuthenticationConverterTests {
 	}
 
 	@Test
-	public void applyWhenNoSemicolonThenEmpty() {
+	public void applyWhenNoColonThenEmpty() {
 		Mono<Authentication> result = apply(this.request.header(HttpHeaders.AUTHORIZATION, "Basic dXNlcg=="));
 		assertThat(result.block()).isNull();
 	}
@@ -102,6 +102,16 @@ public class ServerHttpBasicAuthenticationConverterTests {
 		Mono<Authentication> result = apply(
 				this.request.header(HttpHeaders.AUTHORIZATION, "token dXNlcjpwYXNzd29yZA=="));
 		assertThat(result.block()).isNull();
+	}
+
+	@Test
+	public void applyWhenNonAsciiThenAuthentication() {
+		Mono<Authentication> result = apply(
+				this.request.header(HttpHeaders.AUTHORIZATION, "Basic w7xzZXI6cGFzc3fDtnJk"));
+		UsernamePasswordAuthenticationToken authentication = result.cast(UsernamePasswordAuthenticationToken.class)
+				.block();
+		assertThat(authentication.getPrincipal()).isEqualTo("üser");
+		assertThat(authentication.getCredentials()).isEqualTo("passwörd");
 	}
 
 	private Mono<Authentication> apply(MockServerHttpRequest.BaseBuilder<?> request) {


### PR DESCRIPTION
This changes `ServerHttpBasicAuthenticationConverter` to use utf-8 rather than the platform's default encoding, as per #10903.

- use an explicit charset (utf-8)
- remove useless argument to substring
- add test with non-ASCII characters
- rename test to use proper character name