### PR TITLE
Add method to customize EntityDescriptor and SPSSODescriptor

### DIFF
--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/metadata/OpenSamlMetadataResolverTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/metadata/OpenSamlMetadataResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,6 +76,17 @@ public class OpenSamlMetadataResolverTests {
 		OpenSamlMetadataResolver openSamlMetadataResolver = new OpenSamlMetadataResolver();
 		String metadata = openSamlMetadataResolver.resolve(relyingPartyRegistration);
 		assertThat(metadata).doesNotContain("ResponseLocation");
+	}
+
+	@Test
+	public void resolveWhenEntityDescriptorCustomizerThenUses() {
+		RelyingPartyRegistration relyingPartyRegistration = TestRelyingPartyRegistrations.full()
+				.entityId("originalEntityId").build();
+		OpenSamlMetadataResolver openSamlMetadataResolver = new OpenSamlMetadataResolver();
+		openSamlMetadataResolver.setEntityDescriptorCustomizer(
+				(parameters) -> parameters.getEntityDescriptor().setEntityID("overriddenEntityId"));
+		String metadata = openSamlMetadataResolver.resolve(relyingPartyRegistration);
+		assertThat(metadata).contains("<EntityDescriptor").contains("entityID=\"overriddenEntityId\"");
 	}
 
 }


### PR DESCRIPTION
This PR does the following:

* Adds a new method to the `OpenSamlMetadataResolver` to allow customization of the `EntityDescriptor` and `SPSSODescriptor` before SAML metadata is generated

Closes gh-10839
