### PR TITLE
Make the `DelegatingPasswordEncoder` work correctly, even if the prefix and suffix are the same

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/password/DelegatingPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password/DelegatingPasswordEncoder.java
@@ -119,6 +119,7 @@ import java.util.Map;
  * @author Rob Winch
  * @author Michael Simons
  * @author heowc
+ * @author Jihoon Cha
  * @since 5.0
  * @see org.springframework.security.crypto.factory.PasswordEncoderFactories
  */
@@ -172,6 +173,9 @@ public class DelegatingPasswordEncoder implements PasswordEncoder {
 		}
 		if (idSuffix == null || idSuffix.isEmpty()) {
 			throw new IllegalArgumentException("suffix cannot be empty");
+		}
+		if (idPrefix.contains(idSuffix)) {
+			throw new IllegalArgumentException("idPrefix " + idPrefix + " cannot contain idSuffix " + idSuffix);
 		}
 
 		if (!idToPasswordEncoder.containsKey(idForEncode)) {

--- a/crypto/src/test/java/org/springframework/security/crypto/password/DelegatingPasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/password/DelegatingPasswordEncoderTests.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
  * @author Rob Winch
  * @author Michael Simons
  * @author heowc
+ * @author Jihoon Cha
  * @since 5.0
  */
 @ExtendWith(MockitoExtension.class)
@@ -119,9 +120,9 @@ public class DelegatingPasswordEncoderTests {
 
 	@Test
 	public void constructorWhenIdContainsPrefixThenIllegalArgumentException() {
-		this.delegates.put('$' + this.bcryptId, this.bcrypt);
+		this.delegates.put('{' + this.bcryptId, this.bcrypt);
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new DelegatingPasswordEncoder(this.bcryptId, this.delegates, "$", "$"));
+				.isThrownBy(() -> new DelegatingPasswordEncoder(this.bcryptId, this.delegates));
 	}
 
 	@Test
@@ -129,6 +130,12 @@ public class DelegatingPasswordEncoderTests {
 		this.delegates.put(this.bcryptId + '$', this.bcrypt);
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> new DelegatingPasswordEncoder(this.bcryptId, this.delegates, "", "$"));
+	}
+
+	@Test
+	public void constructorWhenPrefixContainsSuffixThenIllegalArgumentException() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> new DelegatingPasswordEncoder(this.bcryptId, this.delegates, "$", "$"));
 	}
 
 	@Test


### PR DESCRIPTION
You can inject prefix and suffix when calling the constructor of `DelegatingPasswordEncoder`. And you can also inject the **"same"** prefix and suffix. In this case the instantiation of `DelegatingPasswordEncoder` works fine, but calling the `matches(CharSequence, String)` method throws an exception. There is a bug in the methods `extractId(String)` and `extractEncodedPassword(String)`.