### PR TITLE
RelyingPartyRegistrations#fromMetadataLocation: prioritize REDIRECT binding for sso and logout

### DIFF
--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/registration/OpenSamlMetadataAssertingPartyDetailsConverter.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/registration/OpenSamlMetadataAssertingPartyDetailsConverter.java
@@ -139,7 +139,9 @@ class OpenSamlMetadataAssertingPartyDetailsConverter {
 				continue;
 			}
 			party.singleSignOnServiceLocation(singleSignOnService.getLocation()).singleSignOnServiceBinding(binding);
-			break;
+			if (binding.equals(Saml2MessageBinding.REDIRECT)) {
+				break;
+			}
 		}
 		for (SingleLogoutService singleLogoutService : idpssoDescriptor.getSingleLogoutServices()) {
 			Saml2MessageBinding binding;
@@ -156,7 +158,9 @@ class OpenSamlMetadataAssertingPartyDetailsConverter {
 					? singleLogoutService.getLocation() : singleLogoutService.getResponseLocation();
 			party.singleLogoutServiceLocation(singleLogoutService.getLocation())
 					.singleLogoutServiceResponseLocation(responseLocation).singleLogoutServiceBinding(binding);
-			break;
+			if (binding.equals(Saml2MessageBinding.REDIRECT)) {
+				break;
+			}
 		}
 		return party;
 	}


### PR DESCRIPTION
## Context

Since the introduction of SameSite cookie restrictions, SAML's SSO and Logout with POST break the SavedRequest behavior. See issues:
-  Saml2AuthenticationRequestRepository does not work in combination with Spring Session #10828 
- Spring session does not redirect back to original request in [spring-session](https://github.com/spring-projects/spring-session/issues/1577)

In their service metadata, some services have multiple `SingleSignOnService` entries, because they support both `POST` and `REDIRECT` bindings, see [examples](#examples) . Same is theoretically possible for `SingleLogoutService`, but I have not personally seen examples in the wild.

Currently, the `OpenSamlMetadataAssertingPartyDetailsConverter` takes whichever binding is first. So if `POST` comes first, it is selected, leading to the above "issues".

## Proposed solution

Instead of selection the first `SingleSignOnService` available, iterate over all `SingleSignOnService`s and select the first `REDIRECT`-bound.

Note: I'm proposing this against `5.7.x` but I'm unsure whether I should do this against `main` instead. I feel it is a feature change that should go in the next minor, but it could come before Spring Security 6.

## Examples

#### Okta

```
<md:SingleSignOnService 
    Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" 
    Location="https://REDACTED.okta.com/app/REDACTED/sso/saml"
/>
<md:SingleSignOnService 
    Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" 
    Location="https://REDACTED.okta.com/app/REDACTED/sso/saml"
/>
```

#### Workspace One

```
<md:SingleSignOnService 
    Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" 
    Location="https://REDACTED.workspaceair.com/SAAS/auth/federation/sso"
/>
<md:SingleSignOnService 
    Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" 
    Location="https://REDACTED.workspaceair.com/SAAS/auth/federation/sso"
/>
```