### PR TITLE
Enabling authenticationIsRequired to be overridden for custom checks.…

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilter.java
@@ -198,7 +198,7 @@ public class BasicAuthenticationFilter extends OncePerRequestFilter {
 		chain.doFilter(request, response);
 	}
 
-	private boolean authenticationIsRequired(String username) {
+	protected boolean authenticationIsRequired(String username) {
 		// Only reauthenticate if username doesn't match SecurityContextHolder and user
 		// isn't authenticated (see SEC-53)
 		Authentication existingAuth = SecurityContextHolder.getContext().getAuthentication();


### PR DESCRIPTION
Fixes BasicAuthenticationFilter skips re-authentication if username changes and Authentication object is not UsernamePasswordAuthenticationToken #10347


