### PR TITLE
Update spring-data-bom to 2022.0.0-M2

### DIFF
--- a/dependencies/spring-security-dependencies.gradle
+++ b/dependencies/spring-security-dependencies.gradle
@@ -11,7 +11,7 @@ dependencies {
 	api platform("io.projectreactor:reactor-bom:2020.0.17")
 	api platform("io.rsocket:rsocket-bom:1.1.1")
 	api platform("org.junit:junit-bom:5.8.2")
-	api platform("org.springframework.data:spring-data-bom:2022.0.0-M1")
+	api platform("org.springframework.data:spring-data-bom:2022.0.0-M2")
 	api platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion")
 	api platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.0")
 	api platform("com.fasterxml.jackson:jackson-bom:2.13.2")


### PR DESCRIPTION
Closes gh-10978

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
