### PR TITLE
Convert URLs to String before equals/hashcode

### DIFF
--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/user/OAuth2UserAuthorityTests.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/user/OAuth2UserAuthorityTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.security.oauth2.core.user;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
 
@@ -34,6 +36,21 @@ public class OAuth2UserAuthorityTests {
 	private static final String AUTHORITY = "ROLE_USER";
 
 	private static final Map<String, Object> ATTRIBUTES = Collections.singletonMap("username", "test");
+
+	private static final OAuth2UserAuthority AUTHORITY_WITH_OBJECTURL;
+
+	private static final OAuth2UserAuthority AUTHORITY_WITH_STRINGURL;
+	static {
+		try {
+			AUTHORITY_WITH_OBJECTURL = new OAuth2UserAuthority(
+					Collections.singletonMap("someurl", new URL("https://localhost")));
+			AUTHORITY_WITH_STRINGURL = new OAuth2UserAuthority(
+					Collections.singletonMap("someurl", "https://localhost"));
+		}
+		catch (MalformedURLException ex) {
+			throw new RuntimeException(ex);
+		}
+	}
 
 	@Test
 	public void constructorWhenAuthorityIsNullThenThrowIllegalArgumentException() {
@@ -56,6 +73,24 @@ public class OAuth2UserAuthorityTests {
 		OAuth2UserAuthority userAuthority = new OAuth2UserAuthority(AUTHORITY, ATTRIBUTES);
 		assertThat(userAuthority.getAuthority()).isEqualTo(AUTHORITY);
 		assertThat(userAuthority.getAttributes()).isEqualTo(ATTRIBUTES);
+	}
+
+	@Test
+	public void equalsRegardlessOfUrlType() {
+		assertThat(AUTHORITY_WITH_OBJECTURL).isEqualTo(AUTHORITY_WITH_OBJECTURL);
+		assertThat(AUTHORITY_WITH_STRINGURL).isEqualTo(AUTHORITY_WITH_STRINGURL);
+
+		assertThat(AUTHORITY_WITH_OBJECTURL).isEqualTo(AUTHORITY_WITH_STRINGURL);
+		assertThat(AUTHORITY_WITH_STRINGURL).isEqualTo(AUTHORITY_WITH_OBJECTURL);
+	}
+
+	@Test
+	public void hashCodeIsSameRegardlessOfUrlType() {
+		assertThat(AUTHORITY_WITH_OBJECTURL.hashCode()).isEqualTo(AUTHORITY_WITH_OBJECTURL.hashCode());
+		assertThat(AUTHORITY_WITH_STRINGURL.hashCode()).isEqualTo(AUTHORITY_WITH_STRINGURL.hashCode());
+
+		assertThat(AUTHORITY_WITH_OBJECTURL.hashCode()).isEqualTo(AUTHORITY_WITH_STRINGURL.hashCode());
+		assertThat(AUTHORITY_WITH_STRINGURL.hashCode()).isEqualTo(AUTHORITY_WITH_OBJECTURL.hashCode());
 	}
 
 }


### PR DESCRIPTION
java.net.URL performs DNS lookups whenever its equals/hashCode is
used. Thus attribute values of type java.net.URL need to be converted
to something else before they are used for equals/hashCode.

This PR performs the conversion in equals/hashCode. Thus the
actual attributes remain the same as originally given in the
constructor. This brings some overhead from constructing a new
map in every equals/hashCode invocation, but since there likely
aren't that many attributes, I think performance doesn't need to
be considered here.

Closes gh-10673
