### PR TITLE
Fix saml2 authentication-requests documentation

### DIFF
--- a/docs/modules/ROOT/pages/servlet/saml2/login/authentication-requests.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/login/authentication-requests.adoc
@@ -8,7 +8,7 @@ This filter by default responds to endpoint `+/saml2/authenticate/{registrationI
 
 For example, if you were deployed to `https://rp.example.com` and you gave your registration an ID of `okta`, you could navigate to:
 
-`https://rp.example.org/saml2/authenticate/ping`
+`https://rp.example.org/saml2/authenticate/okta`
 
 and the result would be a redirect that included a `SAMLRequest` parameter containing the signed, deflated, and encoded `<saml2:AuthnRequest>`.
 


### PR DESCRIPTION
looks like `ping` is some registration id used in the past.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
