### PR TITLE
Add task to update version in antora.yml

### DIFF
--- a/.github/workflows/release-next-version.yml
+++ b/.github/workflows/release-next-version.yml
@@ -88,11 +88,15 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
       - name: Update version and push
+        # antoraUpdateVersion can only be run after updateProjectVersion completes, in order get the updated project version
         run: |
           export GRADLE_ENTERPRISE_CACHE_USERNAME="$GRADLE_ENTERPRISE_CACHE_USER"
           export GRADLE_ENTERPRISE_CACHE_PASSWORD="$GRADLE_ENTERPRISE_CACHE_PASSWORD"
           export GRADLE_ENTERPRISE_ACCESS_KEY="$GRADLE_ENTERPRISE_SECRET_ACCESS_KEY"
-          ./gradlew updateProjectVersion -Pcommit=true
+          ./gradlew :updateProjectVersion
+          ./gradlew :spring-security-docs:antoraUpdateVersion
+          updatedVersion=$(cat gradle.properties | grep "version=" | awk -F'=' '{print $2}')
+          git commit -m "Release $updatedVersion"
           git push
   notify_result:
     name: Check for failures

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -28,7 +28,7 @@ gradlePlugin {
 	plugins {
 		checkAntoraVersion {
 			id = "org.springframework.antora.check-version"
-			implementationClass = "org.springframework.gradle.antora.CheckAntoraVersionPlugin"
+			implementationClass = "org.springframework.gradle.antora.AntoraVersionPlugin"
 		}
 		trang {
 			id = "trang"

--- a/buildSrc/src/main/java/org/springframework/gradle/antora/AntoraVersionPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/gradle/antora/AntoraVersionPlugin.java
@@ -8,7 +8,7 @@ import org.gradle.api.Task;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 
-public class CheckAntoraVersionPlugin implements Plugin<Project> {
+public class AntoraVersionPlugin implements Plugin<Project> {
 	public static final String ANTORA_CHECK_VERSION_TASK_NAME = "antoraCheckVersion";
 
 	@Override
@@ -35,32 +35,29 @@ public class CheckAntoraVersionPlugin implements Plugin<Project> {
 				});
 			}
 		});
+		 project.getTasks().register("antoraUpdateVersion", UpdateAntoraVersionTask.class, new Action<UpdateAntoraVersionTask>() {
+			@Override
+			public void execute(UpdateAntoraVersionTask antoraUpdateVersion) {
+				antoraUpdateVersion.setGroup("Release");
+				antoraUpdateVersion.setDescription("Updates the antora.yml version properties to match the Gradle version");
+				antoraUpdateVersion.getAntoraYmlFile().fileProvider(project.provider(() -> project.file("antora.yml")));
+			}
+		});
 	}
 
 	private static String getDefaultAntoraVersion(Project project) {
 		String projectVersion = getProjectVersion(project);
-		int preReleaseIndex = getSnapshotIndex(projectVersion);
-		return isSnapshot(projectVersion) ? projectVersion.substring(0, preReleaseIndex) : projectVersion;
+		return AntoraVersionUtils.getDefaultAntoraVersion(projectVersion);
 	}
 
 	private static String getDefaultAntoraPrerelease(Project project) {
 		String projectVersion = getProjectVersion(project);
-		if (isSnapshot(projectVersion)) {
-			int preReleaseIndex = getSnapshotIndex(projectVersion);
-			return projectVersion.substring(preReleaseIndex);
-		}
-		if (isPreRelease(projectVersion)) {
-			return Boolean.TRUE.toString();
-		}
-		return null;
+		return AntoraVersionUtils.getDefaultAntoraPrerelease(projectVersion);
 	}
 
 	private static String getDefaultAntoraDisplayVersion(Project project) {
 		String projectVersion = getProjectVersion(project);
-		if (!isSnapshot(projectVersion) && isPreRelease(projectVersion)) {
-			return getDefaultAntoraVersion(project);
-		}
-		return null;
+		return AntoraVersionUtils.getDefaultAntoraDisplayVersion(projectVersion);
 	}
 
 	private static String getProjectVersion(Project project) {
@@ -71,15 +68,4 @@ public class CheckAntoraVersionPlugin implements Plugin<Project> {
 		return String.valueOf(projectVersion);
 	}
 
-	private static boolean isSnapshot(String projectVersion) {
-		return getSnapshotIndex(projectVersion) >= 0;
-	}
-
-	private static int getSnapshotIndex(String projectVersion) {
-		return projectVersion.lastIndexOf("-SNAPSHOT");
-	}
-
-	private static boolean isPreRelease(String projectVersion) {
-		return projectVersion.lastIndexOf("-") >= 0;
-	}
 }

--- a/buildSrc/src/main/java/org/springframework/gradle/antora/AntoraVersionUtils.java
+++ b/buildSrc/src/main/java/org/springframework/gradle/antora/AntoraVersionUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.gradle.antora;
+
+public class AntoraVersionUtils {
+
+	public static String getDefaultAntoraVersion(String projectVersion) {
+		int preReleaseIndex = getSnapshotIndex(projectVersion);
+		return isSnapshot(projectVersion) ? projectVersion.substring(0, preReleaseIndex) : projectVersion;
+	}
+
+	public static String getDefaultAntoraPrerelease(String projectVersion) {
+		if (isSnapshot(projectVersion)) {
+			int preReleaseIndex = getSnapshotIndex(projectVersion);
+			return projectVersion.substring(preReleaseIndex);
+		}
+		if (isPreRelease(projectVersion)) {
+			return Boolean.TRUE.toString();
+		}
+		return null;
+	}
+
+	public static String getDefaultAntoraDisplayVersion(String projectVersion) {
+		if (!isSnapshot(projectVersion) && isPreRelease(projectVersion)) {
+			return getDefaultAntoraVersion(projectVersion);
+		}
+		return null;
+	}
+
+	private static boolean isSnapshot(String projectVersion) {
+		return getSnapshotIndex(projectVersion) >= 0;
+	}
+
+	private static int getSnapshotIndex(String projectVersion) {
+		return projectVersion.lastIndexOf("-SNAPSHOT");
+	}
+
+	private static boolean isPreRelease(String projectVersion) {
+		return projectVersion.lastIndexOf("-") >= 0;
+	}
+}

--- a/buildSrc/src/main/java/org/springframework/gradle/antora/UpdateAntoraVersionTask.java
+++ b/buildSrc/src/main/java/org/springframework/gradle/antora/UpdateAntoraVersionTask.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2019-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.gradle.antora;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.nodes.NodeTuple;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Representer;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import org.springframework.gradle.github.milestones.NextVersionYml;
+
+public abstract class UpdateAntoraVersionTask extends DefaultTask {
+
+	@TaskAction
+	public void update() throws IOException {
+		String projectVersion = getProject().getVersion().toString();
+		File antoraYmlFile = getAntoraYmlFile().getAsFile().get();
+		String updatedAntoraVersion = AntoraVersionUtils.getDefaultAntoraVersion(projectVersion);
+		String updatedAntoraPrerelease = AntoraVersionUtils.getDefaultAntoraPrerelease(projectVersion);
+		String updatedAntoraDisplayVersion = AntoraVersionUtils.getDefaultAntoraDisplayVersion(projectVersion);
+
+		Representer representer = new Representer();
+		representer.getPropertyUtils().setSkipMissingProperties(true);
+
+		Yaml yaml = new Yaml(new Constructor(AntoraYml.class), representer);
+		AntoraYml antoraYml = yaml.load(new FileInputStream(antoraYmlFile));
+
+		System.out.println("Updating the version parameters in " + antoraYmlFile.getName() + " to version: "
+				+ updatedAntoraVersion + ", prerelease: " + updatedAntoraPrerelease + ", display_version: "
+				+ updatedAntoraDisplayVersion);
+		antoraYml.setVersion(updatedAntoraVersion);
+		antoraYml.setPrerelease(updatedAntoraPrerelease);
+		antoraYml.setDisplay_version(updatedAntoraDisplayVersion);
+
+		FileWriter outputWriter = new FileWriter(antoraYmlFile);
+		getYaml().dump(antoraYml, outputWriter);
+	}
+
+	@InputFile
+	public abstract RegularFileProperty getAntoraYmlFile();
+
+	public static class AntoraYml {
+
+		private String name;
+
+		private String version;
+
+		private String prerelease;
+
+		private String display_version;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public String getVersion() {
+			return version;
+		}
+
+		public void setVersion(String version) {
+			this.version = version;
+		}
+
+		public String getPrerelease() {
+			return prerelease;
+		}
+
+		public void setPrerelease(String prerelease) {
+			this.prerelease = prerelease;
+		}
+
+		public String getDisplay_version() {
+			return display_version;
+		}
+
+		public void setDisplay_version(String display_version) {
+			this.display_version = display_version;
+		}
+
+	}
+
+	private Yaml getYaml() {
+		Representer representer = new Representer() {
+			@Override
+			protected NodeTuple representJavaBeanProperty(Object javaBean,
+					org.yaml.snakeyaml.introspector.Property property, Object propertyValue, Tag customTag) {
+				// Don't write out null values
+				if (propertyValue == null) {
+					return null;
+				}
+				else {
+					return super.representJavaBeanProperty(javaBean, property, propertyValue, customTag);
+				}
+			}
+		};
+		representer.addClassTag(AntoraYml.class, Tag.MAP);
+		DumperOptions ymlOptions = new DumperOptions();
+		ymlOptions.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+		ymlOptions.setDefaultScalarStyle(DumperOptions.ScalarStyle.SINGLE_QUOTED);
+		return new Yaml(representer, ymlOptions);
+	}
+
+}

--- a/buildSrc/src/main/java/org/springframework/security/convention/versions/UpdateProjectVersionPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/security/convention/versions/UpdateProjectVersionPlugin.java
@@ -27,11 +27,9 @@ public class UpdateProjectVersionPlugin implements Plugin<Project> {
 			@Override
 			public void execute(UpdateProjectVersionTask updateProjectVersionTask) {
 				updateProjectVersionTask.setGroup("Release");
-				updateProjectVersionTask.setDescription(
-						"Updates the project version to the next release in gradle.properties and optionally commits the changes");
+				updateProjectVersionTask.setDescription("Updates the project version to the next release in gradle.properties");
 				updateProjectVersionTask.dependsOn("gitHubNextReleaseMilestone");
 				updateProjectVersionTask.getNextVersionFile().fileProvider(project.provider(() -> project.file("next-release.yml")));
-				updateProjectVersionTask.setCommit("true".equals(project.findProperty("commit")));
 			}
 		});
 		project.getTasks().register("updateToSnapshotVersion", UpdateToSnapshotVersionTask.class, new Action<UpdateToSnapshotVersionTask>() {

--- a/buildSrc/src/main/java/org/springframework/security/convention/versions/UpdateProjectVersionTask.java
+++ b/buildSrc/src/main/java/org/springframework/security/convention/versions/UpdateProjectVersionTask.java
@@ -37,10 +37,6 @@ public abstract class UpdateProjectVersionTask extends DefaultTask {
 	@InputFile
 	public abstract RegularFileProperty getNextVersionFile();
 
-	@Input
-	@Optional
-	private Boolean commit;
-
 	@TaskAction
 	public void checkReleaseDueToday() throws FileNotFoundException {
 		File nextVersionFile = getNextVersionFile().getAsFile().get();
@@ -62,20 +58,6 @@ public abstract class UpdateProjectVersionTask extends DefaultTask {
 			gradlePropertiesText = gradlePropertiesText.replace("version=" + currentVersion, "version=" + nextVersion);
 			return gradlePropertiesText;
 		});
-		if (this.commit) {
-			System.out.println("Committing the version update");
-			File rootDir = getProject().getRootDir();
-			String commitMessage = "Release " + nextVersion;
-			CommandLineUtils.runCommand(rootDir, "git", "commit", "-am", commitMessage);
-		}
-	}
-
-	public Boolean getCommit() {
-		return commit;
-	}
-
-	public void setCommit(Boolean commit) {
-		this.commit = commit;
 	}
 
 }

--- a/buildSrc/src/test/java/org/springframework/gradle/antora/AntoraVersionPluginTests.java
+++ b/buildSrc/src/test/java/org/springframework/gradle/antora/AntoraVersionPluginTests.java
@@ -15,16 +15,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIOException;
 
-class CheckAntoraVersionPluginTests {
+class AntoraVersionPluginTests {
 
 	@Test
 	void defaultsPropertiesWhenSnapshot() {
 		String expectedVersion = "1.0.0-SNAPSHOT";
 		Project project = ProjectBuilder.builder().build();
 		project.setVersion(expectedVersion);
-		project.getPluginManager().apply(CheckAntoraVersionPlugin.class);
+		project.getPluginManager().apply(AntoraVersionPlugin.class);
 
-		Task task = project.getTasks().findByName(CheckAntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
+		Task task = project.getTasks().findByName(AntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
 
 		assertThat(task).isInstanceOf(CheckAntoraVersionTask.class);
 
@@ -40,9 +40,9 @@ class CheckAntoraVersionPluginTests {
 		String expectedVersion = "1.0.0-M1";
 		Project project = ProjectBuilder.builder().build();
 		project.setVersion(expectedVersion);
-		project.getPluginManager().apply(CheckAntoraVersionPlugin.class);
+		project.getPluginManager().apply(AntoraVersionPlugin.class);
 
-		Task task = project.getTasks().findByName(CheckAntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
+		Task task = project.getTasks().findByName(AntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
 
 		assertThat(task).isInstanceOf(CheckAntoraVersionTask.class);
 
@@ -58,9 +58,9 @@ class CheckAntoraVersionPluginTests {
 		String expectedVersion = "1.0.0-RC1";
 		Project project = ProjectBuilder.builder().build();
 		project.setVersion(expectedVersion);
-		project.getPluginManager().apply(CheckAntoraVersionPlugin.class);
+		project.getPluginManager().apply(AntoraVersionPlugin.class);
 
-		Task task = project.getTasks().findByName(CheckAntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
+		Task task = project.getTasks().findByName(AntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
 
 		assertThat(task).isInstanceOf(CheckAntoraVersionTask.class);
 
@@ -76,9 +76,9 @@ class CheckAntoraVersionPluginTests {
 		String expectedVersion = "1.0.0";
 		Project project = ProjectBuilder.builder().build();
 		project.setVersion(expectedVersion);
-		project.getPluginManager().apply(CheckAntoraVersionPlugin.class);
+		project.getPluginManager().apply(AntoraVersionPlugin.class);
 
-		Task task = project.getTasks().findByName(CheckAntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
+		Task task = project.getTasks().findByName(AntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
 
 		assertThat(task).isInstanceOf(CheckAntoraVersionTask.class);
 
@@ -92,9 +92,9 @@ class CheckAntoraVersionPluginTests {
 	@Test
 	void explicitProperties() {
 		Project project = ProjectBuilder.builder().build();
-		project.getPluginManager().apply(CheckAntoraVersionPlugin.class);
+		project.getPluginManager().apply(AntoraVersionPlugin.class);
 
-		Task task = project.getTasks().findByName(CheckAntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
+		Task task = project.getTasks().findByName(AntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
 
 		CheckAntoraVersionTask checkAntoraVersionTask = (CheckAntoraVersionTask) task;
 		checkAntoraVersionTask.getAntoraVersion().set("1.0.0");
@@ -110,9 +110,9 @@ class CheckAntoraVersionPluginTests {
 		Project project = ProjectBuilder.builder().build();
 		File rootDir = project.getRootDir();
 		IOUtils.write("version: '1.0.0'", new FileOutputStream(new File(rootDir, "antora.yml")), StandardCharsets.UTF_8);
-		project.getPluginManager().apply(CheckAntoraVersionPlugin.class);
+		project.getPluginManager().apply(AntoraVersionPlugin.class);
 
-		Task task = project.getTasks().findByName(CheckAntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
+		Task task = project.getTasks().findByName(AntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
 
 		assertThat(task).isInstanceOf(CheckAntoraVersionTask.class);
 
@@ -125,9 +125,9 @@ class CheckAntoraVersionPluginTests {
 		String expectedVersion = "1.0.0-SNAPSHOT";
 		Project project = ProjectBuilder.builder().build();
 		project.setVersion(expectedVersion);
-		project.getPluginManager().apply(CheckAntoraVersionPlugin.class);
+		project.getPluginManager().apply(AntoraVersionPlugin.class);
 
-		Task task = project.getTasks().findByName(CheckAntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
+		Task task = project.getTasks().findByName(AntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
 
 		assertThat(task).isInstanceOf(CheckAntoraVersionTask.class);
 
@@ -142,9 +142,9 @@ class CheckAntoraVersionPluginTests {
 		File rootDir = project.getRootDir();
 		IOUtils.write("version: '1.0.0'", new FileOutputStream(new File(rootDir, "antora.yml")), StandardCharsets.UTF_8);
 		project.setVersion(expectedVersion);
-		project.getPluginManager().apply(CheckAntoraVersionPlugin.class);
+		project.getPluginManager().apply(AntoraVersionPlugin.class);
 
-		Task task = project.getTasks().findByName(CheckAntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
+		Task task = project.getTasks().findByName(AntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
 
 		assertThat(task).isInstanceOf(CheckAntoraVersionTask.class);
 
@@ -160,9 +160,9 @@ class CheckAntoraVersionPluginTests {
 		File rootDir = project.getRootDir();
 		IOUtils.write("version: '1.0.0'\nprerelease: '-SNAPSHOT'", new FileOutputStream(new File(rootDir, "antora.yml")), StandardCharsets.UTF_8);
 		project.setVersion(expectedVersion);
-		project.getPluginManager().apply(CheckAntoraVersionPlugin.class);
+		project.getPluginManager().apply(AntoraVersionPlugin.class);
 
-		Task task = project.getTasks().findByName(CheckAntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
+		Task task = project.getTasks().findByName(AntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
 
 		assertThat(task).isInstanceOf(CheckAntoraVersionTask.class);
 
@@ -177,9 +177,9 @@ class CheckAntoraVersionPluginTests {
 		File rootDir = project.getRootDir();
 		IOUtils.write("version: '1.0.0-M1'\nprerelease: 'true'\ndisplay_version: '1.0.0-M1'", new FileOutputStream(new File(rootDir, "antora.yml")), StandardCharsets.UTF_8);
 		project.setVersion(expectedVersion);
-		project.getPluginManager().apply(CheckAntoraVersionPlugin.class);
+		project.getPluginManager().apply(AntoraVersionPlugin.class);
 
-		Task task = project.getTasks().findByName(CheckAntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
+		Task task = project.getTasks().findByName(AntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
 
 		assertThat(task).isInstanceOf(CheckAntoraVersionTask.class);
 
@@ -194,9 +194,9 @@ class CheckAntoraVersionPluginTests {
 		File rootDir = project.getRootDir();
 		IOUtils.write("version: '1.0.0-RC1'\nprerelease: 'true'\ndisplay_version: '1.0.0-RC1'", new FileOutputStream(new File(rootDir, "antora.yml")), StandardCharsets.UTF_8);
 		project.setVersion(expectedVersion);
-		project.getPluginManager().apply(CheckAntoraVersionPlugin.class);
+		project.getPluginManager().apply(AntoraVersionPlugin.class);
 
-		Task task = project.getTasks().findByName(CheckAntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
+		Task task = project.getTasks().findByName(AntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
 
 		assertThat(task).isInstanceOf(CheckAntoraVersionTask.class);
 
@@ -211,9 +211,9 @@ class CheckAntoraVersionPluginTests {
 		File rootDir = project.getRootDir();
 		IOUtils.write("version: '1.0.0'", new FileOutputStream(new File(rootDir, "antora.yml")), StandardCharsets.UTF_8);
 		project.setVersion(expectedVersion);
-		project.getPluginManager().apply(CheckAntoraVersionPlugin.class);
+		project.getPluginManager().apply(AntoraVersionPlugin.class);
 
-		Task task = project.getTasks().findByName(CheckAntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
+		Task task = project.getTasks().findByName(AntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
 
 		assertThat(task).isInstanceOf(CheckAntoraVersionTask.class);
 
@@ -226,9 +226,9 @@ class CheckAntoraVersionPluginTests {
 		Project project = ProjectBuilder.builder().build();
 		File rootDir = project.getRootDir();
 		IOUtils.write("version: '1.0.0'", new FileOutputStream(new File(rootDir, "antora.yml")), StandardCharsets.UTF_8);
-		project.getPluginManager().apply(CheckAntoraVersionPlugin.class);
+		project.getPluginManager().apply(AntoraVersionPlugin.class);
 
-		Task task = project.getTasks().findByName(CheckAntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
+		Task task = project.getTasks().findByName(AntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
 
 		assertThat(task).isInstanceOf(CheckAntoraVersionTask.class);
 		CheckAntoraVersionTask checkAntoraVersionTask = (CheckAntoraVersionTask) task;
@@ -241,9 +241,9 @@ class CheckAntoraVersionPluginTests {
 		Project project = ProjectBuilder.builder().build();
 		File rootDir = project.getRootDir();
 		IOUtils.write("version: '1.0.0'\nprerelease: '-SNAPSHOT'", new FileOutputStream(new File(rootDir, "antora.yml")), StandardCharsets.UTF_8);
-		project.getPluginManager().apply(CheckAntoraVersionPlugin.class);
+		project.getPluginManager().apply(AntoraVersionPlugin.class);
 
-		Task task = project.getTasks().findByName(CheckAntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
+		Task task = project.getTasks().findByName(AntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
 
 		assertThat(task).isInstanceOf(CheckAntoraVersionTask.class);
 		CheckAntoraVersionTask checkAntoraVersionTask = (CheckAntoraVersionTask) task;
@@ -257,9 +257,9 @@ class CheckAntoraVersionPluginTests {
 		Project project = ProjectBuilder.builder().build();
 		File rootDir = project.getRootDir();
 		IOUtils.write("name: 'ROOT'\nversion: '1.0.0'", new FileOutputStream(new File(rootDir, "antora.yml")), StandardCharsets.UTF_8);
-		project.getPluginManager().apply(CheckAntoraVersionPlugin.class);
+		project.getPluginManager().apply(AntoraVersionPlugin.class);
 
-		Task task = project.getTasks().findByName(CheckAntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
+		Task task = project.getTasks().findByName(AntoraVersionPlugin.ANTORA_CHECK_VERSION_TASK_NAME);
 
 		assertThat(task).isInstanceOf(CheckAntoraVersionTask.class);
 		CheckAntoraVersionTask checkAntoraVersionTask = (CheckAntoraVersionTask) task;


### PR DESCRIPTION
This PR changes the following:

1) Adds a task that updates the antora.yml based on the version in gradle.properties

```
./gradlew :spring-security-docs:antoraUpdateVersion
```

note 1: in order for this task to detect the updated version it needs to run after `updateProjectVersion` has completed. In other words, combining the following commands will result in the antora.yml being out of date `./gradlew :updateProjectVersion :spring-security-docs:antoraUpdateVersion`

note 2: This command writes out YAML using single quoted style to ensure special characters are interpreted as Strings. This does not cause any problems with Antora generating our documentation.

2) Removes the option to commit from the `updateProjectVersion`. This is needed so that the antora update can happen after the gradle.properties version update and before the commit.

3) Updates the release workflow to perform the commit
