### PR TITLE
Update Spring Framework version to 5.3.18

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 aspectjVersion=1.9.8
 springJavaformatVersion=0.0.31
 springBootVersion=2.4.2
-springFrameworkVersion=5.3.16
+springFrameworkVersion=5.3.18
 openSamlVersion=3.4.6
 version=5.6.3-SNAPSHOT
 kotlinVersion=1.5.32


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->

This PR
* Updates the `5.6.x` base to fetch the Spring Framework [v5.3.18](https://github.com/spring-projects/spring-framework/releases/tag/v5.3.18) addressing CVE-2022-22965. See related blog post here: https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement