### PR TITLE
Make getters of handlers publically accessible

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.java
@@ -452,11 +452,11 @@ public abstract class AbstractAuthenticationProcessingFilter extends GenericFilt
 		this.securityContextRepository = securityContextRepository;
 	}
 
-	protected AuthenticationSuccessHandler getSuccessHandler() {
+	public AuthenticationSuccessHandler getSuccessHandler() {
 		return this.successHandler;
 	}
 
-	protected AuthenticationFailureHandler getFailureHandler() {
+	public AuthenticationFailureHandler getFailureHandler() {
 		return this.failureHandler;
 	}
 


### PR DESCRIPTION
Changes AbstractAuthenticationProcessingFilter getters of success and failure handlers to public visibility so that allowSessionCreation flag can be configured, see also gh-11053.