### PR TITLE
Allow custom relay state

### DIFF
--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/OpenSamlAuthenticationRequestResolver.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/OpenSamlAuthenticationRequestResolver.java
@@ -129,7 +129,7 @@ class OpenSamlAuthenticationRequestResolver {
 		if (authnRequest.getID() == null) {
 			authnRequest.setID("ARQ" + UUID.randomUUID().toString().substring(1));
 		}
-		String relayState = relayStateResolver.convert(request);
+		String relayState = this.relayStateResolver.convert(request);
 		Saml2MessageBinding binding = registration.getAssertingPartyDetails().getSingleSignOnServiceBinding();
 		if (binding == Saml2MessageBinding.POST) {
 			if (registration.getAssertingPartyDetails().getWantAuthnRequestsSigned()) {

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/OpenSamlAuthenticationRequestResolver.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/OpenSamlAuthenticationRequestResolver.java
@@ -36,6 +36,7 @@ import org.opensaml.saml.saml2.core.impl.IssuerBuilder;
 import org.opensaml.saml.saml2.core.impl.NameIDBuilder;
 import org.w3c.dom.Element;
 
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.saml2.Saml2Exception;
 import org.springframework.security.saml2.core.OpenSamlInitializationService;
 import org.springframework.security.saml2.core.Saml2ParameterNames;
@@ -71,6 +72,8 @@ class OpenSamlAuthenticationRequestResolver {
 
 	private final NameIDBuilder nameIdBuilder;
 
+	private Converter<HttpServletRequest, String> relayStateResolver = (request) -> UUID.randomUUID().toString();
+
 	/**
 	 * Construct a {@link OpenSamlAuthenticationRequestResolver} using the provided
 	 * parameters
@@ -91,6 +94,10 @@ class OpenSamlAuthenticationRequestResolver {
 		Assert.notNull(this.issuerBuilder, "issuerBuilder must be configured in OpenSAML");
 		this.nameIdBuilder = (NameIDBuilder) registry.getBuilderFactory().getBuilder(NameID.DEFAULT_ELEMENT_NAME);
 		Assert.notNull(this.nameIdBuilder, "nameIdBuilder must be configured in OpenSAML");
+	}
+
+	void setRelayStateResolver(Converter<HttpServletRequest, String> relayStateResolver) {
+		this.relayStateResolver = relayStateResolver;
 	}
 
 	<T extends AbstractSaml2AuthenticationRequest> T resolve(HttpServletRequest request) {
@@ -122,7 +129,7 @@ class OpenSamlAuthenticationRequestResolver {
 		if (authnRequest.getID() == null) {
 			authnRequest.setID("ARQ" + UUID.randomUUID().toString().substring(1));
 		}
-		String relayState = UUID.randomUUID().toString();
+		String relayState = relayStateResolver.convert(request);
 		Saml2MessageBinding binding = registration.getAssertingPartyDetails().getSingleSignOnServiceBinding();
 		if (binding == Saml2MessageBinding.POST) {
 			if (registration.getAssertingPartyDetails().getWantAuthnRequestsSigned()) {

--- a/saml2/saml2-service-provider/src/opensaml4Main/java/org/springframework/security/saml2/provider/service/web/authentication/OpenSaml4AuthenticationRequestResolver.java
+++ b/saml2/saml2-service-provider/src/opensaml4Main/java/org/springframework/security/saml2/provider/service/web/authentication/OpenSaml4AuthenticationRequestResolver.java
@@ -23,6 +23,7 @@ import java.util.function.Consumer;
 import jakarta.servlet.http.HttpServletRequest;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.saml2.provider.service.authentication.AbstractSaml2AuthenticationRequest;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.security.saml2.provider.service.web.RelyingPartyRegistrationResolver;
@@ -75,6 +76,14 @@ public final class OpenSaml4AuthenticationRequestResolver implements Saml2Authen
 	public void setClock(Clock clock) {
 		Assert.notNull(clock, "clock must not be null");
 		this.clock = clock;
+	}
+
+	/**
+	 * Use this {@link Converter<HttpServletRequest, String>} to compute the RelayState
+	 * @param relayStateResolver the {@link Converter<HttpServletRequest, String>} to use
+	 */
+	public void setRelayStateResolver(Converter<HttpServletRequest, String> relayStateResolver) {
+		this.authnRequestResolver.setRelayStateResolver(relayStateResolver);
 	}
 
 	public static final class AuthnRequestContext {

--- a/saml2/saml2-service-provider/src/opensaml4Main/java/org/springframework/security/saml2/provider/service/web/authentication/OpenSaml4AuthenticationRequestResolver.java
+++ b/saml2/saml2-service-provider/src/opensaml4Main/java/org/springframework/security/saml2/provider/service/web/authentication/OpenSaml4AuthenticationRequestResolver.java
@@ -79,10 +79,12 @@ public final class OpenSaml4AuthenticationRequestResolver implements Saml2Authen
 	}
 
 	/**
-	 * Use this {@link Converter<HttpServletRequest, String>} to compute the RelayState
-	 * @param relayStateResolver the {@link Converter<HttpServletRequest, String>} to use
+	 * Use this {@link Converter} to compute the RelayState
+	 * @param relayStateResolver the {@link Converter} to use
+	 * @since 5.7
 	 */
 	public void setRelayStateResolver(Converter<HttpServletRequest, String> relayStateResolver) {
+		Assert.notNull(relayStateResolver, "relayStateResolver cannot be null");
 		this.authnRequestResolver.setRelayStateResolver(relayStateResolver);
 	}
 


### PR DESCRIPTION
This addresses issue #11065.

I've a couple of questions:

 - [OpenSamlAuthenticationRequestResolver.java](https://github.com/spring-projects/spring-security/compare/main...exeba:custom-relay-state?expand=1#diff-156c59b85e9f8743eb095ea6dc8b4603a9ad1999c0f7f4c9f75359aec2af9805) used to have all final fields. Is it ok to add a non-final field?
 - I tried to add a test case but it seems that ./gradelw test just compiles without executing the tests, am I missing something?