### PR TITLE
@EnableMethodSecurity doesn't resolve annotations on interfaces through a Proxy

### DIFF
--- a/core/src/main/java/org/springframework/security/authorization/method/AbstractAuthorizationManagerRegistry.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/AbstractAuthorizationManagerRegistry.java
@@ -22,7 +22,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.aopalliance.intercept.MethodInvocation;
 
-import org.springframework.aop.support.AopUtils;
 import org.springframework.core.MethodClassKey;
 import org.springframework.lang.NonNull;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -46,7 +45,7 @@ abstract class AbstractAuthorizationManagerRegistry {
 	final AuthorizationManager<MethodInvocation> getManager(MethodInvocation methodInvocation) {
 		Method method = methodInvocation.getMethod();
 		Object target = methodInvocation.getThis();
-		Class<?> targetClass = (target != null) ? AopUtils.getTargetClass(target) : null;
+		Class<?> targetClass = (target != null) ? target.getClass() : null;
 		MethodClassKey cacheKey = new MethodClassKey(method, targetClass);
 		return this.cachedManagers.computeIfAbsent(cacheKey, (k) -> resolveManager(method, targetClass));
 	}

--- a/core/src/main/java/org/springframework/security/authorization/method/AbstractExpressionAttributeRegistry.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/AbstractExpressionAttributeRegistry.java
@@ -22,7 +22,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.aopalliance.intercept.MethodInvocation;
 
-import org.springframework.aop.support.AopUtils;
 import org.springframework.core.MethodClassKey;
 import org.springframework.lang.NonNull;
 
@@ -43,7 +42,7 @@ abstract class AbstractExpressionAttributeRegistry<T extends ExpressionAttribute
 	final T getAttribute(MethodInvocation mi) {
 		Method method = mi.getMethod();
 		Object target = mi.getThis();
-		Class<?> targetClass = (target != null) ? AopUtils.getTargetClass(target) : null;
+		Class<?> targetClass = (target != null) ? target.getClass() : null;
 		return getAttribute(method, targetClass);
 	}
 


### PR DESCRIPTION
@EnableMethodSecurity doesn't resolve annotations on interfaces through a Proxy

Removed proxy unwrapping in case of resolving Method Security annotations,
this cause an issue when interfaces which are implemented by the proxy was skipped,
resulting in a missing security checks on those methods.

Closes gh-11175

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
