### PR TITLE
createEvaluationContext should defer lookup of Authentication

### DIFF
--- a/core/src/main/java/org/springframework/security/access/expression/AbstractSecurityExpressionHandler.java
+++ b/core/src/main/java/org/springframework/security/access/expression/AbstractSecurityExpressionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.util.Assert;
  * objects.
  *
  * @author Luke Taylor
+ * @author Evgeniy Cheban
  * @since 3.1
  */
 public abstract class AbstractSecurityExpressionHandler<T>
@@ -114,6 +115,10 @@ public abstract class AbstractSecurityExpressionHandler<T>
 
 	public void setPermissionEvaluator(PermissionEvaluator permissionEvaluator) {
 		this.permissionEvaluator = permissionEvaluator;
+	}
+
+	protected BeanResolver getBeanResolver() {
+		return this.beanResolver;
 	}
 
 	@Override

--- a/core/src/main/java/org/springframework/security/access/expression/SecurityExpressionHandler.java
+++ b/core/src/main/java/org/springframework/security/access/expression/SecurityExpressionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.security.access.expression;
 
+import java.util.function.Supplier;
+
 import org.springframework.aop.framework.AopInfrastructureBean;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.ExpressionParser;
@@ -26,6 +28,7 @@ import org.springframework.security.core.Authentication;
  * expressions from the implementation of the underlying expression objects
  *
  * @author Luke Taylor
+ * @author Evgeniy Cheban
  * @since 3.1
  */
 public interface SecurityExpressionHandler<T> extends AopInfrastructureBean {
@@ -40,5 +43,20 @@ public interface SecurityExpressionHandler<T> extends AopInfrastructureBean {
 	 * invocation type.
 	 */
 	EvaluationContext createEvaluationContext(Authentication authentication, T invocation);
+
+	/**
+	 * Provides an evaluation context in which to evaluate security expressions for the
+	 * invocation type. You can override this method in order to provide a custom
+	 * implementation that uses lazy initialization of the {@link Authentication} object.
+	 * By default, this method uses eager initialization of the {@link Authentication}
+	 * object.
+	 * @param authentication the {@link Supplier} of the {@link Authentication} to use
+	 * @param invocation the {@link T} to use
+	 * @return the {@link EvaluationContext} to use
+	 * @since 5.8
+	 */
+	default EvaluationContext createEvaluationContext(Supplier<Authentication> authentication, T invocation) {
+		return createEvaluationContext(authentication.get(), invocation);
+	}
 
 }

--- a/core/src/main/java/org/springframework/security/access/expression/SecurityExpressionRoot.java
+++ b/core/src/main/java/org/springframework/security/access/expression/SecurityExpressionRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.security.access.expression;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
@@ -26,16 +27,18 @@ import org.springframework.security.authentication.AuthenticationTrustResolver;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.util.Assert;
 
 /**
  * Base root object for use in Spring Security expression evaluations.
  *
  * @author Luke Taylor
+ * @author Evgeniy Cheban
  * @since 3.0
  */
 public abstract class SecurityExpressionRoot implements SecurityExpressionOperations {
 
-	protected final Authentication authentication;
+	private final Supplier<Authentication> authentication;
 
 	private AuthenticationTrustResolver trustResolver;
 
@@ -72,10 +75,18 @@ public abstract class SecurityExpressionRoot implements SecurityExpressionOperat
 	 * @param authentication the {@link Authentication} to use. Cannot be null.
 	 */
 	public SecurityExpressionRoot(Authentication authentication) {
-		if (authentication == null) {
-			throw new IllegalArgumentException("Authentication object cannot be null");
-		}
-		this.authentication = authentication;
+		this(() -> authentication);
+	}
+
+	/**
+	 * Creates a new instance that uses lazy initialization of the {@link Authentication}
+	 * object.
+	 * @param authentication the {@link Supplier} of the {@link Authentication} to use.
+	 * Cannot be null.
+	 * @since 5.8
+	 */
+	public SecurityExpressionRoot(Supplier<Authentication> authentication) {
+		this.authentication = new AuthenticationSupplier(authentication);
 	}
 
 	@Override
@@ -111,7 +122,7 @@ public abstract class SecurityExpressionRoot implements SecurityExpressionOperat
 
 	@Override
 	public final Authentication getAuthentication() {
-		return this.authentication;
+		return this.authentication.get();
 	}
 
 	@Override
@@ -126,7 +137,7 @@ public abstract class SecurityExpressionRoot implements SecurityExpressionOperat
 
 	@Override
 	public final boolean isAnonymous() {
-		return this.trustResolver.isAnonymous(this.authentication);
+		return this.trustResolver.isAnonymous(getAuthentication());
 	}
 
 	@Override
@@ -136,13 +147,13 @@ public abstract class SecurityExpressionRoot implements SecurityExpressionOperat
 
 	@Override
 	public final boolean isRememberMe() {
-		return this.trustResolver.isRememberMe(this.authentication);
+		return this.trustResolver.isRememberMe(getAuthentication());
 	}
 
 	@Override
 	public final boolean isFullyAuthenticated() {
-		return !this.trustResolver.isAnonymous(this.authentication)
-				&& !this.trustResolver.isRememberMe(this.authentication);
+		Authentication authentication = getAuthentication();
+		return !this.trustResolver.isAnonymous(authentication) && !this.trustResolver.isRememberMe(authentication);
 	}
 
 	/**
@@ -151,7 +162,7 @@ public abstract class SecurityExpressionRoot implements SecurityExpressionOperat
 	 * @return
 	 */
 	public Object getPrincipal() {
-		return this.authentication.getPrincipal();
+		return getAuthentication().getPrincipal();
 	}
 
 	public void setTrustResolver(AuthenticationTrustResolver trustResolver) {
@@ -181,7 +192,7 @@ public abstract class SecurityExpressionRoot implements SecurityExpressionOperat
 
 	private Set<String> getAuthoritySet() {
 		if (this.roles == null) {
-			Collection<? extends GrantedAuthority> userAuthorities = this.authentication.getAuthorities();
+			Collection<? extends GrantedAuthority> userAuthorities = getAuthentication().getAuthorities();
 			if (this.roleHierarchy != null) {
 				userAuthorities = this.roleHierarchy.getReachableGrantedAuthorities(userAuthorities);
 			}
@@ -192,12 +203,12 @@ public abstract class SecurityExpressionRoot implements SecurityExpressionOperat
 
 	@Override
 	public boolean hasPermission(Object target, Object permission) {
-		return this.permissionEvaluator.hasPermission(this.authentication, target, permission);
+		return this.permissionEvaluator.hasPermission(getAuthentication(), target, permission);
 	}
 
 	@Override
 	public boolean hasPermission(Object targetId, String targetType, Object permission) {
-		return this.permissionEvaluator.hasPermission(this.authentication, (Serializable) targetId, targetType,
+		return this.permissionEvaluator.hasPermission(getAuthentication(), (Serializable) targetId, targetType,
 				permission);
 	}
 
@@ -223,6 +234,29 @@ public abstract class SecurityExpressionRoot implements SecurityExpressionOperat
 			return role;
 		}
 		return defaultRolePrefix + role;
+	}
+
+	private static final class AuthenticationSupplier implements Supplier<Authentication> {
+
+		private Authentication value;
+
+		private final Supplier<Authentication> delegate;
+
+		private AuthenticationSupplier(Supplier<Authentication> delegate) {
+			Assert.notNull(delegate, "delegate cannot be null");
+			this.delegate = delegate;
+		}
+
+		@Override
+		public Authentication get() {
+			if (this.value == null) {
+				Authentication authentication = this.delegate.get();
+				Assert.notNull(authentication, "Authentication object cannot be null");
+				this.value = authentication;
+			}
+			return this.value;
+		}
+
 	}
 
 }

--- a/core/src/main/java/org/springframework/security/access/expression/method/MethodSecurityEvaluationContext.java
+++ b/core/src/main/java/org/springframework/security/access/expression/method/MethodSecurityEvaluationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.security.core.parameters.DefaultSecurityParameterName
  *
  * @author Luke Taylor
  * @author Daniel Bustamante
+ * @author Evgeniy Cheban
  * @since 3.0
  */
 class MethodSecurityEvaluationContext extends MethodBasedEvaluationContext {
@@ -50,6 +51,11 @@ class MethodSecurityEvaluationContext extends MethodBasedEvaluationContext {
 	MethodSecurityEvaluationContext(Authentication user, MethodInvocation mi,
 			ParameterNameDiscoverer parameterNameDiscoverer) {
 		super(mi.getThis(), getSpecificMethod(mi), mi.getArguments(), parameterNameDiscoverer);
+	}
+
+	MethodSecurityEvaluationContext(MethodSecurityExpressionOperations root, MethodInvocation mi,
+			ParameterNameDiscoverer parameterNameDiscoverer) {
+		super(root, getSpecificMethod(mi), mi.getArguments(), parameterNameDiscoverer);
 	}
 
 	private static Method getSpecificMethod(MethodInvocation mi) {

--- a/core/src/main/java/org/springframework/security/access/expression/method/MethodSecurityExpressionRoot.java
+++ b/core/src/main/java/org/springframework/security/access/expression/method/MethodSecurityExpressionRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.security.access.expression.method;
 
+import java.util.function.Supplier;
+
 import org.springframework.security.access.expression.SecurityExpressionRoot;
 import org.springframework.security.core.Authentication;
 
@@ -23,6 +25,7 @@ import org.springframework.security.core.Authentication;
  * Extended expression root object which contains extra method-specific functionality.
  *
  * @author Luke Taylor
+ * @author Evgeniy Cheban
  * @since 3.0
  */
 class MethodSecurityExpressionRoot extends SecurityExpressionRoot implements MethodSecurityExpressionOperations {
@@ -35,6 +38,10 @@ class MethodSecurityExpressionRoot extends SecurityExpressionRoot implements Met
 
 	MethodSecurityExpressionRoot(Authentication a) {
 		super(a);
+	}
+
+	MethodSecurityExpressionRoot(Supplier<Authentication> authentication) {
+		super(authentication);
 	}
 
 	@Override

--- a/core/src/main/java/org/springframework/security/authorization/method/PostAuthorizeAuthorizationManager.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/PostAuthorizeAuthorizationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ public final class PostAuthorizeAuthorizationManager implements AuthorizationMan
 		if (attribute == ExpressionAttribute.NULL_ATTRIBUTE) {
 			return null;
 		}
-		EvaluationContext ctx = this.expressionHandler.createEvaluationContext(authentication.get(),
+		EvaluationContext ctx = this.expressionHandler.createEvaluationContext(authentication,
 				mi.getMethodInvocation());
 		this.expressionHandler.setReturnObject(mi.getResult(), ctx);
 		boolean granted = ExpressionUtils.evaluateAsBoolean(attribute.getExpression(), ctx);

--- a/core/src/main/java/org/springframework/security/authorization/method/PostFilterAuthorizationMethodInterceptor.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/PostFilterAuthorizationMethodInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,7 +128,7 @@ public final class PostFilterAuthorizationMethodInterceptor
 		if (attribute == ExpressionAttribute.NULL_ATTRIBUTE) {
 			return returnedObject;
 		}
-		EvaluationContext ctx = this.expressionHandler.createEvaluationContext(AUTHENTICATION_SUPPLIER.get(), mi);
+		EvaluationContext ctx = this.expressionHandler.createEvaluationContext(AUTHENTICATION_SUPPLIER, mi);
 		return this.expressionHandler.filter(returnedObject, attribute.getExpression(), ctx);
 	}
 

--- a/core/src/main/java/org/springframework/security/authorization/method/PreAuthorizeAuthorizationManager.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/PreAuthorizeAuthorizationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ public final class PreAuthorizeAuthorizationManager implements AuthorizationMana
 		if (attribute == ExpressionAttribute.NULL_ATTRIBUTE) {
 			return null;
 		}
-		EvaluationContext ctx = this.expressionHandler.createEvaluationContext(authentication.get(), mi);
+		EvaluationContext ctx = this.expressionHandler.createEvaluationContext(authentication, mi);
 		boolean granted = ExpressionUtils.evaluateAsBoolean(attribute.getExpression(), ctx);
 		return new ExpressionAttributeAuthorizationDecision(granted, attribute);
 	}

--- a/core/src/main/java/org/springframework/security/authorization/method/PreFilterAuthorizationMethodInterceptor.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/PreFilterAuthorizationMethodInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,7 +126,7 @@ public final class PreFilterAuthorizationMethodInterceptor
 		if (attribute == PreFilterExpressionAttribute.NULL_ATTRIBUTE) {
 			return mi.proceed();
 		}
-		EvaluationContext ctx = this.expressionHandler.createEvaluationContext(AUTHENTICATION_SUPPLIER.get(), mi);
+		EvaluationContext ctx = this.expressionHandler.createEvaluationContext(AUTHENTICATION_SUPPLIER, mi);
 		Object filterTarget = findFilterTarget(attribute.filterTarget, ctx, mi);
 		this.expressionHandler.filter(filterTarget, attribute.getExpression(), ctx);
 		return mi.proceed();

--- a/messaging/src/main/java/org/springframework/security/messaging/access/expression/MessageSecurityExpressionRoot.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/access/expression/MessageSecurityExpressionRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.security.messaging.access.expression;
 
+import java.util.function.Supplier;
+
 import org.springframework.messaging.Message;
 import org.springframework.security.access.expression.SecurityExpressionRoot;
 import org.springframework.security.core.Authentication;
@@ -24,6 +26,7 @@ import org.springframework.security.core.Authentication;
  * The {@link SecurityExpressionRoot} used for {@link Message} expressions.
  *
  * @author Rob Winch
+ * @author Evgeniy Cheban
  * @since 4.0
  */
 public class MessageSecurityExpressionRoot extends SecurityExpressionRoot {
@@ -31,6 +34,17 @@ public class MessageSecurityExpressionRoot extends SecurityExpressionRoot {
 	public final Message<?> message;
 
 	public MessageSecurityExpressionRoot(Authentication authentication, Message<?> message) {
+		this(() -> authentication, message);
+	}
+
+	/**
+	 * Creates an instance for the given {@link Supplier} of the {@link Authentication}
+	 * and {@link Message}.
+	 * @param authentication the {@link Supplier} of the {@link Authentication} to use
+	 * @param message the {@link Message} to use
+	 * @since 5.8
+	 */
+	public MessageSecurityExpressionRoot(Supplier<Authentication> authentication, Message<?> message) {
 		super(authentication);
 		this.message = message;
 	}

--- a/web/src/main/java/org/springframework/security/web/access/expression/DefaultHttpSecurityExpressionHandler.java
+++ b/web/src/main/java/org/springframework/security/web/access/expression/DefaultHttpSecurityExpressionHandler.java
@@ -16,6 +16,10 @@
 
 package org.springframework.security.web.access.expression;
 
+import java.util.function.Supplier;
+
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.security.access.expression.AbstractSecurityExpressionHandler;
 import org.springframework.security.access.expression.SecurityExpressionHandler;
 import org.springframework.security.access.expression.SecurityExpressionOperations;
@@ -40,7 +44,22 @@ public class DefaultHttpSecurityExpressionHandler extends AbstractSecurityExpres
 	private String defaultRolePrefix = "ROLE_";
 
 	@Override
+	public EvaluationContext createEvaluationContext(Supplier<Authentication> authentication,
+			RequestAuthorizationContext context) {
+		WebSecurityExpressionRoot root = createSecurityExpressionRoot(authentication, context);
+		StandardEvaluationContext ctx = new StandardEvaluationContext(root);
+		ctx.setBeanResolver(getBeanResolver());
+		context.getVariables().forEach(ctx::setVariable);
+		return ctx;
+	}
+
+	@Override
 	protected SecurityExpressionOperations createSecurityExpressionRoot(Authentication authentication,
+			RequestAuthorizationContext context) {
+		return createSecurityExpressionRoot(() -> authentication, context);
+	}
+
+	private WebSecurityExpressionRoot createSecurityExpressionRoot(Supplier<Authentication> authentication,
 			RequestAuthorizationContext context) {
 		WebSecurityExpressionRoot root = new WebSecurityExpressionRoot(authentication, context.getRequest());
 		root.setRoleHierarchy(getRoleHierarchy());

--- a/web/src/main/java/org/springframework/security/web/access/expression/WebExpressionAuthorizationManager.java
+++ b/web/src/main/java/org/springframework/security/web/access/expression/WebExpressionAuthorizationManager.java
@@ -16,7 +16,6 @@
 
 package org.springframework.security.web.access.expression;
 
-import java.util.Map;
 import java.util.function.Supplier;
 
 import org.springframework.expression.EvaluationContext;
@@ -72,10 +71,7 @@ public final class WebExpressionAuthorizationManager implements AuthorizationMan
 	 */
 	@Override
 	public AuthorizationDecision check(Supplier<Authentication> authentication, RequestAuthorizationContext context) {
-		EvaluationContext ctx = this.expressionHandler.createEvaluationContext(authentication.get(), context);
-		for (Map.Entry<String, String> entry : context.getVariables().entrySet()) {
-			ctx.setVariable(entry.getKey(), entry.getValue());
-		}
+		EvaluationContext ctx = this.expressionHandler.createEvaluationContext(authentication, context);
 		boolean granted = ExpressionUtils.evaluateAsBoolean(this.expression, ctx);
 		return new ExpressionAuthorizationDecision(granted, this.expression);
 	}

--- a/web/src/main/java/org/springframework/security/web/access/expression/WebSecurityExpressionRoot.java
+++ b/web/src/main/java/org/springframework/security/web/access/expression/WebSecurityExpressionRoot.java
@@ -16,6 +16,8 @@
 
 package org.springframework.security.web.access.expression;
 
+import java.util.function.Supplier;
+
 import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.security.access.expression.SecurityExpressionRoot;
@@ -36,17 +38,17 @@ public class WebSecurityExpressionRoot extends SecurityExpressionRoot {
 	public final HttpServletRequest request;
 
 	public WebSecurityExpressionRoot(Authentication a, FilterInvocation fi) {
-		this(a, fi.getRequest());
+		this(() -> a, fi.getRequest());
 	}
 
 	/**
-	 * Creates an instance for the given {@link Authentication} and
-	 * {@link HttpServletRequest}.
-	 * @param authentication the {@link Authentication} to use
+	 * Creates an instance for the given {@link Supplier} of the {@link Authentication}
+	 * and {@link HttpServletRequest}.
+	 * @param authentication the {@link Supplier} of the {@link Authentication} to use
 	 * @param request the {@link HttpServletRequest} to use
 	 * @since 5.8
 	 */
-	public WebSecurityExpressionRoot(Authentication authentication, HttpServletRequest request) {
+	public WebSecurityExpressionRoot(Supplier<Authentication> authentication, HttpServletRequest request) {
 		super(authentication);
 		this.request = request;
 	}


### PR DESCRIPTION
`createEvaluationContext` should defer lookup of `Authentication`

- Added `createEvaluationContext` method that accepts `Supplier<Authentication>`
- Refactored classes that use `EvaluationContext` to use lazy initialization of `Authentication`

Closes gh-9667

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
