### PR TITLE
Fix visibility on addSessionAuthenticationStrategy in SessionManagementConfigurer

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
@@ -260,7 +260,7 @@ public final class SessionManagementConfigurer<H extends HttpSecurityBuilder<H>>
 	 * @param sessionAuthenticationStrategy
 	 * @return the {@link SessionManagementConfigurer} for further customizations
 	 */
-	SessionManagementConfigurer<H> addSessionAuthenticationStrategy(
+	public SessionManagementConfigurer<H> addSessionAuthenticationStrategy(
 			SessionAuthenticationStrategy sessionAuthenticationStrategy) {
 		this.sessionAuthenticationStrategies.add(sessionAuthenticationStrategy);
 		return this;


### PR DESCRIPTION
Hi

I believe this is a simple oversight since the class is `final` and the documentation points toward a public facing method.

A backport would be appreciated if possible!

Thanks