### PR TITLE
Use Base64 encoder with no CRLF in output for SAML 2.0 messages

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LoginConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LoginConfigurerTests.java
@@ -260,7 +260,7 @@ public class Saml2LoginConfigurerTests {
 	public void authenticateWithInvalidDeflatedSAMLResponseThenFailureHandlerUses() throws Exception {
 		this.spring.register(CustomAuthenticationFailureHandler.class).autowire();
 		byte[] invalidDeflated = "invalid".getBytes();
-		String encoded = Saml2Utils.samlEncodeNotRfc2045(invalidDeflated);
+		String encoded = Saml2Utils.samlEncode(invalidDeflated);
 		MockHttpServletRequestBuilder request = get("/login/saml2/sso/registration-id").queryParam("SAMLResponse",
 				encoded);
 		this.mvc.perform(request);

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/Saml2Utils.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/Saml2Utils.java
@@ -36,7 +36,7 @@ final class Saml2Utils {
 	}
 
 	static String samlEncode(byte[] b) {
-		return Base64.getMimeEncoder().encodeToString(b);
+		return Base64.getEncoder().encodeToString(b);
 	}
 
 	static byte[] samlDecode(String s) {

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/Saml2Utils.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/Saml2Utils.java
@@ -40,7 +40,7 @@ final class Saml2Utils {
 	}
 
 	static String samlEncode(byte[] b) {
-		return Base64.getMimeEncoder().encodeToString(b);
+		return Base64.getEncoder().encodeToString(b);
 	}
 
 	static byte[] samlDecode(String s) {

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/Saml2Utils.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/Saml2Utils.java
@@ -40,7 +40,7 @@ final class Saml2Utils {
 	}
 
 	static String samlEncode(byte[] b) {
-		return Base64.getMimeEncoder().encodeToString(b);
+		return Base64.getEncoder().encodeToString(b);
 	}
 
 	static byte[] samlDecode(String s) {

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2Utils.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2Utils.java
@@ -40,7 +40,7 @@ final class Saml2Utils {
 	}
 
 	static String samlEncode(byte[] b) {
-		return Base64.getMimeEncoder().encodeToString(b);
+		return Base64.getEncoder().encodeToString(b);
 	}
 
 	static byte[] samlDecode(String s) {

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/core/Saml2Utils.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/core/Saml2Utils.java
@@ -32,13 +32,8 @@ public final class Saml2Utils {
 	private Saml2Utils() {
 	}
 
-	@Deprecated
-	public static String samlEncodeNotRfc2045(byte[] b) {
-		return Base64.getEncoder().encodeToString(b);
-	}
-
 	public static String samlEncode(byte[] b) {
-		return Base64.getMimeEncoder().encodeToString(b);
+		return Base64.getEncoder().encodeToString(b);
 	}
 
 	public static byte[] samlDecode(String s) {

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/web/Saml2AuthenticationTokenConverterTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/web/Saml2AuthenticationTokenConverterTests.java
@@ -65,7 +65,7 @@ public class Saml2AuthenticationTokenConverterTests {
 				.willReturn(this.relyingPartyRegistration);
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setParameter(Saml2ParameterNames.SAML_RESPONSE,
-				Saml2Utils.samlEncodeNotRfc2045("response".getBytes(StandardCharsets.UTF_8)));
+				Saml2Utils.samlEncode("response".getBytes(StandardCharsets.UTF_8)));
 		Saml2AuthenticationToken token = converter.convert(request);
 		assertThat(token.getSaml2Response()).isEqualTo("response");
 		assertThat(token.getRelyingPartyRegistration().getRegistrationId())
@@ -79,7 +79,7 @@ public class Saml2AuthenticationTokenConverterTests {
 		given(resolver.resolve(any(HttpServletRequest.class), any())).willReturn(this.relyingPartyRegistration);
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setParameter(Saml2ParameterNames.SAML_RESPONSE,
-				Saml2Utils.samlEncodeNotRfc2045("response".getBytes(StandardCharsets.UTF_8)));
+				Saml2Utils.samlEncode("response".getBytes(StandardCharsets.UTF_8)));
 		Saml2AuthenticationToken token = converter.convert(request);
 		assertThat(token.getSaml2Response()).isEqualTo("response");
 		assertThat(token.getRelyingPartyRegistration().getRegistrationId())
@@ -131,7 +131,7 @@ public class Saml2AuthenticationTokenConverterTests {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("GET");
 		byte[] deflated = Saml2Utils.samlDeflate("response");
-		String encoded = Saml2Utils.samlEncodeNotRfc2045(deflated);
+		String encoded = Saml2Utils.samlEncode(deflated);
 		request.setParameter(Saml2ParameterNames.SAML_RESPONSE, encoded);
 		Saml2AuthenticationToken token = converter.convert(request);
 		assertThat(token.getSaml2Response()).isEqualTo("response");


### PR DESCRIPTION
Saml2 message BASE64-encode results will not have line wrapped. 

gh-11262