### PR TITLE
Fixed typo in comment for changePassword method

### DIFF
--- a/core/src/main/java/org/springframework/security/provisioning/UserDetailsManager.java
+++ b/core/src/main/java/org/springframework/security/provisioning/UserDetailsManager.java
@@ -45,7 +45,7 @@ public interface UserDetailsManager extends UserDetailsService {
 
 	/**
 	 * Modify the current user's password. This should change the user's password in the
-	 * persistent user repository (datbase, LDAP etc).
+	 * persistent user repository (database, LDAP etc).
 	 * @param oldPassword current password (for re-authentication if required)
 	 * @param newPassword the password to change to
 	 */


### PR DESCRIPTION
Updated the comment for the changePassword interface method.  It had wrongly typed in `datbase` instead of `database`.