### PR TITLE
Use 'md:' prefix with EntityDescriptor tag in the metadata xml

### DIFF
--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/metadata/OpenSamlMetadataResolver.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/metadata/OpenSamlMetadataResolver.java
@@ -75,7 +75,7 @@ public final class OpenSamlMetadataResolver implements Saml2MetadataResolver {
 
 	@Override
 	public String resolve(RelyingPartyRegistration relyingPartyRegistration) {
-		EntityDescriptor entityDescriptor = build(EntityDescriptor.ELEMENT_QNAME);
+		EntityDescriptor entityDescriptor = build(EntityDescriptor.DEFAULT_ELEMENT_NAME);
 		entityDescriptor.setEntityID(relyingPartyRegistration.getEntityId());
 		SPSSODescriptor spSsoDescriptor = buildSpSsoDescriptor(relyingPartyRegistration);
 		entityDescriptor.getRoleDescriptors(SPSSODescriptor.DEFAULT_ELEMENT_NAME).add(spSsoDescriptor);

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/metadata/OpenSamlMetadataResolverTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/metadata/OpenSamlMetadataResolverTests.java
@@ -36,7 +36,7 @@ public class OpenSamlMetadataResolverTests {
 				.assertionConsumerServiceBinding(Saml2MessageBinding.REDIRECT).build();
 		OpenSamlMetadataResolver openSamlMetadataResolver = new OpenSamlMetadataResolver();
 		String metadata = openSamlMetadataResolver.resolve(relyingPartyRegistration);
-		assertThat(metadata).contains("<EntityDescriptor").contains("entityID=\"rp-entity-id\"")
+		assertThat(metadata).contains("<md:EntityDescriptor").contains("entityID=\"rp-entity-id\"")
 				.contains("<md:KeyDescriptor use=\"signing\">").contains("<md:KeyDescriptor use=\"encryption\">")
 				.contains("<ds:X509Certificate>MIICgTCCAeoCCQCuVzyqFgMSyDANBgkqhkiG9w0BAQsFADCBhDELMAkGA1UEBh")
 				.contains("Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\"")
@@ -52,7 +52,7 @@ public class OpenSamlMetadataResolverTests {
 				.build();
 		OpenSamlMetadataResolver openSamlMetadataResolver = new OpenSamlMetadataResolver();
 		String metadata = openSamlMetadataResolver.resolve(relyingPartyRegistration);
-		assertThat(metadata).contains("<EntityDescriptor").contains("entityID=\"rp-entity-id\"")
+		assertThat(metadata).contains("<md:EntityDescriptor").contains("entityID=\"rp-entity-id\"")
 				.doesNotContain("<md:KeyDescriptor use=\"signing\">")
 				.doesNotContain("<md:KeyDescriptor use=\"encryption\">")
 				.contains("Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\"")
@@ -86,7 +86,7 @@ public class OpenSamlMetadataResolverTests {
 		openSamlMetadataResolver.setEntityDescriptorCustomizer(
 				(parameters) -> parameters.getEntityDescriptor().setEntityID("overriddenEntityId"));
 		String metadata = openSamlMetadataResolver.resolve(relyingPartyRegistration);
-		assertThat(metadata).contains("<EntityDescriptor").contains("entityID=\"overriddenEntityId\"");
+		assertThat(metadata).contains("<md:EntityDescriptor").contains("entityID=\"overriddenEntityId\"");
 	}
 
 }


### PR DESCRIPTION
Create the EntityDescriptor object with `EntityDescriptor.DEFAULT_ELEMENT_NAME` instead of `EntityDescriptor.ELEMENT_QNAME`. That ensures the EntityDescriptor tag is marshalled to xml with the `md:` prefix, consistent with all other metadata tag elements.

I have signed the CLA.

Closes #11283
