### PR TITLE
Remove dependency on commons-codec by using java.util.Base64 (for 5.8.x)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,12 +73,6 @@ updateDependenciesSettings {
 		alphaBetaVersions()
 		snapshotVersions()
 		addRule { components ->
-			components.withModule("commons-codec:commons-codec") { selection ->
-				ModuleComponentIdentifier candidate = selection.getCandidate();
-				if (!candidate.getVersion().equals(selection.getCurrentVersion())) {
-					selection.reject("commons-codec updates break saml tests");
-				}
-			}
 			components.withModule("org.python:jython") { selection ->
 				ModuleComponentIdentifier candidate = selection.getCandidate();
 				if (!candidate.getVersion().equals(selection.getCurrentVersion())) {

--- a/dependencies/spring-security-dependencies.gradle
+++ b/dependencies/spring-security-dependencies.gradle
@@ -23,7 +23,6 @@ dependencies {
 		api "com.squareup.okhttp3:mockwebserver:3.14.9"
 		api "com.squareup.okhttp3:okhttp:3.14.9"
 		api "com.unboundid:unboundid-ldapsdk:4.0.14"
-		api "commons-codec:commons-codec:1.15"
 		api "commons-collections:commons-collections:3.2.2"
 		api "io.mockk:mockk:1.12.3"
 		api "io.projectreactor.tools:blockhound:1.0.6.RELEASE"

--- a/messaging/spring-security-messaging.gradle
+++ b/messaging/spring-security-messaging.gradle
@@ -15,7 +15,6 @@ dependencies {
 	optional 'jakarta.servlet:jakarta.servlet-api'
 
 	testImplementation project(path: ':spring-security-core', configuration: 'tests')
-	testImplementation 'commons-codec:commons-codec'
 	testImplementation "org.assertj:assertj-core"
 	testImplementation "org.junit.jupiter:junit-jupiter-api"
 	testImplementation "org.junit.jupiter:junit-jupiter-params"

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/Saml2AuthenticationTokenConverter.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/Saml2AuthenticationTokenConverter.java
@@ -18,14 +18,13 @@ package org.springframework.security.saml2.provider.service.web;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.function.Function;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterOutputStream;
 
 import javax.servlet.http.HttpServletRequest;
-
-import org.apache.commons.codec.CodecPolicy;
-import org.apache.commons.codec.binary.Base64;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpMethod;
@@ -49,7 +48,11 @@ import org.springframework.util.Assert;
  */
 public final class Saml2AuthenticationTokenConverter implements AuthenticationConverter {
 
-	private static Base64 BASE64 = new Base64(0, new byte[] { '\n' }, false, CodecPolicy.STRICT);
+	// MimeDecoder allows extra line-breaks as well as other non-alphabet values.
+	// This matches the behaviour of the commons-codec decoder.
+	private static final Base64.Decoder BASE64 = Base64.getMimeDecoder();
+
+	private static final Base64Checker BASE_64_CHECKER = new Base64Checker();
 
 	private final RelyingPartyRegistrationResolver relyingPartyRegistrationResolver;
 
@@ -127,6 +130,7 @@ public final class Saml2AuthenticationTokenConverter implements AuthenticationCo
 
 	private byte[] samlDecode(String base64EncodedPayload) {
 		try {
+			BASE_64_CHECKER.checkAcceptable(base64EncodedPayload);
 			return BASE64.decode(base64EncodedPayload);
 		}
 		catch (Exception ex) {
@@ -147,6 +151,60 @@ public final class Saml2AuthenticationTokenConverter implements AuthenticationCo
 			throw new Saml2AuthenticationException(
 					new Saml2Error(Saml2ErrorCodes.INVALID_RESPONSE, "Unable to inflate string"), ex);
 		}
+	}
+
+	static class Base64Checker {
+
+		private static final int[] values = genValueMapping();
+
+		Base64Checker() {
+
+		}
+
+		private static int[] genValueMapping() {
+			byte[] alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+					.getBytes(StandardCharsets.ISO_8859_1);
+
+			int[] values = new int[256];
+			Arrays.fill(values, -1);
+			for (int i = 0; i < alphabet.length; i++) {
+				values[alphabet[i] & 0xff] = i;
+			}
+			return values;
+		}
+
+		boolean isAcceptable(String s) {
+			int goodChars = 0;
+			int lastGoodCharVal = -1;
+
+			// count number of characters from Base64 alphabet
+			for (int i = 0; i < s.length(); i++) {
+				int val = values[0xff & s.charAt(i)];
+				if (val != -1) {
+					lastGoodCharVal = val;
+					goodChars++;
+				}
+			}
+
+			// in cases of an incomplete final chunk, ensure the unused bits are zero
+			switch (goodChars % 4) {
+			case 0:
+				return true;
+			case 2:
+				return (lastGoodCharVal & 0b1111) == 0;
+			case 3:
+				return (lastGoodCharVal & 0b11) == 0;
+			default:
+				return false;
+			}
+		}
+
+		void checkAcceptable(String ins) {
+			if (!isAcceptable(ins)) {
+				throw new IllegalArgumentException("Unaccepted Encoding");
+			}
+		}
+
 	}
 
 }

--- a/web/spring-security-web.gradle
+++ b/web/spring-security-web.gradle
@@ -20,7 +20,6 @@ dependencies {
 	provided 'jakarta.servlet:jakarta.servlet-api'
 
 	testImplementation project(path: ':spring-security-core', configuration: 'tests')
-	testImplementation 'commons-codec:commons-codec'
 	testImplementation 'io.projectreactor:reactor-test'
 	testImplementation 'jakarta.xml.bind:jakarta.xml.bind-api'
 	testImplementation 'org.hamcrest:hamcrest'

--- a/web/src/test/java/org/springframework/security/test/web/CodecTestUtils.java
+++ b/web/src/test/java/org/springframework/security/test/web/CodecTestUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.test.web;
+
+import java.util.Base64;
+
+import org.springframework.util.DigestUtils;
+
+public final class CodecTestUtils {
+
+	private CodecTestUtils() {
+	}
+
+	public static String encodeBase64(String unencoded) {
+		return Base64.getEncoder().encodeToString(unencoded.getBytes());
+	}
+
+	public static String encodeBase64(byte[] unencoded) {
+		return Base64.getEncoder().encodeToString(unencoded);
+	}
+
+	public static String decodeBase64(String encoded) {
+		return new String(Base64.getDecoder().decode(encoded));
+	}
+
+	public static boolean isBase64(byte[] arrayOctet) {
+		try {
+			Base64.getMimeDecoder().decode(arrayOctet);
+			return true;
+
+		}
+		catch (Exception ex) {
+			return false;
+		}
+	}
+
+	public static String md5Hex(String data) {
+		return DigestUtils.md5DigestAsHex(data.getBytes());
+	}
+
+}

--- a/web/src/test/java/org/springframework/security/web/authentication/www/BasicAuthenticationConverterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/www/BasicAuthenticationConverterTests.java
@@ -18,7 +18,6 @@ package org.springframework.security.web.authentication.www;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.commons.codec.binary.Base64;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,6 +28,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.test.web.CodecTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -57,7 +57,7 @@ public class BasicAuthenticationConverterTests {
 	public void testNormalOperation() {
 		String token = "rod:koala";
 		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.addHeader("Authorization", "Basic " + new String(Base64.encodeBase64(token.getBytes())));
+		request.addHeader("Authorization", "Basic " + CodecTestUtils.encodeBase64(token));
 		UsernamePasswordAuthenticationToken authentication = this.converter.convert(request);
 		verify(this.authenticationDetailsSource).buildDetails(any());
 		assertThat(authentication).isNotNull();
@@ -68,7 +68,7 @@ public class BasicAuthenticationConverterTests {
 	public void requestWhenAuthorizationSchemeInMixedCaseThenAuthenticates() {
 		String token = "rod:koala";
 		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.addHeader("Authorization", "BaSiC " + new String(Base64.encodeBase64(token.getBytes())));
+		request.addHeader("Authorization", "BaSiC " + CodecTestUtils.encodeBase64(token));
 		UsernamePasswordAuthenticationToken authentication = this.converter.convert(request);
 		verify(this.authenticationDetailsSource).buildDetails(any());
 		assertThat(authentication).isNotNull();
@@ -88,7 +88,7 @@ public class BasicAuthenticationConverterTests {
 	public void testWhenInvalidBasicAuthorizationTokenThenError() {
 		String token = "NOT_A_VALID_TOKEN_AS_MISSING_COLON";
 		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.addHeader("Authorization", "Basic " + new String(Base64.encodeBase64(token.getBytes())));
+		request.addHeader("Authorization", "Basic " + CodecTestUtils.encodeBase64(token));
 		assertThatExceptionOfType(BadCredentialsException.class).isThrownBy(() -> this.converter.convert(request));
 	}
 
@@ -103,7 +103,7 @@ public class BasicAuthenticationConverterTests {
 	public void convertWhenEmptyPassword() {
 		String token = "rod:";
 		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.addHeader("Authorization", "Basic " + new String(Base64.encodeBase64(token.getBytes())));
+		request.addHeader("Authorization", "Basic " + CodecTestUtils.encodeBase64(token));
 		UsernamePasswordAuthenticationToken authentication = this.converter.convert(request);
 		verify(this.authenticationDetailsSource).buildDetails(any());
 		assertThat(authentication).isNotNull();

--- a/web/src/test/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilterTests.java
@@ -23,7 +23,6 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.codec.binary.Base64;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,6 +38,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.web.CodecTestUtils;
 import org.springframework.security.web.authentication.WebAuthenticationDetails;
 import org.springframework.security.web.context.SecurityContextRepository;
 import org.springframework.web.util.WebUtils;
@@ -105,7 +105,7 @@ public class BasicAuthenticationFilterTests {
 	public void testInvalidBasicAuthorizationTokenIsIgnored() throws Exception {
 		String token = "NOT_A_VALID_TOKEN_AS_MISSING_COLON";
 		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.addHeader("Authorization", "Basic " + new String(Base64.encodeBase64(token.getBytes())));
+		request.addHeader("Authorization", "Basic " + CodecTestUtils.encodeBase64(token));
 		request.setServletPath("/some_file.html");
 		request.setSession(new MockHttpSession());
 		final MockHttpServletResponse response = new MockHttpServletResponse();
@@ -135,7 +135,7 @@ public class BasicAuthenticationFilterTests {
 	public void testNormalOperation() throws Exception {
 		String token = "rod:koala";
 		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.addHeader("Authorization", "Basic " + new String(Base64.encodeBase64(token.getBytes())));
+		request.addHeader("Authorization", "Basic " + CodecTestUtils.encodeBase64(token));
 		request.setServletPath("/some_file.html");
 		// Test
 		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
@@ -151,7 +151,7 @@ public class BasicAuthenticationFilterTests {
 	public void doFilterWhenSchemeLowercaseThenCaseInsensitveMatchWorks() throws Exception {
 		String token = "rod:koala";
 		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.addHeader("Authorization", "basic " + new String(Base64.encodeBase64(token.getBytes())));
+		request.addHeader("Authorization", "basic " + CodecTestUtils.encodeBase64(token));
 		request.setServletPath("/some_file.html");
 		// Test
 		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
@@ -166,7 +166,7 @@ public class BasicAuthenticationFilterTests {
 	public void doFilterWhenSchemeMixedCaseThenCaseInsensitiveMatchWorks() throws Exception {
 		String token = "rod:koala";
 		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.addHeader("Authorization", "BaSiC " + new String(Base64.encodeBase64(token.getBytes())));
+		request.addHeader("Authorization", "BaSiC " + CodecTestUtils.encodeBase64(token));
 		request.setServletPath("/some_file.html");
 		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
 		FilterChain chain = mock(FilterChain.class);
@@ -201,7 +201,7 @@ public class BasicAuthenticationFilterTests {
 	public void testSuccessLoginThenFailureLoginResultsInSessionLosingToken() throws Exception {
 		String token = "rod:koala";
 		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.addHeader("Authorization", "Basic " + new String(Base64.encodeBase64(token.getBytes())));
+		request.addHeader("Authorization", "Basic " + CodecTestUtils.encodeBase64(token));
 		request.setServletPath("/some_file.html");
 		final MockHttpServletResponse response1 = new MockHttpServletResponse();
 		FilterChain chain = mock(FilterChain.class);
@@ -213,7 +213,7 @@ public class BasicAuthenticationFilterTests {
 		// NOW PERFORM FAILED AUTHENTICATION
 		token = "otherUser:WRONG_PASSWORD";
 		request = new MockHttpServletRequest();
-		request.addHeader("Authorization", "Basic " + new String(Base64.encodeBase64(token.getBytes())));
+		request.addHeader("Authorization", "Basic " + CodecTestUtils.encodeBase64(token));
 		final MockHttpServletResponse response2 = new MockHttpServletResponse();
 		chain = mock(FilterChain.class);
 		this.filter.doFilter(request, response2, chain);
@@ -229,7 +229,7 @@ public class BasicAuthenticationFilterTests {
 	public void testWrongPasswordContinuesFilterChainIfIgnoreFailureIsTrue() throws Exception {
 		String token = "rod:WRONG_PASSWORD";
 		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.addHeader("Authorization", "Basic " + new String(Base64.encodeBase64(token.getBytes())));
+		request.addHeader("Authorization", "Basic " + CodecTestUtils.encodeBase64(token));
 		request.setServletPath("/some_file.html");
 		request.setSession(new MockHttpSession());
 		this.filter = new BasicAuthenticationFilter(this.manager);
@@ -245,7 +245,7 @@ public class BasicAuthenticationFilterTests {
 	public void testWrongPasswordReturnsForbiddenIfIgnoreFailureIsFalse() throws Exception {
 		String token = "rod:WRONG_PASSWORD";
 		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.addHeader("Authorization", "Basic " + new String(Base64.encodeBase64(token.getBytes())));
+		request.addHeader("Authorization", "Basic " + CodecTestUtils.encodeBase64(token));
 		request.setServletPath("/some_file.html");
 		request.setSession(new MockHttpSession());
 		assertThat(this.filter.isIgnoreFailure()).isFalse();
@@ -263,7 +263,7 @@ public class BasicAuthenticationFilterTests {
 	public void skippedOnErrorDispatch() throws Exception {
 		String token = "bad:credentials";
 		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.addHeader("Authorization", "Basic " + new String(Base64.encodeBase64(token.getBytes())));
+		request.addHeader("Authorization", "Basic " + CodecTestUtils.encodeBase64(token));
 		request.setServletPath("/some_file.html");
 		request.setAttribute(WebUtils.ERROR_REQUEST_URI_ATTRIBUTE, "/error");
 		MockHttpServletResponse response = new MockHttpServletResponse();
@@ -287,7 +287,7 @@ public class BasicAuthenticationFilterTests {
 		String token = "rod:äöü";
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addHeader("Authorization",
-				"Basic " + new String(Base64.encodeBase64(token.getBytes(StandardCharsets.UTF_8))));
+				"Basic " + CodecTestUtils.encodeBase64(token.getBytes(StandardCharsets.UTF_8)));
 		request.setServletPath("/some_file.html");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		// Test
@@ -316,7 +316,7 @@ public class BasicAuthenticationFilterTests {
 		String token = "rod:äöü";
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addHeader("Authorization",
-				"Basic " + new String(Base64.encodeBase64(token.getBytes(StandardCharsets.ISO_8859_1))));
+				"Basic " + CodecTestUtils.encodeBase64(token.getBytes(StandardCharsets.ISO_8859_1)));
 		request.setServletPath("/some_file.html");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		// Test
@@ -345,7 +345,7 @@ public class BasicAuthenticationFilterTests {
 		String token = "rod:äöü";
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addHeader("Authorization",
-				"Basic " + new String(Base64.encodeBase64(token.getBytes(StandardCharsets.UTF_8))));
+				"Basic " + CodecTestUtils.encodeBase64(token.getBytes(StandardCharsets.UTF_8)));
 		request.setServletPath("/some_file.html");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		// Test
@@ -378,7 +378,7 @@ public class BasicAuthenticationFilterTests {
 		this.filter.setSecurityContextRepository(securityContextRepository);
 		String token = "rod:koala";
 		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.addHeader("Authorization", "Basic " + new String(Base64.encodeBase64(token.getBytes())));
+		request.addHeader("Authorization", "Basic " + CodecTestUtils.encodeBase64(token));
 		request.setServletPath("/some_file.html");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		// Test

--- a/web/src/test/java/org/springframework/security/web/authentication/www/DigestAuthenticationEntryPointTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/www/DigestAuthenticationEntryPointTests.java
@@ -18,13 +18,12 @@ package org.springframework.security.web.authentication.www;
 
 import java.util.Map;
 
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.test.web.CodecTestUtils;
 import org.springframework.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,11 +40,11 @@ public class DigestAuthenticationEntryPointTests {
 		// Check the nonce seems to be generated correctly
 		// format of nonce is:
 		// base64(expirationTime + ":" + md5Hex(expirationTime + ":" + key))
-		assertThat(Base64.isArrayByteBase64(nonce.getBytes())).isTrue();
-		String decodedNonce = new String(Base64.decodeBase64(nonce.getBytes()));
+		assertThat(CodecTestUtils.isBase64(nonce.getBytes())).isTrue();
+		String decodedNonce = CodecTestUtils.decodeBase64(nonce);
 		String[] nonceTokens = StringUtils.delimitedListToStringArray(decodedNonce, ":");
 		assertThat(nonceTokens).hasSize(2);
-		String expectedNonceSignature = DigestUtils.md5Hex(nonceTokens[0] + ":" + "key");
+		String expectedNonceSignature = CodecTestUtils.md5Hex(nonceTokens[0] + ":" + "key");
 		assertThat(nonceTokens[1]).isEqualTo(expectedNonceSignature);
 	}
 

--- a/web/src/test/java/org/springframework/security/web/authentication/www/DigestAuthenticationFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/www/DigestAuthenticationFilterTests.java
@@ -24,8 +24,6 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +39,7 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.cache.NullUserCache;
+import org.springframework.security.test.web.CodecTestUtils;
 import org.springframework.security.web.context.SecurityContextRepository;
 import org.springframework.util.StringUtils;
 
@@ -106,9 +105,9 @@ public class DigestAuthenticationFilterTests {
 
 	private static String generateNonce(int validitySeconds, String key) {
 		long expiryTime = System.currentTimeMillis() + (validitySeconds * 1000);
-		String signatureValue = DigestUtils.md5Hex(expiryTime + ":" + key);
+		String signatureValue = CodecTestUtils.md5Hex(expiryTime + ":" + key);
 		String nonceValue = expiryTime + ":" + signatureValue;
-		return new String(Base64.encodeBase64(nonceValue.getBytes()));
+		return CodecTestUtils.encodeBase64(nonceValue);
 	}
 
 	@AfterEach
@@ -183,7 +182,7 @@ public class DigestAuthenticationFilterTests {
 	@Test
 	public void testInvalidDigestAuthorizationTokenGeneratesError() throws Exception {
 		String token = "NOT_A_VALID_TOKEN_AS_MISSING_COLON";
-		this.request.addHeader("Authorization", "Digest " + new String(Base64.encodeBase64(token.getBytes())));
+		this.request.addHeader("Authorization", "Digest " + CodecTestUtils.encodeBase64(token));
 		MockHttpServletResponse response = executeFilterInContainerSimulator(this.filter, this.request, false);
 		assertThat(response.getStatus()).isEqualTo(401);
 		assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
@@ -211,7 +210,7 @@ public class DigestAuthenticationFilterTests {
 
 	@Test
 	public void testNonceWithIncorrectSignatureForNumericFieldReturnsForbidden() throws Exception {
-		String nonce = new String(Base64.encodeBase64("123456:incorrectStringPassword".getBytes()));
+		String nonce = CodecTestUtils.encodeBase64("123456:incorrectStringPassword");
 		String responseDigest = DigestAuthUtils.generateDigest(false, USERNAME, REALM, PASSWORD, "GET", REQUEST_URI,
 				QOP, nonce, NC, CNONCE);
 		this.request.addHeader("Authorization",
@@ -223,7 +222,7 @@ public class DigestAuthenticationFilterTests {
 
 	@Test
 	public void testNonceWithNonNumericFirstElementReturnsForbidden() throws Exception {
-		String nonce = new String(Base64.encodeBase64("hello:ignoredSecondElement".getBytes()));
+		String nonce = CodecTestUtils.encodeBase64("hello:ignoredSecondElement");
 		String responseDigest = DigestAuthUtils.generateDigest(false, USERNAME, REALM, PASSWORD, "GET", REQUEST_URI,
 				QOP, nonce, NC, CNONCE);
 		this.request.addHeader("Authorization",
@@ -235,7 +234,7 @@ public class DigestAuthenticationFilterTests {
 
 	@Test
 	public void testNonceWithoutTwoColonSeparatedElementsReturnsForbidden() throws Exception {
-		String nonce = new String(Base64.encodeBase64("a base 64 string without a colon".getBytes()));
+		String nonce = CodecTestUtils.encodeBase64("a base 64 string without a colon");
 		String responseDigest = DigestAuthUtils.generateDigest(false, USERNAME, REALM, PASSWORD, "GET", REQUEST_URI,
 				QOP, nonce, NC, CNONCE);
 		this.request.addHeader("Authorization",


### PR DESCRIPTION
gh-11318

Replace commons-codec Base64 with `java.util.Base64`
