### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/algolia-index.yml
+++ b/.github/workflows/algolia-index.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 10 * * *' # Once per day at 10am UTC
   workflow_dispatch: # Manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   update:
     name: Update Algolia Index

--- a/.github/workflows/antora-generate.yml
+++ b/.github/workflows/antora-generate.yml
@@ -10,6 +10,9 @@ on:
 env:
   GH_ACTIONS_REPO_TOKEN: ${{ secrets.GH_ACTIONS_REPO_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/clean_build_artifacts.yml
+++ b/.github/workflows/clean_build_artifacts.yml
@@ -3,8 +3,13 @@ on:
   schedule:
     - cron: '0 10 * * *' # Once per day at 10am UTC
 
+permissions:
+  contents: read
+
 jobs:
   main:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
       - name: Delete artifacts in cron job

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -233,6 +233,8 @@ jobs:
           DOCS_SSH_KEY: ${{ secrets.DOCS_SSH_KEY }}
           DOCS_HOST: ${{ secrets.DOCS_HOST }}
   perform_release:
+    permissions:
+      contents: write  # for Git to git push
     name: Perform release
     needs: [prerequisites, deploy_artifacts, deploy_docs, deploy_schema]
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-reference.yml
+++ b/.github/workflows/deploy-reference.yml
@@ -7,6 +7,9 @@ on:
     - cron: '0 10 * * *' # Once per day at 10am UTC
   workflow_dispatch: # Manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: deploy

--- a/.github/workflows/milestone-spring-releasetrain.yml
+++ b/.github/workflows/milestone-spring-releasetrain.yml
@@ -7,6 +7,8 @@ env:
   TITLE: ${{ github.event.milestone.title }}
 jobs:
   spring-releasetrain-checks:    
+    permissions:
+      contents: none
     name: Check DueOn is on a Release Date
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-build-workflow.yml
+++ b/.github/workflows/pr-build-workflow.yml
@@ -5,6 +5,9 @@ on: pull_request
 env:
   RUN_JOBS: ${{ github.repository == 'spring-projects/spring-security' }}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
