### PR TITLE
Allow customization of redirect strategy

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2ClientConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2ClientConfigurer.java
@@ -34,6 +34,7 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequest
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.savedrequest.RequestCache;
 import org.springframework.util.Assert;
 
@@ -171,6 +172,8 @@ public final class OAuth2ClientConfigurer<B extends HttpSecurityBuilder<B>>
 
 		private AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository;
 
+		private RedirectStrategy authorizationRedirectStrategy;
+
 		private OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> accessTokenResponseClient;
 
 		private AuthorizationCodeGrantConfigurer() {
@@ -199,6 +202,17 @@ public final class OAuth2ClientConfigurer<B extends HttpSecurityBuilder<B>>
 				AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository) {
 			Assert.notNull(authorizationRequestRepository, "authorizationRequestRepository cannot be null");
 			this.authorizationRequestRepository = authorizationRequestRepository;
+			return this;
+		}
+
+		/**
+		 * Sets the redirect strategy for Authorization Endpoint redirect URI.
+		 * @param authorizationRedirectStrategy the redirect strategy
+		 * @return the {@link AuthorizationCodeGrantConfigurer} for further configuration
+		 */
+		public AuthorizationCodeGrantConfigurer authorizationRedirectStrategy(
+				RedirectStrategy authorizationRedirectStrategy) {
+			this.authorizationRedirectStrategy = authorizationRedirectStrategy;
 			return this;
 		}
 
@@ -246,6 +260,9 @@ public final class OAuth2ClientConfigurer<B extends HttpSecurityBuilder<B>>
 			if (this.authorizationRequestRepository != null) {
 				authorizationRequestRedirectFilter
 						.setAuthorizationRequestRepository(this.authorizationRequestRepository);
+			}
+			if (this.authorizationRedirectStrategy != null) {
+				authorizationRequestRedirectFilter.setAuthorizationRedirectStrategy(this.authorizationRedirectStrategy);
 			}
 			RequestCache requestCache = builder.getSharedObject(RequestCache.class);
 			if (requestCache != null) {

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2LoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2LoginConfigurer.java
@@ -68,6 +68,7 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.authentication.DelegatingAuthenticationEntryPoint;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.authentication.ui.DefaultLoginPageGeneratingFilter;
@@ -367,6 +368,10 @@ public final class OAuth2LoginConfigurer<B extends HttpSecurityBuilder<B>>
 			authorizationRequestFilter
 					.setAuthorizationRequestRepository(this.authorizationEndpointConfig.authorizationRequestRepository);
 		}
+		if (this.authorizationEndpointConfig.authorizationRedirectStrategy != null) {
+			authorizationRequestFilter
+					.setAuthorizationRedirectStrategy(this.authorizationEndpointConfig.authorizationRedirectStrategy);
+		}
 		RequestCache requestCache = http.getSharedObject(RequestCache.class);
 		if (requestCache != null) {
 			authorizationRequestFilter.setRequestCache(requestCache);
@@ -539,6 +544,8 @@ public final class OAuth2LoginConfigurer<B extends HttpSecurityBuilder<B>>
 
 		private AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository;
 
+		private RedirectStrategy authorizationRedirectStrategy;
+
 		private AuthorizationEndpointConfig() {
 		}
 
@@ -578,6 +585,17 @@ public final class OAuth2LoginConfigurer<B extends HttpSecurityBuilder<B>>
 				AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository) {
 			Assert.notNull(authorizationRequestRepository, "authorizationRequestRepository cannot be null");
 			this.authorizationRequestRepository = authorizationRequestRepository;
+			return this;
+		}
+
+		/**
+		 * Sets the redirect strategy for Authorization Endpoint redirect URI.
+		 * @param authorizationRedirectStrategy the redirect strategy
+		 * @return the {@link AuthorizationEndpointConfig} for further configuration
+		 */
+		public AuthorizationEndpointConfig authorizationRedirectStrategy(
+				RedirectStrategy authorizationRedirectStrategy) {
+			this.authorizationRedirectStrategy = authorizationRedirectStrategy;
 			return this;
 		}
 

--- a/config/src/main/java/org/springframework/security/config/http/OAuth2ClientBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/http/OAuth2ClientBeanDefinitionParser.java
@@ -44,6 +44,8 @@ final class OAuth2ClientBeanDefinitionParser implements BeanDefinitionParser {
 
 	private static final String ATT_AUTHORIZATION_REQUEST_RESOLVER_REF = "authorization-request-resolver-ref";
 
+	private static final String ATT_AUTHORIZATION_REDIRECT_STRATEGY_REF = "authorization-redirect-strategy-ref";
+
 	private static final String ATT_ACCESS_TOKEN_RESPONSE_CLIENT_REF = "access-token-response-client-ref";
 
 	private final BeanReference requestCache;
@@ -83,6 +85,7 @@ final class OAuth2ClientBeanDefinitionParser implements BeanDefinitionParser {
 		}
 		BeanMetadataElement authorizationRequestRepository = getAuthorizationRequestRepository(
 				authorizationCodeGrantElt);
+		BeanMetadataElement authorizationRedirectStrategy = getAuthorizationRedirectStrategy(authorizationCodeGrantElt);
 		BeanDefinitionBuilder authorizationRequestRedirectFilterBuilder = BeanDefinitionBuilder
 				.rootBeanDefinition(OAuth2AuthorizationRequestRedirectFilter.class);
 		String authorizationRequestResolverRef = (authorizationCodeGrantElt != null)
@@ -95,6 +98,7 @@ final class OAuth2ClientBeanDefinitionParser implements BeanDefinitionParser {
 		}
 		this.authorizationRequestRedirectFilter = authorizationRequestRedirectFilterBuilder
 				.addPropertyValue("authorizationRequestRepository", authorizationRequestRepository)
+				.addPropertyValue("authorizationRedirectStrategy", authorizationRedirectStrategy)
 				.addPropertyValue("requestCache", this.requestCache).getBeanDefinition();
 		BeanDefinitionBuilder authorizationCodeGrantFilterBldr = BeanDefinitionBuilder
 				.rootBeanDefinition(OAuth2AuthorizationCodeGrantFilter.class)
@@ -123,6 +127,16 @@ final class OAuth2ClientBeanDefinitionParser implements BeanDefinitionParser {
 		}
 		return BeanDefinitionBuilder.rootBeanDefinition(
 				"org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository")
+				.getBeanDefinition();
+	}
+
+	private BeanMetadataElement getAuthorizationRedirectStrategy(Element element) {
+		String authorizationRedirectStrategyRef = (element != null)
+				? element.getAttribute(ATT_AUTHORIZATION_REDIRECT_STRATEGY_REF) : null;
+		if (StringUtils.hasText(authorizationRedirectStrategyRef)) {
+			return new RuntimeBeanReference(authorizationRedirectStrategyRef);
+		}
+		return BeanDefinitionBuilder.rootBeanDefinition("org.springframework.security.web.DefaultRedirectStrategy")
 				.getBeanDefinition();
 	}
 

--- a/config/src/main/java/org/springframework/security/config/http/OAuth2LoginBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/http/OAuth2LoginBeanDefinitionParser.java
@@ -87,6 +87,8 @@ final class OAuth2LoginBeanDefinitionParser implements BeanDefinitionParser {
 
 	private static final String ATT_AUTHORIZATION_REQUEST_RESOLVER_REF = "authorization-request-resolver-ref";
 
+	private static final String ATT_AUTHORIZATION_REDIRECT_STRATEGY_REF = "authorization-redirect-strategy-ref";
+
 	private static final String ATT_ACCESS_TOKEN_RESPONSE_CLIENT_REF = "access-token-response-client-ref";
 
 	private static final String ATT_USER_AUTHORITIES_MAPPER_REF = "user-authorities-mapper-ref";
@@ -199,6 +201,7 @@ final class OAuth2LoginBeanDefinitionParser implements BeanDefinitionParser {
 		}
 		oauth2AuthorizationRequestRedirectFilterBuilder
 				.addPropertyValue("authorizationRequestRepository", authorizationRequestRepository)
+				.addPropertyValue("authorizationRedirectStrategy", getAuthorizationRedirectStrategy(element))
 				.addPropertyValue("requestCache", this.requestCache);
 		this.oauth2AuthorizationRequestRedirectFilter = oauth2AuthorizationRequestRedirectFilterBuilder
 				.getBeanDefinition();
@@ -258,6 +261,15 @@ final class OAuth2LoginBeanDefinitionParser implements BeanDefinitionParser {
 		}
 		return BeanDefinitionBuilder.rootBeanDefinition(
 				"org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository")
+				.getBeanDefinition();
+	}
+
+	private BeanMetadataElement getAuthorizationRedirectStrategy(Element element) {
+		String authorizationRedirectStrategyRef = element.getAttribute(ATT_AUTHORIZATION_REDIRECT_STRATEGY_REF);
+		if (StringUtils.hasText(authorizationRedirectStrategyRef)) {
+			return new RuntimeBeanReference(authorizationRedirectStrategyRef);
+		}
+		return BeanDefinitionBuilder.rootBeanDefinition("org.springframework.security.web.DefaultRedirectStrategy")
 				.getBeanDefinition();
 	}
 

--- a/config/src/main/kotlin/org/springframework/security/config/annotation/web/oauth2/client/AuthorizationCodeGrantDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/annotation/web/oauth2/client/AuthorizationCodeGrantDsl.kt
@@ -23,6 +23,7 @@ import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCo
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
+import org.springframework.security.web.RedirectStrategy
 
 /**
  * A Kotlin DSL to configure OAuth 2.0 Authorization Code Grant.
@@ -31,6 +32,7 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequ
  * @since 5.3
  * @property authorizationRequestResolver the resolver used for resolving [OAuth2AuthorizationRequest]'s.
  * @property authorizationRequestRepository the repository used for storing [OAuth2AuthorizationRequest]'s.
+ * @property authorizationRedirectStrategy the redirect strategy for Authorization Endpoint redirect URI.
  * @property accessTokenResponseClient the client used for requesting the access token credential
  * from the Token Endpoint.
  */
@@ -38,12 +40,14 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequ
 class AuthorizationCodeGrantDsl {
     var authorizationRequestResolver: OAuth2AuthorizationRequestResolver? = null
     var authorizationRequestRepository: AuthorizationRequestRepository<OAuth2AuthorizationRequest>? = null
+    var authorizationRedirectStrategy: RedirectStrategy? = null
     var accessTokenResponseClient: OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest>? = null
 
     internal fun get(): (OAuth2ClientConfigurer<HttpSecurity>.AuthorizationCodeGrantConfigurer) -> Unit {
         return { authorizationCodeGrant ->
             authorizationRequestResolver?.also { authorizationCodeGrant.authorizationRequestResolver(authorizationRequestResolver) }
             authorizationRequestRepository?.also { authorizationCodeGrant.authorizationRequestRepository(authorizationRequestRepository) }
+            authorizationRedirectStrategy?.also { authorizationCodeGrant.authorizationRedirectStrategy(authorizationRedirectStrategy) }
             accessTokenResponseClient?.also { authorizationCodeGrant.accessTokenResponseClient(accessTokenResponseClient) }
         }
     }

--- a/config/src/main/kotlin/org/springframework/security/config/annotation/web/oauth2/login/AuthorizationEndpointDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/annotation/web/oauth2/login/AuthorizationEndpointDsl.kt
@@ -21,6 +21,7 @@ import org.springframework.security.config.annotation.web.configurers.oauth2.cli
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
+import org.springframework.security.web.RedirectStrategy
 
 /**
  * A Kotlin DSL to configure the Authorization Server's Authorization Endpoint using
@@ -31,18 +32,21 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequ
  * @property baseUri the base URI used for authorization requests.
  * @property authorizationRequestResolver the resolver used for resolving [OAuth2AuthorizationRequest]'s.
  * @property authorizationRequestRepository the repository used for storing [OAuth2AuthorizationRequest]'s.
+ * @property authorizationRedirectStrategy the redirect strategy for Authorization Endpoint redirect URI.
  */
 @OAuth2LoginSecurityMarker
 class AuthorizationEndpointDsl {
     var baseUri: String? = null
     var authorizationRequestResolver: OAuth2AuthorizationRequestResolver? = null
     var authorizationRequestRepository: AuthorizationRequestRepository<OAuth2AuthorizationRequest>? = null
+    var authorizationRedirectStrategy: RedirectStrategy? = null
 
     internal fun get(): (OAuth2LoginConfigurer<HttpSecurity>.AuthorizationEndpointConfig) -> Unit {
         return { authorizationEndpoint ->
             baseUri?.also { authorizationEndpoint.baseUri(baseUri) }
             authorizationRequestResolver?.also { authorizationEndpoint.authorizationRequestResolver(authorizationRequestResolver) }
             authorizationRequestRepository?.also { authorizationEndpoint.authorizationRequestRepository(authorizationRequestRepository) }
+            authorizationRedirectStrategy?.also { authorizationEndpoint.authorizationRedirectStrategy(authorizationRedirectStrategy) }
         }
     }
 }

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerOAuth2ClientDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerOAuth2ClientDsl.kt
@@ -22,6 +22,7 @@ import org.springframework.security.oauth2.client.registration.ReactiveClientReg
 import org.springframework.security.oauth2.client.web.server.ServerAuthorizationRequestRepository
 import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizedClientRepository
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
+import org.springframework.security.web.server.ServerRedirectStrategy
 import org.springframework.security.web.server.authentication.ServerAuthenticationConverter
 import org.springframework.web.server.ServerWebExchange
 
@@ -37,6 +38,7 @@ import org.springframework.web.server.ServerWebExchange
  * @property clientRegistrationRepository the repository of client registrations.
  * @property authorizedClientRepository the repository for authorized client(s).
  * @property authorizationRequestRepository the repository to use for storing [OAuth2AuthorizationRequest]s.
+ * @property authorizationRedirectStrategy the redirect strategy for Authorization Endpoint redirect URI.
  */
 @ServerSecurityMarker
 class ServerOAuth2ClientDsl {
@@ -45,6 +47,7 @@ class ServerOAuth2ClientDsl {
     var clientRegistrationRepository: ReactiveClientRegistrationRepository? = null
     var authorizedClientRepository: ServerOAuth2AuthorizedClientRepository? = null
     var authorizationRequestRepository: ServerAuthorizationRequestRepository<OAuth2AuthorizationRequest>? = null
+    var authorizationRedirectStrategy: ServerRedirectStrategy? = null
 
     internal fun get(): (ServerHttpSecurity.OAuth2ClientSpec) -> Unit {
         return { oauth2Client ->
@@ -53,6 +56,7 @@ class ServerOAuth2ClientDsl {
             clientRegistrationRepository?.also { oauth2Client.clientRegistrationRepository(clientRegistrationRepository) }
             authorizedClientRepository?.also { oauth2Client.authorizedClientRepository(authorizedClientRepository) }
             authorizationRequestRepository?.also { oauth2Client.authorizationRequestRepository(authorizationRequestRepository) }
+            authorizationRedirectStrategy?.also { oauth2Client.authorizationRedirectStrategy(authorizationRedirectStrategy) }
         }
     }
 }

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerOAuth2LoginDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerOAuth2LoginDsl.kt
@@ -24,6 +24,7 @@ import org.springframework.security.oauth2.client.web.server.ServerAuthorization
 import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizationRequestResolver
 import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizedClientRepository
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
+import org.springframework.security.web.server.ServerRedirectStrategy
 import org.springframework.security.web.server.authentication.ServerAuthenticationConverter
 import org.springframework.security.web.server.authentication.ServerAuthenticationFailureHandler
 import org.springframework.security.web.server.authentication.ServerAuthenticationSuccessHandler
@@ -49,6 +50,7 @@ import org.springframework.web.server.ServerWebExchange
  * @property authorizedClientRepository the repository for authorized client(s).
  * @property authorizationRequestRepository the repository to use for storing [OAuth2AuthorizationRequest]s.
  * @property authorizationRequestResolver the resolver used for resolving [OAuth2AuthorizationRequest]s.
+ * @property authorizationRedirectStrategy the redirect strategy for Authorization Endpoint redirect URI.
  * @property authenticationMatcher the [ServerWebExchangeMatcher] used for determining if the request is an
  * authentication request.
  */
@@ -64,6 +66,7 @@ class ServerOAuth2LoginDsl {
     var authorizedClientRepository: ServerOAuth2AuthorizedClientRepository? = null
     var authorizationRequestRepository: ServerAuthorizationRequestRepository<OAuth2AuthorizationRequest>? = null
     var authorizationRequestResolver: ServerOAuth2AuthorizationRequestResolver? = null
+    var authorizationRedirectStrategy: ServerRedirectStrategy? = null
     var authenticationMatcher: ServerWebExchangeMatcher? = null
 
     internal fun get(): (ServerHttpSecurity.OAuth2LoginSpec) -> Unit {
@@ -78,6 +81,7 @@ class ServerOAuth2LoginDsl {
             authorizedClientRepository?.also { oauth2Login.authorizedClientRepository(authorizedClientRepository) }
             authorizationRequestRepository?.also { oauth2Login.authorizationRequestRepository(authorizationRequestRepository) }
             authorizationRequestResolver?.also { oauth2Login.authorizationRequestResolver(authorizationRequestResolver) }
+            authorizationRedirectStrategy?.also { oauth2Login.authorizationRedirectStrategy(authorizationRedirectStrategy) }
             authenticationMatcher?.also { oauth2Login.authenticationMatcher(authenticationMatcher) }
         }
     }

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.0.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.0.rnc
@@ -496,6 +496,9 @@ oauth2-login.attlist &=
 	## Reference to the OAuth2AuthorizationRequestResolver
 	attribute authorization-request-resolver-ref {xsd:token}?
 oauth2-login.attlist &=
+	## Reference to the authorization RedirectStrategy
+	attribute authorization-redirect-strategy-ref {xsd:token}?
+oauth2-login.attlist &=
 	## Reference to the OAuth2AccessTokenResponseClient
 	attribute access-token-response-client-ref {xsd:token}?
 oauth2-login.attlist &=
@@ -542,6 +545,9 @@ authorization-code-grant =
 authorization-code-grant.attlist &=
 	## Reference to the AuthorizationRequestRepository
 	attribute authorization-request-repository-ref {xsd:token}?
+authorization-code-grant.attlist &=
+    ## Reference to the authorization RedirectStrategy
+	attribute authorization-redirect-strategy-ref {xsd:token}?
 authorization-code-grant.attlist &=
 	## Reference to the OAuth2AuthorizationRequestResolver
 	attribute authorization-request-resolver-ref {xsd:token}?

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.0.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.0.xsd
@@ -1603,6 +1603,12 @@
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="authorization-redirect-strategy-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to the authorization RedirectStrategy
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
       <xs:attribute name="access-token-response-client-ref" type="xs:token">
          <xs:annotation>
             <xs:documentation>Reference to the OAuth2AccessTokenResponseClient
@@ -1703,6 +1709,12 @@
       <xs:attribute name="authorization-request-repository-ref" type="xs:token">
          <xs:annotation>
             <xs:documentation>Reference to the AuthorizationRequestRepository
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="authorization-redirect-strategy-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to the authorization RedirectStrategy
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2ClientConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2ClientConfigurerTests.java
@@ -58,6 +58,8 @@ import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.web.DefaultRedirectStrategy;
+import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.savedrequest.RequestCache;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -68,6 +70,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -94,6 +97,8 @@ public class OAuth2ClientConfigurerTests {
 	private static OAuth2AuthorizedClientRepository authorizedClientRepository;
 
 	private static OAuth2AuthorizationRequestResolver authorizationRequestResolver;
+
+	private static RedirectStrategy authorizationRedirectStrategy;
 
 	private static OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> accessTokenResponseClient;
 
@@ -130,6 +135,7 @@ public class OAuth2ClientConfigurerTests {
 				authorizedClientService);
 		authorizationRequestResolver = new DefaultOAuth2AuthorizationRequestResolver(clientRegistrationRepository,
 				"/oauth2/authorization");
+		authorizationRedirectStrategy = new DefaultRedirectStrategy();
 		OAuth2AccessTokenResponse accessTokenResponse = OAuth2AccessTokenResponse.withToken("access-token-1234")
 				.tokenType(OAuth2AccessToken.TokenType.BEARER).expiresIn(300).build();
 		accessTokenResponseClient = mock(OAuth2AccessTokenResponseClient.class);
@@ -261,6 +267,19 @@ public class OAuth2ClientConfigurerTests {
 		verify(authorizationRequestResolver).resolve(any());
 	}
 
+	@Test
+	public void configureWhenCustomAuthorizationRedirectStrategySetThenAuthorizationRedirectStrategyUsed()
+			throws Exception {
+		authorizationRedirectStrategy = mock(RedirectStrategy.class);
+		this.spring.register(OAuth2ClientConfig.class).autowire();
+		// @formatter:off
+		this.mockMvc.perform(get("/oauth2/authorization/registration-1"))
+				.andExpect(status().isOk())
+				.andReturn();
+		// @formatter:on
+		verify(authorizationRedirectStrategy).sendRedirect(any(), any(), anyString());
+	}
+
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class OAuth2ClientConfig extends WebSecurityConfigurerAdapter {
@@ -278,6 +297,7 @@ public class OAuth2ClientConfigurerTests {
 				.oauth2Client()
 					.authorizationCodeGrant()
 						.authorizationRequestResolver(authorizationRequestResolver)
+						.authorizationRedirectStrategy(authorizationRedirectStrategy)
 						.accessTokenResponseClient(accessTokenResponseClient);
 			// @formatter:on
 		}

--- a/config/src/test/java/org/springframework/security/config/http/OAuth2ClientBeanDefinitionParserTests.java
+++ b/config/src/test/java/org/springframework/security/config/http/OAuth2ClientBeanDefinitionParserTests.java
@@ -44,6 +44,7 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.core.endpoint.TestOAuth2AccessTokenResponses;
 import org.springframework.security.test.context.annotation.SecurityTestExecutionListeners;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.RedirectStrategy;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -55,6 +56,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -89,6 +91,9 @@ public class OAuth2ClientBeanDefinitionParserTests {
 
 	@Autowired(required = false)
 	private OAuth2AuthorizationRequestResolver authorizationRequestResolver;
+
+	@Autowired(required = false)
+	private RedirectStrategy authorizationRedirectStrategy;
 
 	@Autowired(required = false)
 	private OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> accessTokenResponseClient;
@@ -146,6 +151,16 @@ public class OAuth2ClientBeanDefinitionParserTests {
 						+ "scope=scope1%20scope2&state=state&redirect_uri=http://localhost/callback/google"));
 		// @formatter:on
 		verify(this.authorizationRequestResolver).resolve(any());
+	}
+
+	@Test
+	public void requestWhenCustomAuthorizationRedirectStrategyThenCalled() throws Exception {
+		this.spring.configLocations(xml("CustomAuthorizationRedirectStrategy")).autowire();
+		// @formatter:off
+		this.mvc.perform(get("/oauth2/authorization/google"))
+				.andExpect(status().isOk());
+		// @formatter:on
+		verify(this.authorizationRedirectStrategy).sendRedirect(any(), any(), anyString());
 	}
 
 	@Test

--- a/config/src/test/java/org/springframework/security/config/http/OAuth2LoginBeanDefinitionParserTests.java
+++ b/config/src/test/java/org/springframework/security/config/http/OAuth2LoginBeanDefinitionParserTests.java
@@ -63,6 +63,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
 import org.springframework.security.oauth2.jwt.TestJwts;
 import org.springframework.security.test.context.annotation.SecurityTestExecutionListeners;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.savedrequest.RequestCache;
@@ -77,6 +78,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -115,6 +117,9 @@ public class OAuth2LoginBeanDefinitionParserTests {
 
 	@Autowired(required = false)
 	private OAuth2AuthorizationRequestResolver authorizationRequestResolver;
+
+	@Autowired(required = false)
+	private RedirectStrategy authorizationRedirectStrategy;
 
 	@Autowired(required = false)
 	private OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> accessTokenResponseClient;
@@ -371,6 +376,17 @@ public class OAuth2LoginBeanDefinitionParserTests {
 				.andExpect(status().is3xxRedirection());
 		// @formatter:on
 		verify(this.authorizationRequestResolver).resolve(any());
+	}
+
+	@Test
+	public void requestWhenCustomAuthorizationRedirectStrategyThenCalled() throws Exception {
+		this.spring.configLocations(this.xml("SingleClientRegistration-WithCustomAuthorizationRedirectStrategy"))
+				.autowire();
+		// @formatter:off
+		this.mvc.perform(get("/oauth2/authorization/google-login"))
+				.andExpect(status().isOk());
+		// @formatter:on
+		verify(this.authorizationRedirectStrategy).sendRedirect(any(), any(), anyString());
 	}
 
 	// gh-5347

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/client/AuthorizationCodeGrantDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/client/AuthorizationCodeGrantDslTests.kt
@@ -43,6 +43,8 @@ import org.springframework.security.oauth2.core.OAuth2AccessToken
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames
+import org.springframework.security.web.DefaultRedirectStrategy
+import org.springframework.security.web.RedirectStrategy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
@@ -94,6 +96,40 @@ class AuthorizationCodeGrantDslTests {
                 oauth2Client {
                     authorizationCodeGrant {
                         authorizationRequestRepository = REQUEST_REPOSITORY
+                    }
+                }
+                authorizeRequests {
+                    authorize(anyRequest, authenticated)
+                }
+            }
+            return http.build()
+        }
+    }
+
+    @Test
+    fun `oauth2Client when custom authorization redirect strategy then redirect strategy used`() {
+        this.spring.register(RedirectStrategyConfig::class.java, ClientConfig::class.java).autowire()
+        mockkObject(RedirectStrategyConfig.REDIRECT_STRATEGY)
+        every { RedirectStrategyConfig.REDIRECT_STRATEGY.sendRedirect(any(), any(), any()) }
+
+        this.mockMvc.get("/oauth2/authorization/registrationId")
+
+        verify(exactly = 1) { RedirectStrategyConfig.REDIRECT_STRATEGY.sendRedirect(any(), any(), any()) }
+    }
+
+    @EnableWebSecurity
+    open class RedirectStrategyConfig {
+
+        companion object {
+            val REDIRECT_STRATEGY: RedirectStrategy = DefaultRedirectStrategy()
+        }
+
+        @Bean
+        open fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+            http {
+                oauth2Client {
+                    authorizationCodeGrant {
+                        authorizationRedirectStrategy = REDIRECT_STRATEGY
                     }
                 }
                 authorizeRequests {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerOAuth2ClientDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerOAuth2ClientDslTests.kt
@@ -39,7 +39,9 @@ import org.springframework.security.oauth2.client.web.server.WebSessionOAuth2Ser
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames
 import org.springframework.security.oauth2.server.resource.web.server.ServerBearerTokenAuthenticationConverter
+import org.springframework.security.web.server.DefaultServerRedirectStrategy
 import org.springframework.security.web.server.SecurityWebFilterChain
+import org.springframework.security.web.server.ServerRedirectStrategy
 import org.springframework.security.web.server.authentication.ServerAuthenticationConverter
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.web.reactive.config.EnableWebFlux
@@ -125,6 +127,41 @@ class ServerOAuth2ClientDslTests {
             return http {
                 oauth2Client {
                     authorizationRequestRepository = AUTHORIZATION_REQUEST_REPOSITORY
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `OAuth2 client when authorization redirect strategy configured then custom redirect strategy used`() {
+        this.spring.register(AuthorizationRedirectStrategyConfig::class.java, ClientConfig::class.java).autowire()
+        mockkObject(AuthorizationRedirectStrategyConfig.AUTHORIZATION_REDIRECT_STRATEGY)
+        every {
+            AuthorizationRedirectStrategyConfig.AUTHORIZATION_REDIRECT_STRATEGY.sendRedirect(any(), any())
+        } returns Mono.empty()
+
+        this.client.get()
+            .uri("/oauth2/authorization/google")
+            .exchange()
+
+        verify(exactly = 1) {
+            AuthorizationRedirectStrategyConfig.AUTHORIZATION_REDIRECT_STRATEGY.sendRedirect(any(), any())
+        }
+    }
+
+    @EnableWebFluxSecurity
+    @EnableWebFlux
+    open class AuthorizationRedirectStrategyConfig {
+
+        companion object {
+            val AUTHORIZATION_REDIRECT_STRATEGY : ServerRedirectStrategy = DefaultServerRedirectStrategy()
+        }
+
+        @Bean
+        open fun springWebFilterChain(http: ServerHttpSecurity): SecurityWebFilterChain {
+            return http {
+                oauth2Client {
+                    authorizationRedirectStrategy = AUTHORIZATION_REDIRECT_STRATEGY
                 }
             }
         }

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerOAuth2LoginDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerOAuth2LoginDslTests.kt
@@ -35,7 +35,9 @@ import org.springframework.security.oauth2.client.web.server.ServerAuthorization
 import org.springframework.security.oauth2.client.web.server.WebSessionOAuth2ServerAuthorizationRequestRepository
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
 import org.springframework.security.oauth2.server.resource.web.server.ServerBearerTokenAuthenticationConverter
+import org.springframework.security.web.server.DefaultServerRedirectStrategy
 import org.springframework.security.web.server.SecurityWebFilterChain
+import org.springframework.security.web.server.ServerRedirectStrategy
 import org.springframework.security.web.server.authentication.ServerAuthenticationConverter
 import org.springframework.security.web.server.util.matcher.IpAddressServerWebExchangeMatcher
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher
@@ -136,6 +138,38 @@ class ServerOAuth2LoginDslTests {
             return http {
                 oauth2Login {
                     authorizationRequestRepository = AUTHORIZATION_REQUEST_REPOSITORY
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `OAuth2 login when authorization redirect strategy configured then custom redirect strategy used`() {
+        this.spring.register(AuthorizationRedirectStrategyConfig::class.java, ClientConfig::class.java).autowire()
+        mockkObject(AuthorizationRedirectStrategyConfig.AUTHORIZATION_REDIRECT_STRATEGY)
+        every {
+            AuthorizationRedirectStrategyConfig.AUTHORIZATION_REDIRECT_STRATEGY.sendRedirect(any(), any())
+        } returns Mono.empty()
+        this.client.get()
+            .uri("/oauth2/authorization/google")
+            .exchange()
+
+        verify(exactly = 1) { AuthorizationRedirectStrategyConfig.AUTHORIZATION_REDIRECT_STRATEGY.sendRedirect(any(), any()) }
+    }
+
+    @EnableWebFluxSecurity
+    @EnableWebFlux
+    open class AuthorizationRedirectStrategyConfig {
+
+        companion object {
+            val AUTHORIZATION_REDIRECT_STRATEGY : ServerRedirectStrategy = DefaultServerRedirectStrategy()
+        }
+
+        @Bean
+        open fun springWebFilterChain(http: ServerHttpSecurity): SecurityWebFilterChain {
+            return http {
+                oauth2Login {
+                    authorizationRedirectStrategy = AUTHORIZATION_REDIRECT_STRATEGY
                 }
             }
         }

--- a/config/src/test/resources/org/springframework/security/config/http/OAuth2ClientBeanDefinitionParserTests-CustomAuthorizationRedirectStrategy.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/OAuth2ClientBeanDefinitionParserTests-CustomAuthorizationRedirectStrategy.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2002-2022 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<b:beans xmlns:b="http://www.springframework.org/schema/beans"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xmlns="http://www.springframework.org/schema/security"
+		xsi:schemaLocation="
+			http://www.springframework.org/schema/security
+			https://www.springframework.org/schema/security/spring-security.xsd
+			http://www.springframework.org/schema/beans
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<http auto-config="true">
+		<oauth2-client>
+			<authorization-code-grant
+					authorization-redirect-strategy-ref="authorizationRedirectStrategy"/>
+		</oauth2-client>
+	</http>
+
+	<b:bean id="authorizationRedirectStrategy" class="org.mockito.Mockito" factory-method="mock">
+		<b:constructor-arg value="org.springframework.security.web.RedirectStrategy"/>
+	</b:bean>
+
+	<client-registrations>
+		<client-registration registration-id="google"
+							 client-id="google-client-id"
+							 client-secret="google-client-secret"
+							 redirect-uri="http://localhost/callback/google"
+							 scope="scope1,scope2"
+							 provider-id="google"/>
+	</client-registrations>
+
+	<b:import resource="userservice.xml"/>
+</b:beans>

--- a/config/src/test/resources/org/springframework/security/config/http/OAuth2LoginBeanDefinitionParserTests-SingleClientRegistration-WithCustomAuthorizationRedirectStrategy.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/OAuth2LoginBeanDefinitionParserTests-SingleClientRegistration-WithCustomAuthorizationRedirectStrategy.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2002-2022 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<b:beans xmlns:b="http://www.springframework.org/schema/beans"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xmlns="http://www.springframework.org/schema/security"
+		xsi:schemaLocation="
+			http://www.springframework.org/schema/security
+			https://www.springframework.org/schema/security/spring-security.xsd
+			http://www.springframework.org/schema/beans
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<http auto-config="true">
+		<intercept-url pattern="/**" access="authenticated"/>
+		<oauth2-login authorization-redirect-strategy-ref="authorizationRedirectStrategy"/>
+	</http>
+
+	<b:bean id="authorizationRedirectStrategy" class="org.mockito.Mockito" factory-method="mock">
+			<b:constructor-arg value="org.springframework.security.web.RedirectStrategy"/>
+	</b:bean>
+
+	<b:import resource="../oauth2/client/google-registration.xml"/>
+	<b:import resource="userservice.xml"/>
+</b:beans>

--- a/docs/modules/ROOT/pages/servlet/appendix/namespace/http.adoc
+++ b/docs/modules/ROOT/pages/servlet/appendix/namespace/http.adoc
@@ -983,6 +983,11 @@ Reference to the `AuthorizationRequestRepository`.
 Reference to the `OAuth2AuthorizationRequestResolver`.
 
 
+[[nsa-oauth2-login-authorization-redirect-strategy-ref]]
+* **authorization-redirect-strategy-ref**
+Reference to the authorization `RedirectStrategy`.
+
+
 [[nsa-oauth2-login-access-token-response-client-ref]]
 * **access-token-response-client-ref**
 Reference to the `OAuth2AccessTokenResponseClient`.
@@ -1081,6 +1086,11 @@ Configures xref:servlet/oauth2/client/authorization-grants.adoc#oauth2Client-aut
 [[nsa-authorization-code-grant-authorization-request-repository-ref]]
 * **authorization-request-repository-ref**
 Reference to the `AuthorizationRequestRepository`.
+
+
+[[nsa-authorization-code-grant-authorization-redirect-strategy-ref]]
+* **authorization-redirect-strategy-ref**
+Reference to the authorization `RedirectStrategy`.
 
 
 [[nsa-authorization-code-grant-authorization-request-resolver-ref]]

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/OAuth2AuthorizationRequestRedirectFilter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/OAuth2AuthorizationRequestRedirectFilter.java
@@ -95,7 +95,7 @@ public class OAuth2AuthorizationRequestRedirectFilter extends OncePerRequestFilt
 
 	private final ThrowableAnalyzer throwableAnalyzer = new DefaultThrowableAnalyzer();
 
-	private final RedirectStrategy authorizationRedirectStrategy = new DefaultRedirectStrategy();
+	private RedirectStrategy authorizationRedirectStrategy = new DefaultRedirectStrategy();
 
 	private OAuth2AuthorizationRequestResolver authorizationRequestResolver;
 
@@ -137,6 +137,15 @@ public class OAuth2AuthorizationRequestRedirectFilter extends OncePerRequestFilt
 	public OAuth2AuthorizationRequestRedirectFilter(OAuth2AuthorizationRequestResolver authorizationRequestResolver) {
 		Assert.notNull(authorizationRequestResolver, "authorizationRequestResolver cannot be null");
 		this.authorizationRequestResolver = authorizationRequestResolver;
+	}
+
+	/**
+	 * Sets the redirect strategy for Authorization Endpoint redirect URI.
+	 * @param authorizationRedirectStrategy the redirect strategy
+	 */
+	public void setAuthorizationRedirectStrategy(RedirectStrategy authorizationRedirectStrategy) {
+		Assert.notNull(authorizationRedirectStrategy, "authorizationRedirectStrategy cannot be null");
+		this.authorizationRedirectStrategy = authorizationRedirectStrategy;
 	}
 
 	/**

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/server/OAuth2AuthorizationRequestRedirectWebFilter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/server/OAuth2AuthorizationRequestRedirectWebFilter.java
@@ -75,7 +75,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  */
 public class OAuth2AuthorizationRequestRedirectWebFilter implements WebFilter {
 
-	private final ServerRedirectStrategy authorizationRedirectStrategy = new DefaultServerRedirectStrategy();
+	private ServerRedirectStrategy authorizationRedirectStrategy = new DefaultServerRedirectStrategy();
 
 	private final ServerOAuth2AuthorizationRequestResolver authorizationRequestResolver;
 
@@ -103,6 +103,15 @@ public class OAuth2AuthorizationRequestRedirectWebFilter implements WebFilter {
 			ServerOAuth2AuthorizationRequestResolver authorizationRequestResolver) {
 		Assert.notNull(authorizationRequestResolver, "authorizationRequestResolver cannot be null");
 		this.authorizationRequestResolver = authorizationRequestResolver;
+	}
+
+	/**
+	 * Sets the redirect strategy for Authorization Endpoint redirect URI.
+	 * @param authorizationRedirectStrategy the redirect strategy
+	 */
+	public void setAuthorizationRedirectStrategy(ServerRedirectStrategy authorizationRedirectStrategy) {
+		Assert.notNull(authorizationRedirectStrategy, "authorizationRedirectStrategy cannot be null");
+		this.authorizationRedirectStrategy = authorizationRedirectStrategy;
 	}
 
 	/**

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/OAuth2AuthorizationRequestRedirectFilterTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/OAuth2AuthorizationRequestRedirectFilterTests.java
@@ -17,6 +17,7 @@
 package org.springframework.security.oauth2.client.web;
 
 import java.lang.reflect.Constructor;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,7 +30,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.oauth2.client.ClientAuthorizationRequiredException;
@@ -39,6 +42,7 @@ import org.springframework.security.oauth2.client.registration.InMemoryClientReg
 import org.springframework.security.oauth2.client.registration.TestClientRegistrations;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.savedrequest.RequestCache;
 import org.springframework.util.ClassUtils;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -113,6 +117,11 @@ public class OAuth2AuthorizationRequestRedirectFilterTests {
 	@Test
 	public void setAuthorizationRequestRepositoryWhenAuthorizationRequestRepositoryIsNullThenThrowIllegalArgumentException() {
 		assertThatIllegalArgumentException().isThrownBy(() -> this.filter.setAuthorizationRequestRepository(null));
+	}
+
+	@Test
+	public void setAuthorizationRedirectStrategyWhenAuthorizationRedirectStrategyIsNullThenThrowIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.filter.setAuthorizationRedirectStrategy(null));
 	}
 
 	@Test
@@ -330,6 +339,33 @@ public class OAuth2AuthorizationRequestRedirectFilterTests {
 				+ "response_type=code&client_id=client-id&" + "scope=read:user&state=.{15,}&"
 				+ "redirect_uri=http://localhost/login/oauth2/code/registration-id&"
 				+ "login_hint=user@provider\\.com");
+	}
+
+	@Test
+	public void doFilterWhenCustomAuthorizationRedirectStrategySetThenCustomAuthorizationRedirectStrategyUsed()
+			throws Exception {
+		String requestUri = OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI + "/"
+				+ this.registration1.getRegistrationId();
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", requestUri);
+		request.setServletPath(requestUri);
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+		RedirectStrategy customRedirectStrategy = (httpRequest, httpResponse, url) -> {
+			String redirectUrl = httpResponse.encodeRedirectURL(url);
+			httpResponse.setStatus(HttpStatus.OK.value());
+			httpResponse.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN_VALUE);
+			httpResponse.getWriter().write(redirectUrl);
+			httpResponse.getWriter().flush();
+		};
+		this.filter.setAuthorizationRedirectStrategy(customRedirectStrategy);
+		this.filter.doFilter(request, response, filterChain);
+		verifyZeroInteractions(filterChain);
+		assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+		assertThat(response.getContentType()).isEqualTo(MediaType.TEXT_PLAIN_VALUE);
+		assertThat(response.getContentAsString(StandardCharsets.UTF_8))
+				.matches("https://example.com/login/oauth/authorize\\?" + "response_type=code&client_id=client-id&"
+						+ "scope=read:user&state=.{15,}&"
+						+ "redirect_uri=http://localhost/login/oauth2/code/registration-id");
 	}
 
 }

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/server/OAuth2AuthorizationRequestRedirectWebFilterTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/server/OAuth2AuthorizationRequestRedirectWebFilterTests.java
@@ -17,6 +17,7 @@
 package org.springframework.security.oauth2.client.web.server;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -24,13 +25,20 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.security.oauth2.client.ClientAuthorizationRequiredException;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.TestClientRegistrations;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.web.server.ServerRedirectStrategy;
 import org.springframework.security.web.server.savedrequest.ServerRequestCache;
 import org.springframework.test.web.reactive.server.FluxExchangeResult;
 import org.springframework.test.web.reactive.server.WebTestClient;
@@ -79,6 +87,11 @@ public class OAuth2AuthorizationRequestRedirectWebFilterTests {
 		this.clientRepository = null;
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> new OAuth2AuthorizationRequestRedirectWebFilter(this.clientRepository));
+	}
+
+	@Test
+	public void setterWhenAuthorizationRedirectStrategyNullThenIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.filter.setAuthorizationRedirectStrategy(null));
 	}
 
 	@Test
@@ -192,6 +205,48 @@ public class OAuth2AuthorizationRequestRedirectWebFilterTests {
 				.expectStatus().is3xxRedirection()
 				.returnResult(String.class);
 		// @formatter:on
+		verifyNoInteractions(this.requestCache);
+	}
+
+	@Test
+	public void filterWhenCustomRedirectStrategySetThenRedirectUriInResponseBody() {
+		given(this.clientRepository.findByRegistrationId(this.registration.getRegistrationId()))
+				.willReturn(Mono.just(this.registration));
+		given(this.authzRequestRepository.saveAuthorizationRequest(any(), any())).willReturn(Mono.empty());
+		ServerRedirectStrategy customRedirectStrategy = (exchange, location) -> {
+			ServerHttpResponse response = exchange.getResponse();
+			response.setStatusCode(HttpStatus.OK);
+			response.getHeaders().setContentType(MediaType.TEXT_PLAIN);
+			DataBuffer buffer = exchange.getResponse().bufferFactory()
+					.wrap(location.toASCIIString().getBytes(StandardCharsets.UTF_8));
+
+			return exchange.getResponse().writeWith(Flux.just(buffer));
+		};
+		this.filter.setAuthorizationRedirectStrategy(customRedirectStrategy);
+		this.filter.setRequestCache(this.requestCache);
+
+		FluxExchangeResult<String> result = this.client.get()
+				.uri("https://example.com/oauth2/authorization/registration-id").exchange().expectHeader()
+				.contentType(MediaType.TEXT_PLAIN).expectStatus().isOk().returnResult(String.class);
+
+		// @formatter:off
+		StepVerifier.create(result.getResponseBody())
+				.assertNext((uri) -> {
+					URI location = URI.create(uri);
+
+					assertThat(location)
+							.hasScheme("https")
+							.hasHost("example.com")
+							.hasPath("/login/oauth/authorize")
+							.hasParameter("response_type", "code")
+							.hasParameter("client_id", "client-id")
+							.hasParameter("scope", "read:user")
+							.hasParameter("state")
+							.hasParameter("redirect_uri", "https://example.com/login/oauth2/code/registration-id");
+				})
+				.verifyComplete();
+		// @formatter:on
+
 		verifyNoInteractions(this.requestCache);
 	}
 


### PR DESCRIPTION
The default redirect strategy will provide authorization redirect
URI within HTTP 302 response Location header.
Allowing the configuration of custom redirect strategy will provide
an option for the clients to obtain the authorization URI from e.g.
HTTP response body as JSON payload, without a need to handle
automatic redirection initiated by the HTTP Location header.

Closes gh-11373

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
