### PR TITLE
Set the useTrailingSlashMatch to true for tests

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/builders/WebSecurityTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/builders/WebSecurityTests.java
@@ -232,6 +232,7 @@ public class WebSecurityTests {
 		@Override
 		public void configurePathMatch(PathMatchConfigurer configurer) {
 			configurer.setUseSuffixPatternMatch(true);
+			configurer.setUseTrailingSlashMatch(true);
 		}
 
 	}

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/AuthorizeRequestsTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/AuthorizeRequestsTests.java
@@ -662,6 +662,7 @@ public class AuthorizeRequestsTests {
 		@Override
 		public void configurePathMatch(PathMatchConfigurer configurer) {
 			configurer.setUseSuffixPatternMatch(true);
+			configurer.setUseTrailingSlashMatch(true);
 		}
 
 	}

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/HttpSecurityRequestMatchersTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/HttpSecurityRequestMatchersTests.java
@@ -491,6 +491,7 @@ public class HttpSecurityRequestMatchersTests {
 		@Override
 		public void configurePathMatch(PathMatchConfigurer configurer) {
 			configurer.setUseSuffixPatternMatch(true);
+			configurer.setUseTrailingSlashMatch(true);
 		}
 
 	}

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/UrlAuthorizationConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/UrlAuthorizationConfigurerTests.java
@@ -262,6 +262,7 @@ public class UrlAuthorizationConfigurerTests {
 		@Override
 		public void configurePathMatch(PathMatchConfigurer configurer) {
 			configurer.setUseSuffixPatternMatch(true);
+			configurer.setUseTrailingSlashMatch(true);
 		}
 
 	}

--- a/config/src/test/java/org/springframework/security/htmlunit/server/WebTestClientHtmlUnitDriverBuilderTests.java
+++ b/config/src/test/java/org/springframework/security/htmlunit/server/WebTestClientHtmlUnitDriverBuilderTests.java
@@ -74,7 +74,7 @@ public class WebTestClientHtmlUnitDriverBuilderTests {
 	class HelloWorldController {
 
 		@ResponseBody
-		@GetMapping(produces = MediaType.TEXT_HTML_VALUE)
+		@GetMapping(path = "/", produces = MediaType.TEXT_HTML_VALUE)
 		String index() {
 			// @formatter:off
 			return "<html>\n"

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/AuthorizeHttpRequestsDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/AuthorizeHttpRequestsDslTests.kt
@@ -188,6 +188,7 @@ class AuthorizeHttpRequestsDslTests {
     open class LegacyMvcMatchingConfig : WebMvcConfigurer {
         override fun configurePathMatch(configurer: PathMatchConfigurer) {
             configurer.setUseSuffixPatternMatch(true)
+            configurer.setUseTrailingSlashMatch(true)
         }
     }
 

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/AuthorizeRequestsDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/AuthorizeRequestsDslTests.kt
@@ -178,6 +178,7 @@ class AuthorizeRequestsDslTests {
     open class LegacyMvcMatchingConfig : WebMvcConfigurer {
         override fun configurePathMatch(configurer: PathMatchConfigurer) {
             configurer.setUseSuffixPatternMatch(true)
+            configurer.setUseTrailingSlashMatch(true)
         }
     }
 

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerJwtDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerJwtDslTests.kt
@@ -278,7 +278,7 @@ class ServerJwtDslTests {
 
     @RestController
     internal class BaseController {
-        @GetMapping
+        @GetMapping("/")
         fun index() {
         }
     }

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-MvcMatchers.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-MvcMatchers.xml
@@ -33,7 +33,7 @@
 	</http>
 
 	<mvc:annotation-driven>
-		<mvc:path-matching suffix-pattern="true"/>
+		<mvc:path-matching suffix-pattern="true" trailing-slash="true"/>
 	</mvc:annotation-driven>
 
 	<b:bean name="path" class="org.springframework.security.config.http.InterceptUrlConfigTests.PathController"/>

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-MvcMatchersServletPath.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-MvcMatchersServletPath.xml
@@ -33,7 +33,7 @@
 	</http>
 
 	<mvc:annotation-driven>
-		<mvc:path-matching suffix-pattern="true"/>
+		<mvc:path-matching suffix-pattern="true" trailing-slash="true"/>
 	</mvc:annotation-driven>
 
 	<b:bean name="path" class="org.springframework.security.config.http.InterceptUrlConfigTests.PathController"/>

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsAuthenticationStatelessTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsAuthenticationStatelessTests.java
@@ -95,7 +95,7 @@ public class SecurityMockMvcRequestPostProcessorsAuthenticationStatelessTests {
 		@RestController
 		static class Controller {
 
-			@RequestMapping
+			@RequestMapping("/")
 			String hello() {
 				return "Hello";
 			}

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsTestSecurityContextStatelessTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsTestSecurityContextStatelessTests.java
@@ -89,7 +89,7 @@ public class SecurityMockMvcRequestPostProcessorsTestSecurityContextStatelessTes
 		@RestController
 		static class Controller {
 
-			@RequestMapping
+			@RequestMapping("/")
 			String hello() {
 				return "Hello";
 			}


### PR DESCRIPTION
The Spring MVC changed the default behavior for trailing slash match
with https://github.com/spring-projects/spring-framework/issues/28552.
This causes failures in Spring Security's tests.

Setting the `useTrailingSlashMatch` to `true` ensures that Spring
Security will work for users who have modified the default configuration.
Specifing the request mapper with trailing slash path ensures that the tests
are successful when default behavior is used.

Closes gh-11451

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
