### PR TITLE
Remove deprecation warnings with Context.putAll

### DIFF
--- a/test/src/main/java/org/springframework/security/test/context/support/ReactorContextTestExecutionListener.java
+++ b/test/src/main/java/org/springframework/security/test/context/support/ReactorContextTestExecutionListener.java
@@ -22,6 +22,7 @@ import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Operators;
 import reactor.util.context.Context;
+import reactor.util.context.ContextView;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
@@ -107,7 +108,7 @@ public class ReactorContextTestExecutionListener extends DelegatingTestExecution
 					return context;
 				}
 				Context toMerge = ReactiveSecurityContextHolder.withSecurityContext(Mono.just(this.securityContext));
-				return toMerge.putAll(context);
+				return toMerge.putAll(context.readOnly());
 			}
 
 			@Override

--- a/web/src/main/java/org/springframework/security/web/server/context/ReactorContextWebFilter.java
+++ b/web/src/main/java/org/springframework/security/web/server/context/ReactorContextWebFilter.java
@@ -49,8 +49,8 @@ public class ReactorContextWebFilter implements WebFilter {
 	}
 
 	private Context withSecurityContext(Context mainContext, ServerWebExchange exchange) {
-		return mainContext
-				.putAll(this.repository.load(exchange).as(ReactiveSecurityContextHolder::withSecurityContext));
+		return mainContext.putAll(
+				this.repository.load(exchange).as(ReactiveSecurityContextHolder::withSecurityContext).readOnly());
 	}
 
 }


### PR DESCRIPTION
Closes gh-11476

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
