### PR TITLE
Remove default value for access parameter

### DIFF
--- a/config/src/main/kotlin/org/springframework/security/config/annotation/web/AuthorizeRequestsDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/annotation/web/AuthorizeRequestsDsl.kt
@@ -46,7 +46,7 @@ class AuthorizeRequestsDsl : AbstractRequestMatcherDsl() {
      * (i.e. "hasAuthority('ROLE_USER') and hasAuthority('ROLE_SUPER')")
      */
     fun authorize(matches: RequestMatcher = AnyRequestMatcher.INSTANCE,
-                  access: String = "authenticated") {
+                  access: String) {
         authorizationRules.add(MatcherAuthorizationRule(matches, access))
     }
 
@@ -65,7 +65,7 @@ class AuthorizeRequestsDsl : AbstractRequestMatcherDsl() {
      * @param access the SpEL expression to secure the matching request
      * (i.e. "hasAuthority('ROLE_USER') and hasAuthority('ROLE_SUPER')")
      */
-    fun authorize(pattern: String, access: String = "authenticated") {
+    fun authorize(pattern: String, access: String) {
         authorizationRules.add(PatternAuthorizationRule(pattern = pattern,
                                                         patternType = PATTERN_TYPE,
                                                         rule = access))
@@ -87,7 +87,7 @@ class AuthorizeRequestsDsl : AbstractRequestMatcherDsl() {
      * @param access the SpEL expression to secure the matching request
      * (i.e. "hasAuthority('ROLE_USER') and hasAuthority('ROLE_SUPER')")
      */
-    fun authorize(method: HttpMethod, pattern: String, access: String = "authenticated") {
+    fun authorize(method: HttpMethod, pattern: String, access: String) {
         authorizationRules.add(PatternAuthorizationRule(pattern = pattern,
                                                         patternType = PATTERN_TYPE,
                                                         httpMethod = method,
@@ -111,7 +111,7 @@ class AuthorizeRequestsDsl : AbstractRequestMatcherDsl() {
      * @param access the SpEL expression to secure the matching request
      * (i.e. "hasAuthority('ROLE_USER') and hasAuthority('ROLE_SUPER')")
      */
-    fun authorize(pattern: String, servletPath: String, access: String = "authenticated") {
+    fun authorize(pattern: String, servletPath: String, access: String) {
         authorizationRules.add(PatternAuthorizationRule(pattern = pattern,
                                                         patternType = PATTERN_TYPE,
                                                         servletPath = servletPath,
@@ -136,7 +136,7 @@ class AuthorizeRequestsDsl : AbstractRequestMatcherDsl() {
      * @param access the SpEL expression to secure the matching request
      * (i.e. "hasAuthority('ROLE_USER') and hasAuthority('ROLE_SUPER')")
      */
-    fun authorize(method: HttpMethod, pattern: String, servletPath: String, access: String = "authenticated") {
+    fun authorize(method: HttpMethod, pattern: String, servletPath: String, access: String) {
         authorizationRules.add(PatternAuthorizationRule(pattern = pattern,
                                                         patternType = PATTERN_TYPE,
                                                         servletPath = servletPath,


### PR DESCRIPTION
Closes gh-10957

The test below shows the issue with "authenticated" access as a default parameter.
After fix the test is not relevant as the problem is solved at the compilation phase.
This is a breaking change, for example, when a user has `authorize("/path")` instead of `authorize("/path", authenticated)` in config.
```
@Test
fun `request when authorize with servletPath and default access`() {
    this.spring.register(ServletPathAndDefaultAccessConfig::class.java).autowire()

    this.mockMvc.perform(MockMvcRequestBuilders.get("/servletPath/path")
        .with { request ->
            request.servletPath = "/servletPath"
            request
        })
        .andExpect(status().isUnauthorized)

    this.mockMvc.perform(MockMvcRequestBuilders.get("/servletPath/path")
        .with(httpBasic("user", "password"))
        .with { request ->
            request.servletPath = "/servletPath"
            request
        })
        .andExpect(status().isOk)
}

@EnableWebSecurity
@EnableWebMvc
open class ServletPathAndDefaultAccessConfig {
    @Bean
    open fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
        http {
            authorizeRequests {
                // before fix:
                // a user intends to invoke authorize(pattern, servletPath, access ["authenticated" by default]),
                // but in fact get authorize(pattern, access)
                authorize("/path", "/servletPath")

                // after fix:
                // a user must explicitly specify "authenticated" to invoke authorize(pattern, servletPath, access)
                authorize("/path", "/servletPath", authenticated)
            }
            httpBasic { }
        }
        return http.build()
    }

    @RestController
    internal class PathController {
        @GetMapping("/path")
        fun path() {
        }
    }

    @Bean
    open fun userDetailsService(): UserDetailsService {
        val userDetails = User.withDefaultPasswordEncoder()
            .username("user")
            .password("password")
            .roles("USER")
            .build()
        return InMemoryUserDetailsManager(userDetails)
    }
}
```
