### PR TITLE
Add Kotlin example for WebTestClient setup docs

### DIFF
--- a/docs/modules/ROOT/pages/reactive/test/web/setup.adoc
+++ b/docs/modules/ROOT/pages/reactive/test/web/setup.adoc
@@ -2,7 +2,9 @@
 
 The basic setup looks like this:
 
-[source,java]
+====
+.Java
+[source,java,role="primary"]
 ----
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = HelloWebfluxMethodApplication.class)
@@ -19,9 +21,35 @@ public class HelloWebfluxMethodApplicationTests {
 			// add Spring Security test Support
 			.apply(springSecurity())
 			.configureClient()
-			.filter(basicAuthentication())
+			.filter(basicAuthentication("user", "password"))
 			.build();
 	}
 	// ...
 }
 ----
+
+.Kotlin
+[source,kotlin,role="secondary"]
+----
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration(classes = [HelloWebfluxMethodApplication::class])
+class HelloWebfluxMethodApplicationTests {
+    @Autowired
+    lateinit var context: ApplicationContext
+
+    lateinit var rest: WebTestClient
+
+    @BeforeEach
+    fun setup() {
+        this.rest = WebTestClient
+            .bindToApplicationContext(this.context)
+            // add Spring Security test Support
+            .apply(springSecurity())
+            .configureClient()
+            .filter(basicAuthentication("user", "password"))
+            .build()
+    }
+    // ...
+}
+----
+====


### PR DESCRIPTION
Closes gh-9998

basicAuthentication() is deprecated, so updated to basicAuthentication("user", "password")
