### PR TITLE
Set LogoutRepository on Saml2 Logout Success Handler in LogoutConfigurer

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurer.java
@@ -272,6 +272,7 @@ public final class Saml2LogoutConfigurer<H extends HttpSecurityBuilder<H>>
 		LogoutHandler[] logoutHandlers = this.logoutHandlers.toArray(new LogoutHandler[0]);
 		Saml2RelyingPartyInitiatedLogoutSuccessHandler logoutRequestSuccessHandler = createSaml2LogoutRequestSuccessHandler(
 				registrations);
+		logoutRequestSuccessHandler.setLogoutRequestRepository(this.logoutRequestConfigurer.logoutRequestRepository);
 		LogoutFilter logoutFilter = new LogoutFilter(logoutRequestSuccessHandler, logoutHandlers);
 		logoutFilter.setLogoutRequestMatcher(createLogoutMatcher());
 		return postProcess(logoutFilter);

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurerTests.java
@@ -407,7 +407,7 @@ public class Saml2LogoutConfigurerTests {
 		this.mvc.perform(get("/logout/saml2/slo").param("SAMLResponse", "samlResponse")).andReturn();
 		verify(getBean(Saml2LogoutResponseValidator.class)).validate(any());
 	}
-	
+
 	@Test
 	public void saml2LogoutWhenCustomLogoutRequestRepositoryThenUses() throws Exception {
 		this.spring.register(Saml2LogoutComponentsConfig.class).autowire();

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurerTests.java
@@ -85,6 +85,7 @@ import org.springframework.web.util.UriUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.mock;
 import static org.mockito.BDDMockito.verify;
@@ -405,6 +406,18 @@ public class Saml2LogoutConfigurerTests {
 				.willReturn(Saml2LogoutValidatorResult.success());
 		this.mvc.perform(get("/logout/saml2/slo").param("SAMLResponse", "samlResponse")).andReturn();
 		verify(getBean(Saml2LogoutResponseValidator.class)).validate(any());
+	}
+	
+	@Test
+	public void saml2LogoutWhenCustomLogoutRequestRepositoryThenUses() throws Exception {
+		this.spring.register(Saml2LogoutComponentsConfig.class).autowire();
+		RelyingPartyRegistration registration = this.repository.findByRegistrationId("registration-id");
+		Saml2LogoutRequest logoutRequest = Saml2LogoutRequest.withRelyingPartyRegistration(registration)
+				.samlRequest(this.rpLogoutRequest).id(this.rpLogoutRequestId).relayState(this.rpLogoutRequestRelayState)
+				.parameters((params) -> params.put("Signature", this.rpLogoutRequestSignature)).build();
+		given(getBean(Saml2LogoutRequestResolver.class).resolve(any(), any())).willReturn(logoutRequest);
+		this.mvc.perform(post("/logout").with(authentication(this.user)).with(csrf()));
+		verify(getBean(Saml2LogoutRequestRepository.class)).saveLogoutRequest(eq(logoutRequest), any(), any());
 	}
 
 	@Test


### PR DESCRIPTION
The `Saml2LogoutConfigurer.class` will use the configured `Saml2LogoutRequestRepository.class` and set it on the `Saml2RelyingPartyInitiatedLogoutSuccessHandler.class`.

I added this change to make progress on [gh-11363](https://github.com/spring-projects/spring-security/issues/11363).