### PR TITLE
Remove Configuration meta-annotation from Enable* annotations

### DIFF
--- a/config/src/integration-test/java/org/springframework/security/config/annotation/authentication/ldap/LdapAuthenticationProviderBuilderSecurityBuilderTests.java
+++ b/config/src/integration-test/java/org/springframework/security/config/annotation/authentication/ldap/LdapAuthenticationProviderBuilderSecurityBuilderTests.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.ldap.core.support.BaseLdapPathContextSource;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -155,6 +156,7 @@ public class LdapAuthenticationProviderBuilderSecurityBuilderTests {
 		return port;
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultLdapConfig extends BaseLdapProviderConfig {
 
@@ -170,6 +172,7 @@ public class LdapAuthenticationProviderBuilderSecurityBuilderTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class GroupRolesConfig extends BaseLdapProviderConfig {
 
@@ -202,6 +205,7 @@ public class LdapAuthenticationProviderBuilderSecurityBuilderTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class GroupSubtreeSearchConfig extends BaseLdapProviderConfig {
 
@@ -219,6 +223,7 @@ public class LdapAuthenticationProviderBuilderSecurityBuilderTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RolePrefixConfig extends BaseLdapProviderConfig {
 
@@ -235,6 +240,7 @@ public class LdapAuthenticationProviderBuilderSecurityBuilderTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class BindAuthenticationConfig extends BaseLdapServerConfig {
 
@@ -252,6 +258,7 @@ public class LdapAuthenticationProviderBuilderSecurityBuilderTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PasswordEncoderConfig extends BaseLdapServerConfig {
 
@@ -270,6 +277,7 @@ public class LdapAuthenticationProviderBuilderSecurityBuilderTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	abstract static class BaseLdapServerConfig extends BaseLdapProviderConfig {
 
@@ -283,6 +291,7 @@ public class LdapAuthenticationProviderBuilderSecurityBuilderTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableGlobalAuthentication
 	@Import(ObjectPostProcessorConfiguration.class)

--- a/config/src/integration-test/java/org/springframework/security/config/annotation/authentication/ldap/LdapAuthenticationProviderConfigurerTests.java
+++ b/config/src/integration-test/java/org/springframework/security/config/annotation/authentication/ldap/LdapAuthenticationProviderConfigurerTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.ldap.LdapAuthenticationProviderBuilderSecurityBuilderTests.BaseLdapProviderConfig;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -114,6 +115,7 @@ public class LdapAuthenticationProviderConfigurerTests {
 		this.mockMvc.perform(request).andExpect(expectedUser);
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class MultiLdapAuthenticationProvidersConfig extends WebSecurityConfigurerAdapter {
 
@@ -135,6 +137,7 @@ public class LdapAuthenticationProviderConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class MultiLdapWithCustomRolePrefixAuthenticationProvidersConfig extends WebSecurityConfigurerAdapter {
 
@@ -158,6 +161,7 @@ public class LdapAuthenticationProviderConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class LdapWithRandomPortConfig extends WebSecurityConfigurerAdapter {
 
@@ -176,6 +180,7 @@ public class LdapAuthenticationProviderConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class GroupSubtreeSearchConfig extends BaseLdapProviderConfig {
 

--- a/config/src/integration-test/java/org/springframework/security/config/annotation/authentication/ldap/NamespaceLdapAuthenticationProviderTestsConfigs.java
+++ b/config/src/integration-test/java/org/springframework/security/config/annotation/authentication/ldap/NamespaceLdapAuthenticationProviderTestsConfigs.java
@@ -16,6 +16,7 @@
 
 package org.springframework.security.config.annotation.authentication.ldap;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -29,6 +30,7 @@ import org.springframework.security.ldap.userdetails.PersonContextMapper;
  */
 public class NamespaceLdapAuthenticationProviderTestsConfigs {
 
+	@Configuration
 	@EnableWebSecurity
 	static class LdapAuthenticationProviderConfig extends WebSecurityConfigurerAdapter {
 
@@ -44,6 +46,7 @@ public class NamespaceLdapAuthenticationProviderTestsConfigs {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomLdapAuthenticationProviderConfig extends WebSecurityConfigurerAdapter {
 
@@ -73,6 +76,7 @@ public class NamespaceLdapAuthenticationProviderTestsConfigs {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomAuthoritiesPopulatorConfig extends WebSecurityConfigurerAdapter {
 
@@ -90,6 +94,7 @@ public class NamespaceLdapAuthenticationProviderTestsConfigs {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PasswordCompareLdapConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/integration-test/java/org/springframework/security/config/ldap/EmbeddedLdapServerContextSourceFactoryBeanITests.java
+++ b/config/src/integration-test/java/org/springframework/security/config/ldap/EmbeddedLdapServerContextSourceFactoryBeanITests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.UnsatisfiedDependencyException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.ldap.core.support.LdapContextSource;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -81,6 +82,7 @@ public class EmbeddedLdapServerContextSourceFactoryBeanITests {
 				.withMessageContaining("managerPassword is required if managerDn is supplied");
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FromEmbeddedLdapServerConfig {
 
@@ -98,6 +100,7 @@ public class EmbeddedLdapServerContextSourceFactoryBeanITests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PortZeroConfig {
 
@@ -118,6 +121,7 @@ public class EmbeddedLdapServerContextSourceFactoryBeanITests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomLdifAndRootConfig {
 
@@ -139,6 +143,7 @@ public class EmbeddedLdapServerContextSourceFactoryBeanITests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomManagerDnConfig {
 
@@ -161,6 +166,7 @@ public class EmbeddedLdapServerContextSourceFactoryBeanITests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomManagerDnNoPasswordConfig {
 

--- a/config/src/integration-test/java/org/springframework/security/config/ldap/LdapBindAuthenticationManagerFactoryITests.java
+++ b/config/src/integration-test/java/org/springframework/security/config/ldap/LdapBindAuthenticationManagerFactoryITests.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.ldap.core.DirContextAdapter;
 import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.ldap.core.support.BaseLdapPathContextSource;
@@ -131,6 +132,7 @@ public class LdapBindAuthenticationManagerFactoryITests {
 				.andExpect(authenticated().withUsername("bob"));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FromContextSourceConfig extends BaseLdapServerConfig {
 
@@ -143,6 +145,7 @@ public class LdapBindAuthenticationManagerFactoryITests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomAuthoritiesMapperConfig extends BaseLdapServerConfig {
 
@@ -158,6 +161,7 @@ public class LdapBindAuthenticationManagerFactoryITests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomAuthoritiesPopulatorConfig extends BaseLdapServerConfig {
 
@@ -173,6 +177,7 @@ public class LdapBindAuthenticationManagerFactoryITests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomUserDetailsContextMapperConfig extends BaseLdapServerConfig {
 
@@ -188,6 +193,7 @@ public class LdapBindAuthenticationManagerFactoryITests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomUserDnPatternsConfig extends BaseLdapServerConfig {
 
@@ -200,6 +206,7 @@ public class LdapBindAuthenticationManagerFactoryITests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomUserSearchConfig extends BaseLdapServerConfig {
 
@@ -213,6 +220,7 @@ public class LdapBindAuthenticationManagerFactoryITests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	abstract static class BaseLdapServerConfig implements DisposableBean {
 

--- a/config/src/integration-test/java/org/springframework/security/config/ldap/LdapPasswordComparisonAuthenticationManagerFactoryITests.java
+++ b/config/src/integration-test/java/org/springframework/security/config/ldap/LdapPasswordComparisonAuthenticationManagerFactoryITests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.ldap.core.support.BaseLdapPathContextSource;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -59,6 +60,7 @@ public class LdapPasswordComparisonAuthenticationManagerFactoryITests {
 		this.mockMvc.perform(formLogin().user("bob").password("bob")).andExpect(authenticated().withUsername("bob"));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomPasswordEncoderConfig extends BaseLdapServerConfig {
 
@@ -72,6 +74,7 @@ public class LdapPasswordComparisonAuthenticationManagerFactoryITests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomPasswordAttributeConfig extends BaseLdapServerConfig {
 
@@ -86,6 +89,7 @@ public class LdapPasswordComparisonAuthenticationManagerFactoryITests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	abstract static class BaseLdapServerConfig implements DisposableBean {
 

--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/EnableGlobalAuthentication.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/EnableGlobalAuthentication.java
@@ -22,7 +22,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -106,7 +105,6 @@ import org.springframework.security.config.annotation.web.servlet.configuration.
 @Target(ElementType.TYPE)
 @Documented
 @Import(AuthenticationConfiguration.class)
-@Configuration
 public @interface EnableGlobalAuthentication {
 
 }

--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/EnableGlobalMethodSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/EnableGlobalMethodSecurity.java
@@ -23,7 +23,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.springframework.context.annotation.AdviceMode;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.Ordered;
 import org.springframework.security.access.annotation.Secured;
@@ -49,7 +48,6 @@ import org.springframework.security.config.annotation.authentication.configurati
 @Documented
 @Import({ GlobalMethodSecuritySelector.class })
 @EnableGlobalAuthentication
-@Configuration
 public @interface EnableGlobalMethodSecurity {
 
 	/**

--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/EnableMethodSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/EnableMethodSecurity.java
@@ -23,7 +23,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.springframework.context.annotation.AdviceMode;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.access.prepost.PostAuthorize;
@@ -41,7 +40,6 @@ import org.springframework.security.access.prepost.PreFilter;
 @Target(ElementType.TYPE)
 @Documented
 @Import(MethodSecuritySelector.class)
-@Configuration
 public @interface EnableMethodSecurity {
 
 	/**

--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/EnableReactiveMethodSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/EnableReactiveMethodSecurity.java
@@ -23,7 +23,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.springframework.context.annotation.AdviceMode;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.Ordered;
 
@@ -36,7 +35,6 @@ import org.springframework.core.Ordered;
 @Target(ElementType.TYPE)
 @Documented
 @Import(ReactiveMethodSecuritySelector.class)
-@Configuration
 public @interface EnableReactiveMethodSecurity {
 
 	/**

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configuration/EnableWebSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configuration/EnableWebSecurity.java
@@ -22,7 +22,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.config.annotation.authentication.configuration.EnableGlobalAuthentication;
 import org.springframework.security.config.annotation.web.WebSecurityConfigurer;
@@ -86,7 +85,6 @@ import org.springframework.security.web.SecurityFilterChain;
 @Import({ WebSecurityConfiguration.class, SpringWebMvcImportSelector.class, OAuth2ImportSelector.class,
 		HttpSecurityConfiguration.class })
 @EnableGlobalAuthentication
-@Configuration
 public @interface EnableWebSecurity {
 
 	/**

--- a/config/src/main/java/org/springframework/security/config/annotation/web/reactive/EnableWebFluxSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/reactive/EnableWebFluxSecurity.java
@@ -22,7 +22,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 
@@ -34,6 +33,7 @@ import org.springframework.security.config.web.server.ServerHttpSecurity;
  * A minimal configuration can be found below:
  *
  * <pre class="code">
+ * &#064;Configuration
  * &#064;EnableWebFluxSecurity
  * public class MyMinimalSecurityConfiguration {
  *
@@ -53,6 +53,7 @@ import org.springframework.security.config.web.server.ServerHttpSecurity;
  * {@code ServerHttpSecurity}.
  *
  * <pre class="code">
+ * &#064;Configuration
  * &#064;EnableWebFluxSecurity
  * public class MyExplicitSecurityConfiguration {
  *     &#064;Bean
@@ -86,7 +87,6 @@ import org.springframework.security.config.web.server.ServerHttpSecurity;
 @Documented
 @Import({ ServerHttpSecurityConfiguration.class, WebFluxSecurityConfiguration.class,
 		ReactiveOAuth2ClientImportSelector.class })
-@Configuration
 public @interface EnableWebFluxSecurity {
 
 }

--- a/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
@@ -198,6 +198,7 @@ import org.springframework.web.server.WebFilterChain;
  * A minimal configuration can be found below:
  *
  * <pre class="code">
+ * &#064;Configuration
  * &#064;EnableWebFluxSecurity
  * public class MyMinimalSecurityConfiguration {
  *
@@ -217,6 +218,7 @@ import org.springframework.web.server.WebFilterChain;
  * {@code ServerHttpSecurity}.
  *
  * <pre class="code">
+ * &#064;Configuration
  * &#064;EnableWebFluxSecurity
  * public class MyExplicitSecurityConfiguration {
  *

--- a/config/src/main/kotlin/org/springframework/security/config/annotation/web/HttpSecurityDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/annotation/web/HttpSecurityDsl.kt
@@ -32,6 +32,7 @@ import jakarta.servlet.http.HttpServletRequest
  * Example:
  *
  * ```
+ * @Configuration
  * @EnableWebSecurity
  * class SecurityConfig : WebSecurityConfigurerAdapter() {
  *
@@ -82,6 +83,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -122,6 +124,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -151,6 +154,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -179,6 +183,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -208,6 +213,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig {
      *
@@ -240,6 +246,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -268,6 +275,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -297,6 +305,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -327,6 +336,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -355,6 +365,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -386,6 +397,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -414,6 +426,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -443,6 +456,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -470,6 +484,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -496,6 +511,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -524,6 +540,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -549,6 +566,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -579,6 +597,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -607,6 +626,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -637,6 +657,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -665,6 +686,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -691,6 +713,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -719,6 +742,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -746,6 +770,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -773,6 +798,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -799,6 +825,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -826,6 +853,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -852,6 +880,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -879,6 +908,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -913,6 +943,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *

--- a/config/src/main/kotlin/org/springframework/security/config/annotation/web/OAuth2ClientDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/annotation/web/OAuth2ClientDsl.kt
@@ -64,6 +64,7 @@ class OAuth2ClientDsl {
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *

--- a/config/src/main/kotlin/org/springframework/security/config/annotation/web/OAuth2LoginDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/annotation/web/OAuth2LoginDsl.kt
@@ -95,6 +95,7 @@ class OAuth2LoginDsl {
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -124,6 +125,7 @@ class OAuth2LoginDsl {
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -153,6 +155,7 @@ class OAuth2LoginDsl {
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -182,6 +185,7 @@ class OAuth2LoginDsl {
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *

--- a/config/src/main/kotlin/org/springframework/security/config/annotation/web/OAuth2ResourceServerDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/annotation/web/OAuth2ResourceServerDsl.kt
@@ -55,6 +55,7 @@ class OAuth2ResourceServerDsl {
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -83,6 +84,7 @@ class OAuth2ResourceServerDsl {
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *

--- a/config/src/main/kotlin/org/springframework/security/config/annotation/web/SessionManagementDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/annotation/web/SessionManagementDsl.kt
@@ -50,6 +50,7 @@ class SessionManagementDsl {
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *
@@ -77,6 +78,7 @@ class SessionManagementDsl {
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebSecurity
      * class SecurityConfig : WebSecurityConfigurerAdapter() {
      *

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerHttpSecurityDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerHttpSecurityDsl.kt
@@ -29,6 +29,7 @@ import org.springframework.web.server.WebFilter
  * Example:
  *
  * ```
+ * @Configuration
  * @EnableWebFluxSecurity
  * class SecurityConfig {
  *
@@ -72,6 +73,7 @@ class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val in
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *
@@ -100,6 +102,7 @@ class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val in
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *
@@ -125,6 +128,7 @@ class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val in
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *
@@ -150,6 +154,7 @@ class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val in
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *
@@ -175,6 +180,7 @@ class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val in
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *
@@ -204,6 +210,7 @@ class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val in
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *
@@ -234,6 +241,7 @@ class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val in
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *
@@ -261,6 +269,7 @@ class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val in
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *
@@ -291,6 +300,7 @@ class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val in
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *
@@ -325,6 +335,7 @@ class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val in
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *
@@ -354,6 +365,7 @@ class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val in
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *
@@ -385,6 +397,7 @@ class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val in
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *
@@ -414,6 +427,7 @@ class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val in
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *
@@ -441,6 +455,7 @@ class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val in
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *
@@ -467,6 +482,7 @@ class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val in
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *
@@ -493,6 +509,7 @@ class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val in
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *
@@ -521,6 +538,7 @@ class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val in
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *
@@ -551,6 +569,7 @@ class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val in
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *
@@ -579,6 +598,7 @@ class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val in
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *
@@ -607,6 +627,7 @@ class ServerHttpSecurityDsl(private val http: ServerHttpSecurity, private val in
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerOAuth2ResourceServerDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerOAuth2ResourceServerDsl.kt
@@ -51,6 +51,7 @@ class ServerOAuth2ResourceServerDsl {
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *
@@ -80,6 +81,7 @@ class ServerOAuth2ResourceServerDsl {
      * Example:
      *
      * ```
+     * @Configuration
      * @EnableWebFluxSecurity
      * class SecurityConfig {
      *

--- a/config/src/test/java/org/springframework/security/config/annotation/authentication/AuthenticationManagerBuilderTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/authentication/AuthenticationManagerBuilderTests.java
@@ -165,6 +165,7 @@ public class AuthenticationManagerBuilderTests {
 				.andExpect(authenticated().withUsername("joe").withRoles("USER"));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class MultiAuthenticationProvidersConfig extends WebSecurityConfigurerAdapter {
 
@@ -182,6 +183,7 @@ public class AuthenticationManagerBuilderTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PasswordEncoderGlobalConfig extends WebSecurityConfigurerAdapter {
 
@@ -201,6 +203,7 @@ public class AuthenticationManagerBuilderTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PasswordEncoderConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/authentication/NamespaceAuthenticationManagerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/authentication/NamespaceAuthenticationManagerTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -73,6 +74,7 @@ public class NamespaceAuthenticationManagerTests {
 		this.mockMvc.perform(formLogin()).andExpect(notNullCredentials);
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class EraseCredentialsTrueDefaultConfig extends WebSecurityConfigurerAdapter {
 
@@ -87,6 +89,7 @@ public class NamespaceAuthenticationManagerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class EraseCredentialsFalseConfig extends WebSecurityConfigurerAdapter {
 
@@ -102,6 +105,7 @@ public class NamespaceAuthenticationManagerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class GlobalEraseCredentialsFalseConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/authentication/NamespaceAuthenticationProviderTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/authentication/NamespaceAuthenticationProviderTests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -60,6 +61,7 @@ public class NamespaceAuthenticationProviderTests {
 		this.mockMvc.perform(formLogin()).andExpect(authenticated().withUsername("user"));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AuthenticationProviderRefConfig extends WebSecurityConfigurerAdapter {
 
@@ -80,6 +82,7 @@ public class NamespaceAuthenticationProviderTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class UserServiceRefConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/authentication/NamespaceJdbcUserServiceTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/authentication/NamespaceJdbcUserServiceTests.java
@@ -70,6 +70,7 @@ public class NamespaceJdbcUserServiceTests {
 		this.mockMvc.perform(formLogin()).andExpect(dba);
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class JdbcUserServiceConfig extends WebSecurityConfigurerAdapter {
 
@@ -100,6 +101,7 @@ public class NamespaceJdbcUserServiceTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomJdbcUserServiceSampleConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/authentication/NamespacePasswordEncoderTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/authentication/NamespacePasswordEncoderTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -68,6 +69,7 @@ public class NamespacePasswordEncoderTests {
 		this.mockMvc.perform(formLogin()).andExpect(authenticated());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PasswordEncoderWithInMemoryConfig extends WebSecurityConfigurerAdapter {
 
@@ -84,6 +86,7 @@ public class NamespacePasswordEncoderTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PasswordEncoderWithJdbcConfig extends WebSecurityConfigurerAdapter {
 
@@ -108,6 +111,7 @@ public class NamespacePasswordEncoderTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PasswordEncoderWithUserDetailsServiceConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/authentication/PasswordEncoderConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/authentication/PasswordEncoderConfigurerTests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -55,6 +56,7 @@ public class PasswordEncoderConfigurerTests {
 		this.mockMvc.perform(formLogin()).andExpect(authenticated());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PasswordEncoderConfig extends WebSecurityConfigurerAdapter {
 
@@ -80,6 +82,7 @@ public class PasswordEncoderConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PasswordEncoderNoAuthManagerLoadsConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/authentication/configuration/AuthenticationConfigurationPublishTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/authentication/configuration/AuthenticationConfigurationPublishTests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.authentication.AuthenticationEventPublisher;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -57,6 +58,7 @@ public class AuthenticationConfigurationPublishTests {
 		this.authenticationManager = authenticationConfiguration.getAuthenticationManager();
 	}
 
+	@Configuration
 	@EnableGlobalAuthentication
 	@Import(AuthenticationTestConfiguration.class)
 	static class Config {

--- a/config/src/test/java/org/springframework/security/config/annotation/authentication/configuration/AuthenticationConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/authentication/configuration/AuthenticationConfigurationTests.java
@@ -296,16 +296,19 @@ public class AuthenticationConfigurationTests {
 		assertThatExceptionOfType(AlreadyBuiltException.class).isThrownBy(ap::build);
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(securedEnabled = true)
 	static class GlobalMethodSecurityAutowiredConfig {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class WebSecurityConfig {
 
 	}
 
+	@Configuration
 	@EnableWebMvcSecurity
 	static class WebMvcSecurityConfig {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/authentication/configuration/EnableGlobalAuthenticationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/authentication/configuration/EnableGlobalAuthenticationTests.java
@@ -72,6 +72,7 @@ public class EnableGlobalAuthenticationTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalAuthentication
 	static class BeanProxyEnabledByDefaultConfig {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/EnableReactiveMethodSecurityTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/EnableReactiveMethodSecurityTests.java
@@ -28,6 +28,7 @@ import reactor.util.context.Context;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
@@ -402,6 +403,7 @@ public class EnableReactiveMethodSecurityTests {
 		return publisher(Flux.just(data));
 	}
 
+	@Configuration
 	@EnableReactiveMethodSecurity
 	static class Config {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecurityConfigurationTests.java
@@ -277,11 +277,13 @@ public class GlobalMethodSecurityConfigurationTests {
 		assertThat(methodInterceptor.getSecurityMetadataSource()).isSameAs(methodSecurityMetadataSource);
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity
 	public static class IllegalStateGlobalMethodSecurityConfig extends GlobalMethodSecurityConfiguration {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity
 	public static class CustomMetadataSourceConfig extends GlobalMethodSecurityConfiguration {
 
@@ -293,6 +295,7 @@ public class GlobalMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	public static class InMemoryAuthWithGlobalMethodSecurityConfig extends GlobalMethodSecurityConfiguration {
 
@@ -312,6 +315,7 @@ public class GlobalMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	static class CustomTrustResolverConfig {
 
@@ -327,6 +331,7 @@ public class GlobalMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true, proxyTargetClass = true)
 	static class ExpressionHandlerHasBeanResolverSetConfig {
 
@@ -342,6 +347,7 @@ public class GlobalMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	static class MethodSecurityServiceConfig {
 
@@ -352,6 +358,7 @@ public class GlobalMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	public static class AutowirePermissionEvaluatorConfig {
 
@@ -367,6 +374,7 @@ public class GlobalMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	public static class MultiPermissionEvaluatorConfig {
 
@@ -387,6 +395,7 @@ public class GlobalMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	static class ParentConfig {
 
@@ -407,6 +416,7 @@ public class GlobalMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	static class Sec2479ChildConfig {
 
@@ -417,6 +427,7 @@ public class GlobalMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	static class Sec2815Config {
 
@@ -450,6 +461,7 @@ public class GlobalMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	static class Sec9845Config {
 
@@ -486,6 +498,7 @@ public class GlobalMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true, mode = AdviceMode.ASPECTJ)
 	@EnableTransactionManagement
 	static class Sec3005Config {
@@ -536,6 +549,7 @@ public class GlobalMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	static class CustomGrantedAuthorityConfig {
 
@@ -564,6 +578,7 @@ public class GlobalMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(securedEnabled = true)
 	static class EmptyRolePrefixGrantedAuthorityConfig {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/NamespaceGlobalMethodSecurityExpressionHandlerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/NamespaceGlobalMethodSecurityExpressionHandlerTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
@@ -66,6 +67,7 @@ public class NamespaceGlobalMethodSecurityExpressionHandlerTests {
 				.isThrownBy(() -> this.service.postHasPermission("denied"));
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	public static class CustomAccessDecisionManagerConfig extends GlobalMethodSecurityConfiguration {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/NamespaceGlobalMethodSecurityTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/NamespaceGlobalMethodSecurityTests.java
@@ -234,6 +234,7 @@ public class NamespaceGlobalMethodSecurityTests {
 		assertThatExceptionOfType(AccessDeniedException.class).isThrownBy(() -> this.service.preAuthorize());
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
 	public static class CustomAccessDecisionManagerConfig extends GlobalMethodSecurityConfiguration {
 
@@ -264,6 +265,7 @@ public class NamespaceGlobalMethodSecurityTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	public static class CustomAfterInvocationManagerConfig extends GlobalMethodSecurityConfiguration {
 
@@ -294,6 +296,7 @@ public class NamespaceGlobalMethodSecurityTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	public static class CustomAuthenticationConfig extends GlobalMethodSecurityConfiguration {
 
@@ -319,6 +322,7 @@ public class NamespaceGlobalMethodSecurityTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity
 	public static class CustomMethodSecurityMetadataSourceConfig extends GlobalMethodSecurityConfiguration {
 
@@ -342,11 +346,13 @@ public class NamespaceGlobalMethodSecurityTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(mode = AdviceMode.ASPECTJ, securedEnabled = true)
 	public static class AspectJModeConfig {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(mode = AdviceMode.ASPECTJ, securedEnabled = true)
 	public static class AspectJModeExtendsGMSCConfig extends GlobalMethodSecurityConfiguration {
 
@@ -380,44 +386,52 @@ public class NamespaceGlobalMethodSecurityTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(order = -135, jsr250Enabled = true)
 	@Import(AdvisorOrderConfig.class)
 	public static class CustomOrderConfig {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(jsr250Enabled = true)
 	@Import(AdvisorOrderConfig.class)
 	public static class DefaultOrderConfig {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(jsr250Enabled = true)
 	@Import(AdvisorOrderConfig.class)
 	public static class DefaultOrderExtendsMethodSecurityConfig extends GlobalMethodSecurityConfiguration {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	public static class PreAuthorizeConfig {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	public static class PreAuthorizeExtendsGMSCConfig extends GlobalMethodSecurityConfiguration {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(proxyTargetClass = true, prePostEnabled = true)
 	public static class ProxyTargetClassConfig {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	public static class DefaultProxyConfig {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(securedEnabled = true)
 	public static class CustomRunAsManagerConfig extends GlobalMethodSecurityConfiguration {
 
@@ -430,6 +444,7 @@ public class NamespaceGlobalMethodSecurityTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(securedEnabled = true)
 	public static class SecuredConfig {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/PrePostMethodSecurityConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/PrePostMethodSecurityConfigurationTests.java
@@ -406,6 +406,7 @@ public class PrePostMethodSecurityConfigurationTests {
 		this.methodSecurityService.preAuthorizeBean(true);
 	}
 
+	@Configuration
 	@EnableMethodSecurity
 	static class MethodSecurityServiceConfig {
 
@@ -421,6 +422,7 @@ public class PrePostMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableMethodSecurity(jsr250Enabled = true)
 	static class BusinessServiceConfig {
 
@@ -431,6 +433,7 @@ public class PrePostMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableMethodSecurity(prePostEnabled = false, securedEnabled = true)
 	static class SecuredConfig {
 
@@ -441,6 +444,7 @@ public class PrePostMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableMethodSecurity(prePostEnabled = false, jsr250Enabled = true)
 	static class Jsr250Config {
 
@@ -451,6 +455,7 @@ public class PrePostMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableMethodSecurity(securedEnabled = true, jsr250Enabled = true)
 	static class MethodSecurityServiceEnabledConfig {
 
@@ -461,6 +466,7 @@ public class PrePostMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableMethodSecurity
 	static class CustomPermissionEvaluatorConfig {
 
@@ -485,6 +491,7 @@ public class PrePostMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableMethodSecurity
 	static class CustomGrantedAuthorityDefaultsConfig {
 
@@ -495,6 +502,7 @@ public class PrePostMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableMethodSecurity
 	static class CustomAuthorizationManagerBeforeAdviceConfig {
 
@@ -513,6 +521,7 @@ public class PrePostMethodSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableMethodSecurity
 	static class CustomAuthorizationManagerAfterAdviceConfig {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/SampleEnableGlobalMethodSecurityTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/SampleEnableGlobalMethodSecurityTests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
@@ -75,6 +76,7 @@ public class SampleEnableGlobalMethodSecurityTests {
 				.isThrownBy(() -> this.methodSecurityService.hasPermission("denied"));
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	static class SampleWebSecurityConfig {
 
@@ -95,6 +97,7 @@ public class SampleEnableGlobalMethodSecurityTests {
 
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	public static class CustomPermissionEvaluatorWebSecurityConfig extends GlobalMethodSecurityConfiguration {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/sec2758/Sec2758Tests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/sec2758/Sec2758Tests.java
@@ -24,6 +24,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.PriorityOrdered;
 import org.springframework.security.access.annotation.Jsr250MethodSecurityMetadataSource;
@@ -77,6 +78,7 @@ public class Sec2758Tests {
 		this.service.doPreAuthorize();
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableGlobalMethodSecurity(prePostEnabled = true, jsr250Enabled = true)
 	static class SecurityConfig extends WebSecurityConfigurerAdapter {

--- a/config/src/test/java/org/springframework/security/config/annotation/web/AbstractRequestMatcherRegistryAnyMatcherTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/AbstractRequestMatcherRegistryAnyMatcherTests.java
@@ -19,6 +19,7 @@ package org.springframework.security.config.annotation.web;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -73,6 +74,7 @@ public class AbstractRequestMatcherRegistryAnyMatcherTests {
 		context.refresh();
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AntMatchersAfterAnyRequestConfig extends WebSecurityConfigurerAdapter {
 
@@ -88,6 +90,7 @@ public class AbstractRequestMatcherRegistryAnyMatcherTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class MvcMatchersAfterAnyRequestConfig extends WebSecurityConfigurerAdapter {
 
@@ -103,6 +106,7 @@ public class AbstractRequestMatcherRegistryAnyMatcherTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RegexMatchersAfterAnyRequestConfig extends WebSecurityConfigurerAdapter {
 
@@ -118,6 +122,7 @@ public class AbstractRequestMatcherRegistryAnyMatcherTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AnyRequestAfterItselfConfig extends WebSecurityConfigurerAdapter {
 
@@ -133,6 +138,7 @@ public class AbstractRequestMatcherRegistryAnyMatcherTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RequestMatchersAfterAnyRequestConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/HttpSecurityHeadersTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/HttpSecurityHeadersTests.java
@@ -86,6 +86,7 @@ public class HttpSecurityHeadersTests {
 		// @formatter:on
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/SampleWebSecurityConfigurerAdapterTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/SampleWebSecurityConfigurerAdapterTests.java
@@ -213,6 +213,7 @@ public class SampleWebSecurityConfigurerAdapterTests {
 	 *
 	 * @author Rob Winch
 	 */
+	@Configuration
 	@EnableWebSecurity
 	public static class HelloWorldWebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
 
@@ -260,6 +261,7 @@ public class SampleWebSecurityConfigurerAdapterTests {
 	 *
 	 * @author Rob Winch
 	 */
+	@Configuration
 	@EnableWebSecurity
 	public static class SampleWebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
 
@@ -333,6 +335,7 @@ public class SampleWebSecurityConfigurerAdapterTests {
 	 *
 	 * @author Rob Winch
 	 */
+	@Configuration
 	@EnableWebSecurity
 	public static class SampleMultiHttpSecurityConfig {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/WebSecurityConfigurerAdapterMockitoTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/WebSecurityConfigurerAdapterMockitoTests.java
@@ -27,6 +27,7 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.support.SpringFactoriesLoader;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -110,6 +111,7 @@ public class WebSecurityConfigurerAdapterMockitoTests {
 		this.context = context;
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class Config extends WebSecurityConfigurerAdapter {
 
@@ -137,6 +139,7 @@ public class WebSecurityConfigurerAdapterMockitoTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class WebAsyncPopulatedByDefaultConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/WebSecurityConfigurerAdapterTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/WebSecurityConfigurerAdapterTests.java
@@ -199,6 +199,7 @@ public class WebSecurityConfigurerAdapterTests {
 				any(Authentication.class));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HeadersArePopulatedByDefaultConfig extends WebSecurityConfigurerAdapter {
 
@@ -217,6 +218,7 @@ public class WebSecurityConfigurerAdapterTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class InMemoryAuthWithWebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter
 			implements ApplicationListener<AuthenticationSuccessEvent> {
@@ -239,6 +241,7 @@ public class WebSecurityConfigurerAdapterTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class InMemoryConfigureProtectedConfig extends WebSecurityConfigurerAdapter {
 
@@ -259,6 +262,7 @@ public class WebSecurityConfigurerAdapterTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class InMemoryConfigureGlobalConfig extends WebSecurityConfigurerAdapter {
 
@@ -279,6 +283,7 @@ public class WebSecurityConfigurerAdapterTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OverrideContentNegotiationStrategySharedObjectConfig extends WebSecurityConfigurerAdapter {
 
@@ -299,6 +304,7 @@ public class WebSecurityConfigurerAdapterTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ContentNegotiationStrategyDefaultSharedObjectConfig extends WebSecurityConfigurerAdapter {
 
@@ -322,6 +328,7 @@ public class WebSecurityConfigurerAdapterTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class UserDetailsServiceConfig extends WebSecurityConfigurerAdapter {
 
@@ -366,6 +373,7 @@ public class WebSecurityConfigurerAdapterTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ApplicationContextSharedObjectConfig extends WebSecurityConfigurerAdapter {
 
@@ -379,6 +387,7 @@ public class WebSecurityConfigurerAdapterTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomTrustResolverConfig extends WebSecurityConfigurerAdapter {
 
@@ -408,6 +417,7 @@ public class WebSecurityConfigurerAdapterTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomAuthenticationEventPublisherBean extends WebSecurityConfigurerAdapter {
 
@@ -424,6 +434,7 @@ public class WebSecurityConfigurerAdapterTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomAuthenticationEventPublisherDsl extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/builders/HttpConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/builders/HttpConfigurationTests.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -72,6 +73,7 @@ public class HttpConfigurationTests {
 		this.mockMvc.perform(get("/api/b")).andExpect(status().isUnauthorized());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class UnregisteredFilterConfig extends WebSecurityConfigurerAdapter {
 
@@ -104,6 +106,7 @@ public class HttpConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RequestMatcherRegistryConfigs extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/builders/HttpSecurityAddFilterTest.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/builders/HttpSecurityAddFilterTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.test.SpringTestContext;
@@ -151,6 +152,7 @@ public class HttpSecurityAddFilterTest {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class MyFilterMultipleAfterConfig extends WebSecurityConfigurerAdapter {
 
@@ -165,6 +167,7 @@ public class HttpSecurityAddFilterTest {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class MyFilterMultipleBeforeConfig extends WebSecurityConfigurerAdapter {
 
@@ -179,6 +182,7 @@ public class HttpSecurityAddFilterTest {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class MyFilterMultipleAtConfig extends WebSecurityConfigurerAdapter {
 
@@ -193,6 +197,7 @@ public class HttpSecurityAddFilterTest {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class MyOtherFilterRelativeToMyFilterAfterConfig {
 
@@ -208,6 +213,7 @@ public class HttpSecurityAddFilterTest {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class MyOtherFilterRelativeToMyFilterBeforeConfig {
 
@@ -223,6 +229,7 @@ public class HttpSecurityAddFilterTest {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class MyOtherFilterRelativeToMyFilterAtConfig {
 
@@ -238,6 +245,7 @@ public class HttpSecurityAddFilterTest {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class MyOtherFilterBeforeToMyFilterMultipleAfterConfig {
 
@@ -254,6 +262,7 @@ public class HttpSecurityAddFilterTest {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class MyAnotherFilterRelativeToMyCustomFiltersMultipleConfig {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/builders/HttpSecurityAuthenticationManagerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/builders/HttpSecurityAuthenticationManagerTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -73,6 +74,7 @@ public class HttpSecurityAuthenticationManagerTests {
 		verifyNoInteractions(AuthenticationManagerBuilderConfig.USER_DETAILS_SERVICE);
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AuthenticationManagerConfig extends WebSecurityConfigurerAdapter {
 
@@ -92,6 +94,7 @@ public class HttpSecurityAuthenticationManagerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AuthenticationManagerBuilderConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/builders/NamespaceHttpTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/builders/NamespaceHttpTests.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.AccessDecisionManager;
 import org.springframework.security.access.ConfigAttribute;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -275,6 +276,7 @@ public class NamespaceHttpTests {
 				.isAssignableFrom(config.filterInvocationSecurityMetadataSourceType);
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AccessDecisionManagerRefConfig extends WebSecurityConfigurerAdapter {
 
@@ -292,6 +294,7 @@ public class NamespaceHttpTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AccessDeniedPageConfig extends WebSecurityConfigurerAdapter {
 
@@ -310,6 +313,7 @@ public class NamespaceHttpTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AuthenticationManagerRefConfig extends WebSecurityConfigurerAdapter {
 
@@ -333,6 +337,7 @@ public class NamespaceHttpTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CreateSessionAlwaysConfig extends WebSecurityConfigurerAdapter {
 
@@ -350,6 +355,7 @@ public class NamespaceHttpTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CreateSessionStatelessConfig extends WebSecurityConfigurerAdapter {
 
@@ -367,6 +373,7 @@ public class NamespaceHttpTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class IfRequiredConfig extends WebSecurityConfigurerAdapter {
 
@@ -387,6 +394,7 @@ public class NamespaceHttpTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CreateSessionNeverConfig extends WebSecurityConfigurerAdapter {
 
@@ -404,6 +412,7 @@ public class NamespaceHttpTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class EntryPointRefConfig extends WebSecurityConfigurerAdapter {
 
@@ -423,6 +432,7 @@ public class NamespaceHttpTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class JaasApiProvisionConfig extends WebSecurityConfigurerAdapter {
 
@@ -436,6 +446,7 @@ public class NamespaceHttpTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RealmConfig extends WebSecurityConfigurerAdapter {
 
@@ -453,6 +464,7 @@ public class NamespaceHttpTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RequestMatcherAntConfig extends WebSecurityConfigurerAdapter {
 
@@ -466,6 +478,7 @@ public class NamespaceHttpTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RequestMatcherRegexConfig extends WebSecurityConfigurerAdapter {
 
@@ -479,6 +492,7 @@ public class NamespaceHttpTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RequestMatcherRefConfig extends WebSecurityConfigurerAdapter {
 
@@ -501,6 +515,7 @@ public class NamespaceHttpTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SecurityNoneConfig extends WebSecurityConfigurerAdapter {
 
@@ -515,6 +530,7 @@ public class NamespaceHttpTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SecurityContextRepoConfig extends WebSecurityConfigurerAdapter {
 
@@ -543,6 +559,7 @@ public class NamespaceHttpTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ServletApiProvisionConfig extends WebSecurityConfigurerAdapter {
 
@@ -560,6 +577,7 @@ public class NamespaceHttpTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ServletApiProvisionDefaultsConfig extends WebSecurityConfigurerAdapter {
 
@@ -587,6 +605,7 @@ public class NamespaceHttpTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class UseExpressionsConfig extends WebSecurityConfigurerAdapter {
 
@@ -616,6 +635,7 @@ public class NamespaceHttpTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DisableUseExpressionsConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/builders/WebSecurityTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/builders/WebSecurityTests.java
@@ -237,6 +237,7 @@ public class WebSecurityTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RequestRejectedHandlerConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configuration/AuthenticationPrincipalArgumentResolverTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configuration/AuthenticationPrincipalArgumentResolverTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -75,6 +76,7 @@ public class AuthenticationPrincipalArgumentResolverTests {
 		// @formatter:on
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class Config {

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configuration/EnableWebSecurityTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configuration/EnableWebSecurityTests.java
@@ -100,6 +100,7 @@ public class EnableWebSecurityTests {
 		assertThat(parentBean.getChild()).isNotSameAs(childBean);
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SecurityConfig extends WebSecurityConfigurerAdapter {
 
@@ -136,11 +137,13 @@ public class EnableWebSecurityTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity(debug = true)
 	static class DebugSecurityConfig extends WebSecurityConfigurerAdapter {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class AuthenticationPrincipalConfig extends WebSecurityConfigurerAdapter {
@@ -161,6 +164,7 @@ public class EnableWebSecurityTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class SecurityFilterChainAuthenticationPrincipalConfig {
@@ -182,6 +186,7 @@ public class EnableWebSecurityTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class BeanProxyEnabledByDefaultConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configuration/HttpSecurityConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configuration/HttpSecurityConfigurationTests.java
@@ -269,6 +269,7 @@ public class HttpSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultWithFilterChainConfig {
 
@@ -279,6 +280,7 @@ public class HttpSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AuthorizeRequestsConfig {
 
@@ -295,6 +297,7 @@ public class HttpSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SecurityEnabledConfig {
 
@@ -329,6 +332,7 @@ public class HttpSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AuthorizeHttpRequestsBeforeAuthorizeRequestsConfig {
 
@@ -348,6 +352,7 @@ public class HttpSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AuthorizeHttpRequestsAfterAuthorizeRequestsConfig {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configuration/OAuth2ClientConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configuration/OAuth2ClientConfigurationTests.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.test.SpringTestContext;
@@ -212,6 +213,7 @@ public class OAuth2ClientConfigurationTests {
 		verifyNoInteractions(authorizedClientRepository);
 	}
 
+	@Configuration
 	@EnableWebMvc
 	@EnableWebSecurity
 	static class OAuth2AuthorizedClientArgumentResolverConfig extends WebSecurityConfigurerAdapter {
@@ -252,6 +254,7 @@ public class OAuth2ClientConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebMvc
 	@EnableWebSecurity
 	static class OAuth2AuthorizedClientRepositoryRegisteredTwiceConfig extends WebSecurityConfigurerAdapter {
@@ -289,6 +292,7 @@ public class OAuth2ClientConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebMvc
 	@EnableWebSecurity
 	static class ClientRegistrationRepositoryNotRegisteredConfig extends WebSecurityConfigurerAdapter {
@@ -306,6 +310,7 @@ public class OAuth2ClientConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebMvc
 	@EnableWebSecurity
 	static class ClientRegistrationRepositoryRegisteredTwiceConfig extends WebSecurityConfigurerAdapter {
@@ -343,6 +348,7 @@ public class OAuth2ClientConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebMvc
 	@EnableWebSecurity
 	static class AccessTokenResponseClientRegisteredTwiceConfig extends WebSecurityConfigurerAdapter {
@@ -380,6 +386,7 @@ public class OAuth2ClientConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebMvc
 	@EnableWebSecurity
 	static class OAuth2AuthorizedClientManagerRegisteredConfig extends WebSecurityConfigurerAdapter {

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configuration/Sec2515Tests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configuration/Sec2515Tests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.FatalBeanException;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.test.SpringTestContext;
@@ -72,6 +73,7 @@ public class Sec2515Tests {
 		this.spring.register(SecurityConfig.class).autowire();
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class StackOverflowSecurityConfig extends WebSecurityConfigurerAdapter {
 
@@ -83,6 +85,7 @@ public class Sec2515Tests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomBeanNameStackOverflowSecurityConfig extends WebSecurityConfigurerAdapter {
 
@@ -94,6 +97,7 @@ public class Sec2515Tests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CanLoadWithChildConfig extends WebSecurityConfigurerAdapter {
 
@@ -107,6 +111,7 @@ public class Sec2515Tests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SecurityConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configuration/SecurityReactorContextConfigurationResourceServerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configuration/SecurityReactorContextConfigurationResourceServerTests.java
@@ -104,6 +104,7 @@ public class SecurityReactorContextConfigurationResourceServerTests {
 		verify(strategy, atLeastOnce()).getContext();
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class BearerFilterConfig extends WebSecurityConfigurerAdapter {
 
@@ -120,6 +121,7 @@ public class SecurityReactorContextConfigurationResourceServerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class BearerFilterlessConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configuration/SecurityReactorContextConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configuration/SecurityReactorContextConfigurationTests.java
@@ -33,6 +33,7 @@ import reactor.core.publisher.Operators;
 import reactor.test.StepVerifier;
 import reactor.util.context.Context;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -268,6 +269,7 @@ public class SecurityReactorContextConfigurationTests {
 		verify(strategy, times(2)).getContext();
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SecurityConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurationTests.java
@@ -439,6 +439,7 @@ public class WebSecurityConfigurationTests {
 		assertThat(privilegeEvaluator.isAllowed("/another", user)).isTrue();
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(AuthenticationTestConfiguration.class)
 	static class SortedWebSecurityConfigurerAdaptersConfig {
@@ -512,6 +513,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(AuthenticationTestConfiguration.class)
 	static class SortedSecurityFilterChainConfig {
@@ -568,6 +570,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(AuthenticationTestConfiguration.class)
 	static class OrderOnBeanDefinitionsSecurityFilterChainConfig {
@@ -607,6 +610,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(AuthenticationTestConfiguration.class)
 	static class DuplicateOrderConfig {
@@ -643,6 +647,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PrivilegeEvaluatorConfigurerAdapterConfig extends WebSecurityConfigurerAdapter {
 
@@ -655,6 +660,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class WebSecurityExpressionHandlerConfig extends WebSecurityConfigurerAdapter {
 
@@ -677,6 +683,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NullWebSecurityExpressionHandlerConfig extends WebSecurityConfigurerAdapter {
 
@@ -687,6 +694,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class WebSecurityExpressionHandlerDefaultsConfig extends WebSecurityConfigurerAdapter {
 
@@ -701,6 +709,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class WebSecurityExpressionHandlerRoleHierarchyBeanConfig extends WebSecurityConfigurerAdapter {
 
@@ -713,6 +722,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class WebSecurityExpressionHandlerPermissionEvaluatorBeanConfig extends WebSecurityConfigurerAdapter {
 
@@ -736,6 +746,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class WebInvocationPrivilegeEvaluatorDefaultsConfig extends WebSecurityConfigurerAdapter {
 
@@ -750,6 +761,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AuthorizeRequestsFilterChainConfig {
 
@@ -766,6 +778,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultExpressionHandlerSetsBeanResolverConfig extends WebSecurityConfigurerAdapter {
 
@@ -807,6 +820,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ParentConfig extends WebSecurityConfigurerAdapter {
 
@@ -817,6 +831,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ChildConfig extends WebSecurityConfigurerAdapter {
 
@@ -827,6 +842,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@Import(AuthenticationTestConfiguration.class)
 	@EnableGlobalAuthentication
 	static class GlobalAuthenticationWebSecurityConfigurerAdaptersConfig {
@@ -868,6 +884,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(AuthenticationTestConfiguration.class)
 	static class AdapterAndFilterChainConfig {
@@ -904,6 +921,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(AuthenticationTestConfiguration.class)
 	static class WebSecurityCustomizerConfig {
@@ -915,6 +933,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(AuthenticationTestConfiguration.class)
 	static class CustomizerAndFilterChainConfig {
@@ -938,6 +957,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(AuthenticationTestConfiguration.class)
 	static class CustomizerAndAdapterConfig {
@@ -965,6 +985,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(AuthenticationTestConfiguration.class)
 	static class CustomizerAndAdapterIgnoringConfig {
@@ -986,6 +1007,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(AuthenticationTestConfiguration.class)
 	static class OrderedCustomizerConfig {
@@ -1004,6 +1026,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class MultipleAuthenticationManagersConfig {
 
@@ -1072,6 +1095,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class TwoSecurityFilterChainConfig {
 
@@ -1095,6 +1119,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity(debug = true)
 	static class TwoSecurityFilterChainDebugConfig {
 
@@ -1118,6 +1143,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(AuthenticationTestConfiguration.class)
 	static class MultipleSecurityFilterChainConfig {
@@ -1153,6 +1179,7 @@ public class WebSecurityConfigurationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(AuthenticationTestConfiguration.class)
 	static class MultipleSecurityFilterChainIgnoringConfig {

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configuration/sec2377/a/Sec2377AConfig.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configuration/sec2377/a/Sec2377AConfig.java
@@ -16,9 +16,11 @@
 
 package org.springframework.security.config.annotation.web.configuration.sec2377.a;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
+@Configuration
 @EnableWebSecurity
 public class Sec2377AConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configuration/sec2377/b/Sec2377BConfig.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configuration/sec2377/b/Sec2377BConfig.java
@@ -16,9 +16,11 @@
 
 package org.springframework.security.config.annotation.web.configuration.sec2377.b;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
+@Configuration
 @EnableWebSecurity
 public class Sec2377BConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/AnonymousConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/AnonymousConfigurerTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.config.annotation.SecurityContextChangedListenerConfig;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -89,6 +90,7 @@ public class AnonymousConfigurerTests {
 		this.mockMvc.perform(get("/")).andExpect(status().isOk());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class InvokeTwiceDoesNotOverride extends WebSecurityConfigurerAdapter {
@@ -107,6 +109,7 @@ public class AnonymousConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class AnonymousPrincipalInLambdaConfig extends WebSecurityConfigurerAdapter {
@@ -150,6 +153,7 @@ public class AnonymousConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AnonymousWithDefaultsInLambdaConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/AuthorizeHttpRequestsConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/AuthorizeHttpRequestsConfigurerTests.java
@@ -542,6 +542,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 		this.mvc.perform(requestWithUser).andExpect(status().isForbidden());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NoRequestsConfig {
 
@@ -556,6 +557,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NoRequestsNoParameterConfig {
 
@@ -571,6 +573,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class IncompleteMappingConfig {
 
@@ -585,6 +588,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class IncompleteMappingNoParameterConfig {
 
@@ -601,6 +605,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AfterAnyRequestConfig {
 
@@ -618,6 +623,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomAuthorizationManagerConfig {
 
@@ -636,6 +642,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomAuthorizationManagerNoParameterConfig {
 
@@ -654,6 +661,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ObjectPostProcessorConfig {
 
@@ -686,6 +694,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RoleUserAnyAuthorityConfig {
 
@@ -704,6 +713,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RoleUserAuthorityConfig {
 
@@ -722,6 +732,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RoleUserOrRoleAdminAuthorityConfig {
 
@@ -740,6 +751,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RoleUserConfig {
 
@@ -756,6 +768,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RoleUserOrAdminConfig {
 
@@ -772,6 +785,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DenyAllConfig {
 
@@ -790,6 +804,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PermitAllConfig {
 
@@ -806,6 +821,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class InvokeTwiceDoesNotResetConfig {
 
@@ -825,6 +841,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebMvc
 	@EnableWebSecurity
 	static class ServletPathConfig {
@@ -842,6 +859,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AuthenticatedConfig {
 
@@ -860,6 +878,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ExpressionRoleUserConfig {
 
@@ -876,6 +895,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ExpressionRoleUserOrAdminConfig {
 
@@ -892,6 +912,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ExpressionIpAddressLocalhostConfig {
 
@@ -937,6 +958,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FullyAuthenticatedConfig {
 
@@ -960,6 +982,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RememberMeConfig {
 
@@ -983,6 +1006,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AnonymousConfig {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ChannelSecurityConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ChannelSecurityConfigurerTests.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.ObjectPostProcessor;
@@ -128,6 +129,7 @@ public class ChannelSecurityConfigurerTests {
 		this.mvc.perform(get("/test-3")).andExpect(redirectedUrl("https://localhost/test-3"));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ObjectPostProcessorConfig extends WebSecurityConfigurerAdapter {
 
@@ -158,6 +160,7 @@ public class ChannelSecurityConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DuplicateInvocationsDoesNotOverrideConfig extends WebSecurityConfigurerAdapter {
 
@@ -174,6 +177,7 @@ public class ChannelSecurityConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RequiresChannelInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -190,6 +194,7 @@ public class ChannelSecurityConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RequiresChannelWithTestUrlRedirectStrategy extends WebSecurityConfigurerAdapter {
 
@@ -221,6 +226,7 @@ public class ChannelSecurityConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class RequiresChannelMultiMvcMatchersConfig {
@@ -248,6 +254,7 @@ public class ChannelSecurityConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class RequiresChannelMultiMvcMatchersInLambdaConfig {

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/CorsConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/CorsConfigurerTests.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -181,6 +182,7 @@ public class CorsConfigurerTests {
 				.andExpect(header().exists("X-Content-Type-Options"));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultCorsConfig extends WebSecurityConfigurerAdapter {
 
@@ -197,6 +199,7 @@ public class CorsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebMvc
 	@EnableWebSecurity
 	static class MvcCorsConfig extends WebSecurityConfigurerAdapter {
@@ -225,6 +228,7 @@ public class CorsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebMvc
 	@EnableWebSecurity
 	static class MvcCorsInLambdaConfig extends WebSecurityConfigurerAdapter {
@@ -254,6 +258,7 @@ public class CorsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ConfigSourceConfig extends WebSecurityConfigurerAdapter {
 
@@ -280,6 +285,7 @@ public class CorsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ConfigSourceInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -307,6 +313,7 @@ public class CorsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CorsFilterConfig extends WebSecurityConfigurerAdapter {
 
@@ -333,6 +340,7 @@ public class CorsConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CorsFilterInLambdaConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurerIgnoringRequestMatchersTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurerIgnoringRequestMatchersTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -79,6 +80,7 @@ public class CsrfConfigurerIgnoringRequestMatchersTests {
 		this.mvc.perform(put("/no-csrf")).andExpect(status().isOk());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class IgnoringRequestMatchers extends WebSecurityConfigurerAdapter {
 
@@ -96,6 +98,7 @@ public class CsrfConfigurerIgnoringRequestMatchersTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class IgnoringRequestInLambdaMatchers extends WebSecurityConfigurerAdapter {
 
@@ -115,6 +118,7 @@ public class CsrfConfigurerIgnoringRequestMatchersTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class IgnoringPathsAndMatchers extends WebSecurityConfigurerAdapter {
 
@@ -132,6 +136,7 @@ public class CsrfConfigurerIgnoringRequestMatchersTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class IgnoringPathsAndMatchersInLambdaConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurerNoWebMvcTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurerNoWebMvcTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -73,6 +74,7 @@ public class CsrfConfigurerNoWebMvcTests {
 		this.context = annotationConfigApplicationContext;
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class EnableWebConfig extends WebSecurityConfigurerAdapter {
 
@@ -82,6 +84,7 @@ public class CsrfConfigurerNoWebMvcTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class EnableWebOverrideRequestDataConfig {
 
@@ -93,6 +96,7 @@ public class CsrfConfigurerNoWebMvcTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class EnableWebMvcConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurerTests.java
@@ -418,6 +418,7 @@ public class CsrfConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CsrfAppliedDefaultConfig extends WebSecurityConfigurerAdapter {
 
@@ -427,6 +428,7 @@ public class CsrfConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DisableCsrfConfig extends WebSecurityConfigurerAdapter {
 
@@ -441,6 +443,7 @@ public class CsrfConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DisableCsrfInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -454,6 +457,7 @@ public class CsrfConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DisableCsrfEnablesRequestCacheConfig extends WebSecurityConfigurerAdapter {
 
@@ -482,6 +486,7 @@ public class CsrfConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CsrfDisablesPostRequestFromRequestCacheConfig extends WebSecurityConfigurerAdapter {
 
@@ -512,6 +517,7 @@ public class CsrfConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class InvalidSessionUrlConfig extends WebSecurityConfigurerAdapter {
 
@@ -528,6 +534,7 @@ public class CsrfConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RequireCsrfProtectionMatcherConfig extends WebSecurityConfigurerAdapter {
 
@@ -544,6 +551,7 @@ public class CsrfConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RequireCsrfProtectionMatcherInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -559,6 +567,7 @@ public class CsrfConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CsrfTokenRepositoryConfig extends WebSecurityConfigurerAdapter {
 
@@ -586,6 +595,7 @@ public class CsrfConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CsrfTokenRepositoryInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -602,6 +612,7 @@ public class CsrfConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AccessDeniedHandlerConfig extends WebSecurityConfigurerAdapter {
 
@@ -618,6 +629,7 @@ public class CsrfConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultAccessDeniedHandlerForConfig extends WebSecurityConfigurerAdapter {
 
@@ -636,6 +648,7 @@ public class CsrfConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FormLoginConfig extends WebSecurityConfigurerAdapter {
 
@@ -649,6 +662,7 @@ public class CsrfConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class LogoutAllowsGetConfig extends WebSecurityConfigurerAdapter {
 
@@ -665,6 +679,7 @@ public class CsrfConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NullRequireCsrfProtectionMatcherConfig extends WebSecurityConfigurerAdapter {
 
@@ -679,6 +694,7 @@ public class CsrfConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultDoesNotCreateSession extends WebSecurityConfigurerAdapter {
 
@@ -706,6 +722,7 @@ public class CsrfConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NullAuthenticationStrategy extends WebSecurityConfigurerAdapter {
 
@@ -720,6 +737,7 @@ public class CsrfConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CsrfAuthenticationStrategyConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/DefaultFiltersTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/DefaultFiltersTests.java
@@ -131,6 +131,7 @@ public class DefaultFiltersTests {
 		assertThat(response.getRedirectedUrl()).isEqualTo("/login?logout");
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FilterChainProxyBuilderMissingConfig {
 
@@ -155,6 +156,7 @@ public class DefaultFiltersTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NullWebInvocationPrivilegeEvaluatorConfig extends WebSecurityConfigurerAdapter {
 
@@ -169,6 +171,7 @@ public class DefaultFiltersTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FilterChainProxyBuilderIgnoringConfig extends WebSecurityConfigurerAdapter {
 
@@ -192,6 +195,7 @@ public class DefaultFiltersTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultFiltersConfigPermitAll extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/DefaultLoginPageConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/DefaultLoginPageConfigurerTests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.config.annotation.ObjectPostProcessor;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -310,6 +311,7 @@ public class DefaultLoginPageConfigurerTests {
 		this.mvc.perform(get("/logout").with(user("user"))).andExpect(status().isNotFound());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultLoginPageConfig extends WebSecurityConfigurerAdapter {
 
@@ -335,6 +337,7 @@ public class DefaultLoginPageConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultLoginPageCustomLogoutSuccessHandlerConfig extends WebSecurityConfigurerAdapter {
 
@@ -354,6 +357,7 @@ public class DefaultLoginPageConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultLoginPageCustomLogoutSuccessUrlConfig extends WebSecurityConfigurerAdapter {
 
@@ -373,6 +377,7 @@ public class DefaultLoginPageConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultLoginPageWithRememberMeConfig extends WebSecurityConfigurerAdapter {
 
@@ -391,6 +396,7 @@ public class DefaultLoginPageConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultLoginWithCustomAuthenticationEntryPointConfig extends WebSecurityConfigurerAdapter {
 
@@ -410,6 +416,7 @@ public class DefaultLoginPageConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ObjectPostProcessorConfig extends WebSecurityConfigurerAdapter {
 
@@ -432,6 +439,7 @@ public class DefaultLoginPageConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultLogoutPageConfig extends WebSecurityConfigurerAdapter {
 
@@ -448,6 +456,7 @@ public class DefaultLoginPageConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class LogoutDisabledConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ExceptionHandlingConfigurerAccessDeniedHandlerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ExceptionHandlingConfigurerAccessDeniedHandlerTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -74,6 +75,7 @@ public class ExceptionHandlingConfigurerAccessDeniedHandlerTests {
 		this.mvc.perform(get("/goodbye")).andExpect(status().isIAmATeapot());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RequestMatcherBasedAccessDeniedHandlerConfig extends WebSecurityConfigurerAdapter {
 
@@ -99,6 +101,7 @@ public class ExceptionHandlingConfigurerAccessDeniedHandlerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RequestMatcherBasedAccessDeniedHandlerInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -129,6 +132,7 @@ public class ExceptionHandlingConfigurerAccessDeniedHandlerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SingleRequestMatcherAccessDeniedHandlerConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ExceptionHandlingConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ExceptionHandlingConfigurerTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
@@ -228,6 +229,7 @@ public class ExceptionHandlingConfigurerTests {
 				any(HttpServletResponse.class), any(AuthenticationException.class));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ObjectPostProcessorConfig extends WebSecurityConfigurerAdapter {
 
@@ -257,6 +259,7 @@ public class ExceptionHandlingConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultSecurityConfig {
 
@@ -272,6 +275,7 @@ public class ExceptionHandlingConfigurerTests {
 			// @formatter:off
 		}
 	}
+	@Configuration
 	@EnableWebSecurity
 	static class HttpBasicAndFormLoginEntryPointsConfig extends WebSecurityConfigurerAdapter {
 		@Override
@@ -295,6 +299,7 @@ public class ExceptionHandlingConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OverrideContentNegotiationStrategySharedObjectConfig extends WebSecurityConfigurerAdapter {
 
@@ -307,11 +312,13 @@ public class ExceptionHandlingConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultHttpConfig extends WebSecurityConfigurerAdapter {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class BasicAuthenticationEntryPointBeforeFormLoginConfig extends WebSecurityConfigurerAdapter {
 
@@ -330,6 +337,7 @@ public class ExceptionHandlingConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class InvokeTwiceDoesNotOverrideConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ExpressionUrlAuthorizationConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ExpressionUrlAuthorizationConfigurerTests.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.AccessDecisionManager;
 import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.access.event.AuthorizedEvent;
@@ -549,6 +550,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 		this.mvc.perform(requestWithUser).andExpect(status().isForbidden());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HasRoleStartingWithRoleConfig extends WebSecurityConfigurerAdapter {
 
@@ -563,6 +565,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NoSpecificAccessDecisionManagerConfig extends WebSecurityConfigurerAdapter {
 
@@ -584,6 +587,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NoRequestsConfig extends WebSecurityConfigurerAdapter {
 
@@ -597,6 +601,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class IncompleteMappingConfig extends WebSecurityConfigurerAdapter {
 
@@ -612,6 +617,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RoleUserAnyAuthorityConfig extends WebSecurityConfigurerAdapter {
 
@@ -628,6 +634,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RoleUserAuthorityConfig extends WebSecurityConfigurerAdapter {
 
@@ -644,6 +651,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RoleUserOrRoleAdminAuthorityConfig extends WebSecurityConfigurerAdapter {
 
@@ -660,6 +668,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RoleUserConfig extends WebSecurityConfigurerAdapter {
 
@@ -674,6 +683,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RoleUserWithTestRolePrefixConfig extends WebSecurityConfigurerAdapter {
 
@@ -693,6 +703,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RoleUserWithEmptyRolePrefixConfig extends WebSecurityConfigurerAdapter {
 
@@ -712,6 +723,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RoleUserOrAdminConfig extends WebSecurityConfigurerAdapter {
 
@@ -726,6 +738,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RoleUserOrAdminWithTestRolePrefixConfig extends WebSecurityConfigurerAdapter {
 
@@ -745,6 +758,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RoleUserOrAdminWithEmptyRolePrefixConfig extends WebSecurityConfigurerAdapter {
 
@@ -764,6 +778,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HasIpAddressConfig extends WebSecurityConfigurerAdapter {
 
@@ -780,6 +795,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AnonymousConfig extends WebSecurityConfigurerAdapter {
 
@@ -796,6 +812,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RememberMeConfig extends WebSecurityConfigurerAdapter {
 
@@ -823,6 +840,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DenyAllConfig extends WebSecurityConfigurerAdapter {
 
@@ -839,6 +857,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NotDenyAllConfig extends WebSecurityConfigurerAdapter {
 
@@ -855,6 +874,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FullyAuthenticatedConfig extends WebSecurityConfigurerAdapter {
 
@@ -873,6 +893,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AccessConfig extends WebSecurityConfigurerAdapter {
 
@@ -891,6 +912,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class InvokeTwiceDoesNotResetConfig extends WebSecurityConfigurerAdapter {
 
@@ -909,6 +931,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AllPropertiesWorkConfig extends WebSecurityConfigurerAdapter {
 
@@ -932,6 +955,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AuthorizedRequestsWithPostProcessorConfig extends WebSecurityConfigurerAdapter {
 
@@ -961,6 +985,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class UseBeansInExpressions extends WebSecurityConfigurerAdapter {
 
@@ -991,6 +1016,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomExpressionRootConfig extends WebSecurityConfigurerAdapter {
 
@@ -1041,6 +1067,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class Sec3011Config extends WebSecurityConfigurerAdapter {
 
@@ -1070,6 +1097,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PermissionEvaluatorConfig extends WebSecurityConfigurerAdapter {
 
@@ -1105,6 +1133,7 @@ public class ExpressionUrlAuthorizationConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RoleHierarchyConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/FormLoginConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/FormLoginConfigurerTests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.ObjectPostProcessor;
 import org.springframework.security.config.annotation.SecurityContextChangedListenerConfig;
@@ -375,6 +376,7 @@ public class FormLoginConfigurerTests {
 		verify(ObjectPostProcessorConfig.objectPostProcessor).postProcess(any(ExceptionTranslationFilter.class));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RequestCacheConfig extends WebSecurityConfigurerAdapter {
 
@@ -392,6 +394,7 @@ public class FormLoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RequestCacheBeanConfig {
 
@@ -402,6 +405,7 @@ public class FormLoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FormLoginConfig extends WebSecurityConfigurerAdapter {
 
@@ -437,6 +441,7 @@ public class FormLoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FormLoginInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -463,6 +468,7 @@ public class FormLoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FormLoginConfigPermitAll extends WebSecurityConfigurerAdapter {
 
@@ -480,6 +486,7 @@ public class FormLoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FormLoginDefaultsConfig extends WebSecurityConfigurerAdapter {
 
@@ -501,6 +508,7 @@ public class FormLoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FormLoginDefaultsInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -523,6 +531,7 @@ public class FormLoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FormLoginLoginProcessingUrlConfig extends WebSecurityConfigurerAdapter {
 
@@ -559,6 +568,7 @@ public class FormLoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FormLoginLoginProcessingUrlInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -597,6 +607,7 @@ public class FormLoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FormLoginUsesPortMapperConfig extends WebSecurityConfigurerAdapter {
 
@@ -622,6 +633,7 @@ public class FormLoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PermitAllIgnoresFailureHandlerConfig extends WebSecurityConfigurerAdapter {
 
@@ -642,6 +654,7 @@ public class FormLoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DuplicateInvocationsDoesNotOverrideConfig extends WebSecurityConfigurerAdapter {
 
@@ -667,6 +680,7 @@ public class FormLoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FormLoginUserForwardAuthenticationSuccessAndFailureConfig extends WebSecurityConfigurerAdapter {
 
@@ -697,6 +711,7 @@ public class FormLoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ObjectPostProcessorConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/HeadersConfigurerEagerHeadersTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/HeadersConfigurerEagerHeadersTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.config.annotation.ObjectPostProcessor;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -58,6 +59,7 @@ public class HeadersConfigurerEagerHeadersTests {
 				.andExpect(header().string("X-XSS-Protection", "1; mode=block"));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	public static class HeadersAtTheBeginningOfRequestConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/HeadersConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/HeadersConfigurerTests.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -544,6 +545,7 @@ public class HeadersConfigurerTests {
 				HttpHeaders.CROSS_ORIGIN_EMBEDDER_POLICY, HttpHeaders.CROSS_ORIGIN_RESOURCE_POLICY);
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HeadersConfig extends WebSecurityConfigurerAdapter {
 
@@ -557,6 +559,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HeadersInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -570,6 +573,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ContentTypeOptionsConfig extends WebSecurityConfigurerAdapter {
 
@@ -585,6 +589,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ContentTypeOptionsInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -602,6 +607,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FrameOptionsConfig extends WebSecurityConfigurerAdapter {
 
@@ -617,6 +623,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HstsConfig extends WebSecurityConfigurerAdapter {
 
@@ -632,6 +639,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CacheControlConfig extends WebSecurityConfigurerAdapter {
 
@@ -647,6 +655,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CacheControlInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -664,6 +673,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class XssProtectionConfig extends WebSecurityConfigurerAdapter {
 
@@ -679,6 +689,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class XssProtectionInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -696,6 +707,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HeadersCustomSameOriginConfig extends WebSecurityConfigurerAdapter {
 
@@ -710,6 +722,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HeadersCustomSameOriginInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -726,6 +739,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HpkpConfigNoPins extends WebSecurityConfigurerAdapter {
 
@@ -741,6 +755,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HpkpConfig extends WebSecurityConfigurerAdapter {
 
@@ -757,6 +772,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HpkpConfigWithPins extends WebSecurityConfigurerAdapter {
 
@@ -776,6 +792,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HpkpConfigCustomAge extends WebSecurityConfigurerAdapter {
 
@@ -793,6 +810,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HpkpConfigTerminateConnection extends WebSecurityConfigurerAdapter {
 
@@ -810,6 +828,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HpkpConfigIncludeSubDomains extends WebSecurityConfigurerAdapter {
 
@@ -827,6 +846,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HpkpConfigWithReportURI extends WebSecurityConfigurerAdapter {
 
@@ -844,6 +864,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HpkpConfigWithReportURIAsString extends WebSecurityConfigurerAdapter {
 
@@ -861,6 +882,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HpkpWithReportUriInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -882,6 +904,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ContentSecurityPolicyDefaultConfig extends WebSecurityConfigurerAdapter {
 
@@ -897,6 +920,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ContentSecurityPolicyReportOnlyConfig extends WebSecurityConfigurerAdapter {
 
@@ -913,6 +937,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ContentSecurityPolicyReportOnlyInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -934,6 +959,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ContentSecurityPolicyInvalidConfig extends WebSecurityConfigurerAdapter {
 
@@ -949,6 +975,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ContentSecurityPolicyInvalidInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -968,6 +995,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ContentSecurityPolicyNoDirectivesInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -985,6 +1013,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ReferrerPolicyDefaultConfig extends WebSecurityConfigurerAdapter {
 
@@ -1000,6 +1029,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ReferrerPolicyDefaultInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -1017,6 +1047,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ReferrerPolicyCustomConfig extends WebSecurityConfigurerAdapter {
 
@@ -1032,6 +1063,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ReferrerPolicyCustomInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -1051,6 +1083,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FeaturePolicyConfig extends WebSecurityConfigurerAdapter {
 
@@ -1066,6 +1099,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FeaturePolicyInvalidConfig extends WebSecurityConfigurerAdapter {
 
@@ -1081,6 +1115,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PermissionsPolicyConfig extends WebSecurityConfigurerAdapter {
 
@@ -1096,6 +1131,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PermissionsPolicyStringConfig extends WebSecurityConfigurerAdapter {
 
@@ -1112,6 +1148,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PermissionsPolicyInvalidConfig extends WebSecurityConfigurerAdapter {
 
@@ -1127,6 +1164,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PermissionsPolicyInvalidStringConfig extends WebSecurityConfigurerAdapter {
 
@@ -1143,6 +1181,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HstsWithPreloadConfig extends WebSecurityConfigurerAdapter {
 
@@ -1159,6 +1198,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HstsWithPreloadInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -1176,6 +1216,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CrossOriginCustomPoliciesInLambdaConfig {
 
@@ -1200,6 +1241,7 @@ public class HeadersConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CrossOriginCustomPoliciesConfig {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/HttpBasicConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/HttpBasicConfigurerTests.java
@@ -147,6 +147,7 @@ public class HttpBasicConfigurerTests {
 		verify(listener).securityContextChanged(setAuthentication(UsernamePasswordAuthenticationToken.class));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ObjectPostProcessorConfig extends WebSecurityConfigurerAdapter {
 
@@ -176,6 +177,7 @@ public class HttpBasicConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultsLambdaEntryPointConfig extends WebSecurityConfigurerAdapter {
 
@@ -201,6 +203,7 @@ public class HttpBasicConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultsEntryPointConfig extends WebSecurityConfigurerAdapter {
 
@@ -225,6 +228,7 @@ public class HttpBasicConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomAuthenticationEntryPointConfig extends WebSecurityConfigurerAdapter {
 
@@ -252,6 +256,7 @@ public class HttpBasicConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DuplicateDoesNotOverrideConfig extends WebSecurityConfigurerAdapter {
 
@@ -311,6 +316,7 @@ public class HttpBasicConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HttpBasic {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/Issue55Tests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/Issue55Tests.java
@@ -88,6 +88,7 @@ public class Issue55Tests {
 		return this.spring.getContext().getBean(FilterChainProxy.class).getFilterChains().get(index);
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class WebSecurityConfigurerAdapterDefaultsAuthManagerConfig {
 
@@ -117,6 +118,7 @@ public class Issue55Tests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class MultiWebSecurityConfigurerAdapterDefaultsAuthManagerConfig {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/JeeConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/JeeConfigurerTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.ObjectPostProcessor;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -151,6 +152,7 @@ public class JeeConfigurerTests {
 		this.mvc.perform(authRequest).andExpect(authenticated().withRoles("USER"));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ObjectPostProcessorConfig extends WebSecurityConfigurerAdapter {
 
@@ -180,6 +182,7 @@ public class JeeConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class InvokeTwiceDoesNotOverride extends WebSecurityConfigurerAdapter {
 
@@ -196,6 +199,7 @@ public class JeeConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	public static class JeeMappableRolesConfig extends WebSecurityConfigurerAdapter {
 
@@ -216,6 +220,7 @@ public class JeeConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	public static class JeeMappableAuthoritiesConfig extends WebSecurityConfigurerAdapter {
 
@@ -236,6 +241,7 @@ public class JeeConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	public static class JeeCustomAuthenticatedUserDetailsServiceConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/LogoutConfigurerClearSiteDataTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/LogoutConfigurerClearSiteDataTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -87,6 +88,7 @@ public class LogoutConfigurerClearSiteDataTests {
 		this.mvc.perform(logoutRequest).andExpect(header().stringValues(CLEAR_SITE_DATA_HEADER, HEADER_VALUE));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HttpLogoutConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/LogoutConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/LogoutConfigurerTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.ObjectPostProcessor;
 import org.springframework.security.config.annotation.SecurityContextChangedListenerConfig;
@@ -321,6 +322,7 @@ public class LogoutConfigurerTests {
 		this.mvc.perform(post("/logout").with(csrf())).andExpect(status().isNotFound());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NullLogoutSuccessHandlerConfig extends WebSecurityConfigurerAdapter {
 
@@ -335,6 +337,7 @@ public class LogoutConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NullLogoutSuccessHandlerInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -350,6 +353,7 @@ public class LogoutConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NullMatcherConfig extends WebSecurityConfigurerAdapter {
 
@@ -364,6 +368,7 @@ public class LogoutConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NullMatcherInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -379,6 +384,7 @@ public class LogoutConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ObjectPostProcessorConfig extends WebSecurityConfigurerAdapter {
 
@@ -408,6 +414,7 @@ public class LogoutConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DuplicateDoesNotOverrideConfig extends WebSecurityConfigurerAdapter {
 
@@ -432,6 +439,7 @@ public class LogoutConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CsrfDisabledConfig extends WebSecurityConfigurerAdapter {
 
@@ -447,6 +455,7 @@ public class LogoutConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CsrfDisabledAndCustomLogoutConfig extends WebSecurityConfigurerAdapter {
 
@@ -463,6 +472,7 @@ public class LogoutConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CsrfDisabledAndCustomLogoutInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -478,6 +488,7 @@ public class LogoutConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NullLogoutHandlerConfig extends WebSecurityConfigurerAdapter {
 
@@ -492,6 +503,7 @@ public class LogoutConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NullLogoutHandlerInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -505,6 +517,7 @@ public class LogoutConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RememberMeNoLogoutHandler extends WebSecurityConfigurerAdapter {
 
@@ -521,11 +534,13 @@ public class LogoutConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class BasicSecurityConfig extends WebSecurityConfigurerAdapter {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class LogoutDisabledConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceDebugTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceDebugTests.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.test.SpringTestContext;
@@ -84,11 +85,13 @@ public class NamespaceDebugTests {
 		return this.spring.getContext().getBean("springSecurityFilterChain").getClass();
 	}
 
+	@Configuration
 	@EnableWebSecurity(debug = true)
 	static class DebugWebSecurity extends WebSecurityConfigurerAdapter {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NoDebugWebSecurity extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpAnonymousTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpAnonymousTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -86,6 +87,7 @@ public class NamespaceHttpAnonymousTests {
 		this.mvc.perform(get("/principal")).andExpect(content().string("AnonymousUsernameConfig"));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AnonymousConfig extends WebSecurityConfigurerAdapter {
 
@@ -101,6 +103,7 @@ public class NamespaceHttpAnonymousTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AnonymousDisabledConfig extends WebSecurityConfigurerAdapter {
 
@@ -127,6 +130,7 @@ public class NamespaceHttpAnonymousTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AnonymousGrantedAuthorityConfig extends WebSecurityConfigurerAdapter {
 
@@ -145,6 +149,7 @@ public class NamespaceHttpAnonymousTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AnonymousKeyConfig extends WebSecurityConfigurerAdapter {
 
@@ -162,6 +167,7 @@ public class NamespaceHttpAnonymousTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AnonymousUsernameConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpBasicTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpBasicTests.java
@@ -175,6 +175,7 @@ public class NamespaceHttpBasicTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HttpBasicConfig extends WebSecurityConfigurerAdapter {
 
@@ -191,6 +192,7 @@ public class NamespaceHttpBasicTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HttpBasicLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -208,6 +210,7 @@ public class NamespaceHttpBasicTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomHttpBasicConfig extends WebSecurityConfigurerAdapter {
 
@@ -224,6 +227,7 @@ public class NamespaceHttpBasicTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomHttpBasicLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -241,6 +245,7 @@ public class NamespaceHttpBasicTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AuthenticationDetailsSourceHttpBasicConfig extends WebSecurityConfigurerAdapter {
 
@@ -263,6 +268,7 @@ public class NamespaceHttpBasicTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AuthenticationDetailsSourceHttpBasicLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -285,6 +291,7 @@ public class NamespaceHttpBasicTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class EntryPointRefHttpBasicConfig extends WebSecurityConfigurerAdapter {
 
@@ -304,6 +311,7 @@ public class NamespaceHttpBasicTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class EntryPointRefHttpBasicLambdaConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpCustomFilterTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpCustomFilterTests.java
@@ -98,6 +98,7 @@ public class NamespaceHttpCustomFilterTests {
 		return assertThat(filters);
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomFilterBeforeConfig extends WebSecurityConfigurerAdapter {
 
@@ -112,6 +113,7 @@ public class NamespaceHttpCustomFilterTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomFilterAfterConfig extends WebSecurityConfigurerAdapter {
 
@@ -126,6 +128,7 @@ public class NamespaceHttpCustomFilterTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomFilterPositionConfig extends WebSecurityConfigurerAdapter {
 
@@ -146,6 +149,7 @@ public class NamespaceHttpCustomFilterTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomFilterPositionAtConfig extends WebSecurityConfigurerAdapter {
 
@@ -164,6 +168,7 @@ public class NamespaceHttpCustomFilterTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NoAuthenticationManagerInHttpConfigurationConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpExpressionHandlerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpExpressionHandlerTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -74,6 +75,7 @@ public class NamespaceHttpExpressionHandlerTests {
 		return verify(this.spring.getContext().getBean(beanName, beanClass));
 	}
 
+	@Configuration
 	@EnableWebMvc
 	@EnableWebSecurity
 	private static class ExpressionHandlerConfig extends WebSecurityConfigurerAdapter {

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpFirewallTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpFirewallTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -69,11 +70,13 @@ public class NamespaceHttpFirewallTests {
 		this.mvc.perform(get("/").param("deny", "true")).andExpect(status().isBadRequest());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HttpFirewallConfig {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomHttpFirewallConfig extends WebSecurityConfigurerAdapter {
 
@@ -84,6 +87,7 @@ public class NamespaceHttpFirewallTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomHttpFirewallBeanConfig {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpFormLoginTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpFormLoginTests.java
@@ -109,6 +109,7 @@ public class NamespaceHttpFormLoginTests {
 		return verify(this.spring.getContext().getBean(beanClass));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FormLoginConfig extends WebSecurityConfigurerAdapter {
 
@@ -153,6 +154,7 @@ public class NamespaceHttpFormLoginTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FormLoginCustomRefsConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpHeadersTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpHeadersTests.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -150,6 +151,7 @@ public class NamespaceHttpHeadersTests {
 		};
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HeadersDefaultConfig extends WebSecurityConfigurerAdapter {
 
@@ -163,6 +165,7 @@ public class NamespaceHttpHeadersTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HeadersCacheControlConfig extends WebSecurityConfigurerAdapter {
 
@@ -178,6 +181,7 @@ public class NamespaceHttpHeadersTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HstsConfig extends WebSecurityConfigurerAdapter {
 
@@ -193,6 +197,7 @@ public class NamespaceHttpHeadersTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HstsCustomConfig extends WebSecurityConfigurerAdapter {
 
@@ -212,6 +217,7 @@ public class NamespaceHttpHeadersTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FrameOptionsSameOriginConfig extends WebSecurityConfigurerAdapter {
 
@@ -229,6 +235,7 @@ public class NamespaceHttpHeadersTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FrameOptionsAllowFromConfig extends WebSecurityConfigurerAdapter {
 
@@ -246,6 +253,7 @@ public class NamespaceHttpHeadersTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class XssProtectionConfig extends WebSecurityConfigurerAdapter {
 
@@ -262,6 +270,7 @@ public class NamespaceHttpHeadersTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class XssProtectionCustomConfig extends WebSecurityConfigurerAdapter {
 
@@ -280,6 +289,7 @@ public class NamespaceHttpHeadersTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ContentTypeOptionsConfig extends WebSecurityConfigurerAdapter {
 
@@ -296,6 +306,7 @@ public class NamespaceHttpHeadersTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HeaderRefConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpInterceptUrlTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpInterceptUrlTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -104,6 +105,7 @@ public class NamespaceHttpInterceptUrlTests {
 				AuthorityUtils.createAuthorityList(role));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HttpInterceptUrlConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpJeeTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpJeeTests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -94,6 +95,7 @@ public class NamespaceHttpJeeTests {
 		return verify(this.spring.getContext().getBean(beanClass));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	public static class JeeMappableRolesConfig extends WebSecurityConfigurerAdapter {
 
@@ -111,6 +113,7 @@ public class NamespaceHttpJeeTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	public static class JeeUserServiceRefConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpLogoutTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpLogoutTests.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -162,6 +163,7 @@ public class NamespaceHttpLogoutTests {
 				.is(new Condition<>(sessionPredicate, "sessionPredicate failed"));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HttpLogoutConfig extends WebSecurityConfigurerAdapter {
 
@@ -171,6 +173,7 @@ public class NamespaceHttpLogoutTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HttpLogoutDisabledInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -181,6 +184,7 @@ public class NamespaceHttpLogoutTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomHttpLogoutConfig extends WebSecurityConfigurerAdapter {
 
@@ -198,6 +202,7 @@ public class NamespaceHttpLogoutTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomHttpLogoutInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -216,6 +221,7 @@ public class NamespaceHttpLogoutTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SuccessHandlerRefHttpLogoutConfig extends WebSecurityConfigurerAdapter {
 
@@ -232,6 +238,7 @@ public class NamespaceHttpLogoutTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SuccessHandlerRefHttpLogoutInLambdaConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpPortMappingsTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpPortMappingsTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -56,6 +57,7 @@ public class NamespaceHttpPortMappingsTests {
 		this.mvc.perform(get("https://localhost:9443/user")).andExpect(redirectedUrl("http://localhost:9080/user"));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HttpInterceptUrlWithPortMapperConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpRequestCacheTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpRequestCacheTests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -78,6 +79,7 @@ public class NamespaceHttpRequestCacheTests {
 		return verify(this.spring.getContext().getBean(beanClass));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RequestCacheRefConfig extends WebSecurityConfigurerAdapter {
 
@@ -110,6 +112,7 @@ public class NamespaceHttpRequestCacheTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultRequestCacheRefConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpServerAccessDeniedHandlerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpServerAccessDeniedHandlerTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -103,6 +104,7 @@ public class NamespaceHttpServerAccessDeniedHandlerTests {
 		return verify(this.spring.getContext().getBean(beanClass));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AccessDeniedPageConfig extends WebSecurityConfigurerAdapter {
 
@@ -120,6 +122,7 @@ public class NamespaceHttpServerAccessDeniedHandlerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AccessDeniedPageInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -139,6 +142,7 @@ public class NamespaceHttpServerAccessDeniedHandlerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AccessDeniedHandlerRefConfig extends WebSecurityConfigurerAdapter {
 
@@ -161,6 +165,7 @@ public class NamespaceHttpServerAccessDeniedHandlerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AccessDeniedHandlerRefInLambdaConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpX509Tests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpX509Tests.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -131,6 +132,7 @@ public class NamespaceHttpX509Tests {
 		return verify(this.spring.getContext().getBean(beanClass));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	public static class X509Config extends WebSecurityConfigurerAdapter {
@@ -157,6 +159,7 @@ public class NamespaceHttpX509Tests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class AuthenticationDetailsSourceRefConfig extends WebSecurityConfigurerAdapter {
@@ -190,6 +193,7 @@ public class NamespaceHttpX509Tests {
 	}
 
 	@EnableWebMvc
+	@Configuration
 	@EnableWebSecurity
 	public static class SubjectPrincipalRegexConfig extends WebSecurityConfigurerAdapter {
 
@@ -217,6 +221,7 @@ public class NamespaceHttpX509Tests {
 	}
 
 	@EnableWebMvc
+	@Configuration
 	@EnableWebSecurity
 	public static class CustomPrincipalExtractorConfig extends WebSecurityConfigurerAdapter {
 
@@ -249,6 +254,7 @@ public class NamespaceHttpX509Tests {
 	}
 
 	@EnableWebMvc
+	@Configuration
 	@EnableWebSecurity
 	public static class UserDetailsServiceRefConfig extends WebSecurityConfigurerAdapter {
 
@@ -276,6 +282,7 @@ public class NamespaceHttpX509Tests {
 	}
 
 	@EnableWebMvc
+	@Configuration
 	@EnableWebSecurity
 	public static class AuthenticationUserDetailsServiceConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceSessionManagementTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceSessionManagementTests.java
@@ -254,11 +254,13 @@ public class NamespaceSessionManagementTests {
 		return new SessionResultMatcher();
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SessionManagementConfig extends WebSecurityConfigurerAdapter {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomSessionManagementConfig extends WebSecurityConfigurerAdapter {
 
@@ -290,6 +292,7 @@ public class NamespaceSessionManagementTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class InvalidSessionStrategyConfig extends WebSecurityConfigurerAdapter {
 
@@ -311,6 +314,7 @@ public class NamespaceSessionManagementTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RefsSessionManagementConfig extends WebSecurityConfigurerAdapter {
 
@@ -334,6 +338,7 @@ public class NamespaceSessionManagementTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SFPNoneSessionManagementConfig extends WebSecurityConfigurerAdapter {
 
@@ -350,6 +355,7 @@ public class NamespaceSessionManagementTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SFPMigrateSessionManagementConfig extends WebSecurityConfigurerAdapter {
 
@@ -365,6 +371,7 @@ public class NamespaceSessionManagementTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SFPPostProcessedConfig extends WebSecurityConfigurerAdapter {
 
@@ -385,6 +392,7 @@ public class NamespaceSessionManagementTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SFPNewSessionSessionManagementConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/PasswordManagementConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/PasswordManagementConfigurerTests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.test.SpringTestContext;
@@ -84,6 +85,7 @@ public class PasswordManagementConfigurerTests {
 				.withMessage("changePasswordPage cannot be empty");
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PasswordManagementWithDefaultChangePasswordPageConfig {
 
@@ -98,6 +100,7 @@ public class PasswordManagementConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PasswordManagementWithCustomChangePasswordPageConfig {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/PermitAllSupportTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/PermitAllSupportTests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -89,6 +90,7 @@ public class PermitAllSupportTests {
 						"permitAll only works with either HttpSecurity.authorizeRequests() or HttpSecurity.authorizeHttpRequests()");
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PermitAllConfig extends WebSecurityConfigurerAdapter {
 
@@ -107,6 +109,7 @@ public class PermitAllSupportTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PermitAllConfigAuthorizeHttpRequests extends WebSecurityConfigurerAdapter {
 
@@ -125,6 +128,7 @@ public class PermitAllSupportTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PermitAllConfigWithBothConfigs extends WebSecurityConfigurerAdapter {
 
@@ -146,6 +150,7 @@ public class PermitAllSupportTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NoAuthorizedUrlsConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/PortMapperConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/PortMapperConfigurerTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -63,6 +64,7 @@ public class PortMapperConfigurerTests {
 		this.mockMvc.perform(get("http://localhost:543")).andExpect(redirectedUrl("https://localhost:123"));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class InvokeTwiceDoesNotOverride extends WebSecurityConfigurerAdapter {
 
@@ -82,6 +84,7 @@ public class PortMapperConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class HttpMapsToInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -102,6 +105,7 @@ public class PortMapperConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomPortMapperInLambdaConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/RememberMeConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/RememberMeConfigurerTests.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.authentication.RememberMeAuthenticationToken;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
@@ -302,6 +303,7 @@ public class RememberMeConfigurerTests {
 		this.mvc.perform(requestWithRememberme).andExpect(remembermeAuthentication);
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NullUserDetailsConfig extends WebSecurityConfigurerAdapter {
 
@@ -331,6 +333,7 @@ public class RememberMeConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ObjectPostProcessorConfig extends WebSecurityConfigurerAdapter {
 
@@ -369,6 +372,7 @@ public class RememberMeConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DuplicateDoesNotOverrideConfig extends WebSecurityConfigurerAdapter {
 
@@ -403,6 +407,7 @@ public class RememberMeConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class UserDetailsServiceBeanConfig {
 
@@ -423,6 +428,7 @@ public class RememberMeConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RememberMeConfig extends WebSecurityConfigurerAdapter {
 
@@ -450,6 +456,7 @@ public class RememberMeConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RememberMeInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -477,6 +484,7 @@ public class RememberMeConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RememberMeCookieDomainConfig extends WebSecurityConfigurerAdapter {
 
@@ -505,6 +513,7 @@ public class RememberMeConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RememberMeCookieDomainInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -535,6 +544,7 @@ public class RememberMeConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RememberMeCookieNameAndRememberMeServicesConfig extends WebSecurityConfigurerAdapter {
 
@@ -567,6 +577,7 @@ public class RememberMeConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FallbackRememberMeKeyConfig extends RememberMeConfig {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurerTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
@@ -299,6 +300,7 @@ public class RequestCacheConfigurerTests {
 		// @formatter:on
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ObjectPostProcessorConfig extends WebSecurityConfigurerAdapter {
 
@@ -328,6 +330,7 @@ public class RequestCacheConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class InvokeTwiceDoesNotOverrideConfig extends WebSecurityConfigurerAdapter {
 
@@ -346,6 +349,7 @@ public class RequestCacheConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RequestCacheDefaultsConfig extends WebSecurityConfigurerAdapter {
 
@@ -362,6 +366,7 @@ public class RequestCacheConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RequestCacheDisabledConfig extends WebSecurityConfigurerAdapter {
 
@@ -373,6 +378,7 @@ public class RequestCacheConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RequestCacheDisabledInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -391,6 +397,7 @@ public class RequestCacheConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RequestCacheInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -409,6 +416,7 @@ public class RequestCacheConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomRequestCacheInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -430,6 +438,7 @@ public class RequestCacheConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultSecurityConfig {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/RequestMatcherConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/RequestMatcherConfigurerTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -67,6 +68,7 @@ public class RequestMatcherConfigurerTests {
 		// @formatter:on
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class Sec2908Config extends WebSecurityConfigurerAdapter {
 
@@ -87,6 +89,7 @@ public class RequestMatcherConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AuthorizeRequestInLambdaConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/SecurityContextConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/SecurityContextConfigurerTests.java
@@ -139,6 +139,7 @@ public class SecurityContextConfigurerTests {
 		assertThat(securityContext.getAuthentication()).isNotNull();
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ObjectPostProcessorConfig extends WebSecurityConfigurerAdapter {
 
@@ -168,6 +169,7 @@ public class SecurityContextConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DuplicateDoesNotOverrideConfig extends WebSecurityConfigurerAdapter {
 
@@ -221,6 +223,7 @@ public class SecurityContextConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SecurityContextWithDefaultsInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -244,6 +247,7 @@ public class SecurityContextConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SecurityContextDisabledInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -267,6 +271,7 @@ public class SecurityContextConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NullSecurityContextRepositoryInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -293,6 +298,7 @@ public class SecurityContextConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RequireExplicitSaveConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ServletApiConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ServletApiConfigurerTests.java
@@ -211,6 +211,7 @@ public class ServletApiConfigurerTests {
 		}
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ObjectPostProcessorConfig extends WebSecurityConfigurerAdapter {
 
@@ -240,6 +241,7 @@ public class ServletApiConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ServletApiConfig extends WebSecurityConfigurerAdapter {
 
@@ -259,6 +261,7 @@ public class ServletApiConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomEntryPointConfig extends WebSecurityConfigurerAdapter {
 
@@ -289,6 +292,7 @@ public class ServletApiConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DuplicateInvocationsDoesNotOverrideConfig extends WebSecurityConfigurerAdapter {
 
@@ -305,6 +309,7 @@ public class ServletApiConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SharedTrustResolverConfig extends WebSecurityConfigurerAdapter {
 
@@ -320,6 +325,7 @@ public class ServletApiConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ServletApiWithDefaultsInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -333,6 +339,7 @@ public class ServletApiConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RolePrefixInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -361,6 +368,7 @@ public class ServletApiConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ServletApiWithLogoutConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurerServlet31Tests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurerServlet31Tests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -106,6 +107,7 @@ public class SessionManagementConfigurerServlet31Tests {
 		repo.saveContext(securityContextImpl, requestResponseHolder.getRequest(), requestResponseHolder.getResponse());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SessionManagementDefaultSessionFixationServlet31Config extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurerSessionAuthenticationStrategyTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurerSessionAuthenticationStrategyTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -58,6 +59,7 @@ public class SessionManagementConfigurerSessionAuthenticationStrategyTests {
 				any(Authentication.class), any(HttpServletRequest.class), any(HttpServletResponse.class));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomSessionAuthenticationStrategyConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurerSessionCreationPolicyTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurerSessionCreationPolicyTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -71,6 +72,7 @@ public class SessionManagementConfigurerSessionCreationPolicyTests {
 		assertThat(result.getRequest().getSession(false)).isNotNull();
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class StatelessCreateSessionSharedObjectConfig extends WebSecurityConfigurerAdapter {
 
@@ -82,6 +84,7 @@ public class SessionManagementConfigurerSessionCreationPolicyTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class StatelessCreateSessionUserConfig extends WebSecurityConfigurerAdapter {
 
@@ -97,6 +100,7 @@ public class SessionManagementConfigurerSessionCreationPolicyTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurerTests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.authentication.AuthenticationTrustResolver;
 import org.springframework.security.config.annotation.ObjectPostProcessor;
@@ -339,6 +340,7 @@ public class SessionManagementConfigurerTests {
 		this.mvc.perform(get("/")).andExpect(content().string("encoded"));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SessionManagementRequestCacheConfig extends WebSecurityConfigurerAdapter {
 
@@ -358,6 +360,7 @@ public class SessionManagementConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SessionManagementSecurityContextRepositoryConfig extends WebSecurityConfigurerAdapter {
 
@@ -377,6 +380,7 @@ public class SessionManagementConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class InvokeTwiceDoesNotOverride extends WebSecurityConfigurerAdapter {
 
@@ -393,6 +397,7 @@ public class SessionManagementConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DisableSessionFixationEnableConcurrencyControlConfig extends WebSecurityConfigurerAdapter {
 
@@ -419,6 +424,7 @@ public class SessionManagementConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SFPNewSessionInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -447,6 +453,7 @@ public class SessionManagementConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ConcurrencyControlConfig extends WebSecurityConfigurerAdapter {
 
@@ -473,6 +480,7 @@ public class SessionManagementConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ConcurrencyControlInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -503,6 +511,7 @@ public class SessionManagementConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SessionCreationPolicyStateLessInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -519,6 +528,7 @@ public class SessionManagementConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ObjectPostProcessorConfig extends WebSecurityConfigurerAdapter {
 
@@ -549,6 +559,7 @@ public class SessionManagementConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SharedTrustResolverConfig extends WebSecurityConfigurerAdapter {
 
@@ -564,6 +575,7 @@ public class SessionManagementConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SessionRegistryOneBeanConfig extends WebSecurityConfigurerAdapter {
 
@@ -585,6 +597,7 @@ public class SessionManagementConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SessionRegistryTwoBeansConfig extends WebSecurityConfigurerAdapter {
 
@@ -613,6 +626,7 @@ public class SessionManagementConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultUrlRewriteConfig {
 
@@ -628,6 +642,7 @@ public class SessionManagementConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class EnableUrlRewriteConfig {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurerTransientAuthenticationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurerTransientAuthenticationTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -63,6 +64,7 @@ public class SessionManagementConfigurerTransientAuthenticationTests {
 		assertThat(result.getRequest().getSession(false)).isNotNull();
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class WithTransientAuthenticationConfig extends WebSecurityConfigurerAdapter {
 
@@ -85,6 +87,7 @@ public class SessionManagementConfigurerTransientAuthenticationTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AlwaysCreateSessionConfig extends WithTransientAuthenticationConfig {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/UrlAuthorizationConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/UrlAuthorizationConfigurerTests.java
@@ -268,6 +268,7 @@ public class UrlAuthorizationConfigurerTests {
 	}
 
 	@EnableWebSecurity
+	@Configuration
 	@EnableWebMvc
 	static class MultiMvcMatcherConfig {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/UrlAuthorizationsTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/UrlAuthorizationsTests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.vote.AffirmativeBased;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -129,6 +130,7 @@ public class UrlAuthorizationsTests {
 		return null;
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RoleConfig extends WebSecurityConfigurerAdapter {
 
@@ -148,6 +150,7 @@ public class UrlAuthorizationsTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class NoSpecificAccessDecisionManagerConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2ClientConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2ClientConfigurerTests.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockHttpSession;
@@ -262,6 +263,7 @@ public class OAuth2ClientConfigurerTests {
 	}
 
 	@EnableWebSecurity
+	@Configuration
 	@EnableWebMvc
 	static class OAuth2ClientConfig extends WebSecurityConfigurerAdapter {
 
@@ -306,6 +308,7 @@ public class OAuth2ClientConfigurerTests {
 	}
 
 	@EnableWebSecurity
+	@Configuration
 	@EnableWebMvc
 	static class OAuth2ClientInLambdaConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2LoginConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2LoginConfigurerTests.java
@@ -629,6 +629,7 @@ public class OAuth2LoginConfigurerTests {
 		};
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OAuth2LoginConfig extends CommonWebSecurityConfigurerAdapter
 			implements ApplicationListener<AuthenticationSuccessEvent> {
@@ -653,6 +654,7 @@ public class OAuth2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OAuth2LoginConfigFormLogin extends CommonWebSecurityConfigurerAdapter {
 
@@ -673,6 +675,7 @@ public class OAuth2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OAuth2LoginInLambdaConfig extends CommonLambdaWebSecurityConfigurerAdapter
 			implements ApplicationListener<AuthenticationSuccessEvent> {
@@ -699,6 +702,7 @@ public class OAuth2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OAuth2LoginConfigCustomWithConfigurer extends CommonWebSecurityConfigurerAdapter {
 
@@ -717,6 +721,7 @@ public class OAuth2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OAuth2LoginConfigCustomWithBeanRegistration extends CommonWebSecurityConfigurerAdapter {
 
@@ -741,6 +746,7 @@ public class OAuth2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OAuth2LoginConfigCustomUserServiceBeanRegistration extends WebSecurityConfigurerAdapter {
 
@@ -792,6 +798,7 @@ public class OAuth2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OAuth2LoginConfigLoginProcessingUrl extends CommonWebSecurityConfigurerAdapter {
 
@@ -809,6 +816,7 @@ public class OAuth2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OAuth2LoginConfigCustomAuthorizationRequestResolver extends CommonWebSecurityConfigurerAdapter {
 
@@ -831,6 +839,7 @@ public class OAuth2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OAuth2LoginConfigCustomAuthorizationRequestResolverInLambda
 			extends CommonLambdaWebSecurityConfigurerAdapter {
@@ -858,6 +867,7 @@ public class OAuth2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OAuth2LoginConfigMultipleClients extends CommonWebSecurityConfigurerAdapter {
 
@@ -875,6 +885,7 @@ public class OAuth2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OAuth2LoginConfigAuthorizationCodeClientAndOtherClients extends CommonWebSecurityConfigurerAdapter {
 
@@ -892,6 +903,7 @@ public class OAuth2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OAuth2LoginConfigCustomLoginPage extends CommonWebSecurityConfigurerAdapter {
 
@@ -909,6 +921,7 @@ public class OAuth2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OAuth2LoginConfigCustomLoginPageInLambda extends CommonLambdaWebSecurityConfigurerAdapter {
 
@@ -928,6 +941,7 @@ public class OAuth2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OAuth2LoginConfigWithOidcLogoutSuccessHandler extends CommonWebSecurityConfigurerAdapter {
 
@@ -955,6 +969,7 @@ public class OAuth2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OAuth2LoginWithHttpBasicConfig extends CommonWebSecurityConfigurerAdapter {
 
@@ -973,6 +988,7 @@ public class OAuth2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OAuth2LoginWithXHREntryPointConfig extends CommonWebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
@@ -1437,6 +1437,7 @@ public class OAuth2ResourceServerConfigurerTests {
 		}
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultConfig extends WebSecurityConfigurerAdapter {
 
@@ -1455,6 +1456,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -1476,6 +1478,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class JwkSetUriConfig extends WebSecurityConfigurerAdapter {
 
@@ -1498,6 +1501,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class JwkSetUriInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -1525,6 +1529,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CsrfDisabledConfig extends WebSecurityConfigurerAdapter {
 
@@ -1548,6 +1553,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AnonymousDisabledConfig extends WebSecurityConfigurerAdapter {
 
@@ -1566,6 +1572,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	static class MethodSecurityConfig extends WebSecurityConfigurerAdapter {
@@ -1584,6 +1591,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class JwtlessConfig extends WebSecurityConfigurerAdapter {
 
@@ -1600,6 +1608,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RealmNameConfiguredOnEntryPoint extends WebSecurityConfigurerAdapter {
 
@@ -1624,6 +1633,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class RealmNameConfiguredOnAccessDeniedHandler extends WebSecurityConfigurerAdapter {
 
@@ -1648,6 +1658,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ExceptionHandlingAndResourceServerWithAccessDeniedHandlerConfig extends WebSecurityConfigurerAdapter {
 
@@ -1683,6 +1694,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class JwtAuthenticationConverterConfiguredOnDsl extends WebSecurityConfigurerAdapter {
 
@@ -1707,6 +1719,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomAuthorityMappingConfig extends WebSecurityConfigurerAdapter {
 
@@ -1732,6 +1745,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class BasicAndResourceServerConfig extends WebSecurityConfigurerAdapter {
 
@@ -1764,6 +1778,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class FormAndResourceServerConfig extends WebSecurityConfigurerAdapter {
 
@@ -1783,6 +1798,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OAuth2LoginAndResourceServerConfig extends WebSecurityConfigurerAdapter {
 
@@ -1808,6 +1824,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class JwtHalfConfiguredConfig extends WebSecurityConfigurerAdapter {
 
@@ -1825,6 +1842,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AlwaysSessionCreationConfig extends WebSecurityConfigurerAdapter {
 
@@ -1842,6 +1860,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AllowBearerTokenInRequestBodyConfig extends WebSecurityConfigurerAdapter {
 
@@ -1866,6 +1885,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AllowBearerTokenAsQueryParameterConfig extends WebSecurityConfigurerAdapter {
 
@@ -1890,6 +1910,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class MultipleBearerTokenResolverBeansConfig extends WebSecurityConfigurerAdapter {
 
@@ -1921,6 +1942,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomAuthenticationDetailsSource {
 
@@ -1953,6 +1975,7 @@ public class OAuth2ResourceServerConfigurerTests {
 		}
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomJwtDecoderOnDsl extends WebSecurityConfigurerAdapter {
 
@@ -1977,6 +2000,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomJwtDecoderInLambdaOnDsl extends WebSecurityConfigurerAdapter {
 
@@ -2006,6 +2030,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomJwtDecoderAsBean extends WebSecurityConfigurerAdapter {
 
@@ -2028,6 +2053,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class JwtAuthenticationManagerConfig extends WebSecurityConfigurerAdapter {
 
@@ -2051,6 +2077,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultAndJwtAuthenticationManagerConfig extends WebSecurityConfigurerAdapter {
 
@@ -2084,6 +2111,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomJwtValidatorConfig extends WebSecurityConfigurerAdapter {
 
@@ -2108,6 +2136,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class UnexpiredJwtClockSkewConfig extends WebSecurityConfigurerAdapter {
 
@@ -2130,6 +2159,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ExpiredJwtClockSkewConfig extends WebSecurityConfigurerAdapter {
 
@@ -2149,6 +2179,7 @@ public class OAuth2ResourceServerConfigurerTests {
 					.jwt();
 		}
 	}
+	@Configuration
 	@EnableWebSecurity
 	static class SingleKeyConfig extends WebSecurityConfigurerAdapter {
 		byte[] spec = Base64.getDecoder().decode(
@@ -2180,6 +2211,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomAuthenticationEventPublisher extends WebSecurityConfigurerAdapter {
 
@@ -2207,6 +2239,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OpaqueTokenConfig extends WebSecurityConfigurerAdapter {
 
@@ -2225,6 +2258,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OpaqueTokenInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -2246,6 +2280,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OpaqueTokenAuthenticationManagerConfig extends WebSecurityConfigurerAdapter {
 
@@ -2269,6 +2304,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OpaqueTokenAuthenticationManagerInLambdaConfig extends WebSecurityConfigurerAdapter {
 
@@ -2297,6 +2333,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultAndOpaqueTokenAuthenticationManagerConfig extends WebSecurityConfigurerAdapter {
 
@@ -2330,6 +2367,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OpaqueAndJwtConfig extends WebSecurityConfigurerAdapter {
 
@@ -2346,6 +2384,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class OpaqueTokenHalfConfiguredConfig extends WebSecurityConfigurerAdapter {
 
@@ -2364,6 +2403,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class MultipleIssuersConfig extends WebSecurityConfigurerAdapter {
 
@@ -2385,6 +2425,7 @@ public class OAuth2ResourceServerConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class AuthenticationManagerResolverPlusOtherConfig extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LoginConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LoginConfigurerTests.java
@@ -38,6 +38,7 @@ import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.mock.web.MockFilterChain;
@@ -397,6 +398,7 @@ public class Saml2LoginConfigurerTests {
 		};
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	@Import(Saml2LoginConfigBeans.class)
@@ -412,6 +414,7 @@ public class Saml2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(Saml2LoginConfigBeans.class)
 	static class Saml2LoginConfigWithCustomAuthenticationManager extends WebSecurityConfigurerAdapter {
@@ -424,6 +427,7 @@ public class Saml2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(Saml2LoginConfigBeans.class)
 	static class Saml2LoginConfigWithDefaultAndCustomAuthenticationManager extends WebSecurityConfigurerAdapter {
@@ -442,6 +446,7 @@ public class Saml2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(Saml2LoginConfigBeans.class)
 	static class Saml2LoginConfigWithAuthenticationDefaultsWithPostProcessor extends WebSecurityConfigurerAdapter {
@@ -463,6 +468,7 @@ public class Saml2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(Saml2LoginConfigBeans.class)
 	static class CustomAuthenticationFailureHandler extends WebSecurityConfigurerAdapter {
@@ -478,6 +484,7 @@ public class Saml2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(Saml2LoginConfigBeans.class)
 	static class CustomAuthenticationRequestResolverBean {
@@ -508,6 +515,7 @@ public class Saml2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(Saml2LoginConfigBeans.class)
 	static class CustomAuthenticationRequestResolverDsl {
@@ -540,6 +548,7 @@ public class Saml2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(Saml2LoginConfigBeans.class)
 	static class CustomAuthenticationConverter extends WebSecurityConfigurerAdapter {
@@ -554,6 +563,7 @@ public class Saml2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(Saml2LoginConfigBeans.class)
 	static class CustomAuthenticationConverterBean {
@@ -575,6 +585,7 @@ public class Saml2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(Saml2LoginConfigBeans.class)
 	static class CustomAuthenticationRequestRepository {
@@ -596,6 +607,7 @@ public class Saml2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(Saml2LoginConfigBeans.class)
 	static class CustomLoginProcessingUrlDefaultAuthenticationConverter {
@@ -612,6 +624,7 @@ public class Saml2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(Saml2LoginConfigBeans.class)
 	static class CustomAuthenticationRequestUriCustomAuthenticationConverter {
@@ -636,6 +649,7 @@ public class Saml2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(Saml2LoginConfigBeans.class)
 	static class CustomLoginProcessingUrlCustomAuthenticationConverter {
@@ -655,6 +669,7 @@ public class Saml2LoginConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(Saml2LoginConfigBeans.class)
 	static class CustomLoginProcessingUrlSaml2AuthenticationTokenConverterBean {

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurerTests.java
@@ -36,6 +36,7 @@ import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -436,6 +437,7 @@ public class Saml2LogoutConfigurerTests {
 		return new SamlQueryStringRequestPostProcessor();
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(Saml2LoginConfigBeans.class)
 	static class Saml2LogoutDefaultsConfig {
@@ -461,6 +463,7 @@ public class Saml2LogoutConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(Saml2LoginConfigBeans.class)
 	static class Saml2LogoutCsrfDisabledConfig {
@@ -487,6 +490,7 @@ public class Saml2LogoutConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(Saml2LoginConfigBeans.class)
 	static class Saml2LogoutWithHttpGet {
@@ -518,6 +522,7 @@ public class Saml2LogoutConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(Saml2LoginConfigBeans.class)
 	static class Saml2DefaultsWithObjectPostProcessorConfig {
@@ -542,6 +547,7 @@ public class Saml2LogoutConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@Import(Saml2LoginConfigBeans.class)
 	static class Saml2LogoutComponentsConfig {

--- a/config/src/test/java/org/springframework/security/config/annotation/web/reactive/EnableWebFluxSecurityTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/reactive/EnableWebFluxSecurityTests.java
@@ -320,12 +320,14 @@ public class EnableWebFluxSecurityTests {
 		context.refresh();
 	}
 
+	@Configuration
 	@EnableWebFluxSecurity
 	@Import(ReactiveAuthenticationTestConfiguration.class)
 	static class Config {
 
 	}
 
+	@Configuration
 	@EnableWebFluxSecurity
 	static class CustomPasswordEncoderConfig {
 
@@ -342,6 +344,7 @@ public class EnableWebFluxSecurityTests {
 
 	}
 
+	@Configuration
 	@EnableWebFluxSecurity
 	static class MapReactiveUserDetailsServiceConfig {
 
@@ -358,6 +361,7 @@ public class EnableWebFluxSecurityTests {
 
 	}
 
+	@Configuration
 	@EnableWebFluxSecurity
 	@Import(ReactiveAuthenticationTestConfiguration.class)
 	static class MultiSecurityHttpConfig {
@@ -377,6 +381,7 @@ public class EnableWebFluxSecurityTests {
 
 	}
 
+	@Configuration
 	@EnableWebFluxSecurity
 	@EnableWebFlux
 	@Import(ReactiveAuthenticationTestConfiguration.class)
@@ -407,6 +412,7 @@ public class EnableWebFluxSecurityTests {
 
 	}
 
+	@Configuration
 	@EnableWebFluxSecurity
 	@Import(ReactiveAuthenticationTestConfiguration.class)
 	static class BeanProxyEnabledByDefaultConfig {

--- a/config/src/test/java/org/springframework/security/config/annotation/web/reactive/ReactiveOAuth2ClientImportSelectorTest.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/reactive/ReactiveOAuth2ClientImportSelectorTest.java
@@ -23,6 +23,7 @@ import reactor.core.publisher.Mono;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.test.SpringTestContext;
 import org.springframework.security.config.test.SpringTestContextExtension;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
@@ -125,6 +126,7 @@ public class ReactiveOAuth2ClientImportSelectorTest {
 		// @formatter:on
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class OAuth2AuthorizedClientManagerRegisteredConfig {

--- a/config/src/test/java/org/springframework/security/config/authentication/AuthenticationConfigurationGh3935Tests.java
+++ b/config/src/test/java/org/springframework/security/config/authentication/AuthenticationConfigurationGh3935Tests.java
@@ -77,6 +77,7 @@ public class AuthenticationConfigurationGh3935Tests {
 		assertThat(auth.getPrincipal()).isEqualTo(PasswordEncodedUser.user());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class WebSecurity extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/crypto/RsaKeyConversionServicePostProcessorTests.java
+++ b/config/src/test/java/org/springframework/security/config/crypto/RsaKeyConversionServicePostProcessorTests.java
@@ -140,6 +140,7 @@ public class RsaKeyConversionServicePostProcessorTests {
 				.withRootCauseInstanceOf(IllegalArgumentException.class);
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class DefaultConfig {
 

--- a/config/src/test/java/org/springframework/security/config/http/customconfigurer/CustomHttpSecurityConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/http/customconfigurer/CustomHttpSecurityConfigurerTests.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.config.PropertyPlaceholderConfigurer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -109,6 +110,7 @@ public class CustomHttpSecurityConfigurerTests {
 		context.getAutowireCapableBeanFactory().autowireBean(this);
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class Config extends WebSecurityConfigurerAdapter {
 
@@ -133,6 +135,7 @@ public class CustomHttpSecurityConfigurerTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class ConfigCustomize extends WebSecurityConfigurerAdapter {
 

--- a/config/src/test/java/org/springframework/security/config/web/server/HttpsRedirectSpecTests.java
+++ b/config/src/test/java/org/springframework/security/config/web/server/HttpsRedirectSpecTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.test.SpringTestContext;
 import org.springframework.security.config.test.SpringTestContextExtension;
@@ -152,6 +153,7 @@ public class HttpsRedirectSpecTests {
 		// @formatter:on
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class RedirectToHttpConfig {
@@ -167,6 +169,7 @@ public class HttpsRedirectSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class RedirectToHttpsInLambdaConfig {
@@ -182,6 +185,7 @@ public class HttpsRedirectSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class SometimesRedirectToHttpsConfig {
@@ -198,6 +202,7 @@ public class HttpsRedirectSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class SometimesRedirectToHttpsInLambdaConfig {
@@ -216,6 +221,7 @@ public class HttpsRedirectSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class RedirectToHttpsViaCustomPortsConfig {
@@ -237,6 +243,7 @@ public class HttpsRedirectSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class RedirectToHttpsViaCustomPortsInLambdaConfig {

--- a/config/src/test/java/org/springframework/security/config/web/server/OAuth2ClientSpecTests.java
+++ b/config/src/test/java/org/springframework/security/config/web/server/OAuth2ClientSpecTests.java
@@ -204,6 +204,7 @@ public class OAuth2ClientSpecTests {
 		verify(requestCache).getRedirectUri(any());
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class Config {
@@ -239,6 +240,7 @@ public class OAuth2ClientSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class ClientRegistrationConfig {

--- a/config/src/test/java/org/springframework/security/config/web/server/OAuth2LoginTests.java
+++ b/config/src/test/java/org/springframework/security/config/web/server/OAuth2LoginTests.java
@@ -574,6 +574,7 @@ public class OAuth2LoginTests {
 		return this.spring.getContext().getBean(beanClass);
 	}
 
+	@Configuration
 	@EnableWebFluxSecurity
 	static class OAuth2LoginWithMultipleClientRegistrations {
 
@@ -589,6 +590,7 @@ public class OAuth2LoginTests {
 
 	}
 
+	@Configuration
 	@EnableWebFluxSecurity
 	static class OAuth2LoginWithSingleClientRegistrations {
 
@@ -599,6 +601,7 @@ public class OAuth2LoginTests {
 
 	}
 
+	@Configuration
 	@EnableWebFluxSecurity
 	static class OAuth2LoginWithAuthorizationCodeAndClientCredentialsClientRegistration {
 
@@ -838,6 +841,7 @@ public class OAuth2LoginTests {
 	}
 
 	@EnableWebFlux
+	@Configuration
 	@EnableWebFluxSecurity
 	static class OAuth2LoginConfigWithOidcLogoutSuccessHandler {
 

--- a/config/src/test/java/org/springframework/security/config/web/server/OAuth2ResourceServerSpecTests.java
+++ b/config/src/test/java/org/springframework/security/config/web/server/OAuth2ResourceServerSpecTests.java
@@ -45,6 +45,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -616,6 +617,7 @@ public class OAuth2ResourceServerSpecTests {
 		return (GenericWebApplicationContext) this.spring.getContext();
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class PublicKeyConfig {
@@ -636,6 +638,7 @@ public class OAuth2ResourceServerSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class PublicKeyInLambdaConfig {
@@ -661,6 +664,7 @@ public class OAuth2ResourceServerSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class PlaceholderConfig {
@@ -684,6 +688,7 @@ public class OAuth2ResourceServerSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class JwkSetUriConfig {
@@ -714,6 +719,7 @@ public class OAuth2ResourceServerSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class JwkSetUriInLambdaConfig {
@@ -748,6 +754,7 @@ public class OAuth2ResourceServerSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class CustomDecoderConfig {
@@ -771,6 +778,7 @@ public class OAuth2ResourceServerSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class DenyAllConfig {
@@ -791,6 +799,7 @@ public class OAuth2ResourceServerSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class CustomAuthenticationManagerConfig {
@@ -813,6 +822,7 @@ public class OAuth2ResourceServerSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class CustomAuthenticationManagerInLambdaConfig {
@@ -839,6 +849,7 @@ public class OAuth2ResourceServerSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class CustomAuthenticationManagerResolverConfig {
@@ -868,6 +879,7 @@ public class OAuth2ResourceServerSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class CustomBearerTokenServerAuthenticationConverter {
@@ -895,6 +907,7 @@ public class OAuth2ResourceServerSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class CustomJwtAuthenticationConverterConfig {
@@ -926,6 +939,7 @@ public class OAuth2ResourceServerSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class CustomErrorHandlingConfig {
@@ -949,6 +963,7 @@ public class OAuth2ResourceServerSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class IntrospectionConfig {
@@ -980,6 +995,7 @@ public class OAuth2ResourceServerSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class IntrospectionInLambdaConfig {
@@ -1015,6 +1031,7 @@ public class OAuth2ResourceServerSpecTests {
 
 	}
 
+	@Configuration
 	@EnableWebFlux
 	@EnableWebFluxSecurity
 	static class AuthenticationManagerResolverPlusOtherConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/AnonymousDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/AnonymousDslTests.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.authentication.AnonymousAuthenticationToken
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
@@ -59,6 +60,7 @@ class AnonymousDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class PrincipalConfig {
@@ -83,6 +85,7 @@ class AnonymousDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class KeyConfig {
@@ -107,6 +110,7 @@ class AnonymousDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class AnonymousDisabledConfig {
@@ -131,6 +135,7 @@ class AnonymousDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class AnonymousAuthoritiesConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/AuthorizeHttpRequestsDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/AuthorizeHttpRequestsDslTests.kt
@@ -105,6 +105,7 @@ class AuthorizeHttpRequestsDslTests {
             }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class AuthorizeHttpRequestsByRegexConfig {
         @Bean
@@ -162,6 +163,7 @@ class AuthorizeHttpRequestsDslTests {
             }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class AuthorizeHttpRequestsByMvcConfig {
@@ -207,6 +209,7 @@ class AuthorizeHttpRequestsDslTests {
             }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class MvcMatcherPathVariablesConfig {
@@ -253,6 +256,7 @@ class AuthorizeHttpRequestsDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class HasRoleConfig {
@@ -318,6 +322,7 @@ class AuthorizeHttpRequestsDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class HasAnyRoleConfig {
@@ -382,6 +387,7 @@ class AuthorizeHttpRequestsDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class HasAuthorityConfig {
@@ -447,6 +453,7 @@ class AuthorizeHttpRequestsDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class HasAnyAuthorityConfig {
@@ -508,6 +515,7 @@ class AuthorizeHttpRequestsDslTests {
             .andExpect(status().isOk)
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class MvcMatcherServletPathConfig {
@@ -544,6 +552,7 @@ class AuthorizeHttpRequestsDslTests {
             }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class AuthorizeRequestsByMvcConfigWithHttpMethod {
@@ -596,6 +605,7 @@ class AuthorizeHttpRequestsDslTests {
             .andExpect(status().isOk)
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class MvcMatcherServletPathHttpMethodConfig {
@@ -628,6 +638,7 @@ class AuthorizeHttpRequestsDslTests {
             )
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class BothAuthorizeRequestsConfig {
@@ -659,6 +670,7 @@ class AuthorizeHttpRequestsDslTests {
             .andExpect(status().isForbidden)
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class ShouldFilterAllDispatcherTypesTrueDenyAllConfig {
@@ -697,6 +709,7 @@ class AuthorizeHttpRequestsDslTests {
             .andExpect(status().isOk)
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class ShouldFilterAllDispatcherTypesTruePermitAllConfig {
@@ -735,6 +748,7 @@ class AuthorizeHttpRequestsDslTests {
             .andExpect(status().isOk)
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class ShouldFilterAllDispatcherTypesFalseAndDenyAllConfig {
@@ -773,6 +787,7 @@ class AuthorizeHttpRequestsDslTests {
             .andExpect(status().isForbidden)
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class ShouldFilterAllDispatcherTypesOmittedAndDenyAllConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/AuthorizeRequestsDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/AuthorizeRequestsDslTests.kt
@@ -95,6 +95,7 @@ class AuthorizeRequestsDslTests {
             }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class AuthorizeRequestsByRegexConfig {
         @Bean
@@ -152,6 +153,7 @@ class AuthorizeRequestsDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class AuthorizeRequestsByMvcConfig {
@@ -197,6 +199,7 @@ class AuthorizeRequestsDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class MvcMatcherPathVariablesConfig {
@@ -240,6 +243,7 @@ class AuthorizeRequestsDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class HasRoleConfig {
@@ -305,6 +309,7 @@ class AuthorizeRequestsDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class HasAnyRoleConfig {
@@ -375,6 +380,7 @@ class AuthorizeRequestsDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class HasAnyAuthorityConfig {
@@ -436,6 +442,7 @@ class AuthorizeRequestsDslTests {
                 .andExpect(status().isOk)
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class MvcMatcherServletPathConfig {
@@ -459,6 +466,7 @@ class AuthorizeRequestsDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class AuthorizeRequestsByMvcConfigWithHttpMethod{
@@ -496,6 +504,7 @@ class AuthorizeRequestsDslTests {
             }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class MvcMatcherServletPathHttpMethodConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/CorsDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/CorsDslTests.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.BeanCreationException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
@@ -57,6 +58,7 @@ class CorsDslTests {
 
     }
 
+    @Configuration
     @EnableWebSecurity
     open class DefaultCorsConfig {
         @Bean
@@ -80,6 +82,7 @@ class CorsDslTests {
         }
     }
 
+    @Configuration
     @EnableWebMvc
     @EnableWebSecurity
     open class CorsCrossOriginBeanConfig {
@@ -116,6 +119,7 @@ class CorsDslTests {
         }
     }
 
+    @Configuration
     @EnableWebMvc
     @EnableWebSecurity
     open class CorsDisabledConfig {
@@ -155,6 +159,7 @@ class CorsDslTests {
         }
     }
 
+    @Configuration
     @EnableWebMvc
     @EnableWebSecurity
     open class CorsCrossOriginSourceConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/CsrfDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/CsrfDslTests.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.test.SpringTestContext
@@ -80,6 +81,7 @@ class CsrfDslTests {
 
     }
 
+    @Configuration
     @EnableWebSecurity
     open class DefaultCsrfConfig {
         @Bean
@@ -101,6 +103,7 @@ class CsrfDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class CsrfDisabledConfig {
         @Bean
@@ -127,6 +130,7 @@ class CsrfDslTests {
         verify(exactly = 1) { CustomRepositoryConfig.REPO.loadToken(any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class CustomRepositoryConfig {
 
@@ -160,6 +164,7 @@ class CsrfDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class RequireCsrfProtectionMatcherConfig {
         @Bean
@@ -185,6 +190,7 @@ class CsrfDslTests {
 
     }
 
+    @Configuration
     @EnableWebSecurity
     open class CustomStrategyConfig {
 
@@ -229,6 +235,7 @@ class CsrfDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class IgnoringRequestMatchersConfig {
         @Bean
@@ -258,6 +265,7 @@ class CsrfDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class IgnoringAntMatchersConfig {
         @Bean

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/ExceptionHandlingDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/ExceptionHandlingDslTests.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
@@ -59,6 +60,7 @@ class ExceptionHandlingDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class ExceptionHandlingConfig {
@@ -83,6 +85,7 @@ class ExceptionHandlingDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class ExceptionHandlingDisabledConfig {
         @Bean
@@ -111,6 +114,7 @@ class ExceptionHandlingDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class AccessDeniedPageConfig {
@@ -141,6 +145,7 @@ class ExceptionHandlingDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class AccessDeniedHandlerConfig {
@@ -180,6 +185,7 @@ class ExceptionHandlingDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class AccessDeniedHandlerForConfig {
@@ -215,6 +221,7 @@ class ExceptionHandlingDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class AuthenticationEntryPointConfig {
@@ -249,6 +256,7 @@ class ExceptionHandlingDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class AuthenticationEntryPointForConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/FormLoginDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/FormLoginDslTests.kt
@@ -90,6 +90,7 @@ class FormLoginDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class FormLoginConfig {
         @Bean
@@ -112,6 +113,7 @@ class FormLoginDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class AllSecuredConfig {
         @Bean
@@ -137,6 +139,7 @@ class FormLoginDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class LoginPageConfig {
         @Bean
@@ -164,6 +167,7 @@ class FormLoginDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class SuccessHandlerConfig {
         @Bean
@@ -188,6 +192,7 @@ class FormLoginDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class FailureHandlerConfig {
         @Bean
@@ -212,6 +217,7 @@ class FormLoginDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class FailureUrlConfig {
         @Bean
@@ -236,6 +242,7 @@ class FormLoginDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class LoginProcessingUrlConfig {
         @Bean
@@ -260,6 +267,7 @@ class FormLoginDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class DefaultSuccessUrlConfig {
         @Bean
@@ -283,6 +291,7 @@ class FormLoginDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class PermitAllConfig {
         @Bean
@@ -325,6 +334,7 @@ class FormLoginDslTests {
         verify(exactly = 1) { CustomAuthenticationDetailsSourceConfig.AUTHENTICATION_DETAILS_SOURCE.buildDetails(any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class CustomAuthenticationDetailsSourceConfig {
 

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/HeadersDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/HeadersDslTests.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
@@ -65,6 +66,7 @@ class HeadersDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class DefaultHeadersConfig {
         @Bean
@@ -86,6 +88,7 @@ class HeadersDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     @Suppress("DEPRECATION")
     open class FeaturePolicyConfig {
@@ -110,6 +113,7 @@ class HeadersDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class PermissionsPolicyConfig {
         @Bean
@@ -141,6 +145,7 @@ class HeadersDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class HeadersDisabledConfig {
         @Bean
@@ -164,6 +169,7 @@ class HeadersDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class HeaderWriterConfig {
         @Bean

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/HttpBasicDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/HttpBasicDslTests.kt
@@ -87,6 +87,7 @@ class HttpBasicDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class HttpBasicConfig {
         @Bean
@@ -111,6 +112,7 @@ class HttpBasicDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class CustomRealmConfig {
         @Bean
@@ -138,6 +140,7 @@ class HttpBasicDslTests {
         verify(exactly = 1) { CustomAuthenticationEntryPointConfig.ENTRY_POINT.commence(any(), any(), any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class CustomAuthenticationEntryPointConfig {
 
@@ -176,6 +179,7 @@ class HttpBasicDslTests {
         verify(exactly = 1) { CustomAuthenticationDetailsSourceConfig.AUTHENTICATION_DETAILS_SOURCE.buildDetails(any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class CustomAuthenticationDetailsSourceConfig {
 

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/HttpSecurityDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/HttpSecurityDslTests.kt
@@ -110,6 +110,7 @@ class HttpSecurityDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class DefaultSecurityConfig {
         @Bean
@@ -159,6 +160,7 @@ class HttpSecurityDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class SecurityRequestMatcherRequestsConfig {
         @Bean
@@ -173,6 +175,7 @@ class HttpSecurityDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class SecurityRequestMatcherHttpRequestsConfig {
         @Bean
@@ -215,6 +218,7 @@ class HttpSecurityDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class SecurityPatternMatcherRequestsConfig {
@@ -230,6 +234,7 @@ class HttpSecurityDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class SecurityPatternMatcherHttpRequestsConfig {
@@ -269,6 +274,7 @@ class HttpSecurityDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class MultiMatcherRequestsConfig {
@@ -285,6 +291,7 @@ class HttpSecurityDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class MultiMatcherHttpRequestsConfig {
@@ -322,6 +329,7 @@ class HttpSecurityDslTests {
         val AUTHENTICATION_MANAGER: AuthenticationManager = ProviderManager(TestingAuthenticationProvider())
     }
 
+    @Configuration
     @EnableWebSecurity
     open class AuthenticationManagerRequestsConfig {
         @Bean
@@ -337,6 +345,7 @@ class HttpSecurityDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class AuthenticationManagerHttpRequestsConfig {
         @Bean
@@ -362,6 +371,7 @@ class HttpSecurityDslTests {
         assertThat(filters).anyMatch { it is CustomFilter }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class CustomFilterConfig {
@@ -384,6 +394,7 @@ class HttpSecurityDslTests {
         assertThat(filters).anyMatch { it is CustomFilter }
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class CustomFilterConfigReified {
@@ -409,6 +420,7 @@ class HttpSecurityDslTests {
         )
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class CustomFilterAfterConfig {
@@ -435,6 +447,7 @@ class HttpSecurityDslTests {
         )
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class CustomFilterAfterConfigReified{
@@ -461,6 +474,7 @@ class HttpSecurityDslTests {
         )
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class CustomFilterBeforeConfig {
@@ -487,6 +501,7 @@ class HttpSecurityDslTests {
         )
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class CustomFilterBeforeConfigReified{

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/LogoutDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/LogoutDslTests.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.mock.web.MockHttpSession
 import org.springframework.security.authentication.TestingAuthenticationToken
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -68,6 +69,7 @@ class LogoutDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class CustomLogoutUrlConfig {
         @Bean
@@ -93,6 +95,7 @@ class LogoutDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class CustomLogoutRequestMatcherConfig {
         @Bean
@@ -118,6 +121,7 @@ class LogoutDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class SuccessUrlConfig {
         @Bean
@@ -143,6 +147,7 @@ class LogoutDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class SuccessHandlerConfig {
         @Bean
@@ -168,6 +173,7 @@ class LogoutDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class PermitAllConfig {
         @Bean
@@ -204,6 +210,7 @@ class LogoutDslTests {
         assertThat(currentContext.authentication).isNotNull
     }
 
+    @Configuration
     @EnableWebSecurity
     open class ClearAuthenticationFalseConfig {
         @Bean
@@ -233,6 +240,7 @@ class LogoutDslTests {
         assertThat(currentSession.isInvalid).isFalse()
     }
 
+    @Configuration
     @EnableWebSecurity
     open class InvalidateHttpSessionFalseConfig {
         @Bean
@@ -259,6 +267,7 @@ class LogoutDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class DeleteCookiesConfig {
         @Bean
@@ -291,6 +300,7 @@ class LogoutDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class DefaultLogoutSuccessHandlerForConfig {
         @Bean
@@ -318,6 +328,7 @@ class LogoutDslTests {
         verify(exactly = 1) { CustomLogoutHandlerConfig.HANDLER.logout(any(), any(), any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class CustomLogoutHandlerConfig {
 

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/OAuth2ClientDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/OAuth2ClientDslTests.kt
@@ -64,6 +64,7 @@ class OAuth2ClientDslTests {
         this.spring.register(ClientRepoConfig::class.java).autowire()
     }
 
+    @Configuration
     @EnableWebSecurity
     open class ClientRepoConfig {
         @Bean
@@ -119,6 +120,7 @@ class OAuth2ClientDslTests {
         verify(exactly = 1) { ClientRepositoryConfig.CLIENT_REPOSITORY.saveAuthorizedClient(any(), any(), any(), any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class ClientRepositoryConfig {
 

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/OAuth2LoginDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/OAuth2LoginDslTests.kt
@@ -62,6 +62,7 @@ class OAuth2LoginDslTests {
         this.spring.register(ClientRepoConfig::class.java).autowire()
     }
 
+    @Configuration
     @EnableWebSecurity
     open class ClientRepoConfig {
         @Bean
@@ -89,6 +90,7 @@ class OAuth2LoginDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class OAuth2LoginConfig {
         @Bean
@@ -110,6 +112,7 @@ class OAuth2LoginDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class LoginPageConfig {
         @Bean
@@ -160,6 +163,7 @@ class OAuth2LoginDslTests {
         verify(exactly = 1) { CustomAuthenticationDetailsSourceConfig.AUTHENTICATION_DETAILS_SOURCE.buildDetails(any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class CustomAuthenticationDetailsSourceConfig {
 

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/OAuth2ResourceServerDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/OAuth2ResourceServerDslTests.kt
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.BeanCreationException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.AuthenticationManagerResolver
@@ -78,6 +79,7 @@ class OAuth2ResourceServerDslTests {
         verify(exactly = 1) { EntryPointConfig.ENTRY_POINT.commence(any(), any(), any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class EntryPointConfig {
 
@@ -116,6 +118,7 @@ class OAuth2ResourceServerDslTests {
         verify(exactly = 1) { BearerTokenResolverConfig.RESOLVER.resolve(any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class BearerTokenResolverConfig {
 
@@ -171,6 +174,7 @@ class OAuth2ResourceServerDslTests {
         verify(exactly = 1) { AccessDeniedHandlerConfig.DENIED_HANDLER.handle(any(), any(), any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class AccessDeniedHandlerConfig {
 
@@ -214,6 +218,7 @@ class OAuth2ResourceServerDslTests {
         verify(exactly = 1) { AuthenticationManagerResolverConfig.RESOLVER.resolve(any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class AuthenticationManagerResolverConfig {
 
@@ -243,6 +248,7 @@ class OAuth2ResourceServerDslTests {
                 .withMessageContaining("authenticationManagerResolver")
     }
 
+    @Configuration
     @EnableWebSecurity
     open class AuthenticationManagerResolverAndOpaqueConfig {
         @Bean

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/PasswordManagementDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/PasswordManagementDslTests.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.test.SpringTestContext
@@ -53,6 +54,7 @@ class PasswordManagementDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class PasswordManagementWithDefaultChangePasswordPageConfig {
         @Bean
@@ -75,6 +77,7 @@ class PasswordManagementDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class PasswordManagementWithCustomChangePasswordPageConfig {
         @Bean

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/PortMapperDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/PortMapperDslTests.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.test.SpringTestContext
@@ -53,6 +54,7 @@ class PortMapperDslTests  {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class PortMapperMapConfig {
         @Bean
@@ -79,6 +81,7 @@ class PortMapperDslTests  {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class CustomPortMapperConfig {
         @Bean

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/RememberMeDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/RememberMeDslTests.kt
@@ -391,6 +391,7 @@ internal class RememberMeDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class RememberMeConfig : DefaultUserConfig() {
         @Bean
@@ -406,6 +407,7 @@ internal class RememberMeDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class RememberMeDomainConfig : DefaultUserConfig() {
         @Bean
@@ -423,6 +425,7 @@ internal class RememberMeDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class RememberMeServicesRefConfig : DefaultUserConfig() {
 
@@ -442,6 +445,7 @@ internal class RememberMeDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class RememberMeSuccessHandlerConfig : DefaultUserConfig() {
 
@@ -461,6 +465,7 @@ internal class RememberMeDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class WithAndWithoutKeyConfig : DefaultUserConfig() {
         @Bean
@@ -491,6 +496,7 @@ internal class RememberMeDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class RememberMeTokenRepositoryConfig : DefaultUserConfig() {
 
@@ -510,6 +516,7 @@ internal class RememberMeDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class RememberMeTokenValidityConfig : DefaultUserConfig() {
         @Bean
@@ -524,6 +531,7 @@ internal class RememberMeDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class RememberMeUseSecureCookieConfig : DefaultUserConfig() {
         @Bean
@@ -538,6 +546,7 @@ internal class RememberMeDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class RememberMeParameterConfig : DefaultUserConfig() {
         @Bean
@@ -552,6 +561,7 @@ internal class RememberMeDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class RememberMeCookieNameConfig : DefaultUserConfig() {
         @Bean
@@ -566,6 +576,7 @@ internal class RememberMeDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class RememberMeDefaultUserDetailsServiceConfig {
 
@@ -595,6 +606,7 @@ internal class RememberMeDslTests {
 
     }
 
+    @Configuration
     @EnableWebSecurity
     open class RememberMeUserDetailsServiceConfig : DefaultUserConfig() {
 
@@ -616,6 +628,7 @@ internal class RememberMeDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class RememberMeAlwaysRememberConfig : DefaultUserConfig() {
         @Bean

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/RequestCacheDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/RequestCacheDslTests.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.test.SpringTestContext
@@ -56,6 +57,7 @@ class RequestCacheDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class RequestCacheConfig {
         @Bean
@@ -80,6 +82,7 @@ class RequestCacheDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class CustomRequestCacheConfig {
         @Bean

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/RequiresChannelDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/RequiresChannelDslTests.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.access.ConfigAttribute
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
@@ -63,6 +64,7 @@ class RequiresChannelDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class RequiresSecureConfig {
         @Bean
@@ -96,6 +98,7 @@ class RequiresChannelDslTests {
                 .andExpect(MockMvcResultMatchers.status().isOk)
     }
 
+    @Configuration
     @EnableWebSecurity
     @EnableWebMvc
     open class MvcMatcherServletPathConfig {
@@ -129,6 +132,7 @@ class RequiresChannelDslTests {
         verify(exactly = 0) {  ChannelProcessorsConfig.CHANNEL_PROCESSOR.supports(any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class ChannelProcessorsConfig {
 

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/Saml2DslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/Saml2DslTests.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.BeanCreationException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.core.io.ClassPathResource
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.ProviderManager
@@ -69,6 +70,7 @@ class Saml2DslTests {
 
     }
 
+    @Configuration
     @EnableWebSecurity
     open class Saml2LoginNoRelyingPArtyRegistrationRepoConfig {
         @Bean
@@ -90,6 +92,7 @@ class Saml2DslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class Saml2LoginConfig {
 
@@ -133,6 +136,7 @@ class Saml2DslTests {
         verify(exactly = 1) { Saml2LoginCustomAuthenticationManagerConfig.AUTHENTICATION_MANAGER.authenticate(any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class Saml2LoginCustomAuthenticationManagerConfig {
         companion object {

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/SecurityContextDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/SecurityContextDslTests.kt
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.test.SpringTestContext
@@ -64,6 +65,7 @@ class SecurityContextDslTests {
         verify(exactly = 1) { DuplicateDoesNotOverrideConfig.SECURITY_CONTEXT_REPOSITORY.loadContext(any<HttpRequestResponseHolder>()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class DuplicateDoesNotOverrideConfig {
         @Bean
@@ -103,6 +105,7 @@ class SecurityContextDslTests {
         assertThat(securityContext.authentication).isNotNull
     }
 
+    @Configuration
     @EnableWebSecurity
     open class RequireExplicitSaveConfig {
         @Bean

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/SessionManagementDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/SessionManagementDslTests.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.mock.web.MockHttpSession
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
@@ -72,6 +73,7 @@ class SessionManagementDslTests {
             .andExpect(redirectedUrl("/invalid"))
     }
 
+    @Configuration
     @EnableWebSecurity
     open class InvalidSessionUrlConfig {
         @Bean
@@ -99,6 +101,7 @@ class SessionManagementDslTests {
             .andExpect(redirectedUrl("/invalid"))
     }
 
+    @Configuration
     @EnableWebSecurity
     open class InvalidSessionStrategyConfig {
         @Bean
@@ -127,6 +130,7 @@ class SessionManagementDslTests {
             .andExpect(redirectedUrl("/session-auth-error"))
     }
 
+    @Configuration
     @EnableWebSecurity
     open class SessionAuthenticationErrorUrlConfig {
         @Bean
@@ -158,6 +162,7 @@ class SessionManagementDslTests {
             .andExpect(redirectedUrl("/session-auth-error"))
     }
 
+    @Configuration
     @EnableWebSecurity
     open class SessionAuthenticationFailureHandlerConfig {
         @Bean
@@ -184,6 +189,7 @@ class SessionManagementDslTests {
         assertThat(result.request.getSession(false)).isNull()
     }
 
+    @Configuration
     @EnableWebSecurity
     open class StatelessSessionManagementConfig {
         @Bean
@@ -217,6 +223,7 @@ class SessionManagementDslTests {
         verify(exactly = 1) { SessionAuthenticationStrategyConfig.STRATEGY.onAuthentication(any(), any(), any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class SessionAuthenticationStrategyConfig {
 

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/X509DslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/X509DslTests.kt
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.core.io.ClassPathResource
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
@@ -64,6 +65,7 @@ class X509DslTests {
                 .andExpect(authenticated().withUsername("rod"))
     }
 
+    @Configuration
     @EnableWebSecurity
     open class X509Config {
         @Bean
@@ -95,6 +97,7 @@ class X509DslTests {
                 .andExpect(authenticated().withUsername("rod"))
     }
 
+    @Configuration
     @EnableWebSecurity
     open class X509RegexConfig {
         @Bean
@@ -128,6 +131,7 @@ class X509DslTests {
                 .andExpect(authenticated().withUsername("rod"))
     }
 
+    @Configuration
     @EnableWebSecurity
     open class UserDetailsServiceConfig {
         @Bean
@@ -160,6 +164,7 @@ class X509DslTests {
                 .andExpect(authenticated().withUsername("rod"))
     }
 
+    @Configuration
     @EnableWebSecurity
     open class AuthenticationUserDetailsServiceConfig {
         @Bean
@@ -194,6 +199,7 @@ class X509DslTests {
                 .andExpect(authenticated().withUsername("rod"))
     }
 
+    @Configuration
     @EnableWebSecurity
     open class X509PrincipalExtractorConfig {
         @Bean

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/headers/CacheControlDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/headers/CacheControlDslTests.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
@@ -55,6 +56,7 @@ class CacheControlDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class CacheControlConfig {
         @Bean
@@ -81,6 +83,7 @@ class CacheControlDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class CacheControlDisabledConfig {
         @Bean

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/headers/ContentSecurityPolicyDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/headers/ContentSecurityPolicyDslTests.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.invoke
@@ -54,6 +55,7 @@ class ContentSecurityPolicyDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class ContentSecurityPolicyConfig {
         @Bean
@@ -79,6 +81,7 @@ class ContentSecurityPolicyDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class CustomPolicyDirectivesConfig {
         @Bean
@@ -106,6 +109,7 @@ class ContentSecurityPolicyDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class ReportOnlyConfig {
         @Bean

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/headers/ContentTypeOptionsDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/headers/ContentTypeOptionsDslTests.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.invoke
@@ -53,6 +54,7 @@ class ContentTypeOptionsDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class ContentTypeOptionsConfig {
         @Bean
@@ -77,6 +79,7 @@ class ContentTypeOptionsDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class ContentTypeOptionsDisabledConfig {
         @Bean

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/headers/FrameOptionsDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/headers/FrameOptionsDslTests.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.invoke
@@ -55,6 +56,7 @@ class FrameOptionsDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class FrameOptionsConfig {
         @Bean
@@ -80,6 +82,7 @@ class FrameOptionsDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class FrameOptionsDenyConfig {
         @Bean
@@ -107,6 +110,7 @@ class FrameOptionsDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class FrameOptionsSameOriginConfig {
         @Bean
@@ -134,6 +138,7 @@ class FrameOptionsDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class FrameOptionsSameOriginAndDenyConfig {
         @Bean
@@ -162,6 +167,7 @@ class FrameOptionsDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class FrameOptionsDisabledConfig {
         @Bean

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/headers/HttpPublicKeyPinningDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/headers/HttpPublicKeyPinningDslTests.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.test.SpringTestContext
@@ -57,6 +58,7 @@ class HttpPublicKeyPinningDslTests {
         Assertions.assertThat(result.response.headerNames).isEmpty()
     }
 
+    @Configuration
     @EnableWebSecurity
     open class HpkpNoPinConfig {
         @Bean
@@ -82,6 +84,7 @@ class HttpPublicKeyPinningDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class HpkpPinConfig {
         @Bean
@@ -109,6 +112,7 @@ class HttpPublicKeyPinningDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class HpkpMaxAgeConfig {
         @Bean
@@ -137,6 +141,7 @@ class HttpPublicKeyPinningDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class HpkpReportOnlyFalseConfig {
         @Bean
@@ -168,6 +173,7 @@ class HttpPublicKeyPinningDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class HpkpIncludeSubdomainsConfig {
         @Bean
@@ -199,6 +205,7 @@ class HttpPublicKeyPinningDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class HpkpReportUriConfig {
         @Bean
@@ -229,6 +236,7 @@ class HttpPublicKeyPinningDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class HpkpDisabledConfig {
         @Bean

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/headers/HttpStrictTransportSecurityDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/headers/HttpStrictTransportSecurityDslTests.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.invoke
@@ -56,6 +57,7 @@ class HttpStrictTransportSecurityDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class HstsConfig {
         @Bean
@@ -81,6 +83,7 @@ class HttpStrictTransportSecurityDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class HstsPreloadConfig {
         @Bean
@@ -108,6 +111,7 @@ class HttpStrictTransportSecurityDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class HstsMaxAgeConfig {
         @Bean
@@ -135,6 +139,7 @@ class HttpStrictTransportSecurityDslTests {
         Assertions.assertThat(result.response.headerNames).isEmpty()
     }
 
+    @Configuration
     @EnableWebSecurity
     open class HstsCustomMatcherConfig {
         @Bean
@@ -162,6 +167,7 @@ class HttpStrictTransportSecurityDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class HstsDisabledConfig {
         @Bean

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/headers/ReferrerPolicyDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/headers/ReferrerPolicyDslTests.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.invoke
@@ -53,6 +54,7 @@ class ReferrerPolicyDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class ReferrerPolicyConfig {
         @Bean
@@ -77,6 +79,7 @@ class ReferrerPolicyDslTests {
                 }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class ReferrerPolicyCustomPolicyConfig {
         @Bean

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/headers/XssProtectionConfigDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/headers/XssProtectionConfigDslTests.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.invoke
@@ -54,6 +55,7 @@ class XssProtectionConfigDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class XssProtectionConfig {
         @Bean
@@ -79,6 +81,7 @@ class XssProtectionConfigDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class XssProtectionBlockFalseConfig {
         @Bean
@@ -106,6 +109,7 @@ class XssProtectionConfigDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class XssProtectionDisabledConfig {
         @Bean
@@ -133,6 +137,7 @@ class XssProtectionConfigDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class XssProtectionDisabledFunctionConfig {
         @Bean

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/client/AuthorizationCodeGrantDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/client/AuthorizationCodeGrantDslTests.kt
@@ -80,6 +80,7 @@ class AuthorizationCodeGrantDslTests {
         verify(exactly = 1) { RequestRepositoryConfig.REQUEST_REPOSITORY.loadAuthorizationRequest(any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class RequestRepositoryConfig {
 
@@ -131,6 +132,7 @@ class AuthorizationCodeGrantDslTests {
         verify(exactly = 1) { AuthorizedClientConfig.CLIENT.getTokenResponse(any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class AuthorizedClientConfig {
         companion object {
@@ -174,6 +176,7 @@ class AuthorizationCodeGrantDslTests {
         verify(exactly = 1) { requestResolverConfig.requestResolver.resolve(any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class RequestResolverConfig {
 

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/login/AuthorizationEndpointDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/login/AuthorizationEndpointDslTests.kt
@@ -65,6 +65,7 @@ class AuthorizationEndpointDslTests {
         verify(exactly = 1) { ResolverConfig.RESOLVER.resolve(any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class ResolverConfig {
 
@@ -104,6 +105,7 @@ class AuthorizationEndpointDslTests {
         verify(exactly = 1) { RequestRepoConfig.REPOSITORY.saveAuthorizationRequest(any(), any(), any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class RequestRepoConfig {
 
@@ -135,6 +137,7 @@ class AuthorizationEndpointDslTests {
         verify(exactly = 1) { AuthorizationUriConfig.REPOSITORY.saveAuthorizationRequest(any(), any(), any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class AuthorizationUriConfig {
 

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/login/RedirectionEndpointDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/login/RedirectionEndpointDslTests.kt
@@ -102,6 +102,7 @@ class RedirectionEndpointDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class UserServiceConfig {
 

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/login/TokenEndpointDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/login/TokenEndpointDslTests.kt
@@ -93,6 +93,7 @@ class TokenEndpointDslTests {
         verify(exactly = 1) { TokenConfig.CLIENT.getTokenResponse(any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class TokenConfig {
 

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/login/UserInfoEndpointDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/login/UserInfoEndpointDslTests.kt
@@ -101,6 +101,7 @@ class UserInfoEndpointDslTests {
         verify(exactly = 1) { UserServiceConfig.USER_SERVICE.loadUser(any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class UserServiceConfig {
 

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/resourceserver/JwtDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/resourceserver/JwtDslTests.kt
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.core.convert.converter.Converter
 import org.springframework.security.authentication.AbstractAuthenticationToken
 import org.springframework.security.authentication.AuthenticationManager
@@ -74,6 +75,7 @@ class JwtDslTests {
         this.spring.register(CustomJwtDecoderConfig::class.java).autowire()
     }
 
+    @Configuration
     @EnableWebSecurity
     open class CustomJwtDecoderConfig {
         @Bean
@@ -94,6 +96,7 @@ class JwtDslTests {
         this.spring.register(CustomJwkSetUriConfig::class.java).autowire()
     }
 
+    @Configuration
     @EnableWebSecurity
     open class CustomJwkSetUriConfig {
         @Bean
@@ -130,6 +133,7 @@ class JwtDslTests {
         verify(exactly = 1) { CustomJwtAuthenticationConverterConfig.CONVERTER.convert(any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class CustomJwtAuthenticationConverterConfig {
 
@@ -181,6 +185,7 @@ class JwtDslTests {
         verify(exactly = 1) { JwtDecoderAfterJwkSetUriConfig.DECODER.decode(any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class JwtDecoderAfterJwkSetUriConfig {
 
@@ -229,6 +234,7 @@ class JwtDslTests {
         verify(exactly = 1) { AuthenticationManagerConfig.AUTHENTICATION_MANAGER.authenticate(any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class AuthenticationManagerConfig {
 

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/resourceserver/OpaqueTokenDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/resourceserver/OpaqueTokenDslTests.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -101,6 +102,7 @@ class OpaqueTokenDslTests {
         }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class DefaultOpaqueConfig {
 
@@ -146,6 +148,7 @@ class OpaqueTokenDslTests {
         verify(exactly = 1) { CustomIntrospectorConfig.INTROSPECTOR.introspect("token") }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class CustomIntrospectorConfig {
 
@@ -184,6 +187,7 @@ class OpaqueTokenDslTests {
         verify(exactly = 1) { IntrospectorAfterClientCredentialsConfig.INTROSPECTOR.introspect("token") }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class IntrospectorAfterClientCredentialsConfig {
 
@@ -227,6 +231,7 @@ class OpaqueTokenDslTests {
         verify(exactly = 1) { AuthenticationManagerConfig.AUTHENTICATION_MANAGER.authenticate(any()) }
     }
 
+    @Configuration
     @EnableWebSecurity
     open class AuthenticationManagerConfig {
 

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/session/SessionConcurrencyDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/session/SessionConcurrencyDslTests.kt
@@ -75,6 +75,7 @@ class SessionConcurrencyDslTests {
                 .andExpect(redirectedUrl("/login?error"))
     }
 
+    @Configuration
     @EnableWebSecurity
     open class MaximumSessionsConfig {
         @Bean
@@ -106,6 +107,7 @@ class SessionConcurrencyDslTests {
                 .andExpect(redirectedUrl("/expired-session"))
     }
 
+    @Configuration
     @EnableWebSecurity
     open class ExpiredUrlConfig {
 
@@ -145,6 +147,7 @@ class SessionConcurrencyDslTests {
                 .andExpect(redirectedUrl("/expired-session"))
     }
 
+    @Configuration
     @EnableWebSecurity
     open class ExpiredSessionStrategyConfig {
 

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/session/SessionFixationDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/session/SessionFixationDslTests.kt
@@ -68,6 +68,7 @@ class SessionFixationDslTests {
         assertThat(resultingSession.getAttribute("name")).isNull()
     }
 
+    @Configuration
     @EnableWebSecurity
     open class NewSessionConfig {
         @Bean
@@ -103,6 +104,7 @@ class SessionFixationDslTests {
         assertThat(resultingSession.getAttribute("name")).isEqualTo("value")
     }
 
+    @Configuration
     @EnableWebSecurity
     open class MigrateSessionConfig {
         @Bean
@@ -138,6 +140,7 @@ class SessionFixationDslTests {
         assertThat(resultingSession.getAttribute("name")).isEqualTo("value")
     }
 
+    @Configuration
     @EnableWebSecurity
     open class ChangeSessionIdConfig {
         @Bean
@@ -173,6 +176,7 @@ class SessionFixationDslTests {
         assertThat(resultingSession.getAttribute("name")).isEqualTo("value")
     }
 
+    @Configuration
     @EnableWebSecurity
     open class NoneConfig {
         @Bean

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/AuthorizeExchangeDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/AuthorizeExchangeDslTests.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.test.SpringTestContext
 import org.springframework.security.config.test.SpringTestContextExtension
@@ -31,7 +32,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.reactive.config.EnableWebFlux
-import java.util.Base64
+import java.util.*
 
 /**
  * Tests for [AuthorizeExchangeDsl]
@@ -63,6 +64,7 @@ class AuthorizeExchangeDslTests {
                 .expectStatus().isUnauthorized
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class MatcherAuthenticatedConfig {
@@ -86,6 +88,7 @@ class AuthorizeExchangeDslTests {
                 .expectStatus().isOk
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class MatcherPermitAllConfig {
@@ -126,6 +129,7 @@ class AuthorizeExchangeDslTests {
                 .expectStatus().isOk
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class PatternAuthenticatedConfig {
@@ -158,6 +162,7 @@ class AuthorizeExchangeDslTests {
                 .expectStatus().isForbidden
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class HasRoleConfig {
@@ -194,6 +199,7 @@ class AuthorizeExchangeDslTests {
             .expectStatus().isForbidden
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class HasIpAddressConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerAnonymousDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerAnonymousDslTests.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.authentication.AnonymousAuthenticationToken
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -67,6 +68,7 @@ class ServerAnonymousDslTests {
                 .expectBody<String>().isEqualTo("anonymousUser")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class AnonymousConfig {
@@ -89,6 +91,7 @@ class ServerAnonymousDslTests {
                 .expectBody<String>().isEqualTo("anon")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomPrincipalConfig {
@@ -113,6 +116,7 @@ class ServerAnonymousDslTests {
                 .expectBody<String>().consumeWith { body -> assertThat(body.responseBody).isNull() }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class AnonymousDisabledConfig {
@@ -137,6 +141,7 @@ class ServerAnonymousDslTests {
                 .expectBody<String>().isEqualTo("key".hashCode().toString())
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomKeyConfig {
@@ -160,6 +165,7 @@ class ServerAnonymousDslTests {
                 .expectStatus().isOk
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomAuthoritiesConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerCacheControlDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerCacheControlDslTests.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.test.SpringTestContext
@@ -61,6 +62,7 @@ class ServerCacheControlDslTests {
                 .expectHeader().valueEquals(HttpHeaders.PRAGMA, "no-cache")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CacheControlConfig {
@@ -86,6 +88,7 @@ class ServerCacheControlDslTests {
                 .expectHeader().doesNotExist(HttpHeaders.PRAGMA)
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CacheControlDisabledConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerContentSecurityPolicyDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerContentSecurityPolicyDslTests.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.test.SpringTestContext
 import org.springframework.security.config.test.SpringTestContextExtension
@@ -59,6 +60,7 @@ class ServerContentSecurityPolicyDslTests {
                 .expectHeader().valueEquals(ContentSecurityPolicyServerHttpHeadersWriter.CONTENT_SECURITY_POLICY, "default-src 'self'")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class ContentSecurityPolicyConfig {
@@ -82,6 +84,7 @@ class ServerContentSecurityPolicyDslTests {
                 .expectHeader().valueEquals(ContentSecurityPolicyServerHttpHeadersWriter.CONTENT_SECURITY_POLICY, "default-src 'self'; script-src trustedscripts.example.com")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomPolicyDirectivesConfig {
@@ -107,6 +110,7 @@ class ServerContentSecurityPolicyDslTests {
                 .expectHeader().valueEquals(ContentSecurityPolicyServerHttpHeadersWriter.CONTENT_SECURITY_POLICY_REPORT_ONLY, "default-src 'self'")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class ReportOnlyConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerContentTypeOptionsDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerContentTypeOptionsDslTests.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.test.SpringTestContext
 import org.springframework.security.config.test.SpringTestContextExtension
@@ -59,6 +60,7 @@ class ServerContentTypeOptionsDslTests {
                 .expectHeader().valueEquals(ContentTypeOptionsServerHttpHeadersWriter.X_CONTENT_OPTIONS, "nosniff")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class ContentTypeOptionsConfig {
@@ -82,6 +84,7 @@ class ServerContentTypeOptionsDslTests {
                 .expectHeader().doesNotExist(ContentTypeOptionsServerHttpHeadersWriter.X_CONTENT_OPTIONS)
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class ContentTypeOptionsDisabledConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerCorsDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerCorsDslTests.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.test.SpringTestContext
@@ -63,6 +64,7 @@ class ServerCorsDslTests {
                 .expectHeader().valueEquals("Access-Control-Allow-Origin", "*")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CorsBeanConfig {
@@ -94,6 +96,7 @@ class ServerCorsDslTests {
                 .expectHeader().valueEquals("Access-Control-Allow-Origin", "*")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CorsSourceConfig {
@@ -122,6 +125,7 @@ class ServerCorsDslTests {
                 .expectHeader().doesNotExist("Access-Control-Allow-Origin")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CorsDisabledConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerCsrfDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerCsrfDslTests.kt
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
@@ -76,6 +77,7 @@ class ServerCsrfDslTests {
                 .expectStatus().isForbidden
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CsrfConfig {
@@ -97,6 +99,7 @@ class ServerCsrfDslTests {
                 .expectStatus().isOk
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CsrfDisabledConfig {
@@ -137,6 +140,7 @@ class ServerCsrfDslTests {
                 .expectStatus().isOk
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CsrfMatcherConfig {
@@ -173,6 +177,7 @@ class ServerCsrfDslTests {
         verify(exactly = 1) { CustomAccessDeniedHandlerConfig.ACCESS_DENIED_HANDLER.handle(any(), any()) }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomAccessDeniedHandlerConfig {
@@ -205,6 +210,7 @@ class ServerCsrfDslTests {
         verify(exactly = 1) { CustomCsrfTokenRepositoryConfig.TOKEN_REPOSITORY.loadToken(any()) }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomCsrfTokenRepositoryConfig {
@@ -241,6 +247,7 @@ class ServerCsrfDslTests {
                 .expectStatus().isForbidden
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class MultipartFormDataNotEnabledConfig {
@@ -277,6 +284,7 @@ class ServerCsrfDslTests {
                 .expectStatus().isOk
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class MultipartFormDataEnabledConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerExceptionHandlingDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerExceptionHandlingDslTests.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.core.userdetails.MapReactiveUserDetailsService
@@ -70,6 +71,7 @@ class ServerExceptionHandlingDslTests {
         }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class EntryPointConfig {
@@ -98,6 +100,7 @@ class ServerExceptionHandlingDslTests {
                 .expectStatus().isSeeOther
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class AccessDeniedHandlerConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerFormLoginDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerFormLoginDslTests.kt
@@ -83,6 +83,7 @@ class ServerFormLoginDslTests {
         }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class DefaultFormLoginConfig {
@@ -112,6 +113,7 @@ class ServerFormLoginDslTests {
         }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomLoginPageConfig {
@@ -147,6 +149,7 @@ class ServerFormLoginDslTests {
         verify(exactly = 1) { CustomAuthenticationManagerConfig.AUTHENTICATION_MANAGER.authenticate(any()) }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomAuthenticationManagerConfig {
@@ -228,6 +231,7 @@ class ServerFormLoginDslTests {
         }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomConfig {
@@ -268,6 +272,7 @@ class ServerFormLoginDslTests {
         }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomSuccessHandlerConfig {
@@ -303,6 +308,7 @@ class ServerFormLoginDslTests {
         verify(exactly = 1) { CustomSecurityContextRepositoryConfig.SECURITY_CONTEXT_REPOSITORY.save(any(), any()) }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomSecurityContextRepositoryConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerFrameOptionsDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerFrameOptionsDslTests.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.test.SpringTestContext
 import org.springframework.security.config.test.SpringTestContextExtension
@@ -60,6 +61,7 @@ class ServerFrameOptionsDslTests {
                 .expectHeader().valueEquals(XFrameOptionsServerHttpHeadersWriter.X_FRAME_OPTIONS, XFrameOptionsHeaderWriter.XFrameOptionsMode.DENY.name)
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class FrameOptionsConfig {
@@ -83,6 +85,7 @@ class ServerFrameOptionsDslTests {
                 .expectHeader().doesNotExist(XFrameOptionsServerHttpHeadersWriter.X_FRAME_OPTIONS)
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class FrameOptionsDisabledConfig {
@@ -108,6 +111,7 @@ class ServerFrameOptionsDslTests {
                 .expectHeader().valueEquals(XFrameOptionsServerHttpHeadersWriter.X_FRAME_OPTIONS, XFrameOptionsHeaderWriter.XFrameOptionsMode.SAMEORIGIN.name)
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomModeConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerHeadersDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerHeadersDslTests.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.test.SpringTestContext
@@ -73,6 +74,7 @@ class ServerHeadersDslTests {
                 .expectHeader().valueEquals(XXssProtectionServerHttpHeadersWriter.X_XSS_PROTECTION, "1 ; mode=block")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class DefaultHeadersConfig {
@@ -100,6 +102,7 @@ class ServerHeadersDslTests {
                 .expectHeader().doesNotExist(XXssProtectionServerHttpHeadersWriter.X_XSS_PROTECTION)
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class HeadersDisabledConfig {
@@ -123,6 +126,7 @@ class ServerHeadersDslTests {
                 .expectHeader().valueEquals("Feature-Policy", "geolocation 'self'")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     @Suppress("DEPRECATION")
@@ -149,6 +153,7 @@ class ServerHeadersDslTests {
                 .expectHeader().doesNotExist("Cross-Origin-Resource-Policy")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CrossOriginPoliciesConfig {
@@ -172,6 +177,7 @@ class ServerHeadersDslTests {
                 .expectHeader().valueEquals("Cross-Origin-Resource-Policy", "same-origin")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CrossOriginPoliciesCustomConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerHttpBasicDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerHttpBasicDslTests.kt
@@ -87,6 +87,7 @@ class ServerHttpBasicDslTests {
                 .expectStatus().isOk
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class HttpBasicConfig {
@@ -124,6 +125,7 @@ class ServerHttpBasicDslTests {
         verify(exactly = 1) { CustomAuthenticationManagerConfig.AUTHENTICATION_MANAGER.authenticate(any()) }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomAuthenticationManagerConfig {
@@ -167,6 +169,7 @@ class ServerHttpBasicDslTests {
         verify(exactly = 1) { CustomSecurityContextRepositoryConfig.SECURITY_CONTEXT_REPOSITORY.save(any(), any()) }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomSecurityContextRepositoryConfig {
@@ -203,6 +206,7 @@ class ServerHttpBasicDslTests {
         verify(exactly = 1) { CustomAuthenticationEntryPointConfig.ENTRY_POINT.commence(any(), any()) }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomAuthenticationEntryPointConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerHttpSecurityDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerHttpSecurityDslTests.kt
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders
 import org.springframework.security.authentication.ReactiveAuthenticationManager
 import org.springframework.security.authentication.TestingAuthenticationToken
@@ -87,6 +88,7 @@ class ServerHttpSecurityDslTests {
                 .expectStatus().isUnauthorized
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class PatternMatcherConfig {
@@ -127,6 +129,7 @@ class ServerHttpSecurityDslTests {
                 .expectHeader().valueEquals(XXssProtectionServerHttpHeadersWriter.X_XSS_PROTECTION, "1 ; mode=block")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class DefaultSecurityConfig {
@@ -146,6 +149,7 @@ class ServerHttpSecurityDslTests {
         assertThat(filters).last().isExactlyInstanceOf(CustomWebFilter::class.java)
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomWebFilterAtConfig {
@@ -169,6 +173,7 @@ class ServerHttpSecurityDslTests {
         )
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomWebFilterBeforeConfig {
@@ -192,6 +197,7 @@ class ServerHttpSecurityDslTests {
         )
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomWebFilterAfterConfig {
@@ -220,6 +226,7 @@ class ServerHttpSecurityDslTests {
         verify(exactly = 1) { AuthenticationManagerConfig.AUTHENTICATION_MANAGER.authenticate(any()) }
     }
 
+    @Configuration
     @EnableWebFlux
     @EnableWebFluxSecurity
     open class AuthenticationManagerConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerHttpStrictTransportSecurityDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerHttpStrictTransportSecurityDslTests.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.web.server.invoke
 import org.springframework.security.config.test.SpringTestContext
@@ -62,6 +63,7 @@ class ServerHttpStrictTransportSecurityDslTests {
                 .expectHeader().valueEquals(StrictTransportSecurityServerHttpHeadersWriter.STRICT_TRANSPORT_SECURITY, "max-age=31536000 ; includeSubDomains")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class HstsConfig {
@@ -85,6 +87,7 @@ class ServerHttpStrictTransportSecurityDslTests {
                 .expectHeader().doesNotExist(StrictTransportSecurityServerHttpHeadersWriter.STRICT_TRANSPORT_SECURITY)
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class HstsDisabledConfig {
@@ -110,6 +113,7 @@ class ServerHttpStrictTransportSecurityDslTests {
                 .expectHeader().valueEquals(StrictTransportSecurityServerHttpHeadersWriter.STRICT_TRANSPORT_SECURITY, "max-age=1 ; includeSubDomains")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class MaxAgeConfig {
@@ -135,6 +139,7 @@ class ServerHttpStrictTransportSecurityDslTests {
                 .expectHeader().valueEquals(StrictTransportSecurityServerHttpHeadersWriter.STRICT_TRANSPORT_SECURITY, "max-age=31536000")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class IncludeSubdomainsConfig {
@@ -160,6 +165,7 @@ class ServerHttpStrictTransportSecurityDslTests {
                 .expectHeader().valueEquals(StrictTransportSecurityServerHttpHeadersWriter.STRICT_TRANSPORT_SECURITY, "max-age=31536000 ; includeSubDomains ; preload")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class PreloadConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerHttpsRedirectDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerHttpsRedirectDslTests.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.test.SpringTestContext
 import org.springframework.security.config.test.SpringTestContextExtension
@@ -77,6 +78,7 @@ class ServerHttpsRedirectDslTests {
                 .expectStatus().isNotFound
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class HttpRedirectMatcherConfig {
@@ -116,6 +118,7 @@ class ServerHttpsRedirectDslTests {
                 .expectStatus().isNotFound
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class HttpRedirectFunctionConfig {
@@ -152,6 +155,7 @@ class ServerHttpsRedirectDslTests {
         }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class HttpRedirectMatcherAndFunctionConfig {
@@ -183,6 +187,7 @@ class ServerHttpsRedirectDslTests {
         }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class PortMapperConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerJwtDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerJwtDslTests.kt
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.core.convert.converter.Converter
 import org.springframework.http.HttpHeaders
 import org.springframework.security.authentication.AbstractAuthenticationToken
@@ -106,6 +107,7 @@ class ServerJwtDslTests {
                 .expectStatus().isUnauthorized
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class PublicKeyConfig {
@@ -141,6 +143,7 @@ class ServerJwtDslTests {
         verify(exactly = 1) { CustomDecoderConfig.JWT_DECODER.decode("token") }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomDecoderConfig {
@@ -185,6 +188,7 @@ class ServerJwtDslTests {
         assertThat(recordedRequest.path).isEqualTo("/.well-known/jwks.json")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomJwkSetUriConfig {
@@ -242,6 +246,7 @@ class ServerJwtDslTests {
         verify(exactly = 1) { CustomJwtAuthenticationConverterConfig.CONVERTER.convert(any()) }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomJwtAuthenticationConverterConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerLogoutDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerLogoutDslTests.kt
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.test.SpringTestContext
@@ -79,6 +80,7 @@ class ServerLogoutDslTests {
         }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class LogoutConfig {
@@ -109,6 +111,7 @@ class ServerLogoutDslTests {
         }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomUrlConfig {
@@ -141,6 +144,7 @@ class ServerLogoutDslTests {
         }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class RequiresLogoutConfig {
@@ -169,6 +173,7 @@ class ServerLogoutDslTests {
         verify(exactly = 1) { CustomLogoutHandlerConfig.LOGOUT_HANDLER.logout(any(), any()) }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomLogoutHandlerConfig {
@@ -204,6 +209,7 @@ class ServerLogoutDslTests {
         verify(exactly = 1) { CustomLogoutSuccessHandlerConfig.LOGOUT_HANDLER.onLogoutSuccess(any(), any()) }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomLogoutSuccessHandlerConfig {
@@ -234,6 +240,7 @@ class ServerLogoutDslTests {
                 .expectStatus().isNotFound
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class LogoutDisabledConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerOAuth2ClientDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerOAuth2ClientDslTests.kt
@@ -70,6 +70,7 @@ class ServerOAuth2ClientDslTests {
         this.spring.register(ClientRepoConfig::class.java).autowire()
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class ClientRepoConfig {
@@ -112,6 +113,7 @@ class ServerOAuth2ClientDslTests {
         }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class AuthorizationRequestRepositoryConfig {
@@ -158,6 +160,7 @@ class ServerOAuth2ClientDslTests {
         verify(exactly = 1) { AuthenticationConverterConfig.AUTHENTICATION_CONVERTER.convert(any()) }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class AuthenticationConverterConfig {
@@ -210,6 +213,7 @@ class ServerOAuth2ClientDslTests {
         verify(exactly = 1) { AuthenticationManagerConfig.AUTHENTICATION_MANAGER.authenticate(any()) }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class AuthenticationManagerConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerOAuth2LoginDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerOAuth2LoginDslTests.kt
@@ -68,6 +68,7 @@ class ServerOAuth2LoginDslTests {
         this.spring.register(ClientRepoConfig::class.java).autowire()
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class ClientRepoConfig {
@@ -98,6 +99,7 @@ class ServerOAuth2LoginDslTests {
                 .expectStatus().isOk
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class OAuth2LoginConfig {
@@ -123,6 +125,7 @@ class ServerOAuth2LoginDslTests {
         verify(exactly = 1) { AuthorizationRequestRepositoryConfig.AUTHORIZATION_REQUEST_REPOSITORY.removeAuthorizationRequest(any()) }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class AuthorizationRequestRepositoryConfig {
@@ -156,6 +159,7 @@ class ServerOAuth2LoginDslTests {
         verify(exactly = 1) { AuthenticationMatcherConfig.AUTHENTICATION_MATCHER.matches(any()) }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class AuthenticationMatcherConfig {
@@ -189,6 +193,7 @@ class ServerOAuth2LoginDslTests {
         verify(exactly = 1) { AuthenticationConverterConfig.AUTHENTICATION_CONVERTER.convert(any()) }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class AuthenticationConverterConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerOAuth2ResourceServerDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerOAuth2ResourceServerDslTests.kt
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
 import org.springframework.security.authentication.ReactiveAuthenticationManagerResolver
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
@@ -76,6 +77,7 @@ class ServerOAuth2ResourceServerDslTests {
                 .expectStatus().isSeeOther
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class AccessDeniedHandlerConfig {
@@ -106,6 +108,7 @@ class ServerOAuth2ResourceServerDslTests {
                 .expectStatus().isSeeOther
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class AuthenticationEntryPointConfig {
@@ -142,6 +145,7 @@ class ServerOAuth2ResourceServerDslTests {
         verify(exactly = 1) { BearerTokenConverterConfig.CONVERTER.convert(any()) }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class BearerTokenConverterConfig {
@@ -182,6 +186,7 @@ class ServerOAuth2ResourceServerDslTests {
         verify(exactly = 1) { AuthenticationManagerResolverConfig.RESOLVER.resolve(any()) }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class AuthenticationManagerResolverConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerOpaqueTokenDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerOpaqueTokenDslTests.kt
@@ -34,6 +34,7 @@ import org.springframework.security.web.server.SecurityWebFilterChain
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.web.reactive.config.EnableWebFlux
 import jakarta.annotation.PreDestroy
+import org.springframework.context.annotation.Configuration
 
 /**
  * Tests for [ServerOpaqueTokenDsl]
@@ -70,6 +71,7 @@ class ServerOpaqueTokenDslTests {
         assertThat(recordedRequest.path).isEqualTo("/introspect")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class IntrospectorBeanConfig {
@@ -120,6 +122,7 @@ class ServerOpaqueTokenDslTests {
         assertThat(recordedRequest.path).isEqualTo("/introspector")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomIntrospectorConfig {
@@ -167,6 +170,7 @@ class ServerOpaqueTokenDslTests {
         assertThat(recordedRequest.path).isEqualTo("/introspection-uri")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomIntrospectionUriAndCredentialsConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerPasswordManagementDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerPasswordManagementDslTests.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.test.SpringTestContext
 import org.springframework.security.config.test.SpringTestContextExtension
@@ -61,6 +62,7 @@ class ServerPasswordManagementDslTests {
                 .expectHeader().valueEquals(HttpHeaders.LOCATION, "/change-password")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class PasswordManagementWithDefaultChangePasswordPageConfig {
@@ -83,6 +85,7 @@ class ServerPasswordManagementDslTests {
                 .expectHeader().valueEquals(HttpHeaders.LOCATION, "/custom-change-password-page")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class PasswordManagementWithCustomChangePasswordPageConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerPermissionsPolicyDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerPermissionsPolicyDslTests.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.test.SpringTestContext
 import org.springframework.security.config.test.SpringTestContextExtension
@@ -58,6 +59,7 @@ class ServerPermissionsPolicyDslTests {
                 .expectHeader().doesNotExist("Permissions-Policy")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class PermissionsPolicyConfig {
@@ -81,6 +83,7 @@ class ServerPermissionsPolicyDslTests {
                 .expectHeader().valueEquals("Permissions-Policy", "geolocation=(self)")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomPolicyConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerReferrerPolicyDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerReferrerPolicyDslTests.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.test.SpringTestContext
 import org.springframework.security.config.test.SpringTestContextExtension
@@ -60,6 +61,7 @@ class ServerReferrerPolicyDslTests {
                 .expectHeader().valueEquals("Referrer-Policy", ReferrerPolicyHeaderWriter.ReferrerPolicy.NO_REFERRER.policy)
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class ReferrerPolicyConfig {
@@ -83,6 +85,7 @@ class ServerReferrerPolicyDslTests {
                 .expectHeader().valueEquals("Referrer-Policy", ReferrerPolicyServerHttpHeadersWriter.ReferrerPolicy.SAME_ORIGIN.policy)
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class CustomPolicyConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerRequestCacheDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerRequestCacheDslTests.kt
@@ -72,6 +72,7 @@ class ServerRequestCacheDslTests {
         verify(exactly = 1) { RequestCacheConfig.REQUEST_CACHE.saveRequest(any()) }
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class RequestCacheConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerX509DslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerX509DslTests.kt
@@ -91,6 +91,7 @@ class ServerX509DslTests {
                 .expectBody<String>().isEqualTo("rod")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class X509DefaultConfig {
@@ -118,6 +119,7 @@ class ServerX509DslTests {
                 .expectBody<String>().isEqualTo("rod")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class PrincipalExtractorConfig {
@@ -149,6 +151,7 @@ class ServerX509DslTests {
                 .expectBody<String>().isEqualTo("rod")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class AuthenticationManagerConfig {

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerXssProtectionDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerXssProtectionDslTests.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.test.SpringTestContext
 import org.springframework.security.config.test.SpringTestContextExtension
@@ -59,6 +60,7 @@ class ServerXssProtectionDslTests {
                 .expectHeader().valueEquals(XXssProtectionServerHttpHeadersWriter.X_XSS_PROTECTION, "1 ; mode=block")
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class XssConfig {
@@ -82,6 +84,7 @@ class ServerXssProtectionDslTests {
                 .expectHeader().doesNotExist(XXssProtectionServerHttpHeadersWriter.X_XSS_PROTECTION)
     }
 
+    @Configuration
     @EnableWebFluxSecurity
     @EnableWebFlux
     open class XssDisabledConfig {

--- a/docs/modules/ROOT/pages/reactive/authorization/method.adoc
+++ b/docs/modules/ROOT/pages/reactive/authorization/method.adoc
@@ -71,6 +71,7 @@ The following minimal method security configures method security in reactive app
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableReactiveMethodSecurity
 public class SecurityConfig {
 	@Bean
@@ -92,6 +93,7 @@ public class SecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableReactiveMethodSecurity
 class SecurityConfig {
 	@Bean
@@ -168,6 +170,7 @@ When integrating with xref:reactive/configuration/webflux.adoc#jc-webflux[WebFlu
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 @EnableReactiveMethodSecurity
 public class SecurityConfig {
@@ -203,6 +206,7 @@ public class SecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 @EnableReactiveMethodSecurity
 class SecurityConfig {

--- a/docs/modules/ROOT/pages/reactive/configuration/webflux.adoc
+++ b/docs/modules/ROOT/pages/reactive/configuration/webflux.adoc
@@ -18,7 +18,7 @@ The following listing shows a minimal WebFlux Security configuration:
 .Java
 [source,java,role="primary"]
 -----
-
+@Configuration
 @EnableWebFluxSecurity
 public class HelloWebfluxSecurityConfig {
 
@@ -37,6 +37,7 @@ public class HelloWebfluxSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 -----
+@Configuration
 @EnableWebFluxSecurity
 class HelloWebfluxSecurityConfig {
 

--- a/docs/modules/ROOT/pages/reactive/oauth2/client/authorization-grants.adoc
+++ b/docs/modules/ROOT/pages/reactive/oauth2/client/authorization-grants.adoc
@@ -115,6 +115,7 @@ The following example shows how to configure the `DefaultServerOAuth2Authorizati
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -157,6 +158,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 class SecurityConfig {
 
@@ -262,6 +264,7 @@ If you have a custom implementation of `ServerAuthorizationRequestRepository`, y
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 public class OAuth2ClientSecurityConfig {
 
@@ -280,6 +283,7 @@ public class OAuth2ClientSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 class OAuth2ClientSecurityConfig {
 
@@ -335,6 +339,7 @@ Whether you customize `WebClientReactiveAuthorizationCodeTokenResponseClient` or
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 public class OAuth2ClientSecurityConfig {
 
@@ -361,6 +366,7 @@ public class OAuth2ClientSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 class OAuth2ClientSecurityConfig {
 

--- a/docs/modules/ROOT/pages/reactive/oauth2/client/index.adoc
+++ b/docs/modules/ROOT/pages/reactive/oauth2/client/index.adoc
@@ -28,6 +28,7 @@ The following code shows the complete configuration options provided by the `Ser
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 public class OAuth2ClientSecurityConfig {
 
@@ -50,6 +51,7 @@ public class OAuth2ClientSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 class OAuth2ClientSecurityConfig {
 

--- a/docs/modules/ROOT/pages/reactive/oauth2/login/advanced.adoc
+++ b/docs/modules/ROOT/pages/reactive/oauth2/login/advanced.adoc
@@ -27,6 +27,7 @@ The following code shows the complete configuration options available for the `o
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -55,6 +56,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 class OAuth2LoginSecurityConfig {
 
@@ -121,6 +123,7 @@ The following listing shows an example:
 .Java
 [source,java,role="primary",subs="-attributes"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -153,6 +156,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary",subs="-attributes"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 class OAuth2LoginSecurityConfig {
 
@@ -220,6 +224,7 @@ If you would like to customize the Authorization Response redirection endpoint, 
 .Java
 [source,java,role="primary",subs="-attributes"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -238,6 +243,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary",subs="-attributes"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 class OAuth2LoginSecurityConfig {
 
@@ -317,6 +323,7 @@ Register a `GrantedAuthoritiesMapper` `@Bean` to have it automatically applied t
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -364,6 +371,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 class OAuth2LoginSecurityConfig {
 
@@ -413,6 +421,7 @@ The following example shows how to implement and configure a delegation-based st
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -453,6 +462,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 class OAuth2LoginSecurityConfig {
 
@@ -509,6 +519,7 @@ Whether you customize `DefaultReactiveOAuth2UserService` or provide your own imp
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -531,6 +542,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 class OAuth2LoginSecurityConfig {
 
@@ -567,6 +579,7 @@ Whether you customize `OidcReactiveOAuth2UserService` or provide your own implem
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -589,6 +602,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 class OAuth2LoginSecurityConfig {
 
@@ -686,6 +700,7 @@ spring:
 .Java
 [source,java,role="primary",subs="-attributes"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -722,6 +737,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary",subs="-attributes"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 class OAuth2LoginSecurityConfig {
 

--- a/docs/modules/ROOT/pages/reactive/oauth2/login/core.adoc
+++ b/docs/modules/ROOT/pages/reactive/oauth2/login/core.adoc
@@ -325,6 +325,7 @@ The following example shows how to register a `SecurityWebFilterChain` `@Bean` w
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -344,6 +345,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 class OAuth2LoginSecurityConfig {
 
@@ -373,6 +375,7 @@ The following example shows how to completely override the auto-configuration by
 .Java
 [source,java,role="primary",attrs="-attributes"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 public class OAuth2LoginConfig {
 
@@ -414,6 +417,7 @@ public class OAuth2LoginConfig {
 .Kotlin
 [source,kotlin,role="secondary",attrs="-attributes"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 class OAuth2LoginConfig {
 
@@ -465,6 +469,7 @@ If you are not able to use Spring Boot 2.x and would like to configure one of th
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 public class OAuth2LoginConfig {
 
@@ -508,6 +513,7 @@ public class OAuth2LoginConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 class OAuth2LoginConfig {
 

--- a/docs/modules/ROOT/pages/reactive/oauth2/resource-server/opaque-token.adoc
+++ b/docs/modules/ROOT/pages/reactive/oauth2/resource-server/opaque-token.adoc
@@ -204,6 +204,7 @@ You can replace it by exposing the bean within the application:
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 public class MyCustomSecurityConfiguration {
     @Bean
@@ -282,6 +283,7 @@ You can configure an authorization server's Introspection URI <<webflux-oauth2re
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 public class DirectlyConfiguredIntrospectionUri {
     @Bean
@@ -332,6 +334,7 @@ Using `introspectionUri()` takes precedence over any configuration property.
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 public class DirectlyConfiguredIntrospector {
     @Bean
@@ -416,6 +419,7 @@ This means that, to protect an endpoint or method with a scope derived from an O
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebFluxSecurity
 public class MappedAuthorities {
     @Bean

--- a/docs/modules/ROOT/pages/servlet/configuration/java.adoc
+++ b/docs/modules/ROOT/pages/servlet/configuration/java.adoc
@@ -28,6 +28,7 @@ import org.springframework.context.annotation.*;
 import org.springframework.security.config.annotation.authentication.builders.*;
 import org.springframework.security.config.annotation.web.configuration.*;
 
+@Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
 
@@ -191,6 +192,7 @@ The following example has a different configuration for URL's that start with `/
 ====
 [source,java]
 ----
+@Configuration
 @EnableWebSecurity
 public class MultiHttpSecurityConfig {
 	@Bean                                                             <1>
@@ -284,6 +286,7 @@ You can then use the custom DSL:
 ====
 [source,java]
 ----
+@Configuration
 @EnableWebSecurity
 public class Config {
 	@Bean

--- a/docs/modules/ROOT/pages/servlet/configuration/kotlin.adoc
+++ b/docs/modules/ROOT/pages/servlet/configuration/kotlin.adoc
@@ -62,6 +62,7 @@ The following example has a different configuration for URL's that start with `/
 ====
 [source,kotlin]
 ----
+@Configuration
 @EnableWebSecurity
 class MultiHttpSecurityConfig {
     @Bean                                                            <1>

--- a/docs/modules/ROOT/pages/servlet/exploits/csrf.adoc
+++ b/docs/modules/ROOT/pages/servlet/exploits/csrf.adoc
@@ -64,6 +64,7 @@ You can configure `CookieCsrfTokenRepository` in Java or Kotlin configuration by
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
 
@@ -81,6 +82,7 @@ public class WebSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class SecurityConfig {
 
@@ -332,6 +334,7 @@ For example, the following Java Configuration logs out when the `/logout` URL is
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
 
@@ -349,6 +352,7 @@ public class WebSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class SecurityConfig {
 

--- a/docs/modules/ROOT/pages/servlet/exploits/headers.adoc
+++ b/docs/modules/ROOT/pages/servlet/exploits/headers.adoc
@@ -20,6 +20,7 @@ You can do so with the following configuration:
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
 
@@ -52,6 +53,7 @@ public class WebSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class SecurityConfig {
     @Bean
@@ -80,6 +82,7 @@ If you use Spring Security's configuration, the following adds only xref:feature
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
 
@@ -112,6 +115,7 @@ public class WebSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class SecurityConfig {
     @Bean
@@ -138,6 +142,7 @@ If necessary, you can disable all of the HTTP Security response headers with the
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
 
@@ -164,6 +169,7 @@ public class WebSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class SecurityConfig {
     @Bean
@@ -229,6 +235,7 @@ public class WebSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class SecurityConfig {
 
@@ -289,6 +296,7 @@ public class WebSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class SecurityConfig {
 
@@ -319,6 +327,7 @@ The following example explicitly provides HSTS:
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
 
@@ -356,6 +365,7 @@ public class WebSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class SecurityConfig {
 
@@ -387,6 +397,7 @@ You can enable HPKP headers with the following configuration:
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
 
@@ -427,6 +438,7 @@ public class WebSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class SecurityConfig {
 
@@ -460,6 +472,7 @@ For example, the following configuration specifies that Spring Security should n
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
 
@@ -494,6 +507,7 @@ public class WebSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class SecurityConfig {
 
@@ -524,6 +538,7 @@ For example, the following configuration specifies that Spring Security should n
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
 
@@ -556,6 +571,7 @@ public class WebSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class SecurityConfig {
 
@@ -598,6 +614,7 @@ Given the preceding security policy, you can enable the CSP header:
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
 
@@ -631,6 +648,7 @@ public class WebSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class SecurityConfig {
 
@@ -657,6 +675,7 @@ To enable the CSP `report-only` header, provide the following configuration:
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
 
@@ -692,6 +711,7 @@ public class WebSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class SecurityConfig {
 
@@ -723,6 +743,7 @@ You can enable the Referrer Policy header by using the configuration:
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
 
@@ -755,6 +776,7 @@ public class WebSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class SecurityConfig {
 
@@ -795,6 +817,7 @@ You can enable the preceding feature policy header by using the following config
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
 
@@ -825,6 +848,7 @@ public class WebSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class SecurityConfig {
 

--- a/docs/modules/ROOT/pages/servlet/integrations/cors.adoc
+++ b/docs/modules/ROOT/pages/servlet/integrations/cors.adoc
@@ -12,6 +12,7 @@ Users can integrate the `CorsFilter` with Spring Security by providing a `CorsCo
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
 
@@ -39,6 +40,7 @@ public class WebSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 open class WebSecurityConfig {
     @Bean
@@ -85,6 +87,7 @@ If you use Spring MVC's CORS support, you can omit specifying the `CorsConfigura
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
 
@@ -103,6 +106,7 @@ public class WebSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 open class WebSecurityConfig {
     @Bean

--- a/docs/modules/ROOT/pages/servlet/integrations/websocket.adoc
+++ b/docs/modules/ROOT/pages/servlet/integrations/websocket.adoc
@@ -514,6 +514,7 @@ Similarly, you can customize frame options to use the same origin within Java Co
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
 
@@ -534,6 +535,7 @@ public class WebSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 open class WebSecurityConfig {
     @Bean

--- a/docs/modules/ROOT/pages/servlet/oauth2/client/authorization-grants.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/client/authorization-grants.adoc
@@ -132,6 +132,7 @@ The following example shows how to configure the `DefaultOAuth2AuthorizationRequ
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -176,6 +177,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class SecurityConfig {
 
@@ -288,6 +290,7 @@ If you have a custom implementation of `AuthorizationRequestRepository`, you can
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class OAuth2ClientSecurityConfig {
 
@@ -308,6 +311,7 @@ public class OAuth2ClientSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class OAuth2ClientSecurityConfig {
 
@@ -411,6 +415,7 @@ Whether you customize `DefaultAuthorizationCodeTokenResponseClient` or provide y
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class OAuth2ClientSecurityConfig {
 
@@ -431,6 +436,7 @@ public class OAuth2ClientSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class OAuth2ClientSecurityConfig {
 

--- a/docs/modules/ROOT/pages/servlet/oauth2/client/index.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/client/index.adoc
@@ -29,6 +29,7 @@ The following code shows the complete configuration options provided by the `Htt
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class OAuth2ClientSecurityConfig {
 
@@ -53,6 +54,7 @@ public class OAuth2ClientSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class OAuth2ClientSecurityConfig {
 

--- a/docs/modules/ROOT/pages/servlet/oauth2/login/advanced.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/login/advanced.adoc
@@ -13,6 +13,7 @@ The following code shows an example:
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -41,6 +42,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class OAuth2LoginSecurityConfig {
 
@@ -94,6 +96,7 @@ The following code shows the complete configuration options available for the `o
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -130,6 +133,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class OAuth2LoginSecurityConfig {
 
@@ -235,6 +239,7 @@ The following listing shows an example:
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -257,6 +262,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class OAuth2LoginSecurityConfig {
 
@@ -326,6 +332,7 @@ If you would like to customize the Authorization Response `baseUri`, configure i
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -346,6 +353,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class OAuth2LoginSecurityConfig {
 
@@ -438,6 +446,7 @@ Provide an implementation of `GrantedAuthoritiesMapper` and configure it, as fol
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -487,6 +496,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class OAuth2LoginSecurityConfig {
 
@@ -541,6 +551,7 @@ Alternatively, you can register a `GrantedAuthoritiesMapper` `@Bean` to have it 
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -561,6 +572,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class OAuth2LoginSecurityConfig {
 
@@ -594,6 +606,7 @@ The following example shows how to implement and configure a delegation-based st
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -635,6 +648,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class OAuth2LoginSecurityConfig  {
 
@@ -720,6 +734,7 @@ Whether you customize `DefaultOAuth2UserService` or provide your own implementat
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -744,6 +759,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class OAuth2LoginSecurityConfig {
 
@@ -783,6 +799,7 @@ Whether you customize `OidcUserService` or provide your own implementation of `O
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -807,6 +824,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class OAuth2LoginSecurityConfig {
 

--- a/docs/modules/ROOT/pages/servlet/oauth2/login/core.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/login/core.adoc
@@ -328,6 +328,7 @@ The following example shows how to register a `SecurityFilterChain` `@Bean` with
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class OAuth2LoginSecurityConfig {
 
@@ -346,6 +347,7 @@ public class OAuth2LoginSecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class OAuth2LoginSecurityConfig {
 
@@ -463,6 +465,7 @@ If you are not able to use Spring Boot 2.x and would like to configure one of th
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class OAuth2LoginConfig {
 
@@ -505,6 +508,7 @@ public class OAuth2LoginConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 open class OAuth2LoginConfig {
     @Bean

--- a/docs/modules/ROOT/pages/servlet/oauth2/resource-server/jwt.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/resource-server/jwt.adoc
@@ -182,6 +182,7 @@ Replacing this is as simple as exposing the bean within the application:
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class MyCustomSecurityConfiguration {
     @Bean
@@ -204,6 +205,7 @@ public class MyCustomSecurityConfiguration {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class MyCustomSecurityConfiguration {
     @Bean
@@ -303,6 +305,7 @@ An authorization server's JWK Set Uri can be configured <<oauth2resourceserver-j
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class DirectlyConfiguredJwkSetUri {
     @Bean
@@ -324,6 +327,7 @@ public class DirectlyConfiguredJwkSetUri {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class DirectlyConfiguredJwkSetUri {
     @Bean
@@ -367,6 +371,7 @@ More powerful than `jwkSetUri()` is `decoder()`, which will completely replace a
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class DirectlyConfiguredJwtDecoder {
     @Bean
@@ -388,6 +393,7 @@ public class DirectlyConfiguredJwtDecoder {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class DirectlyConfiguredJwtDecoder {
     @Bean
@@ -731,6 +737,7 @@ This means that to protect an endpoint or method with a scope derived from a JWT
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class DirectlyConfiguredJwkSetUri {
     @Bean

--- a/docs/modules/ROOT/pages/servlet/oauth2/resource-server/opaque-token.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/resource-server/opaque-token.adoc
@@ -225,6 +225,7 @@ Replacing this is as simple as exposing the bean within the application:
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class MyCustomSecurityConfiguration {
     @Bean
@@ -247,6 +248,7 @@ public class MyCustomSecurityConfiguration {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class MyCustomSecurityConfiguration {
     @Bean
@@ -343,6 +345,7 @@ An authorization server's Introspection Uri can be configured <<oauth2resourcese
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class DirectlyConfiguredIntrospectionUri {
     @Bean
@@ -365,6 +368,7 @@ public class DirectlyConfiguredIntrospectionUri {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class DirectlyConfiguredIntrospectionUri {
     @Bean
@@ -409,6 +413,7 @@ More powerful than `introspectionUri()` is `introspector()`, which will complete
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class DirectlyConfiguredIntrospector {
     @Bean
@@ -430,6 +435,7 @@ public class DirectlyConfiguredIntrospector {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class DirectlyConfiguredIntrospector {
     @Bean
@@ -492,6 +498,7 @@ This means that to protect an endpoint or method with a scope derived from an Op
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class MappedAuthorities {
     @Bean
@@ -511,6 +518,7 @@ public class MappedAuthorities {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class MappedAuthorities {
     @Bean

--- a/docs/modules/ROOT/pages/servlet/saml2/login/authentication.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/login/authentication.adoc
@@ -22,6 +22,7 @@ For that reason, you can configure `OpenSaml4AuthenticationProvider` 's default 
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
@@ -52,6 +53,7 @@ public class SecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 open class SecurityConfig {
     @Bean
@@ -90,6 +92,7 @@ In that case, the response authentication converter can come in handy, as can be
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class SecurityConfig {
     @Autowired
@@ -123,6 +126,7 @@ public class SecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 open class SecurityConfig {
     @Autowired
@@ -309,6 +313,7 @@ This authentication manager should expect a `Saml2AuthenticationToken` object co
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
@@ -331,6 +336,7 @@ public class SecurityConfig {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 open class SecurityConfig {
     @Bean

--- a/docs/modules/ROOT/pages/servlet/saml2/login/overview.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/login/overview.adoc
@@ -341,6 +341,7 @@ You can replace this by exposing the bean within the application:
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class MyCustomSecurityConfiguration {
     @Bean
@@ -359,6 +360,7 @@ public class MyCustomSecurityConfiguration {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class MyCustomSecurityConfiguration {
     @Bean
@@ -495,6 +497,7 @@ Alternatively, you can directly wire up the repository by using the DSL, which a
 .Java
 [source,java,role="primary"]
 ----
+@Configuration
 @EnableWebSecurity
 public class MyCustomSecurityConfiguration {
     @Bean
@@ -515,6 +518,7 @@ public class MyCustomSecurityConfiguration {
 .Kotlin
 [source,kotlin,role="secondary"]
 ----
+@Configuration
 @EnableWebSecurity
 class MyCustomSecurityConfiguration {
     @Bean

--- a/test/src/test/java/org/springframework/security/test/context/showcase/WithMockUserParentTests.java
+++ b/test/src/test/java/org/springframework/security/test/context/showcase/WithMockUserParentTests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.test.context.showcase.service.HelloMessageService;
@@ -46,6 +47,7 @@ public class WithMockUserParentTests extends WithMockUserParent {
 		assertThat(message).contains("user");
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	@ComponentScan(basePackageClasses = HelloMessageService.class)
 	static class Config {

--- a/test/src/test/java/org/springframework/security/test/context/showcase/WithMockUserTests.java
+++ b/test/src/test/java/org/springframework/security/test/context/showcase/WithMockUserTests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -77,6 +78,7 @@ public class WithMockUserTests {
 		assertThat(message).contains("admin").contains("ADMIN").contains("USER").doesNotContain("ROLE_");
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	@ComponentScan(basePackageClasses = HelloMessageService.class)
 	static class Config {

--- a/test/src/test/java/org/springframework/security/test/context/showcase/WithUserDetailsTests.java
+++ b/test/src/test/java/org/springframework/security/test/context/showcase/WithUserDetailsTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -82,6 +83,7 @@ public class WithUserDetailsTests {
 		return SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 	}
 
+	@Configuration
 	@EnableGlobalMethodSecurity(prePostEnabled = true)
 	@ComponentScan(basePackageClasses = HelloMessageService.class)
 	static class Config {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsAuthenticationStatelessTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsAuthenticationStatelessTests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -70,6 +71,7 @@ public class SecurityMockMvcRequestPostProcessorsAuthenticationStatelessTests {
 		this.mvc.perform(get("/")).andExpect(status().is2xxSuccessful());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class Config extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsCsrfDebugFilterTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsCsrfDebugFilterTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
@@ -53,6 +54,7 @@ public class SecurityMockMvcRequestPostProcessorsCsrfDebugFilterTests {
 		assertThat(csrfTokenRepository).isEqualTo(Config.cookieCsrfTokenRepository);
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class Config extends WebSecurityConfigurerAdapter {
 

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsCsrfTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsCsrfTests.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockHttpSession;
@@ -226,6 +227,7 @@ public class SecurityMockMvcRequestPostProcessorsCsrfTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class Config extends WebSecurityConfigurerAdapter {
 

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsOAuth2ClientTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsOAuth2ClientTests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -147,6 +148,7 @@ public class SecurityMockMvcRequestPostProcessorsOAuth2ClientTests {
 				any(HttpServletRequest.class));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class OAuth2ClientConfig extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsOAuth2LoginTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsOAuth2LoginTests.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -142,6 +143,7 @@ public class SecurityMockMvcRequestPostProcessorsOAuth2LoginTests {
 				.andExpect(content().string("bar"));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class OAuth2LoginConfig extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsOidcLoginTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsOidcLoginTests.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -144,6 +145,7 @@ public class SecurityMockMvcRequestPostProcessorsOidcLoginTests {
 				.andExpect(content().string("bar"));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class OAuth2LoginConfig extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsOpaqueTokenTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsOpaqueTokenTests.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -115,6 +116,7 @@ public class SecurityMockMvcRequestPostProcessorsOpaqueTokenTests {
 				.andExpect(content().string("bar"));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class OAuth2LoginConfig extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsTestSecurityContextStatelessTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsTestSecurityContextStatelessTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -67,6 +68,7 @@ public class SecurityMockMvcRequestPostProcessorsTestSecurityContextStatelessTes
 		this.mvc.perform(get("/")).andExpect(status().is2xxSuccessful());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class Config extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/response/Gh3409Tests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/response/Gh3409Tests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -87,6 +88,7 @@ public class Gh3409Tests {
 		// @formatter:on
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class Config extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/response/SecurityMockMvcResultHandlersTest.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/response/SecurityMockMvcResultHandlersTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -87,6 +88,7 @@ public class SecurityMockMvcResultHandlersTest {
 		assertThat(authentication).isNull();
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class Config {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/response/SecurityMockMvcResultMatchersTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/response/SecurityMockMvcResultMatchersTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -99,6 +100,7 @@ public class SecurityMockMvcResultMatchersTests {
 		);
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class Config extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/response/SecurityMockWithAuthoritiesMvcResultMatchersTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/response/SecurityMockWithAuthoritiesMvcResultMatchersTests.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -78,6 +79,7 @@ public class SecurityMockWithAuthoritiesMvcResultMatchersTests {
 				() -> this.mockMvc.perform(formLogin()).andExpect(authenticated().withAuthorities(grantedAuthorities)));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class Config extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/showcase/csrf/CsrfShowcaseTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/showcase/csrf/CsrfShowcaseTests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -69,6 +70,7 @@ public class CsrfShowcaseTests {
 		this.mvc.perform(post("/")).andExpect(status().isForbidden());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class Config extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/showcase/csrf/CustomCsrfShowcaseTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/showcase/csrf/CustomCsrfShowcaseTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -72,6 +73,7 @@ public class CustomCsrfShowcaseTests {
 		this.mvc.perform(put("/").with(csrf())).andExpect(status().isNotFound());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class Config extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/showcase/csrf/DefaultCsrfShowcaseTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/showcase/csrf/DefaultCsrfShowcaseTests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -66,6 +67,7 @@ public class DefaultCsrfShowcaseTests {
 		this.mvc.perform(put("/")).andExpect(status().isNotFound());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class Config extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/showcase/login/AuthenticationTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/showcase/login/AuthenticationTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -85,6 +86,7 @@ public class AuthenticationTests {
 				.andExpect(redirectedUrl("/login?error")).andExpect(unauthenticated());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class Config extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/showcase/login/CustomConfigAuthenticationTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/showcase/login/CustomConfigAuthenticationTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -86,6 +87,7 @@ public class CustomConfigAuthenticationTests {
 				.andExpect(unauthenticated());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class Config extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/showcase/login/CustomLoginRequestBuilderAuthenticationTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/showcase/login/CustomLoginRequestBuilderAuthenticationTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -76,6 +77,7 @@ public class CustomLoginRequestBuilderAuthenticationTests {
 		return formLogin("/authenticate").userParameter("user").passwordParam("pass");
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class Config extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/showcase/secured/DefaultfSecurityRequestsTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/showcase/secured/DefaultfSecurityRequestsTests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -84,6 +85,7 @@ public class DefaultfSecurityRequestsTests {
 				.andExpect(unauthenticated());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class Config extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/showcase/secured/SecurityRequestsTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/showcase/secured/SecurityRequestsTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -101,6 +102,7 @@ public class SecurityRequestsTests {
 				.andExpect(authenticated().withAuthentication(authentication));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class Config extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/showcase/secured/WithUserAuthenticationTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/showcase/secured/WithUserAuthenticationTests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -85,6 +86,7 @@ public class WithUserAuthenticationTests {
 				.andExpect(authenticated().withUsername("user").withRoles("ADMIN"));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class Config extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/showcase/secured/WithUserClassLevelAuthenticationTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/showcase/secured/WithUserClassLevelAuthenticationTests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -85,6 +86,7 @@ public class WithUserClassLevelAuthenticationTests {
 				.andExpect(unauthenticated());
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class Config extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/showcase/secured/WithUserDetailsAuthenticationTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/showcase/secured/WithUserDetailsAuthenticationTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -76,6 +77,7 @@ public class WithUserDetailsAuthenticationTests {
 				.andExpect(authenticated().withUsername("admin").withRoles("ADMIN", "USER"));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class Config extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/showcase/secured/WithUserDetailsClassLevelAuthenticationTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/showcase/secured/WithUserDetailsClassLevelAuthenticationTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -75,6 +76,7 @@ public class WithUserDetailsClassLevelAuthenticationTests {
 				.andExpect(authenticated().withUsername("admin").withRoles("ADMIN", "USER"));
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	@EnableWebMvc
 	static class Config extends WebSecurityConfigurerAdapter {

--- a/test/src/test/java/org/springframework/security/test/web/support/WebTestUtilsTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/support/WebTestUtilsTests.java
@@ -183,6 +183,7 @@ public class WebTestUtilsTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SecurityNoCsrfConfig extends WebSecurityConfigurerAdapter {
 
@@ -193,6 +194,7 @@ public class WebTestUtilsTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class CustomSecurityConfig extends WebSecurityConfigurerAdapter {
 
@@ -213,6 +215,7 @@ public class WebTestUtilsTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class PartialSecurityConfig extends WebSecurityConfigurerAdapter {
 
@@ -231,11 +234,13 @@ public class WebTestUtilsTests {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SecurityConfigWithDefaults extends WebSecurityConfigurerAdapter {
 
 	}
 
+	@Configuration
 	@EnableWebSecurity
 	static class SecurityContextHolderFilterConfig {
 


### PR DESCRIPTION
Before, Spring Security's @Enable* annotations were meta-annotated with @Configuration.
While convenient, this is not consistent with the rest of the Spring projects and most notably
Spring Framework's @Enable annotations. Additionally, the introduction of support for
@Configuration(proxyBeanMethods=false) in Spring Framework provides a compelling reason to
remove @Configuration meta-annotation from Spring Security's @Enable annotations and allow
users to opt into their preferred configuration mode.

Closes gh-6613

Signed-off-by: Joshua Sattler <joshua.sattler@mailbox.org>

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
