### PR TITLE
Performance enhancement in HttpSessionRequestCache

### DIFF
--- a/web/src/main/java/org/springframework/security/web/savedrequest/HttpSessionRequestCache.java
+++ b/web/src/main/java/org/springframework/security/web/savedrequest/HttpSessionRequestCache.java
@@ -66,12 +66,13 @@ public class HttpSessionRequestCache implements RequestCache {
 			}
 			return;
 		}
-		DefaultSavedRequest savedRequest = new DefaultSavedRequest(request, this.portResolver,
-				this.matchingRequestParameterName);
+
 		if (this.createSessionAllowed || request.getSession(false) != null) {
 			// Store the HTTP request itself. Used by
 			// AbstractAuthenticationProcessingFilter
 			// for redirection after successful authentication (SEC-29)
+			DefaultSavedRequest savedRequest = new DefaultSavedRequest(request, this.portResolver,
+					this.matchingRequestParameterName);
 			request.getSession().setAttribute(this.sessionAttrName, savedRequest);
 			if (this.logger.isDebugEnabled()) {
 				this.logger.debug(LogMessage.format("Saved request %s to session", savedRequest.getRedirectUrl()));


### PR DESCRIPTION
savedRequest is only used in conditional statements.

Thus I moved the constructor for DefaultSavedRequest into the conditional statements. 

Then it will be only executed when  conditions met. 

Accordingly, I expect that there are some performance improvements.