### PR TITLE
 issue 3065 / SEC-2839 - fix 

### DIFF
--- a/config/src/main/java/org/springframework/security/config/SecurityNamespaceHandler.java
+++ b/config/src/main/java/org/springframework/security/config/SecurityNamespaceHandler.java
@@ -102,6 +102,7 @@ public final class SecurityNamespaceHandler implements NamespaceHandler {
 		if (parser == null) {
 			// SEC-1455. Load parsers when required, not just on init().
 			loadParsers();
+			parser = this.parsers.get(name);
 		}
 		if (parser != null) {
 			return parser.parse(element, pc);


### PR DESCRIPTION
Fix issue 3065 / SEC-2839: an old bug where it was possible to parse when the init did not succeed completely. Essentially, it was forgotten to refetch the parser after reloading the parsers.