### PR TITLE
Add new interfaces for BREACH protection

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurer.java
@@ -131,9 +131,10 @@ public final class CsrfConfigurer<H extends HttpSecurityBuilder<H>>
 	}
 
 	/**
-	 * TODO
-	 * @param requestAttributeHandler
-	 * @return
+	 * Specify a {@link CsrfTokenRequestAttributeHandler} to use for making the
+	 * {@code CsrfToken} available as a request attribute.
+	 * @param requestAttributeHandler the {@link CsrfTokenRequestAttributeHandler} to use
+	 * @return the {@link CsrfConfigurer} for further customizations
 	 */
 	public CsrfConfigurer<H> csrfTokenRequestAttributeHandler(
 			CsrfTokenRequestAttributeHandler requestAttributeHandler) {
@@ -142,9 +143,10 @@ public final class CsrfConfigurer<H extends HttpSecurityBuilder<H>>
 	}
 
 	/**
-	 * TODO
-	 * @param requestResolver
-	 * @return
+	 * Specify a {@link CsrfTokenRequestResolver} to use for resolving the token value
+	 * from the request.
+	 * @param requestResolver the {@link CsrfTokenRequestResolver} to use
+	 * @return the {@link CsrfConfigurer} for further customizations
 	 */
 	public CsrfConfigurer<H> csrfTokenRequestResolver(CsrfTokenRequestResolver requestResolver) {
 		this.requestResolver = requestResolver;

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurer.java
@@ -36,6 +36,7 @@ import org.springframework.security.web.csrf.CsrfAuthenticationStrategy;
 import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.csrf.CsrfLogoutHandler;
 import org.springframework.security.web.csrf.CsrfTokenRepository;
+import org.springframework.security.web.csrf.DefaultCsrfTokenRequestHandler;
 import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository;
 import org.springframework.security.web.csrf.LazyCsrfTokenRepository;
 import org.springframework.security.web.csrf.MissingCsrfTokenException;
@@ -127,7 +128,7 @@ public final class CsrfConfigurer<H extends HttpSecurityBuilder<H>>
 	}
 
 	/**
-	 * Sets the {@link CsrfFilter#setCsrfRequestAttributeName(String)}
+	 * Sets the {@link org.springframework.security.web.csrf.DefaultCsrfTokenRequestHandler#setCsrfRequestAttributeName(String)}
 	 * @param csrfRequestAttributeName the attribute name to set the CsrfToken on.
 	 * @return the {@link CsrfConfigurer} for further customizations.
 	 */
@@ -215,7 +216,10 @@ public final class CsrfConfigurer<H extends HttpSecurityBuilder<H>>
 	public void configure(H http) {
 		CsrfFilter filter = new CsrfFilter(this.csrfTokenRepository);
 		if (this.csrfRequestAttributeName != null) {
-			filter.setCsrfRequestAttributeName(this.csrfRequestAttributeName);
+			DefaultCsrfTokenRequestHandler csrfTokenRequestHandler = new DefaultCsrfTokenRequestHandler();
+			csrfTokenRequestHandler.setCsrfRequestAttributeName(this.csrfRequestAttributeName);
+			filter.setRequestAttributeHandler(csrfTokenRequestHandler);
+			filter.setRequestResolver(csrfTokenRequestHandler);
 		}
 		RequestMatcher requireCsrfProtectionMatcher = getRequireCsrfProtectionMatcher();
 		if (requireCsrfProtectionMatcher != null) {

--- a/config/src/main/java/org/springframework/security/config/http/CsrfBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/http/CsrfBeanDefinitionParser.java
@@ -41,7 +41,6 @@ import org.springframework.security.web.access.DelegatingAccessDeniedHandler;
 import org.springframework.security.web.csrf.CsrfAuthenticationStrategy;
 import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.csrf.CsrfLogoutHandler;
-import org.springframework.security.web.csrf.CsrfTokenRequestProcessor;
 import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository;
 import org.springframework.security.web.csrf.LazyCsrfTokenRepository;
 import org.springframework.security.web.csrf.MissingCsrfTokenException;
@@ -68,19 +67,23 @@ public class CsrfBeanDefinitionParser implements BeanDefinitionParser {
 
 	private static final String DISPATCHER_SERVLET_CLASS_NAME = "org.springframework.web.servlet.DispatcherServlet";
 
-	private static final String ATT_REQUEST_ATTRIBUTE_NAME = "request-attribute-name";
-
 	private static final String ATT_MATCHER = "request-matcher-ref";
 
 	private static final String ATT_REPOSITORY = "token-repository-ref";
 
-	private String requestAttributeName;
+	private static final String ATT_REQUEST_ATTRIBUTE_HANDLER = "request-attribute-handler-ref";
+
+	private static final String ATT_REQUEST_RESOLVER = "request-resolver-ref";
 
 	private String csrfRepositoryRef;
 
 	private BeanDefinition csrfFilter;
 
 	private String requestMatcherRef;
+
+	private String requestAttributeHandlerRef;
+
+	private String requestResolverRef;
 
 	@Override
 	public BeanDefinition parse(Element element, ParserContext pc) {
@@ -99,8 +102,9 @@ public class CsrfBeanDefinitionParser implements BeanDefinitionParser {
 		}
 		if (element != null) {
 			this.csrfRepositoryRef = element.getAttribute(ATT_REPOSITORY);
-			this.requestAttributeName = element.getAttribute(ATT_REQUEST_ATTRIBUTE_NAME);
 			this.requestMatcherRef = element.getAttribute(ATT_MATCHER);
+			this.requestAttributeHandlerRef = element.getAttribute(ATT_REQUEST_ATTRIBUTE_HANDLER);
+			this.requestResolverRef = element.getAttribute(ATT_REQUEST_RESOLVER);
 		}
 		if (!StringUtils.hasText(this.csrfRepositoryRef)) {
 			RootBeanDefinition csrfTokenRepository = new RootBeanDefinition(HttpSessionCsrfTokenRepository.class);
@@ -116,12 +120,11 @@ public class CsrfBeanDefinitionParser implements BeanDefinitionParser {
 		if (StringUtils.hasText(this.requestMatcherRef)) {
 			builder.addPropertyReference("requireCsrfProtectionMatcher", this.requestMatcherRef);
 		}
-		if (StringUtils.hasText(this.requestAttributeName)) {
-			BeanDefinition csrfTokenRequestProcessor = BeanDefinitionBuilder
-					.rootBeanDefinition(CsrfTokenRequestProcessor.class)
-					.addPropertyValue("csrfRequestAttributeName", this.requestAttributeName).getBeanDefinition();
-			builder.addPropertyValue("requestAttributeHandler", csrfTokenRequestProcessor);
-			builder.addPropertyValue("requestResolver", csrfTokenRequestProcessor);
+		if (StringUtils.hasText(this.requestAttributeHandlerRef)) {
+			builder.addPropertyReference("requestAttributeHandler", this.requestAttributeHandlerRef);
+		}
+		if (StringUtils.hasText(this.requestResolverRef)) {
+			builder.addPropertyReference("requestResolver", this.requestResolverRef);
 		}
 		this.csrfFilter = builder.getBeanDefinition();
 		return this.csrfFilter;

--- a/config/src/main/java/org/springframework/security/config/http/CsrfBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/http/CsrfBeanDefinitionParser.java
@@ -41,6 +41,7 @@ import org.springframework.security.web.access.DelegatingAccessDeniedHandler;
 import org.springframework.security.web.csrf.CsrfAuthenticationStrategy;
 import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.csrf.CsrfLogoutHandler;
+import org.springframework.security.web.csrf.CsrfTokenRequestProcessor;
 import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository;
 import org.springframework.security.web.csrf.LazyCsrfTokenRepository;
 import org.springframework.security.web.csrf.MissingCsrfTokenException;
@@ -116,7 +117,11 @@ public class CsrfBeanDefinitionParser implements BeanDefinitionParser {
 			builder.addPropertyReference("requireCsrfProtectionMatcher", this.requestMatcherRef);
 		}
 		if (StringUtils.hasText(this.requestAttributeName)) {
-			builder.addPropertyValue("csrfRequestAttributeName", this.requestAttributeName);
+			BeanDefinition csrfTokenRequestProcessor = BeanDefinitionBuilder
+					.rootBeanDefinition(CsrfTokenRequestProcessor.class)
+					.addPropertyValue("csrfRequestAttributeName", this.requestAttributeName).getBeanDefinition();
+			builder.addPropertyValue("requestAttributeHandler", csrfTokenRequestProcessor);
+			builder.addPropertyValue("requestResolver", csrfTokenRequestProcessor);
 		}
 		this.csrfFilter = builder.getBeanDefinition();
 		return this.csrfFilter;

--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.8.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.8.rnc
@@ -1143,14 +1143,17 @@ csrf-options.attlist &=
 	## Specifies if csrf protection should be disabled. Default false (i.e. CSRF protection is enabled).
 	attribute disabled {xsd:boolean}?
 csrf-options.attlist &=
-	## The request attribute name the CsrfToken is set on. Default is to set to CsrfToken.parameterName
-	attribute request-attribute-name { xsd:token }?
-csrf-options.attlist &=
 	## The RequestMatcher instance to be used to determine if CSRF should be applied. Default is any HTTP method except "GET", "TRACE", "HEAD", "OPTIONS"
 	attribute request-matcher-ref { xsd:token }?
 csrf-options.attlist &=
 	## The CsrfTokenRepository to use. The default is HttpSessionCsrfTokenRepository wrapped by LazyCsrfTokenRepository.
 	attribute token-repository-ref { xsd:token }?
+csrf-options.attlist &=
+	## The CsrfTokenRequestAttributeHandler to use. The default is CsrfTokenRequestProcessor.
+	attribute request-attribute-handler-ref { xsd:token }?
+csrf-options.attlist &=
+	## The CsrfTokenRequestResolver to use. The default is CsrfTokenRequestProcessor.
+	attribute request-resolver-ref { xsd:token }?
 
 headers =
 ## Element for configuration of the HeaderWritersFilter. Enables easy setting for the X-Frame-Options, X-XSS-Protection and X-Content-Type-Options headers.

--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.8.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.8.xsd
@@ -3235,13 +3235,6 @@
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="request-attribute-name" type="xs:token">
-         <xs:annotation>
-            <xs:documentation>The request attribute name the CsrfToken is set on. Default is to set to
-                CsrfToken.parameterName
-                </xs:documentation>
-         </xs:annotation>
-      </xs:attribute>
       <xs:attribute name="request-matcher-ref" type="xs:token">
          <xs:annotation>
             <xs:documentation>The RequestMatcher instance to be used to determine if CSRF should be applied. Default is
@@ -3253,6 +3246,18 @@
          <xs:annotation>
             <xs:documentation>The CsrfTokenRepository to use. The default is HttpSessionCsrfTokenRepository wrapped by
                 LazyCsrfTokenRepository.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="request-attribute-handler-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The CsrfTokenRequestAttributeHandler to use. The default is CsrfTokenRequestProcessor.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="request-resolver-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>The CsrfTokenRequestResolver to use. The default is CsrfTokenRequestProcessor.
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configuration/DeferHttpSessionJavaConfigTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configuration/DeferHttpSessionJavaConfigTests.java
@@ -33,6 +33,7 @@ import org.springframework.security.config.test.SpringTestContext;
 import org.springframework.security.config.test.SpringTestContextExtension;
 import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.FilterChainProxy;
+import org.springframework.security.web.csrf.CsrfTokenRequestProcessor;
 import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository;
 import org.springframework.security.web.csrf.LazyCsrfTokenRepository;
 import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
@@ -84,6 +85,8 @@ public class DeferHttpSessionJavaConfigTests {
 			csrfRepository.setDeferLoadToken(true);
 			HttpSessionRequestCache requestCache = new HttpSessionRequestCache();
 			requestCache.setMatchingRequestParameterName("continue");
+			CsrfTokenRequestProcessor requestAttributeHandler = new CsrfTokenRequestProcessor();
+			requestAttributeHandler.setCsrfRequestAttributeName("_csrf");
 			// @formatter:off
 			http
 				.requestCache((cache) -> cache
@@ -99,7 +102,7 @@ public class DeferHttpSessionJavaConfigTests {
 					.requireExplicitAuthenticationStrategy(true)
 				)
 				.csrf((csrf) -> csrf
-					.csrfRequestAttributeName("_csrf")
+					.csrfTokenRequestAttributeHandler(requestAttributeHandler)
 					.csrfTokenRepository(csrfRepository)
 				);
 			// @formatter:on

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -38,10 +39,14 @@ import org.springframework.security.config.test.SpringTestContext;
 import org.springframework.security.config.test.SpringTestContextExtension;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.PasswordEncodedUser;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
+import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.security.web.csrf.CsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestProcessor;
 import org.springframework.security.web.csrf.DefaultCsrfToken;
+import org.springframework.security.web.csrf.XorCsrfTokenRequestProcessor;
 import org.springframework.security.web.firewall.StrictHttpFirewall;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
@@ -55,12 +60,17 @@ import org.springframework.web.servlet.support.RequestDataValueProcessor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.springframework.security.config.Customizer.withDefaults;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
@@ -74,6 +84,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -84,6 +95,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Eleftheria Stein
  * @author Michael Vitz
  * @author Sam Simmons
+ * @author Steve Riesenberg
  */
 @ExtendWith(SpringTestContextExtension.class)
 public class CsrfConfigurerTests {
@@ -405,6 +417,108 @@ public class CsrfConfigurerTests {
 		this.mvc.perform(loginRequest).andExpect(redirectedUrl("/"));
 		verify(CsrfAuthenticationStrategyConfig.STRATEGY, atLeastOnce()).onAuthentication(any(Authentication.class),
 				any(HttpServletRequest.class), any(HttpServletResponse.class));
+	}
+
+	@Test
+	public void getLoginWhenCsrfTokenRequestProcessorSetThenRespondsWithNormalCsrfToken() throws Exception {
+		CsrfTokenRepository csrfTokenRepository = mock(CsrfTokenRepository.class);
+		CsrfToken csrfToken = new DefaultCsrfToken("X-CSRF-TOKEN", "_csrf", "token");
+		given(csrfTokenRepository.generateToken(any(HttpServletRequest.class))).willReturn(csrfToken);
+		CsrfTokenRequestProcessorConfig.REPO = csrfTokenRepository;
+		CsrfTokenRequestProcessorConfig.PROCESSOR = new CsrfTokenRequestProcessor();
+		this.spring.register(CsrfTokenRequestProcessorConfig.class, BasicController.class).autowire();
+		this.mvc.perform(get("/login")).andExpect(status().isOk())
+				.andExpect(content().string(containsString(csrfToken.getToken())));
+		verify(csrfTokenRepository).loadToken(any(HttpServletRequest.class));
+		verify(csrfTokenRepository).generateToken(any(HttpServletRequest.class));
+		verify(csrfTokenRepository).saveToken(eq(csrfToken), any(HttpServletRequest.class),
+				any(HttpServletResponse.class));
+		verifyNoMoreInteractions(csrfTokenRepository);
+	}
+
+	@Test
+	public void loginWhenCsrfTokenRequestProcessorSetAndNormalCsrfTokenThenSuccess() throws Exception {
+		CsrfToken csrfToken = new DefaultCsrfToken("X-CSRF-TOKEN", "_csrf", "token");
+		CsrfTokenRepository csrfTokenRepository = mock(CsrfTokenRepository.class);
+		given(csrfTokenRepository.loadToken(any(HttpServletRequest.class))).willReturn(csrfToken);
+		given(csrfTokenRepository.generateToken(any(HttpServletRequest.class))).willReturn(csrfToken);
+		CsrfTokenRequestProcessorConfig.REPO = csrfTokenRepository;
+		CsrfTokenRequestProcessorConfig.PROCESSOR = new CsrfTokenRequestProcessor();
+		this.spring.register(CsrfTokenRequestProcessorConfig.class, BasicController.class).autowire();
+		// @formatter:off
+		MockHttpServletRequestBuilder loginRequest = post("/login")
+				.header(csrfToken.getHeaderName(), csrfToken.getToken())
+				.param("username", "user")
+				.param("password", "password");
+		// @formatter:on
+		this.mvc.perform(loginRequest).andExpect(redirectedUrl("/"));
+		verify(csrfTokenRepository, times(2)).loadToken(any(HttpServletRequest.class));
+		verify(csrfTokenRepository).saveToken(isNull(), any(HttpServletRequest.class), any(HttpServletResponse.class));
+		verify(csrfTokenRepository).generateToken(any(HttpServletRequest.class));
+		verify(csrfTokenRepository).saveToken(eq(csrfToken), any(HttpServletRequest.class),
+				any(HttpServletResponse.class));
+		verifyNoMoreInteractions(csrfTokenRepository);
+	}
+
+	@Test
+	public void getLoginWhenXorCsrfTokenRequestProcessorSetThenRespondsWithXorCsrfToken() throws Exception {
+		CsrfTokenRepository csrfTokenRepository = mock(CsrfTokenRepository.class);
+		CsrfToken csrfToken = new DefaultCsrfToken("X-CSRF-TOKEN", "_csrf", "token");
+		given(csrfTokenRepository.generateToken(any(HttpServletRequest.class))).willReturn(csrfToken);
+		CsrfTokenRequestProcessorConfig.REPO = csrfTokenRepository;
+		CsrfTokenRequestProcessorConfig.PROCESSOR = new XorCsrfTokenRequestProcessor();
+		this.spring.register(CsrfTokenRequestProcessorConfig.class, BasicController.class).autowire();
+		this.mvc.perform(get("/login")).andExpect(status().isOk())
+				.andExpect(content().string(containsString(csrfToken.getParameterName())))
+				.andExpect(content().string(not(containsString(csrfToken.getToken()))));
+		verify(csrfTokenRepository).loadToken(any(HttpServletRequest.class));
+		verify(csrfTokenRepository).generateToken(any(HttpServletRequest.class));
+		verify(csrfTokenRepository).saveToken(eq(csrfToken), any(HttpServletRequest.class),
+				any(HttpServletResponse.class));
+		verifyNoMoreInteractions(csrfTokenRepository);
+	}
+
+	@Test
+	public void loginWhenXorCsrfTokenRequestProcessorSetAndXorCsrfTokenThenSuccess() throws Exception {
+		CsrfToken csrfToken = new DefaultCsrfToken("X-CSRF-TOKEN", "_csrf", "token");
+		CsrfTokenRepository csrfTokenRepository = mock(CsrfTokenRepository.class);
+		given(csrfTokenRepository.loadToken(any(HttpServletRequest.class))).willReturn(csrfToken);
+		given(csrfTokenRepository.generateToken(any(HttpServletRequest.class))).willReturn(csrfToken);
+		CsrfTokenRequestProcessorConfig.REPO = csrfTokenRepository;
+		CsrfTokenRequestProcessorConfig.PROCESSOR = new XorCsrfTokenRequestProcessor();
+		this.spring.register(CsrfTokenRequestProcessorConfig.class, BasicController.class).autowire();
+		// @formatter:off
+		MockHttpServletRequestBuilder loginRequest = post("/login")
+				.header(csrfToken.getHeaderName(), "sKCSGVHEz_l8Pw==")
+				.param("username", "user")
+				.param("password", "password");
+		// @formatter:on
+		this.mvc.perform(loginRequest).andExpect(redirectedUrl("/"));
+		verify(csrfTokenRepository, times(2)).loadToken(any(HttpServletRequest.class));
+		verify(csrfTokenRepository).saveToken(isNull(), any(HttpServletRequest.class), any(HttpServletResponse.class));
+		verify(csrfTokenRepository).generateToken(any(HttpServletRequest.class));
+		verify(csrfTokenRepository).saveToken(eq(csrfToken), any(HttpServletRequest.class),
+				any(HttpServletResponse.class));
+		verifyNoMoreInteractions(csrfTokenRepository);
+	}
+
+	@Test
+	public void loginWhenXorCsrfTokenRequestProcessorSetAndNormalCsrfTokenThenRespondsWithForbidden() throws Exception {
+		CsrfToken csrfToken = new DefaultCsrfToken("X-CSRF-TOKEN", "_csrf", "token");
+		CsrfTokenRepository csrfTokenRepository = mock(CsrfTokenRepository.class);
+		given(csrfTokenRepository.loadToken(any(HttpServletRequest.class))).willReturn(csrfToken);
+		CsrfTokenRequestProcessorConfig.REPO = csrfTokenRepository;
+		CsrfTokenRequestProcessorConfig.PROCESSOR = new XorCsrfTokenRequestProcessor();
+		this.spring.register(CsrfTokenRequestProcessorConfig.class, BasicController.class).autowire();
+		// @formatter:off
+		MockHttpServletRequestBuilder loginRequest = post("/login")
+				.header(csrfToken.getHeaderName(), csrfToken.getToken())
+				.param("username", "user")
+				.param("password", "password");
+		// @formatter:on
+		this.mvc.perform(loginRequest).andExpect(status().isForbidden());
+		verify(csrfTokenRepository).loadToken(any(HttpServletRequest.class));
+		verifyNoMoreInteractions(csrfTokenRepository);
 	}
 
 	@Configuration
@@ -739,6 +853,43 @@ public class CsrfConfigurerTests {
 
 		@Override
 		protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+			// @formatter:off
+			auth
+					.inMemoryAuthentication()
+					.withUser(PasswordEncodedUser.user());
+			// @formatter:on
+		}
+
+	}
+
+	@Configuration
+	@EnableWebSecurity
+	static class CsrfTokenRequestProcessorConfig {
+
+		static CsrfTokenRepository REPO;
+
+		static CsrfTokenRequestProcessor PROCESSOR;
+
+		@Bean
+		SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+			// @formatter:off
+			http
+				.authorizeHttpRequests((authorize) -> authorize
+					.anyRequest().authenticated()
+				)
+				.formLogin(Customizer.withDefaults())
+				.csrf((csrf) -> csrf
+					.csrfTokenRepository(REPO)
+					.csrfTokenRequestAttributeHandler(PROCESSOR)
+					.csrfTokenRequestResolver(PROCESSOR)
+				);
+			// @formatter:on
+
+			return http.build();
+		}
+
+		@Autowired
+		void configure(AuthenticationManagerBuilder auth) throws Exception {
 			// @formatter:off
 			auth
 					.inMemoryAuthentication()

--- a/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-WithRequestAttrName.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-WithRequestAttrName.xml
@@ -16,14 +16,17 @@
   -->
 
 <b:beans xmlns:b="http://www.springframework.org/schema/beans"
+		 xmlns:p="http://www.springframework.org/schema/p"
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xmlns="http://www.springframework.org/schema/security"
 		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
 		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<http auto-config="true">
-		<csrf request-attribute-name="csrf-attribute-name"/>
+		<csrf request-attribute-handler-ref="requestAttributeHandler"/>
 	</http>
 
+	<b:bean id="requestAttributeHandler" class="org.springframework.security.web.csrf.CsrfTokenRequestProcessor"
+		p:csrfRequestAttributeName="csrf-attribute-name"/>
 	<b:import resource="CsrfConfigTests-shared-userservice.xml"/>
 </b:beans>

--- a/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-WithXorCsrfTokenRequestProcessor.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/CsrfConfigTests-WithXorCsrfTokenRequestProcessor.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2002-2018 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<b:beans xmlns:b="http://www.springframework.org/schema/beans"
+		 xmlns:p="http://www.springframework.org/schema/p"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xmlns="http://www.springframework.org/schema/security"
+		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<http auto-config="true">
+		<csrf request-attribute-handler-ref="requestProcessor" request-resolver-ref="requestProcessor"/>
+	</http>
+
+	<b:bean id="requestProcessor" class="org.springframework.security.web.csrf.XorCsrfTokenRequestProcessor"
+		p:csrfRequestAttributeName="_csrf"/>
+	<b:import resource="CsrfConfigTests-shared-userservice.xml"/>
+</b:beans>

--- a/config/src/test/resources/org/springframework/security/config/http/DeferHttpSessionTests-Explicit.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/DeferHttpSessionTests-Explicit.xml
@@ -30,7 +30,7 @@
 			security-context-explicit-save="true"
 			use-authorization-manager="true">
 		<intercept-url  pattern="/**" access="permitAll"/>
-		<csrf request-attribute-name="_csrf"
+		<csrf request-attribute-handler-ref="requestAttributeHandler"
 			token-repository-ref="csrfRepository"/>
 		<request-cache ref="requestCache"/>
 		<session-management authentication-strategy-explicit-invocation="true"/>
@@ -42,5 +42,7 @@
 	<b:bean id="csrfRepository" class="org.springframework.security.web.csrf.LazyCsrfTokenRepository"
 		c:delegate-ref="httpSessionCsrfRepository"
 	 	p:deferLoadToken="true"/>
+	<b:bean id="requestAttributeHandler" class="org.springframework.security.web.csrf.CsrfTokenRequestProcessor"
+		p:csrfRequestAttributeName="_csrf"/>
 	<b:import resource="CsrfConfigTests-shared-userservice.xml"/>
 </b:beans>

--- a/docs/modules/ROOT/pages/servlet/appendix/namespace/http.adoc
+++ b/docs/modules/ROOT/pages/servlet/appendix/namespace/http.adoc
@@ -775,10 +775,13 @@ It is highly recommended to leave CSRF protection enabled.
 The CsrfTokenRepository to use.
 The default is `HttpSessionCsrfTokenRepository`.
 
-[[nsa-csrf-request-attribute-name]]
-* **request-attribute-name**
-Optional attribute that specifies the request attribute name to set the `CsrfToken` on.
-The default is `CsrfToken.parameterName`.
+[[nsa-csrf-request-attribute-handler-ref]]
+* **request-attribute-handler-ref**
+The optional `CsrfTokenRequestAttributeHandler` to use. The default is `CsrfTokenRequestProcessor`.
+
+[[nsa-csrf-request-resolver-ref]]
+* **request-resolver-ref**
+The optional `CsrfTokenRequestResolver` to use. The default is `CsrfTokenRequestProcessor`.
 
 [[nsa-csrf-request-matcher-ref]]
 * **request-matcher-ref**

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfAuthenticationStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfAuthenticationStrategy.java
@@ -39,7 +39,7 @@ public final class CsrfAuthenticationStrategy implements SessionAuthenticationSt
 
 	private final Log logger = LogFactory.getLog(getClass());
 
-	private final CsrfTokenRequestAttributeHandler requestAttributeHandler = new DefaultCsrfTokenRequestHandler();
+	private CsrfTokenRequestAttributeHandler requestAttributeHandler = new CsrfTokenRequestProcessor();
 
 	private final CsrfTokenRepository csrfTokenRepository;
 
@@ -50,6 +50,14 @@ public final class CsrfAuthenticationStrategy implements SessionAuthenticationSt
 	public CsrfAuthenticationStrategy(CsrfTokenRepository csrfTokenRepository) {
 		Assert.notNull(csrfTokenRepository, "csrfTokenRepository cannot be null");
 		this.csrfTokenRepository = csrfTokenRepository;
+	}
+
+	/**
+	 * TODO
+	 * @param requestAttributeHandler
+	 */
+	public void setRequestAttributeHandler(CsrfTokenRequestAttributeHandler requestAttributeHandler) {
+		this.requestAttributeHandler = requestAttributeHandler;
 	}
 
 	@Override

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfAuthenticationStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfAuthenticationStrategy.java
@@ -39,9 +39,9 @@ public final class CsrfAuthenticationStrategy implements SessionAuthenticationSt
 
 	private final Log logger = LogFactory.getLog(getClass());
 
-	private CsrfTokenRequestAttributeHandler requestAttributeHandler = new CsrfTokenRequestProcessor();
-
 	private final CsrfTokenRepository csrfTokenRepository;
+
+	private CsrfTokenRequestAttributeHandler requestAttributeHandler = new CsrfTokenRequestProcessor();
 
 	/**
 	 * Creates a new instance
@@ -53,10 +53,12 @@ public final class CsrfAuthenticationStrategy implements SessionAuthenticationSt
 	}
 
 	/**
-	 * TODO
-	 * @param requestAttributeHandler
+	 * Specify a {@link CsrfTokenRequestAttributeHandler} to use for making the
+	 * {@code CsrfToken} available as a request attribute.
+	 * @param requestAttributeHandler the {@link CsrfTokenRequestAttributeHandler} to use
 	 */
 	public void setRequestAttributeHandler(CsrfTokenRequestAttributeHandler requestAttributeHandler) {
+		Assert.notNull(requestAttributeHandler, "requestAttributeHandler cannot be null");
 		this.requestAttributeHandler = requestAttributeHandler;
 	}
 

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfAuthenticationStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfAuthenticationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,8 @@ public final class CsrfAuthenticationStrategy implements SessionAuthenticationSt
 
 	private final Log logger = LogFactory.getLog(getClass());
 
+	private final CsrfTokenRequestAttributeHandler requestAttributeHandler = new DefaultCsrfTokenRequestHandler();
+
 	private final CsrfTokenRepository csrfTokenRepository;
 
 	/**
@@ -58,8 +60,7 @@ public final class CsrfAuthenticationStrategy implements SessionAuthenticationSt
 			this.csrfTokenRepository.saveToken(null, request, response);
 			CsrfToken newToken = this.csrfTokenRepository.generateToken(request);
 			this.csrfTokenRepository.saveToken(newToken, request, response);
-			request.setAttribute(CsrfToken.class.getName(), newToken);
-			request.setAttribute(newToken.getParameterName(), newToken);
+			this.requestAttributeHandler.handle(request, newToken);
 			this.logger.debug("Replaced CSRF Token");
 		}
 	}

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
@@ -94,9 +94,9 @@ public final class CsrfFilter extends OncePerRequestFilter {
 	public CsrfFilter(CsrfTokenRepository csrfTokenRepository) {
 		Assert.notNull(csrfTokenRepository, "csrfTokenRepository cannot be null");
 		this.tokenRepository = csrfTokenRepository;
-		DefaultCsrfTokenRequestHandler csrfTokenRequestHandler = new DefaultCsrfTokenRequestHandler();
-		this.requestAttributeHandler = csrfTokenRequestHandler;
-		this.requestResolver = csrfTokenRequestHandler;
+		CsrfTokenRequestProcessor csrfTokenRequestProcessor = new CsrfTokenRequestProcessor();
+		this.requestAttributeHandler = csrfTokenRequestProcessor;
+		this.requestResolver = csrfTokenRequestProcessor;
 	}
 
 	@Override
@@ -123,7 +123,7 @@ public final class CsrfFilter extends OncePerRequestFilter {
 			filterChain.doFilter(request, response);
 			return;
 		}
-		String actualToken = this.requestResolver.resolve(request, csrfToken);
+		String actualToken = this.requestResolver.resolveCsrfTokenValue(request, csrfToken);
 		if (!equalsConstantTime(csrfToken.getToken(), actualToken)) {
 			this.logger.debug(
 					LogMessage.of(() -> "Invalid CSRF token found for " + UrlUtils.buildFullRequestUrl(request)));
@@ -172,7 +172,6 @@ public final class CsrfFilter extends OncePerRequestFilter {
 
 	/**
 	 * TODO
-	 *
 	 * @param requestAttributeHandler
 	 * @since 5.8
 	 */
@@ -182,7 +181,6 @@ public final class CsrfFilter extends OncePerRequestFilter {
 
 	/**
 	 * TODO
-	 *
 	 * @param requestResolver
 	 * @since 5.8
 	 */

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
@@ -58,6 +58,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * </p>
  *
  * @author Rob Winch
+ * @author Steve Riesenberg
  * @since 3.2
  */
 public final class CsrfFilter extends OncePerRequestFilter {
@@ -171,20 +172,32 @@ public final class CsrfFilter extends OncePerRequestFilter {
 	}
 
 	/**
-	 * TODO
-	 * @param requestAttributeHandler
+	 * Specifies a {@link CsrfTokenRequestAttributeHandler} that is used to make the
+	 * {@link CsrfToken} available as a request attribute.
+	 *
+	 * <p>
+	 * The default is {@link CsrfTokenRequestProcessor}.
+	 * </p>
+	 * @param requestAttributeHandler the {@link CsrfTokenRequestAttributeHandler} to use
 	 * @since 5.8
 	 */
 	public void setRequestAttributeHandler(CsrfTokenRequestAttributeHandler requestAttributeHandler) {
+		Assert.notNull(requestAttributeHandler, "requestAttributeHandler cannot be null");
 		this.requestAttributeHandler = requestAttributeHandler;
 	}
 
 	/**
-	 * TODO
-	 * @param requestResolver
+	 * Specifies a {@link CsrfTokenRequestResolver} that is used to resolve the token
+	 * value from the request.
+	 *
+	 * <p>
+	 * The default is {@link CsrfTokenRequestProcessor}.
+	 * </p>
+	 * @param requestResolver the {@link CsrfTokenRequestResolver} to use
 	 * @since 5.8
 	 */
 	public void setRequestResolver(CsrfTokenRequestResolver requestResolver) {
+		Assert.notNull(requestResolver, "requestResolver cannot be null");
 		this.requestResolver = requestResolver;
 	}
 

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRequestAttributeHandler.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRequestAttributeHandler.java
@@ -29,7 +29,6 @@ public interface CsrfTokenRequestAttributeHandler {
 
 	/**
 	 * TODO
-	 *
 	 * @param request
 	 * @param csrfToken
 	 */

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRequestAttributeHandler.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRequestAttributeHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.csrf;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * TODO
+ *
+ * @author Steve Riesenberg
+ * @since 5.8
+ */
+@FunctionalInterface
+public interface CsrfTokenRequestAttributeHandler {
+
+	/**
+	 * TODO
+	 *
+	 * @param request
+	 * @param csrfToken
+	 */
+	void handle(HttpServletRequest request, CsrfToken csrfToken);
+
+}

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRequestAttributeHandler.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRequestAttributeHandler.java
@@ -19,18 +19,22 @@ package org.springframework.security.web.csrf;
 import javax.servlet.http.HttpServletRequest;
 
 /**
- * TODO
+ * A callback interface that is used to make the {@link CsrfToken} created by the
+ * {@link CsrfTokenRepository} available as a request attribute. Implementations of this
+ * interface may choose to perform additional tasks or customize how the token is made
+ * available to the application through request attributes.
  *
  * @author Steve Riesenberg
  * @since 5.8
+ * @see CsrfTokenRequestProcessor
  */
 @FunctionalInterface
 public interface CsrfTokenRequestAttributeHandler {
 
 	/**
-	 * TODO
-	 * @param request
-	 * @param csrfToken
+	 * Handles a request using a {@link CsrfToken}.
+	 * @param request the {@code HttpServletRequest} being handled
+	 * @param csrfToken the {@link CsrfToken} created by the {@link CsrfTokenRepository}
 	 */
 	void handle(HttpServletRequest request, CsrfToken csrfToken);
 

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRequestProcessor.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRequestProcessor.java
@@ -24,7 +24,7 @@ import javax.servlet.http.HttpServletRequest;
  * @author Steve Riesenberg
  * @since 5.8
  */
-public final class DefaultCsrfTokenRequestHandler implements CsrfTokenRequestAttributeHandler, CsrfTokenRequestResolver {
+public class CsrfTokenRequestProcessor implements CsrfTokenRequestAttributeHandler, CsrfTokenRequestResolver {
 
 	private String csrfRequestAttributeName;
 
@@ -36,7 +36,7 @@ public final class DefaultCsrfTokenRequestHandler implements CsrfTokenRequestAtt
 	 * @param csrfRequestAttributeName the name of an additional request attribute with
 	 * the value of the CsrfToken. Default is {@link CsrfToken#getParameterName()}
 	 */
-	public void setCsrfRequestAttributeName(String csrfRequestAttributeName) {
+	public final void setCsrfRequestAttributeName(String csrfRequestAttributeName) {
 		this.csrfRequestAttributeName = csrfRequestAttributeName;
 	}
 
@@ -49,7 +49,7 @@ public final class DefaultCsrfTokenRequestHandler implements CsrfTokenRequestAtt
 	}
 
 	@Override
-	public String resolve(HttpServletRequest request, CsrfToken csrfToken) {
+	public String resolveCsrfTokenValue(HttpServletRequest request, CsrfToken csrfToken) {
 		String actualToken = request.getHeader(csrfToken.getHeaderName());
 		if (actualToken == null) {
 			actualToken = request.getParameter(csrfToken.getParameterName());

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRequestProcessor.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRequestProcessor.java
@@ -19,7 +19,10 @@ package org.springframework.security.web.csrf;
 import javax.servlet.http.HttpServletRequest;
 
 /**
- * TODO
+ * An implementation of the {@link CsrfTokenRequestAttributeHandler} and
+ * {@link CsrfTokenRequestResolver} interfaces that is capable of making the
+ * {@link CsrfToken} available as a request attribute and resolving the token value as
+ * either a header or parameter value of the request.
  *
  * @author Steve Riesenberg
  * @since 5.8

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRequestProcessor.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRequestProcessor.java
@@ -18,6 +18,8 @@ package org.springframework.security.web.csrf;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.springframework.util.Assert;
+
 /**
  * An implementation of the {@link CsrfTokenRequestAttributeHandler} and
  * {@link CsrfTokenRequestResolver} interfaces that is capable of making the
@@ -45,6 +47,8 @@ public class CsrfTokenRequestProcessor implements CsrfTokenRequestAttributeHandl
 
 	@Override
 	public void handle(HttpServletRequest request, CsrfToken csrfToken) {
+		Assert.notNull(request, "request cannot be null");
+		Assert.notNull(csrfToken, "csrfToken cannot be null");
 		request.setAttribute(CsrfToken.class.getName(), csrfToken);
 		String csrfAttrName = (this.csrfRequestAttributeName != null) ? this.csrfRequestAttributeName
 				: csrfToken.getParameterName();
@@ -53,6 +57,8 @@ public class CsrfTokenRequestProcessor implements CsrfTokenRequestAttributeHandl
 
 	@Override
 	public String resolveCsrfTokenValue(HttpServletRequest request, CsrfToken csrfToken) {
+		Assert.notNull(request, "request cannot be null");
+		Assert.notNull(csrfToken, "csrfToken cannot be null");
 		String actualToken = request.getHeader(csrfToken.getHeaderName());
 		if (actualToken == null) {
 			actualToken = request.getParameter(csrfToken.getParameterName());

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRequestResolver.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRequestResolver.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.csrf;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * TODO
+ *
+ * @author Steve Riesenberg
+ * @since 5.8
+ */
+@FunctionalInterface
+public interface CsrfTokenRequestResolver {
+
+	/**
+	 * TODO
+	 *
+	 * @param request
+	 * @param csrfToken
+	 * @return
+	 */
+	String resolve(HttpServletRequest request, CsrfToken csrfToken);
+
+}

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRequestResolver.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRequestResolver.java
@@ -29,11 +29,10 @@ public interface CsrfTokenRequestResolver {
 
 	/**
 	 * TODO
-	 *
 	 * @param request
 	 * @param csrfToken
 	 * @return
 	 */
-	String resolve(HttpServletRequest request, CsrfToken csrfToken);
+	String resolveCsrfTokenValue(HttpServletRequest request, CsrfToken csrfToken);
 
 }

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRequestResolver.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRequestResolver.java
@@ -19,19 +19,23 @@ package org.springframework.security.web.csrf;
 import javax.servlet.http.HttpServletRequest;
 
 /**
- * TODO
+ * Implementations of this interface are capable of resolving the token value of a
+ * {@link CsrfToken} from the provided {@code HttpServletRequest}. Used by the
+ * {@link CsrfFilter}.
  *
  * @author Steve Riesenberg
  * @since 5.8
+ * @see CsrfTokenRequestProcessor
  */
 @FunctionalInterface
 public interface CsrfTokenRequestResolver {
 
 	/**
-	 * TODO
-	 * @param request
-	 * @param csrfToken
-	 * @return
+	 * Returns the token value resolved from the provided {@code HttpServletRequest} and
+	 * {@link CsrfToken} or {@code null} if not available.
+	 * @param request the {@code HttpServletRequest} being processed
+	 * @param csrfToken the {@link CsrfToken} created by the {@link CsrfTokenRepository}
+	 * @return the token value resolved from the request
 	 */
 	String resolveCsrfTokenValue(HttpServletRequest request, CsrfToken csrfToken);
 

--- a/web/src/main/java/org/springframework/security/web/csrf/DefaultCsrfTokenRequestHandler.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/DefaultCsrfTokenRequestHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.csrf;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * TODO
+ *
+ * @author Steve Riesenberg
+ * @since 5.8
+ */
+public final class DefaultCsrfTokenRequestHandler implements CsrfTokenRequestAttributeHandler, CsrfTokenRequestResolver {
+
+	private String csrfRequestAttributeName;
+
+	/**
+	 * The {@link CsrfToken} is available as a request attribute named
+	 * {@code CsrfToken.class.getName()}. By default, an additional request attribute that
+	 * is the same as {@link CsrfToken#getParameterName()} is set. This attribute allows
+	 * overriding the additional attribute.
+	 * @param csrfRequestAttributeName the name of an additional request attribute with
+	 * the value of the CsrfToken. Default is {@link CsrfToken#getParameterName()}
+	 */
+	public void setCsrfRequestAttributeName(String csrfRequestAttributeName) {
+		this.csrfRequestAttributeName = csrfRequestAttributeName;
+	}
+
+	@Override
+	public void handle(HttpServletRequest request, CsrfToken csrfToken) {
+		request.setAttribute(CsrfToken.class.getName(), csrfToken);
+		String csrfAttrName = (this.csrfRequestAttributeName != null) ? this.csrfRequestAttributeName
+				: csrfToken.getParameterName();
+		request.setAttribute(csrfAttrName, csrfToken);
+	}
+
+	@Override
+	public String resolve(HttpServletRequest request, CsrfToken csrfToken) {
+		String actualToken = request.getHeader(csrfToken.getHeaderName());
+		if (actualToken == null) {
+			actualToken = request.getParameter(csrfToken.getParameterName());
+		}
+		return actualToken;
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/csrf/XorCsrfTokenRequestHandler.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/XorCsrfTokenRequestHandler.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.csrf;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.security.crypto.codec.Utf8;
+
+/**
+ * @author Steve Riesenberg
+ */
+public final class XorCsrfTokenRequestHandler implements CsrfTokenRequestAttributeHandler, CsrfTokenRequestResolver {
+
+	private final DefaultCsrfTokenRequestHandler delegate = new DefaultCsrfTokenRequestHandler();
+
+	private SecureRandom secureRandom = new SecureRandom();
+
+	/**
+	 * TODO
+	 *
+	 * @param secureRandom
+	 */
+	public void setSecureRandom(SecureRandom secureRandom) {
+		this.secureRandom = secureRandom;
+	}
+
+	/**
+	 * The {@link CsrfToken} is available as a request attribute named
+	 * {@code CsrfToken.class.getName()}. By default, an additional request attribute that
+	 * is the same as {@link CsrfToken#getParameterName()} is set. This attribute allows
+	 * overriding the additional attribute.
+	 * @param csrfRequestAttributeName the name of an additional request attribute with
+	 * the value of the CsrfToken. Default is {@link CsrfToken#getParameterName()}
+	 */
+	public void setCsrfRequestAttributeName(String csrfRequestAttributeName) {
+		this.delegate.setCsrfRequestAttributeName(csrfRequestAttributeName);
+	}
+
+	@Override
+	public void handle(HttpServletRequest request, CsrfToken csrfToken) {
+		String updatedToken = createXoredCsrfToken(csrfToken.getToken());
+		DefaultCsrfToken updatedCsrfToken = new DefaultCsrfToken(csrfToken.getHeaderName(),
+				csrfToken.getParameterName(), updatedToken);
+		this.delegate.handle(request, updatedCsrfToken);
+	}
+
+	@Override
+	public String resolve(HttpServletRequest request, CsrfToken csrfToken) {
+		String actualToken = this.delegate.resolve(request, csrfToken);
+		byte[] actualBytes;
+		try {
+			actualBytes = Base64.getUrlDecoder().decode(actualToken);
+		}
+		catch (Exception ex) {
+			return null;
+		}
+
+		byte[] tokenBytes = Utf8.encode(csrfToken.getToken());
+		int tokenSize = tokenBytes.length;
+		if (actualBytes.length < tokenSize) {
+			return null;
+		}
+
+		// extract token and random bytes
+		int randomBytesSize = actualBytes.length - tokenSize;
+		byte[] xoredCsrf = new byte[tokenSize];
+		byte[] randomBytes = new byte[randomBytesSize];
+
+		System.arraycopy(actualBytes, 0, randomBytes, 0, randomBytesSize);
+		System.arraycopy(actualBytes, randomBytesSize, xoredCsrf, 0, tokenSize);
+
+		byte[] csrfBytes = xorCsrf(randomBytes, xoredCsrf);
+		return Utf8.decode(csrfBytes);
+	}
+
+	private String createXoredCsrfToken(String token) {
+		byte[] tokenBytes = Utf8.encode(token);
+		byte[] randomBytes = new byte[tokenBytes.length];
+		this.secureRandom.nextBytes(randomBytes);
+
+		byte[] xoredBytes = xorCsrf(randomBytes, tokenBytes);
+		byte[] combinedBytes = new byte[tokenBytes.length + randomBytes.length];
+		System.arraycopy(randomBytes, 0, combinedBytes, 0, randomBytes.length);
+		System.arraycopy(xoredBytes, 0, combinedBytes, randomBytes.length, xoredBytes.length);
+
+		return Base64.getUrlEncoder().encodeToString(combinedBytes);
+	}
+
+	private static byte[] xorCsrf(byte[] randomBytes, byte[] csrfBytes) {
+		int len = Math.min(randomBytes.length, csrfBytes.length);
+		byte[] xoredCsrf = new byte[len];
+		System.arraycopy(csrfBytes, 0, xoredCsrf, 0, csrfBytes.length);
+		for (int i = 0; i < len; i++) {
+			xoredCsrf[i] ^= randomBytes[i];
+		}
+		return xoredCsrf;
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/csrf/XorCsrfTokenRequestProcessor.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/XorCsrfTokenRequestProcessor.java
@@ -24,33 +24,21 @@ import javax.servlet.http.HttpServletRequest;
 import org.springframework.security.crypto.codec.Utf8;
 
 /**
+ * TODO
+ *
  * @author Steve Riesenberg
+ * @since 5.8
  */
-public final class XorCsrfTokenRequestHandler implements CsrfTokenRequestAttributeHandler, CsrfTokenRequestResolver {
-
-	private final DefaultCsrfTokenRequestHandler delegate = new DefaultCsrfTokenRequestHandler();
+public final class XorCsrfTokenRequestProcessor extends CsrfTokenRequestProcessor {
 
 	private SecureRandom secureRandom = new SecureRandom();
 
 	/**
 	 * TODO
-	 *
 	 * @param secureRandom
 	 */
 	public void setSecureRandom(SecureRandom secureRandom) {
 		this.secureRandom = secureRandom;
-	}
-
-	/**
-	 * The {@link CsrfToken} is available as a request attribute named
-	 * {@code CsrfToken.class.getName()}. By default, an additional request attribute that
-	 * is the same as {@link CsrfToken#getParameterName()} is set. This attribute allows
-	 * overriding the additional attribute.
-	 * @param csrfRequestAttributeName the name of an additional request attribute with
-	 * the value of the CsrfToken. Default is {@link CsrfToken#getParameterName()}
-	 */
-	public void setCsrfRequestAttributeName(String csrfRequestAttributeName) {
-		this.delegate.setCsrfRequestAttributeName(csrfRequestAttributeName);
 	}
 
 	@Override
@@ -58,12 +46,12 @@ public final class XorCsrfTokenRequestHandler implements CsrfTokenRequestAttribu
 		String updatedToken = createXoredCsrfToken(csrfToken.getToken());
 		DefaultCsrfToken updatedCsrfToken = new DefaultCsrfToken(csrfToken.getHeaderName(),
 				csrfToken.getParameterName(), updatedToken);
-		this.delegate.handle(request, updatedCsrfToken);
+		super.handle(request, updatedCsrfToken);
 	}
 
 	@Override
-	public String resolve(HttpServletRequest request, CsrfToken csrfToken) {
-		String actualToken = this.delegate.resolve(request, csrfToken);
+	public String resolveCsrfTokenValue(HttpServletRequest request, CsrfToken csrfToken) {
+		String actualToken = super.resolveCsrfTokenValue(request, csrfToken);
 		byte[] actualBytes;
 		try {
 			actualBytes = Base64.getUrlDecoder().decode(actualToken);

--- a/web/src/main/java/org/springframework/security/web/csrf/XorCsrfTokenRequestProcessor.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/XorCsrfTokenRequestProcessor.java
@@ -22,6 +22,7 @@ import java.util.Base64;
 import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.security.crypto.codec.Utf8;
+import org.springframework.util.Assert;
 
 /**
  * An implementation of the {@link CsrfTokenRequestAttributeHandler} and
@@ -42,11 +43,14 @@ public final class XorCsrfTokenRequestProcessor extends CsrfTokenRequestProcesso
 	 * @param secureRandom the {@code SecureRandom} to use to generate random bytes
 	 */
 	public void setSecureRandom(SecureRandom secureRandom) {
+		Assert.notNull(secureRandom, "secureRandom cannot be null");
 		this.secureRandom = secureRandom;
 	}
 
 	@Override
 	public void handle(HttpServletRequest request, CsrfToken csrfToken) {
+		Assert.notNull(request, "request cannot be null");
+		Assert.notNull(csrfToken, "csrfToken cannot be null");
 		String updatedToken = createXoredCsrfToken(this.secureRandom, csrfToken.getToken());
 		DefaultCsrfToken updatedCsrfToken = new DefaultCsrfToken(csrfToken.getHeaderName(),
 				csrfToken.getParameterName(), updatedToken);

--- a/web/src/test/java/org/springframework/security/web/csrf/CsrfAuthenticationStrategyTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CsrfAuthenticationStrategyTests.java
@@ -34,8 +34,10 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 /**
  * @author Rob Winch
@@ -70,6 +72,25 @@ public class CsrfAuthenticationStrategyTests {
 	@Test
 	public void constructorNullCsrfTokenRepository() {
 		assertThatIllegalArgumentException().isThrownBy(() -> new CsrfAuthenticationStrategy(null));
+	}
+
+	@Test
+	public void setRequestAttributeHandlerWhenNullThenIllegalStateException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.strategy.setRequestAttributeHandler(null))
+				.withMessage("requestAttributeHandler cannot be null");
+	}
+
+	@Test
+	public void onAuthenticationWhenCustomRequestAttributeHandlerThenUsed() throws Exception {
+		given(this.csrfTokenRepository.loadToken(this.request)).willReturn(this.existingToken);
+		given(this.csrfTokenRepository.generateToken(this.request)).willReturn(this.generatedToken);
+
+		CsrfTokenRequestAttributeHandler requestAttributeHandler = mock(CsrfTokenRequestAttributeHandler.class);
+		this.strategy.setRequestAttributeHandler(requestAttributeHandler);
+		this.strategy.onAuthentication(new TestingAuthenticationToken("user", "password", "ROLE_USER"), this.request,
+				this.response);
+		verify(requestAttributeHandler).handle(this.request, this.generatedToken);
+		verifyNoMoreInteractions(requestAttributeHandler);
 	}
 
 	@Test

--- a/web/src/test/java/org/springframework/security/web/csrf/CsrfFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CsrfFilterTests.java
@@ -351,9 +351,9 @@ public class CsrfFilterTests {
 			throws ServletException, IOException {
 		CsrfFilter filter = createCsrfFilter(this.tokenRepository);
 		String csrfAttrName = "_csrf";
-		DefaultCsrfTokenRequestHandler csrfTokenRequestAttributeHandler = new DefaultCsrfTokenRequestHandler();
-		csrfTokenRequestAttributeHandler.setCsrfRequestAttributeName(csrfAttrName);
-		filter.setRequestAttributeHandler(csrfTokenRequestAttributeHandler);
+		CsrfTokenRequestProcessor csrfTokenRequestProcessor = new CsrfTokenRequestProcessor();
+		csrfTokenRequestProcessor.setCsrfRequestAttributeName(csrfAttrName);
+		filter.setRequestAttributeHandler(csrfTokenRequestProcessor);
 		CsrfToken expectedCsrfToken = mock(CsrfToken.class);
 		given(this.tokenRepository.loadToken(this.request)).willReturn(expectedCsrfToken);
 

--- a/web/src/test/java/org/springframework/security/web/csrf/CsrfFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CsrfFilterTests.java
@@ -351,7 +351,9 @@ public class CsrfFilterTests {
 			throws ServletException, IOException {
 		CsrfFilter filter = createCsrfFilter(this.tokenRepository);
 		String csrfAttrName = "_csrf";
-		filter.setCsrfRequestAttributeName(csrfAttrName);
+		DefaultCsrfTokenRequestHandler csrfTokenRequestAttributeHandler = new DefaultCsrfTokenRequestHandler();
+		csrfTokenRequestAttributeHandler.setCsrfRequestAttributeName(csrfAttrName);
+		filter.setRequestAttributeHandler(csrfTokenRequestAttributeHandler);
 		CsrfToken expectedCsrfToken = mock(CsrfToken.class);
 		given(this.tokenRepository.loadToken(this.request)).willReturn(expectedCsrfToken);
 

--- a/web/src/test/java/org/springframework/security/web/csrf/CsrfTokenRequestProcessorTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CsrfTokenRequestProcessorTests.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.csrf;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * Tests for {@link CsrfTokenRequestProcessor}.
+ *
+ * @author Steve Riesenberg
+ * @since 5.8
+ */
+public class CsrfTokenRequestProcessorTests {
+
+	private MockHttpServletRequest request;
+
+	private CsrfToken token;
+
+	private CsrfTokenRequestProcessor processor;
+
+	@BeforeEach
+	public void setup() {
+		this.request = new MockHttpServletRequest();
+		this.token = new DefaultCsrfToken("headerName", "paramName", "csrfTokenValue");
+		this.processor = new CsrfTokenRequestProcessor();
+	}
+
+	@Test
+	public void handleWhenRequestIsNullThenThrowsIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.processor.handle(null, this.token))
+				.withMessage("request cannot be null");
+	}
+
+	@Test
+	public void handleWhenCsrfTokenIsNullThenThrowsIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.processor.handle(this.request, null))
+				.withMessage("csrfToken cannot be null");
+	}
+
+	@Test
+	public void handleWhenCsrfRequestAttributeSetThenUsed() {
+		this.processor.setCsrfRequestAttributeName("_csrf");
+		this.processor.handle(this.request, this.token);
+		assertThat(this.request.getAttribute(CsrfToken.class.getName())).isEqualTo(this.token);
+		assertThat(this.request.getAttribute("_csrf")).isEqualTo(this.token);
+	}
+
+	@Test
+	public void handleWhenValidParametersThenRequestAttributesSet() {
+		this.processor.handle(this.request, this.token);
+		assertThat(this.request.getAttribute(CsrfToken.class.getName())).isEqualTo(this.token);
+		assertThat(this.request.getAttribute(this.token.getParameterName())).isEqualTo(this.token);
+	}
+
+	@Test
+	public void resolveCsrfTokenValueWhenRequestIsNullThenThrowsIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.processor.resolveCsrfTokenValue(null, this.token))
+				.withMessage("request cannot be null");
+	}
+
+	@Test
+	public void resolveCsrfTokenValueWhenCsrfTokenIsNullThenThrowsIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.processor.resolveCsrfTokenValue(this.request, null))
+				.withMessage("csrfToken cannot be null");
+	}
+
+	@Test
+	public void resolveCsrfTokenValueWhenTokenNotSetThenReturnsNull() {
+		String tokenValue = this.processor.resolveCsrfTokenValue(this.request, this.token);
+		assertThat(tokenValue).isNull();
+	}
+
+	@Test
+	public void resolveCsrfTokenValueWhenParameterSetThenReturnsTokenValue() {
+		this.request.setParameter(this.token.getParameterName(), this.token.getToken());
+		String tokenValue = this.processor.resolveCsrfTokenValue(this.request, this.token);
+		assertThat(tokenValue).isEqualTo(this.token.getToken());
+	}
+
+	@Test
+	public void resolveCsrfTokenValueWhenHeaderSetThenReturnsTokenValue() {
+		this.request.addHeader(this.token.getHeaderName(), this.token.getToken());
+		String tokenValue = this.processor.resolveCsrfTokenValue(this.request, this.token);
+		assertThat(tokenValue).isEqualTo(this.token.getToken());
+	}
+
+	@Test
+	public void resolveCsrfTokenValueWhenHeaderAndParameterSetThenHeaderIsPreferred() {
+		this.request.addHeader(this.token.getHeaderName(), "header");
+		this.request.setParameter(this.token.getParameterName(), "parameter");
+		String tokenValue = this.processor.resolveCsrfTokenValue(this.request, this.token);
+		assertThat(tokenValue).isEqualTo("header");
+	}
+
+}

--- a/web/src/test/java/org/springframework/security/web/csrf/XorCsrfTokenRequestProcessorTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/XorCsrfTokenRequestProcessorTests.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.csrf;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.Answer;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+/**
+ * Tests for {@link XorCsrfTokenRequestProcessor}.
+ *
+ * @author Steve Riesenberg
+ * @since 5.8
+ */
+public class XorCsrfTokenRequestProcessorTests {
+
+	private static final byte[] XOR_CSRF_TOKEN_BYTES = new byte[] { 1, 1, 1, 96, 99, 98 };
+
+	private static final String XOR_CSRF_TOKEN_VALUE = Base64.getEncoder().encodeToString(XOR_CSRF_TOKEN_BYTES);
+
+	private MockHttpServletRequest request;
+
+	private CsrfToken token;
+
+	private SecureRandom secureRandom;
+
+	private XorCsrfTokenRequestProcessor processor;
+
+	@BeforeEach
+	public void setup() {
+		this.request = new MockHttpServletRequest();
+		this.token = new DefaultCsrfToken("headerName", "paramName", "abc");
+		this.secureRandom = mock(SecureRandom.class);
+		this.processor = new XorCsrfTokenRequestProcessor();
+	}
+
+	@Test
+	public void handleWhenRequestIsNullThenThrowsIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.processor.handle(null, this.token))
+				.withMessage("request cannot be null");
+	}
+
+	@Test
+	public void handleWhenCsrfTokenIsNullThenThrowsIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.processor.handle(this.request, null))
+				.withMessage("csrfToken cannot be null");
+	}
+
+	@Test
+	public void handleWhenCsrfRequestAttributeSetThenUsed() {
+		willAnswer(fillByteArray()).given(this.secureRandom).nextBytes(anyByteArray());
+
+		this.processor.setSecureRandom(this.secureRandom);
+		this.processor.setCsrfRequestAttributeName("_csrf");
+		this.processor.handle(this.request, this.token);
+		assertThat(this.request.getAttribute(CsrfToken.class.getName())).isNotNull();
+		assertThat(this.request.getAttribute("_csrf")).isNotNull();
+
+		CsrfToken csrfTokenAttribute = (CsrfToken) this.request.getAttribute("_csrf");
+		assertThat(csrfTokenAttribute.getToken()).isEqualTo(XOR_CSRF_TOKEN_VALUE);
+	}
+
+	@Test
+	public void handleWhenSecureRandomSetThenUsed() {
+		this.processor.setSecureRandom(this.secureRandom);
+		this.processor.handle(this.request, this.token);
+		verify(this.secureRandom).nextBytes(anyByteArray());
+		verifyNoMoreInteractions(this.secureRandom);
+	}
+
+	@Test
+	public void handleWhenValidParametersThenRequestAttributesSet() {
+		willAnswer(fillByteArray()).given(this.secureRandom).nextBytes(anyByteArray());
+
+		this.processor.setSecureRandom(this.secureRandom);
+		this.processor.handle(this.request, this.token);
+		verify(this.secureRandom).nextBytes(anyByteArray());
+		assertThat(this.request.getAttribute(CsrfToken.class.getName())).isNotNull();
+		assertThat(this.request.getAttribute(this.token.getParameterName())).isNotNull();
+
+		CsrfToken csrfTokenAttribute = (CsrfToken) this.request.getAttribute(CsrfToken.class.getName());
+		assertThat(csrfTokenAttribute.getToken()).isEqualTo(XOR_CSRF_TOKEN_VALUE);
+	}
+
+	@Test
+	public void resolveCsrfTokenValueWhenRequestIsNullThenThrowsIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.processor.resolveCsrfTokenValue(null, this.token))
+				.withMessage("request cannot be null");
+	}
+
+	@Test
+	public void resolveCsrfTokenValueWhenCsrfTokenIsNullThenThrowsIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.processor.resolveCsrfTokenValue(this.request, null))
+				.withMessage("csrfToken cannot be null");
+	}
+
+	@Test
+	public void resolveCsrfTokenValueWhenTokenNotSetThenReturnsNull() {
+		String tokenValue = this.processor.resolveCsrfTokenValue(this.request, this.token);
+		assertThat(tokenValue).isNull();
+	}
+
+	@Test
+	public void resolveCsrfTokenValueWhenParameterSetThenReturnsTokenValue() {
+		this.request.setParameter(this.token.getParameterName(), XOR_CSRF_TOKEN_VALUE);
+		String tokenValue = this.processor.resolveCsrfTokenValue(this.request, this.token);
+		assertThat(tokenValue).isEqualTo(this.token.getToken());
+	}
+
+	@Test
+	public void resolveCsrfTokenValueWhenHeaderSetThenReturnsTokenValue() {
+		this.request.addHeader(this.token.getHeaderName(), XOR_CSRF_TOKEN_VALUE);
+		String tokenValue = this.processor.resolveCsrfTokenValue(this.request, this.token);
+		assertThat(tokenValue).isEqualTo(this.token.getToken());
+	}
+
+	@Test
+	public void resolveCsrfTokenValueWhenHeaderAndParameterSetThenHeaderIsPreferred() {
+		this.request.addHeader(this.token.getHeaderName(), XOR_CSRF_TOKEN_VALUE);
+		this.request.setParameter(this.token.getParameterName(), "invalid");
+		String tokenValue = this.processor.resolveCsrfTokenValue(this.request, this.token);
+		assertThat(tokenValue).isEqualTo(this.token.getToken());
+	}
+
+	private static Answer<Void> fillByteArray() {
+		return (invocation) -> {
+			byte[] bytes = invocation.getArgument(0);
+			Arrays.fill(bytes, (byte) 1);
+			return null;
+		};
+	}
+
+	private static byte[] anyByteArray() {
+		return any(byte[].class);
+	}
+
+}


### PR DESCRIPTION
Draft 2
---

* Add `CsrfTokenRequestAttributeHandler` and `CsrfTokenRequestResolver` interfaces
* Add `CsrfTokenRequestProcessor` and `XorCsrfTokenRequestProcessor` classes
* Move `csrfRequestAttributeName` to `CsrfTokenRequestProcessor`

Issue gh-4001

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
