### PR TITLE
xsd document security-context-explicit-save defaults to true

### DIFF
--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.0.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.0.xsd
@@ -1277,7 +1277,7 @@
       <xs:attribute name="security-context-explicit-save" type="xs:boolean">
          <xs:annotation>
             <xs:documentation>Optional attribute that specifies that the SecurityContext should require explicit saving
-                rather than being synchronized from the SecurityContextHolder. Defaults to "false".
+                rather than being synchronized from the SecurityContextHolder. Defaults to "true".
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>


### PR DESCRIPTION
Fix missing xsd update after gh-11762
