### PR TITLE
Updated reference to architecture page

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/index.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/index.adoc
@@ -2,7 +2,7 @@
 = Authentication
 
 Spring Security provides comprehensive support for xref:features/authentication/index.adoc#authentication[Authentication].
-We start by discussing the overall xref:servlet/architecture.adoc#servlet-architecture[Servlet Authentication Architecture].
+We start by discussing the overall xref:servlet/authentication/architecture.adoc[Servlet Authentication Architecture].
 As you might expect, this section is more abstract describing the architecture without much discussion on how it applies to concrete flows.
 
 If you prefer, you can refer to <<servlet-authentication-mechanisms,Authentication Mechanisms>> for concrete ways in which users can authenticate.


### PR DESCRIPTION
In the context of Servlet Authentication page, "Architecture" should probably link to "Servlet Authentication Architecture" page