### PR TITLE
Add Antora Collector to eliminate the dependency on the generated-docs repository

### DIFF
--- a/antora-playbook-with-worktrees.yml
+++ b/antora-playbook-with-worktrees.yml
@@ -1,6 +1,8 @@
 antora:
   extensions:
   - ./lib/antora/extensions/antora-linked-worktree-patch.js
+  - ./lib/antora/extensions/inject-collector-config.js
+  - '@antora/collector-extension'
   - ./lib/antora/extensions/version-fix.js
   - ./lib/antora/extensions/major-minor-segment.js
 runtime:
@@ -14,12 +16,10 @@ git:
   ensure_git_suffix: false
 content:
   sources:
-    - url: https://github.com/spring-io/spring-generated-docs
-      branches: 'spring-projects/spring-security/{main,5.{{6..9},{1..9}+({0..9})}.{x,+({0..9})}}'
     - url: .
-      branches: '{main,5.{{6..9},{1..9}+({0..9})}.x}'
+      branches: [main, '5.{{6..9},{1..9}+({0..9})}.x']
       worktrees: true # will automatically discover worktrees if they are set up; otherwise, will use git tree
-      tags: '5.{{6..9},{1..9}+({0..9})}.+({0..9})'
+      tags: '5.{{6..9},{1..9}+({0..9})}.+({0..9})?(-RC{1..9})'
       start_path: docs
 asciidoc:
   attributes:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -1,5 +1,7 @@
 antora:
   extensions:
+  - ./lib/antora/extensions/inject-collector-config.js
+  - '@antora/collector-extension'
   - ./lib/antora/extensions/version-fix.js
   - ./lib/antora/extensions/major-minor-segment.js
 runtime:
@@ -13,8 +15,6 @@ git:
   ensure_git_suffix: false
 content:
   sources:
-    - url: https://github.com/spring-io/spring-generated-docs
-      branches: 'spring-projects/spring-security/{main,5.{{6..9},{1..9}+({0..9})}.{x,+({0..9}?(-RC{1..9}))}}'
     - url: https://github.com/spring-projects/spring-security
       branches: [main, '5.{{6..9},{1..9}+({0..9})}.x']
       tags: '5.{{6..9},{1..9}+({0..9})}.+({0..9})?(-RC{1..9})'

--- a/lib/antora/extensions/inject-collector-config.js
+++ b/lib/antora/extensions/inject-collector-config.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const BASE_COMMAND = 'gradlew -PbuildSrc.skipTests=true'
+const JVM_ARGS='-Xmx3g -XX:+HeapDumpOnOutOfMemoryError'
+const REPO_URL = 'https://github.com/spring-projects/spring-security'
+const TASK_NAME=':spring-security-docs:generateAntora'
+
+module.exports.register = function () {
+  this.once('contentAggregated', ({ contentAggregate }) => {
+    for (const { origins } of contentAggregate) {
+      for (const origin of origins) {
+        if (origin.url === REPO_URL && origin.descriptor.ext?.collector === undefined) {
+          origin.descriptor.ext = {
+            collector: {
+              run: {
+                command: `${BASE_COMMAND} "-Dorg.gradle.jvmargs=${JVM_ARGS}" ${TASK_NAME}`,
+                local: true,
+              },
+              scan: {
+                dir: './build/generateAntora',
+              },
+            }
+          }
+        }
+      }
+    }
+  })
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "dependencies": {
     "@antora/cli": "^3.1.0",
-    "@antora/site-generator-default": "^3.1.0"
+    "@antora/site-generator-default": "^3.1.0",
+    "@antora/collector-extension": "1.0.0-alpha.2"
   },
   "overrides": {
     "vinyl-fs": {


### PR DESCRIPTION
- add and register Antora Collector (see https://gitlab.com/antora/antora-collector-extension)
- configure Antora Collection at runtime using another extension

By using an extension to inject the configuration for Antora Collector, it's not necessary to update the content sources to add the configuration and thus allows it to be centrally controlled.