### PR TITLE
switch to offical Antora plugin for Gradle (main branch)

### DIFF
--- a/docs/local-antora-playbook.yml
+++ b/docs/local-antora-playbook.yml
@@ -2,9 +2,6 @@
 antora:
   extensions:
   - ./antora-linked-worktree-patch.js
-runtime:
-  log:
-    format: pretty
 site:
   title: Spring Security
   url: https://docs.spring.io/spring-security/reference

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "spring-security-docs-antora",
-  "private": true,
-  "dependencies": {
-    "@antora/cli": "^3.1.0",
-    "@antora/site-generator-default": "^3.1.0"
-  }
-}

--- a/docs/spring-security-docs.gradle
+++ b/docs/spring-security-docs.gradle
@@ -1,38 +1,32 @@
 plugins {
-	id "io.github.rwinch.antora" version "0.0.2"
-	id "org.springframework.antora.check-version"
+	id 'org.antora' version '1.0.0-alpha.3'
+	id 'org.springframework.antora.check-version'
 }
 
 apply plugin: 'io.spring.convention.docs'
 apply plugin: 'java'
 
-node {
-	version = "16.17.0"
-}
-
 antora {
-	antoraVersion = "3.1.0"
-	playbookFile = file("local-antora-playbook.yml")
-	arguments = ["--clean", "--stacktrace"]
-}
-
-tasks.antora {
-	dependsOn "generateAntora"
+	version = '~3.1'
+	playbook = file('local-antora-playbook.yml')
+	options = ['--clean', '--stacktrace']
 	environment = [
-		"ALGOLIA_API_KEY" : "82c7ead946afbac3cf98c32446154691",
-		"ALGOLIA_APP_ID" : "244V8V9FGG",
-		"ALGOLIA_INDEX_NAME" : "security-docs"
+		'ALGOLIA_API_KEY': '82c7ead946afbac3cf98c32446154691',
+		'ALGOLIA_APP_ID': '244V8V9FGG',
+		'ALGOLIA_INDEX_NAME': 'security-docs'
 	]
 }
 
-tasks.register("generateAntora") {
-	group = "Documentation"
-	description = "Generates the antora.yml for dynamic properties"
+tasks.antora.dependsOn 'generateAntora'
+
+tasks.register('generateAntora') {
+	group = 'Documentation'
+	description = 'Generates the antora.yml for dynamic properties'
 	doLast {
 		def docsTag = snapshotBuild ? 'current' : project.version
 		def ghTag = snapshotBuild ? 'main' : project.version
 		def ghUrl = "https://github.com/spring-projects/spring-security/tree/$ghTag"
-		def ghOldSamplesUrl = "https://github.com/spring-projects/spring-security/tree/5.4.x/samples"
+		def ghOldSamplesUrl = 'https://github.com/spring-projects/spring-security/tree/5.4.x/samples'
 		def ghSamplesUrl = "https://github.com/spring-projects/spring-security-samples/tree/$samplesBranch"
 		def securityDocsUrl = "https://docs.spring.io/spring-security/site/docs/$docsTag"
 		def securityApiUrl = "$securityDocsUrl/api/"
@@ -40,15 +34,15 @@ tasks.register("generateAntora") {
 		def springFrameworkApiUrl = "https://docs.spring.io/spring-framework/docs/$springFrameworkVersion/javadoc-api/"
 		def springFrameworkReferenceUrl = "https://docs.spring.io/spring-framework/docs/$springFrameworkVersion/reference/html/"
 		def versions = resolvedVersions(project.configurations.testRuntimeClasspath)
-		def ymlVersions = ""
+		def ymlVersions = ''
 		versions.call().each { name, version ->
 			ymlVersions += """
     ${name}: ${version}"""
 		}
-		def outputFile = new File("$buildDir/generateAntora/antora.yml")
+		def outputFile = layout.buildDirectory.file('generateAntora/antora.yml').orNull.asFile
 		outputFile.getParentFile().mkdirs()
 		outputFile.createNewFile()
-		def antoraYmlText = file("antora.yml").getText()
+		def antoraYmlText = file('antora.yml').text.trim()
 		outputFile.setText("""$antoraYmlText
 title: Spring Security
 start_page: ROOT:index.adoc
@@ -71,23 +65,23 @@ ${ymlVersions}
 }
 
 dependencies {
-	testImplementation platform(project(":spring-security-dependencies"))
-	testImplementation "com.unboundid:unboundid-ldapsdk"
-	testImplementation "org.apache.directory.server:apacheds-core"
-	testImplementation "org.springframework:spring-core"
+	testImplementation platform(project(':spring-security-dependencies'))
+	testImplementation 'com.unboundid:unboundid-ldapsdk'
+	testImplementation 'org.apache.directory.server:apacheds-core'
+	testImplementation 'org.springframework:spring-core'
 }
 
 def resolvedVersions(Configuration configuration) {
 	return {
 		configuration.resolvedConfiguration
 				.resolvedArtifacts
-				.collectEntries { [(it.name + "-version"): it.moduleVersion.id.version] }
+				.collectEntries { [(it.name + '-version'): it.moduleVersion.id.version] }
 	}
 }
 
 repositories {
 	mavenCentral()
-	maven { url "https://repo.spring.io/release" }
-	maven { url "https://repo.spring.io/milestone" }
-	maven { url "https://repo.spring.io/snapshot" }
+	maven { url 'https://repo.spring.io/release' }
+	maven { url 'https://repo.spring.io/milestone' }
+	maven { url 'https://repo.spring.io/snapshot' }
 }


### PR DESCRIPTION
- lock version to latest release of Antora 3.1
- rename properties on extension block
- use Node.js version provided by plugin
- remove package.json file
- assign environment variables using environments property on extension block
- use single quotes where possible in build script