### PR TITLE
Update default configuration for PasswordEncoders

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/argon2/Argon2PasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/argon2/Argon2PasswordEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,9 +52,9 @@ public class Argon2PasswordEncoder implements PasswordEncoder {
 
 	private static final int DEFAULT_PARALLELISM = 1;
 
-	private static final int DEFAULT_MEMORY = 1 << 12;
+	private static final int DEFAULT_MEMORY = 1 << 14;
 
-	private static final int DEFAULT_ITERATIONS = 3;
+	private static final int DEFAULT_ITERATIONS = 2;
 
 	private final Log logger = LogFactory.getLog(getClass());
 
@@ -68,16 +68,53 @@ public class Argon2PasswordEncoder implements PasswordEncoder {
 
 	private final BytesKeyGenerator saltGenerator;
 
+	/**
+	 * Constructs an Argon2 password encoder with a salt length of 16 bytes, a hash length
+	 * of 32 bytes, parallelism of 1, memory cost of 1 << 12 and 3 iterations.
+	 * @deprecated Use {@link #defaultsForSpringSecurity_v5_2()} instead
+	 */
+	@Deprecated
 	public Argon2PasswordEncoder() {
-		this(DEFAULT_SALT_LENGTH, DEFAULT_HASH_LENGTH, DEFAULT_PARALLELISM, DEFAULT_MEMORY, DEFAULT_ITERATIONS);
+		this(16, 32, 1, 1 << 12, 3);
 	}
 
+	/**
+	 * Constructs an Argon2 password encoder with the provided parameters.
+	 * @param saltLength the salt length (in bytes)
+	 * @param hashLength the hash length (in bytes)
+	 * @param parallelism the parallelism
+	 * @param memory the memory cost
+	 * @param iterations the number of iterations
+	 */
 	public Argon2PasswordEncoder(int saltLength, int hashLength, int parallelism, int memory, int iterations) {
 		this.hashLength = hashLength;
 		this.parallelism = parallelism;
 		this.memory = memory;
 		this.iterations = iterations;
 		this.saltGenerator = KeyGenerators.secureRandom(saltLength);
+	}
+
+	/**
+	 * Constructs an Argon2 password encoder with a salt length of 16 bytes, a hash length
+	 * of 32 bytes, parallelism of 1, memory cost of 1 << 12 and 3 iterations.
+	 * @return the {@link Argon2PasswordEncoder}
+	 * @since 5.8
+	 * @deprecated Use {@link #defaultsForSpringSecurity_v5_8()} instead
+	 */
+	@Deprecated
+	public static Argon2PasswordEncoder defaultsForSpringSecurity_v5_2() {
+		return new Argon2PasswordEncoder(16, 32, 1, 1 << 12, 3);
+	}
+
+	/**
+	 * Constructs an Argon2 password encoder with a salt length of 16 bytes, a hash length
+	 * of 32 bytes, parallelism of 1, memory cost of 1 << 14 and 2 iterations.
+	 * @return the {@link Argon2PasswordEncoder}
+	 * @since 5.8
+	 */
+	public static Argon2PasswordEncoder defaultsForSpringSecurity_v5_8() {
+		return new Argon2PasswordEncoder(DEFAULT_SALT_LENGTH, DEFAULT_HASH_LENGTH, DEFAULT_PARALLELISM, DEFAULT_MEMORY,
+				DEFAULT_ITERATIONS);
 	}
 
 	@Override

--- a/crypto/src/main/java/org/springframework/security/crypto/factory/PasswordEncoderFactories.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/factory/PasswordEncoderFactories.java
@@ -53,7 +53,9 @@ public final class PasswordEncoderFactories {
 	 * <li>noop -
 	 * {@link org.springframework.security.crypto.password.NoOpPasswordEncoder}</li>
 	 * <li>pbkdf2 - {@link Pbkdf2PasswordEncoder}</li>
-	 * <li>scrypt - {@link SCryptPasswordEncoder}</li>
+	 * <li>scrypt - {@link SCryptPasswordEncoder#defaultsForSpringSecurity_v4_1()}</li>
+	 * <li>scrypt@SpringSecurity_v5_8 -
+	 * {@link SCryptPasswordEncoder#defaultsForSpringSecurity_v5_8()}</li>
 	 * <li>SHA-1 - {@code new MessageDigestPasswordEncoder("SHA-1")}</li>
 	 * <li>SHA-256 - {@code new MessageDigestPasswordEncoder("SHA-256")}</li>
 	 * <li>sha256 -
@@ -74,7 +76,8 @@ public final class PasswordEncoderFactories {
 		encoders.put("MD5", new org.springframework.security.crypto.password.MessageDigestPasswordEncoder("MD5"));
 		encoders.put("noop", org.springframework.security.crypto.password.NoOpPasswordEncoder.getInstance());
 		encoders.put("pbkdf2", new Pbkdf2PasswordEncoder());
-		encoders.put("scrypt", new SCryptPasswordEncoder());
+		encoders.put("scrypt", SCryptPasswordEncoder.defaultsForSpringSecurity_v4_1());
+		encoders.put("scrypt@SpringSecurity_v5_8", SCryptPasswordEncoder.defaultsForSpringSecurity_v5_8());
 		encoders.put("SHA-1", new org.springframework.security.crypto.password.MessageDigestPasswordEncoder("SHA-1"));
 		encoders.put("SHA-256",
 				new org.springframework.security.crypto.password.MessageDigestPasswordEncoder("SHA-256"));

--- a/crypto/src/main/java/org/springframework/security/crypto/factory/PasswordEncoderFactories.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/factory/PasswordEncoderFactories.java
@@ -52,7 +52,9 @@ public final class PasswordEncoderFactories {
 	 * <li>MD5 - {@code new MessageDigestPasswordEncoder("MD5")}</li>
 	 * <li>noop -
 	 * {@link org.springframework.security.crypto.password.NoOpPasswordEncoder}</li>
-	 * <li>pbkdf2 - {@link Pbkdf2PasswordEncoder}</li>
+	 * <li>pbkdf2 - {@link Pbkdf2PasswordEncoder#defaultsForSpringSecurity_v5_5()}</li>
+	 * <li>pbkdf2@SpringSecurity_v5_8 -
+	 * {@link Pbkdf2PasswordEncoder#defaultsForSpringSecurity_v5_8()}</li>
 	 * <li>scrypt - {@link SCryptPasswordEncoder#defaultsForSpringSecurity_v4_1()}</li>
 	 * <li>scrypt@SpringSecurity_v5_8 -
 	 * {@link SCryptPasswordEncoder#defaultsForSpringSecurity_v5_8()}</li>
@@ -75,7 +77,8 @@ public final class PasswordEncoderFactories {
 		encoders.put("MD4", new org.springframework.security.crypto.password.Md4PasswordEncoder());
 		encoders.put("MD5", new org.springframework.security.crypto.password.MessageDigestPasswordEncoder("MD5"));
 		encoders.put("noop", org.springframework.security.crypto.password.NoOpPasswordEncoder.getInstance());
-		encoders.put("pbkdf2", new Pbkdf2PasswordEncoder());
+		encoders.put("pbkdf2", Pbkdf2PasswordEncoder.defaultsForSpringSecurity_v5_5());
+		encoders.put("pbkdf2@SpringSecurity_v5_8", Pbkdf2PasswordEncoder.defaultsForSpringSecurity_v5_8());
 		encoders.put("scrypt", SCryptPasswordEncoder.defaultsForSpringSecurity_v4_1());
 		encoders.put("scrypt@SpringSecurity_v5_8", SCryptPasswordEncoder.defaultsForSpringSecurity_v5_8());
 		encoders.put("SHA-1", new org.springframework.security.crypto.password.MessageDigestPasswordEncoder("SHA-1"));

--- a/crypto/src/main/java/org/springframework/security/crypto/factory/PasswordEncoderFactories.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/factory/PasswordEncoderFactories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,9 @@ public final class PasswordEncoderFactories {
 	 * <li>SHA-256 - {@code new MessageDigestPasswordEncoder("SHA-256")}</li>
 	 * <li>sha256 -
 	 * {@link org.springframework.security.crypto.password.StandardPasswordEncoder}</li>
-	 * <li>argon2 - {@link Argon2PasswordEncoder}</li>
+	 * <li>argon2 - {@link Argon2PasswordEncoder#defaultsForSpringSecurity_v5_2()}</li>
+	 * <li>argon2@SpringSecurity_v5_8 -
+	 * {@link Argon2PasswordEncoder#defaultsForSpringSecurity_v5_8()}</li>
 	 * </ul>
 	 * @return the {@link PasswordEncoder} to use
 	 */
@@ -77,7 +79,8 @@ public final class PasswordEncoderFactories {
 		encoders.put("SHA-256",
 				new org.springframework.security.crypto.password.MessageDigestPasswordEncoder("SHA-256"));
 		encoders.put("sha256", new org.springframework.security.crypto.password.StandardPasswordEncoder());
-		encoders.put("argon2", new Argon2PasswordEncoder());
+		encoders.put("argon2", Argon2PasswordEncoder.defaultsForSpringSecurity_v5_2());
+		encoders.put("argon2@SpringSecurity_v5_8", Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8());
 		return new DelegatingPasswordEncoder(encodingId, encoders);
 	}
 

--- a/crypto/src/main/java/org/springframework/security/crypto/scrypt/SCryptPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/scrypt/SCryptPasswordEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,16 @@ import org.springframework.security.crypto.password.PasswordEncoder;
  */
 public class SCryptPasswordEncoder implements PasswordEncoder {
 
+	private static final int DEFAULT_CPU_COST = 65536;
+
+	private static final int DEFAULT_MEMORY_COST = 8;
+
+	private static final int DEFAULT_PARALLELISM = 1;
+
+	private static final int DEFAULT_KEY_LENGTH = 32;
+
+	private static final int DEFAULT_SALT_LENGTH = 16;
+
 	private final Log logger = LogFactory.getLog(getClass());
 
 	private final int cpuCost;
@@ -70,14 +80,20 @@ public class SCryptPasswordEncoder implements PasswordEncoder {
 
 	private final BytesKeyGenerator saltGenerator;
 
+	/**
+	 * Constructs a SCrypt password encoder with cpu cost of 16,384, memory cost of 8,
+	 * parallelization of 1, a key length of 32 and a salt length of 64 bytes.
+	 * @deprecated Use {@link #defaultsForSpringSecurity_v4_1()} instead
+	 */
+	@Deprecated
 	public SCryptPasswordEncoder() {
 		this(16384, 8, 1, 32, 64);
 	}
 
 	/**
-	 * Creates a new instance
+	 * Constructs a SCrypt password encoder with the provided parameters.
 	 * @param cpuCost cpu cost of the algorithm (as defined in scrypt this is N). must be
-	 * power of 2 greater than 1. Default is currently 16,384 or 2^14)
+	 * power of 2 greater than 1. Default is currently 65,536 or 2^16)
 	 * @param memoryCost memory cost of the algorithm (as defined in scrypt this is r)
 	 * Default is currently 8.
 	 * @param parallelization the parallelization of the algorithm (as defined in scrypt
@@ -86,7 +102,7 @@ public class SCryptPasswordEncoder implements PasswordEncoder {
 	 * @param keyLength key length for the algorithm (as defined in scrypt this is dkLen).
 	 * The default is currently 32.
 	 * @param saltLength salt length (as defined in scrypt this is the length of S). The
-	 * default is currently 64.
+	 * default is currently 16.
 	 */
 	public SCryptPasswordEncoder(int cpuCost, int memoryCost, int parallelization, int keyLength, int saltLength) {
 		if (cpuCost <= 1) {
@@ -114,6 +130,29 @@ public class SCryptPasswordEncoder implements PasswordEncoder {
 		this.parallelization = parallelization;
 		this.keyLength = keyLength;
 		this.saltGenerator = KeyGenerators.secureRandom(saltLength);
+	}
+
+	/**
+	 * Constructs a SCrypt password encoder with cpu cost of 16,384, memory cost of 8,
+	 * parallelization of 1, a key length of 32 and a salt length of 64 bytes.
+	 * @return the {@link SCryptPasswordEncoder}
+	 * @since 5.8
+	 * @deprecated Use {@link #defaultsForSpringSecurity_v5_8()} instead
+	 */
+	@Deprecated
+	public static SCryptPasswordEncoder defaultsForSpringSecurity_v4_1() {
+		return new SCryptPasswordEncoder(16384, 8, 1, 32, 64);
+	}
+
+	/**
+	 * Constructs a SCrypt password encoder with cpu cost of 65,536, memory cost of 8,
+	 * parallelization of 1, a key length of 32 and a salt length of 16 bytes.
+	 * @return the {@link SCryptPasswordEncoder}
+	 * @since 5.8
+	 */
+	public static SCryptPasswordEncoder defaultsForSpringSecurity_v5_8() {
+		return new SCryptPasswordEncoder(DEFAULT_CPU_COST, DEFAULT_MEMORY_COST, DEFAULT_PARALLELISM, DEFAULT_KEY_LENGTH,
+				DEFAULT_SALT_LENGTH);
 	}
 
 	@Override

--- a/crypto/src/test/java/org/springframework/security/crypto/argon2/Argon2PasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/argon2/Argon2PasswordEncoderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public class Argon2PasswordEncoderTests {
 	@Mock
 	private BytesKeyGenerator keyGeneratorMock;
 
-	private Argon2PasswordEncoder encoder = new Argon2PasswordEncoder();
+	private Argon2PasswordEncoder encoder = Argon2PasswordEncoder.defaultsForSpringSecurity_v5_2();
 
 	@Test
 	public void encodeDoesNotEqualPassword() {
@@ -128,6 +128,15 @@ public class Argon2PasswordEncoderTests {
 	}
 
 	@Test
+	public void encodeWhenUsingPredictableSaltWithDefaultsForSpringSecurity_v5_8ThenEqualTestHash() throws Exception {
+		this.encoder = Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8();
+		injectPredictableSaltGen();
+		String hash = this.encoder.encode("sometestpassword");
+		assertThat(hash).isEqualTo(
+				"$argon2id$v=19$m=16384,t=2,p=1$QUFBQUFBQUFBQUFBQUFBQQ$zGt5MiNPSUOo4/7jBcJMayCPfcsLJ4c0WUxhwGDIYPw");
+	}
+
+	@Test
 	public void upgradeEncodingWhenSameEncodingThenFalse() {
 		String hash = this.encoder.encode("password");
 		assertThat(this.encoder.upgradeEncoding(hash)).isFalse();
@@ -135,7 +144,7 @@ public class Argon2PasswordEncoderTests {
 
 	@Test
 	public void upgradeEncodingWhenSameStandardParamsThenFalse() {
-		Argon2PasswordEncoder newEncoder = new Argon2PasswordEncoder();
+		Argon2PasswordEncoder newEncoder = Argon2PasswordEncoder.defaultsForSpringSecurity_v5_2();
 		String hash = this.encoder.encode("password");
 		assertThat(newEncoder.upgradeEncoding(hash)).isFalse();
 	}

--- a/crypto/src/test/java/org/springframework/security/crypto/factory/PasswordEncoderFactoriesTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/factory/PasswordEncoderFactoriesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,6 +102,12 @@ public class PasswordEncoderFactoriesTests {
 	@Test
 	public void matchesWhenArgon2ThenWorks() {
 		String encodedPassword = "{argon2}$argon2d$v=19$m=1024,t=1,p=1$c29tZXNhbHQ$Li5eBf5XrCz0cuzQRe9oflYqmA/VAzmzichw4ZYrvEU";
+		assertThat(this.encoder.matches(this.rawPassword, encodedPassword)).isTrue();
+	}
+
+	@Test
+	public void matchesWhenArgon2SpringSecurity_v5_8ThenWorks() {
+		String encodedPassword = "{argon2@SpringSecurity_v5_8}$argon2id$v=19$m=16384,t=2,p=1$v7fN5p91BQbdbA2HfdSPRg$MULpa02CO/6FKfqwuerCFvS7OhMxGFCKUOoWfzt86Rc";
 		assertThat(this.encoder.matches(this.rawPassword, encodedPassword)).isTrue();
 	}
 

--- a/crypto/src/test/java/org/springframework/security/crypto/factory/PasswordEncoderFactoriesTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/factory/PasswordEncoderFactoriesTests.java
@@ -76,6 +76,12 @@ public class PasswordEncoderFactoriesTests {
 	}
 
 	@Test
+	public void matchesWhenPbkdf2SpringSecurity_v5_8ThenWorks() {
+		String encodedPassword = "{pbkdf2@SpringSecurity_v5_8}fefe5120467e5d4ccff442dbb2fa86d276262d97435c0c54e5eebced51ffd144fcb05eb53fea2677216c4f3250010006";
+		assertThat(this.encoder.matches(this.rawPassword, encodedPassword)).isTrue();
+	}
+
+	@Test
 	public void matchesWhenSCryptThenWorks() {
 		String encodedPassword = "{scrypt}$e0801$8bWJaSu2IKSn9Z9kM+TPXfOc/9bdYSrN1oD9qfVThWEwdRTnO7re7Ei+fUZRJ68k9lTyuTeUp4of4g24hHnazw==$OAOec05+bXxvuu/1qZ6NUR+xQYvYv7BeL1QxwRpY5Pc=";
 		assertThat(this.encoder.matches(this.rawPassword, encodedPassword)).isTrue();

--- a/crypto/src/test/java/org/springframework/security/crypto/factory/PasswordEncoderFactoriesTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/factory/PasswordEncoderFactoriesTests.java
@@ -82,6 +82,12 @@ public class PasswordEncoderFactoriesTests {
 	}
 
 	@Test
+	public void matchesWhenSCryptSpringSecurity_v5_8ThenWorks() {
+		String encodedPassword = "{scrypt@SpringSecurity_v5_8}$e0801$vSriIassJwvdNBF1vpSoCenqBxvpT4e+NcLKVsrOVpaZfyRfpUJ6KctkpmketuacWelLU5njpILXM9LLkMXLMw==$vIQQljL257HOcnumyiy1hJBGYHmoXgENIh+NkFvmrGY=";
+		assertThat(this.encoder.matches(this.rawPassword, encodedPassword)).isTrue();
+	}
+
+	@Test
 	public void matchesWhenSHA1ThenWorks() {
 		String encodedPassword = "{SHA-1}{6581QepZz2qd8jVrT2QYPVtK8DuM2n45dVslmc3UTWc=}4f31573948ddbfb8ac9dd80107dfad13fd8f2454";
 		assertThat(this.encoder.matches(this.rawPassword, encodedPassword)).isTrue();

--- a/crypto/src/test/java/org/springframework/security/crypto/password/Pbkdf2PasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/password/Pbkdf2PasswordEncoderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -196,6 +196,14 @@ public class Pbkdf2PasswordEncoderTests {
 		String rawPassword = "password";
 		String encodedPassword = "0123456789abcdef0123456789abcdefc7cfc96cd26b854d096ccbb3308fad860d719eb552ed52ef8352935539158287";
 		assertThat(this.encoderSalt16.matches(rawPassword, encodedPassword)).isTrue();
+	}
+
+	@Test
+	public void matchWhenDefaultsForSpringSecurity_v5_8ThenSuccess() {
+		Pbkdf2PasswordEncoder encoder = Pbkdf2PasswordEncoder.defaultsForSpringSecurity_v5_8();
+		String rawPassword = "password";
+		String encodedPassword = "fefe5120467e5d4ccff442dbb2fa86d276262d97435c0c54e5eebced51ffd144fcb05eb53fea2677216c4f3250010006";
+		assertThat(encoder.matches(rawPassword, encodedPassword)).isTrue();
 	}
 
 	/**

--- a/crypto/src/test/java/org/springframework/security/crypto/scrypt/SCryptPasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/scrypt/SCryptPasswordEncoderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ public class SCryptPasswordEncoderTests {
 
 	@Test
 	public void matches() {
-		SCryptPasswordEncoder encoder = new SCryptPasswordEncoder();
+		SCryptPasswordEncoder encoder = SCryptPasswordEncoder.defaultsForSpringSecurity_v4_1();
 		String result = encoder.encode("password");
 		assertThat(result).isNotEqualTo("password");
 		assertThat(encoder.matches("password", result)).isTrue();
@@ -37,7 +37,7 @@ public class SCryptPasswordEncoderTests {
 
 	@Test
 	public void unicode() {
-		SCryptPasswordEncoder encoder = new SCryptPasswordEncoder();
+		SCryptPasswordEncoder encoder = SCryptPasswordEncoder.defaultsForSpringSecurity_v4_1();
 		String result = encoder.encode("passw\u9292rd");
 		assertThat(encoder.matches("pass\u9292\u9292rd", result)).isFalse();
 		assertThat(encoder.matches("passw\u9292rd", result)).isTrue();
@@ -45,7 +45,7 @@ public class SCryptPasswordEncoderTests {
 
 	@Test
 	public void notMatches() {
-		SCryptPasswordEncoder encoder = new SCryptPasswordEncoder();
+		SCryptPasswordEncoder encoder = SCryptPasswordEncoder.defaultsForSpringSecurity_v4_1();
 		String result = encoder.encode("password");
 		assertThat(encoder.matches("bogus", result)).isFalse();
 	}
@@ -60,15 +60,15 @@ public class SCryptPasswordEncoderTests {
 
 	@Test
 	public void differentPasswordHashes() {
-		SCryptPasswordEncoder encoder = new SCryptPasswordEncoder();
+		SCryptPasswordEncoder encoder = SCryptPasswordEncoder.defaultsForSpringSecurity_v4_1();
 		String password = "secret";
 		assertThat(encoder.encode(password)).isNotEqualTo(encoder.encode(password));
 	}
 
 	@Test
 	public void samePasswordWithDifferentParams() {
-		SCryptPasswordEncoder oldEncoder = new SCryptPasswordEncoder(16384, 8, 1, 32, 64);
-		SCryptPasswordEncoder newEncoder = new SCryptPasswordEncoder();
+		SCryptPasswordEncoder oldEncoder = SCryptPasswordEncoder.defaultsForSpringSecurity_v4_1();
+		SCryptPasswordEncoder newEncoder = SCryptPasswordEncoder.defaultsForSpringSecurity_v5_8();
 		String password = "secret";
 		String oldEncodedPassword = oldEncoder.encode(password);
 		assertThat(newEncoder.matches(password, oldEncodedPassword)).isTrue();
@@ -76,19 +76,19 @@ public class SCryptPasswordEncoderTests {
 
 	@Test
 	public void doesntMatchNullEncodedValue() {
-		SCryptPasswordEncoder encoder = new SCryptPasswordEncoder();
+		SCryptPasswordEncoder encoder = SCryptPasswordEncoder.defaultsForSpringSecurity_v4_1();
 		assertThat(encoder.matches("password", null)).isFalse();
 	}
 
 	@Test
 	public void doesntMatchEmptyEncodedValue() {
-		SCryptPasswordEncoder encoder = new SCryptPasswordEncoder();
+		SCryptPasswordEncoder encoder = SCryptPasswordEncoder.defaultsForSpringSecurity_v4_1();
 		assertThat(encoder.matches("password", "")).isFalse();
 	}
 
 	@Test
 	public void doesntMatchBogusEncodedValue() {
-		SCryptPasswordEncoder encoder = new SCryptPasswordEncoder();
+		SCryptPasswordEncoder encoder = SCryptPasswordEncoder.defaultsForSpringSecurity_v4_1();
 		assertThat(encoder.matches("password", "012345678901234567890123456789")).isFalse();
 	}
 
@@ -122,19 +122,19 @@ public class SCryptPasswordEncoderTests {
 
 	@Test
 	public void upgradeEncodingWhenNullThenFalse() {
-		SCryptPasswordEncoder encoder = new SCryptPasswordEncoder();
+		SCryptPasswordEncoder encoder = SCryptPasswordEncoder.defaultsForSpringSecurity_v4_1();
 		assertThat(encoder.upgradeEncoding(null)).isFalse();
 	}
 
 	@Test
 	public void upgradeEncodingWhenEmptyThenFalse() {
-		SCryptPasswordEncoder encoder = new SCryptPasswordEncoder();
+		SCryptPasswordEncoder encoder = SCryptPasswordEncoder.defaultsForSpringSecurity_v4_1();
 		assertThat(encoder.upgradeEncoding("")).isFalse();
 	}
 
 	@Test
 	public void upgradeEncodingWhenSameEncoderThenFalse() {
-		SCryptPasswordEncoder encoder = new SCryptPasswordEncoder();
+		SCryptPasswordEncoder encoder = SCryptPasswordEncoder.defaultsForSpringSecurity_v4_1();
 		String encoded = encoder.encode("password");
 		assertThat(encoder.upgradeEncoding(encoded)).isFalse();
 	}
@@ -159,8 +159,8 @@ public class SCryptPasswordEncoderTests {
 
 	@Test
 	public void upgradeEncodingWhenInvalidInputThenException() {
-		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new SCryptPasswordEncoder().upgradeEncoding("not-a-scrypt-password"));
+		assertThatIllegalArgumentException().isThrownBy(
+				() -> SCryptPasswordEncoder.defaultsForSpringSecurity_v4_1().upgradeEncoding("not-a-scrypt-password"));
 	}
 
 }


### PR DESCRIPTION
Update default configuration for `Argon2PasswordEncoder`, `SCryptPasswordEncoder` and `Pbkdf2PasswordEncoder`, as per recommended minimums outlined in [OWASP Cheat Sheet Series ](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html).


### Argon2PasswordEncoder

**Recommendation:**
Use Argon2id with a minimum configuration of 15 MiB of memory, an iteration count of 2, and 1 degree of parallelism.

**Previous default configuration:**
memory=4, iterations=3, parallelism=1

**New default configuration:**
memory=16, iterations=2, parallelism=1

### SCryptPasswordEncoder

**Recommendation:**
Use scrypt with a minimum CPU/memory cost parameter of (2^16), a minimum block size of 8 (1024 bytes), and a parallelization parameter of 1.

**Previous default configuration:**
cpuCost=16384, memoryCost=8, parallelism=1

**New default configuration:**
cpuCost=65536, memoryCost=8, parallelism=1

The default salt length was also updated from 64 to 16.

### Pbkdf2PasswordEncoder

**Recommendation:**
If FIPS-140 compliance is required, use PBKDF2 with a work factor of 310,000 or more and set with an internal hash function of HMAC-SHA-256.

**Previous default configuration:**
algorithm=SHA1, iterations=185000, hashLength=256

**New default configuration:**
algorithm=SHA256, iterations=310000, hashLength=256

The default salt length was also updated from 8 to 16.

Closes gh-10506, Closes gh-10489