### PR TITLE
Make X-Xss-Protection header value configurable in ServerHttpSecurity

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HeadersConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HeadersConfigurer.java
@@ -729,7 +729,10 @@ public class HeadersConfigurer<H extends HttpSecurityBuilder<H>>
 		 * If false, will not specify the mode as blocked. In this instance, any content
 		 * will be attempted to be fixed. If true, the content will be replaced with "#".
 		 * @param enabled the new value
+		 * @deprecated use
+		 * {@link XXssConfig#headerValue(XXssProtectionHeaderWriter.HeaderValue)} instead
 		 */
+		@Deprecated
 		public XXssConfig block(boolean enabled) {
 			this.writer.setBlock(enabled);
 			return this;
@@ -757,9 +760,46 @@ public class HeadersConfigurer<H extends HttpSecurityBuilder<H>>
 		 * X-XSS-Protection: 0
 		 * </pre>
 		 * @param enabled the new value
+		 * @deprecated use
+		 * {@link XXssConfig#headerValue(XXssProtectionHeaderWriter.HeaderValue)} instead
 		 */
+		@Deprecated
 		public XXssConfig xssProtectionEnabled(boolean enabled) {
 			this.writer.setEnabled(enabled);
+			return this;
+		}
+
+		/**
+		 * Sets the value of the X-XSS-PROTECTION header. OWASP recommends using
+		 * {@link XXssProtectionHeaderWriter.HeaderValue#DISABLED}.
+		 *
+		 * If {@link XXssProtectionHeaderWriter.HeaderValue#DISABLED}, will specify that
+		 * X-XSS-Protection is disabled. For example:
+		 *
+		 * <pre>
+		 * X-XSS-Protection: 0
+		 * </pre>
+		 *
+		 * If {@link XXssProtectionHeaderWriter.HeaderValue#ENABLED}, will contain a value
+		 * of 1, but will not specify the mode as blocked. In this instance, any content
+		 * will be attempted to be fixed. For example:
+		 *
+		 * <pre>
+		 * X-XSS-Protection: 1
+		 * </pre>
+		 *
+		 * If {@link XXssProtectionHeaderWriter.HeaderValue#ENABLED_MODE_BLOCK}, will
+		 * contain a value of 1 and will specify mode as blocked. The content will be
+		 * replaced with "#". For example:
+		 *
+		 * <pre>
+		 * X-XSS-Protection: 1 ; mode=block
+		 * </pre>
+		 * @param headerValue the new header value
+		 * @since 5.8
+		 */
+		public XXssConfig headerValue(XXssProtectionHeaderWriter.HeaderValue headerValue) {
+			this.writer.setHeaderValue(headerValue);
 			return this;
 		}
 

--- a/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
@@ -2859,6 +2859,18 @@ public class ServerHttpSecurity {
 				return HeaderSpec.this;
 			}
 
+			/**
+			 * Sets the value of x-xss-protection header. OWASP recommends using
+			 * {@link XXssProtectionServerHttpHeadersWriter.HeaderValue#DISABLED}.
+			 * @param headerValue the headerValue
+			 * @return the {@link HeaderSpec} to continue configuring
+			 * @since 5.8
+			 */
+			public HeaderSpec headerValue(XXssProtectionServerHttpHeadersWriter.HeaderValue headerValue) {
+				HeaderSpec.this.xss.setHeaderValue(headerValue);
+				return HeaderSpec.this;
+			}
+
 		}
 
 		/**

--- a/config/src/main/kotlin/org/springframework/security/config/web/server/ServerXssProtectionDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/server/ServerXssProtectionDsl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,13 @@
 
 package org.springframework.security.config.web.server
 
+import org.springframework.security.web.server.header.XXssProtectionServerHttpHeadersWriter.HeaderValue
+
 /**
  * A Kotlin DSL to configure the [ServerHttpSecurity] XSS protection header using
  * idiomatic Kotlin code.
+ *
+ * @property headerValue the value of the X-XSS-Protection header. OWASP recommends [HeaderValue.DISABLED].
  *
  * @author Eleftheria Stein
  * @since 5.4
@@ -26,6 +30,7 @@ package org.springframework.security.config.web.server
 @ServerSecurityMarker
 class ServerXssProtectionDsl {
     private var disabled = false
+    var headerValue: HeaderValue? = null
 
     /**
      * Disables cache control response headers
@@ -36,6 +41,7 @@ class ServerXssProtectionDsl {
 
     internal fun get(): (ServerHttpSecurity.HeaderSpec.XssProtectionSpec) -> Unit {
         return { xss ->
+            headerValue?.also { xss.headerValue(headerValue) }
             if (disabled) {
                 xss.disable()
             }

--- a/config/src/main/kotlin/org/springframework/security/config/web/servlet/headers/XssProtectionConfigDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/web/servlet/headers/XssProtectionConfigDsl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.security.config.web.servlet.headers
 
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer
+import org.springframework.security.web.header.writers.XXssProtectionHeaderWriter.HeaderValue
 
 /**
  * A Kotlin DSL to configure the [HttpSecurity] XSS protection header using
@@ -28,11 +29,15 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
  * @property block whether to specify the mode as blocked
  * @property xssProtectionEnabled if true, the header value will contain a value of 1.
  * If false, will explicitly disable specify that X-XSS-Protection is disabled.
+ * @property headerValue the value of the X-XSS-Protection header. OWASP recommends [HeaderValue.DISABLED].
  */
 @HeadersSecurityMarker
 class XssProtectionConfigDsl {
+    @Deprecated("use headerValue instead")
     var block: Boolean? = null
+    @Deprecated("use headerValue instead")
     var xssProtectionEnabled: Boolean? = null
+    var headerValue: HeaderValue? = null
 
     private var disabled = false
 
@@ -47,6 +52,7 @@ class XssProtectionConfigDsl {
         return { xssProtection ->
             block?.also { xssProtection.block(block!!) }
             xssProtectionEnabled?.also { xssProtection.xssProtectionEnabled(xssProtectionEnabled!!) }
+            headerValue?.also { xssProtection.headerValue(headerValue) }
 
             if (disabled) {
                 xssProtection.disable()

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpHeadersTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpHeadersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.test.SpringTestContext;
 import org.springframework.security.config.test.SpringTestContextExtension;
 import org.springframework.security.web.header.writers.StaticHeadersWriter;
+import org.springframework.security.web.header.writers.XXssProtectionHeaderWriter;
 import org.springframework.security.web.header.writers.frameoptions.StaticAllowFromStrategy;
 import org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter;
 import org.springframework.security.web.util.matcher.AnyRequestMatcher;
@@ -273,8 +274,7 @@ public class NamespaceHttpHeadersTests {
 					// xss-protection@enabled and xss-protection@block
 					.defaultsDisabled()
 					.xssProtection()
-						.xssProtectionEnabled(true)
-						.block(false);
+						.headerValue(XXssProtectionHeaderWriter.HeaderValue.ENABLED);
 			// @formatter:on
 		}
 

--- a/config/src/test/java/org/springframework/security/config/web/server/HeaderSpecTests.java
+++ b/config/src/test/java/org/springframework/security/config/web/server/HeaderSpecTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -292,6 +292,51 @@ public class HeaderSpecTests {
 						.disable()
 				)
 		);
+		// @formatter:on
+		assertHeaders();
+	}
+
+	@Test
+	public void headersWhenXssProtectionValueDisabledThenXssProtectionWritten() {
+		this.expectedHeaders.set(XXssProtectionServerHttpHeadersWriter.X_XSS_PROTECTION, "0");
+		// @formatter:off
+		this.http.headers()
+				.xssProtection()
+				.headerValue(XXssProtectionServerHttpHeadersWriter.HeaderValue.DISABLED);
+		// @formatter:on
+		assertHeaders();
+	}
+
+	@Test
+	public void headersWhenXssProtectionValueEnabledThenXssProtectionWritten() {
+		this.expectedHeaders.set(XXssProtectionServerHttpHeadersWriter.X_XSS_PROTECTION, "1");
+		// @formatter:off
+		this.http.headers()
+				.xssProtection()
+				.headerValue(XXssProtectionServerHttpHeadersWriter.HeaderValue.ENABLED);
+		// @formatter:on
+		assertHeaders();
+	}
+
+	@Test
+	public void headersWhenXssProtectionValueEnabledModeBlockThenXssProtectionWritten() {
+		this.expectedHeaders.set(XXssProtectionServerHttpHeadersWriter.X_XSS_PROTECTION, "1 ; mode=block");
+		// @formatter:off
+		this.http.headers()
+				.xssProtection()
+				.headerValue(XXssProtectionServerHttpHeadersWriter.HeaderValue.ENABLED_MODE_BLOCK);
+		// @formatter:on
+		assertHeaders();
+	}
+
+	@Test
+	public void headersWhenXssProtectionValueDisabledInLambdaThenXssProtectionWritten() {
+		this.expectedHeaders.set(XXssProtectionServerHttpHeadersWriter.X_XSS_PROTECTION, "0");
+		// @formatter:off
+		this.http.headers()
+				.xssProtection((xssProtection) ->
+						xssProtection.headerValue(XXssProtectionServerHttpHeadersWriter.HeaderValue.DISABLED)
+				);
 		// @formatter:on
 		assertHeaders();
 	}

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerXssProtectionDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerXssProtectionDslTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,6 +91,31 @@ class ServerXssProtectionDslTests {
                 headers {
                     xssProtection {
                         disable()
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `request when xss protection value disabled then xss header in response`() {
+        this.spring.register(XssValueDisabledConfig::class.java).autowire()
+
+        this.client.get()
+                .uri("/")
+                .exchange()
+                .expectHeader().valueEquals(XXssProtectionServerHttpHeadersWriter.X_XSS_PROTECTION, "0")
+    }
+
+    @EnableWebFluxSecurity
+    @EnableWebFlux
+    open class XssValueDisabledConfig {
+        @Bean
+        open fun springWebFilterChain(http: ServerHttpSecurity): SecurityWebFilterChain {
+            return http {
+                headers {
+                    xssProtection {
+                        headerValue = XXssProtectionServerHttpHeadersWriter.HeaderValue.DISABLED
                     }
                 }
             }

--- a/web/src/main/java/org/springframework/security/web/header/writers/XXssProtectionHeaderWriter.java
+++ b/web/src/main/java/org/springframework/security/web/header/writers/XXssProtectionHeaderWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.security.web.header.HeaderWriter;
+import org.springframework.util.Assert;
 
 /**
  * Renders the <a href=
@@ -34,25 +35,19 @@ public final class XXssProtectionHeaderWriter implements HeaderWriter {
 
 	private static final String XSS_PROTECTION_HEADER = "X-XSS-Protection";
 
-	private boolean enabled;
-
-	private boolean block;
-
-	private String headerValue;
+	private HeaderValue headerValue;
 
 	/**
 	 * Create a new instance
 	 */
 	public XXssProtectionHeaderWriter() {
-		this.enabled = true;
-		this.block = true;
-		updateHeaderValue();
+		this.headerValue = HeaderValue.ENABLED_MODE_BLOCK;
 	}
 
 	@Override
 	public void writeHeaders(HttpServletRequest request, HttpServletResponse response) {
 		if (!response.containsHeader(XSS_PROTECTION_HEADER)) {
-			response.setHeader(XSS_PROTECTION_HEADER, this.headerValue);
+			response.setHeader(XSS_PROTECTION_HEADER, this.headerValue.toString());
 		}
 	}
 
@@ -77,37 +72,88 @@ public final class XXssProtectionHeaderWriter implements HeaderWriter {
 	 * X-XSS-Protection: 0
 	 * </pre>
 	 * @param enabled the new value
+	 * @deprecated use {@link XXssProtectionHeaderWriter#setHeaderValue(HeaderValue)}
+	 * instead
 	 */
+	@Deprecated
 	public void setEnabled(boolean enabled) {
 		if (!enabled) {
-			setBlock(false);
+			this.headerValue = HeaderValue.DISABLED;
 		}
-		this.enabled = enabled;
-		updateHeaderValue();
+		else if (this.headerValue == HeaderValue.DISABLED) {
+			this.headerValue = HeaderValue.ENABLED;
+		}
 	}
 
 	/**
 	 * If false, will not specify the mode as blocked. In this instance, any content will
 	 * be attempted to be fixed. If true, the content will be replaced with "#".
 	 * @param block the new value
+	 * @deprecated use {@link XXssProtectionHeaderWriter#setHeaderValue(HeaderValue)}
+	 * instead
 	 */
+	@Deprecated
 	public void setBlock(boolean block) {
-		if (!this.enabled && block) {
+		if (this.headerValue == HeaderValue.DISABLED && block) {
 			throw new IllegalArgumentException("Cannot set block to true with enabled false");
 		}
-		this.block = block;
-		updateHeaderValue();
+		this.headerValue = block ? HeaderValue.ENABLED_MODE_BLOCK : HeaderValue.ENABLED;
 	}
 
-	private void updateHeaderValue() {
-		if (!this.enabled) {
-			this.headerValue = "0";
-			return;
+	/**
+	 * Sets the value of the X-XSS-PROTECTION header.
+	 * <p>
+	 * If {@link HeaderValue#DISABLED}, will specify that X-XSS-Protection is disabled.
+	 * For example:
+	 *
+	 * <pre>
+	 * X-XSS-Protection: 0
+	 * </pre>
+	 * <p>
+	 * If {@link HeaderValue#ENABLED}, will contain a value of 1, but will not specify the
+	 * mode as blocked. In this instance, any content will be attempted to be fixed. For
+	 * example:
+	 *
+	 * <pre>
+	 * X-XSS-Protection: 1
+	 * </pre>
+	 * <p>
+	 * If {@link HeaderValue#ENABLED_MODE_BLOCK}, will contain a value of 1 and will
+	 * specify mode as blocked. The content will be replaced with "#". For example:
+	 *
+	 * <pre>
+	 * X-XSS-Protection: 1 ; mode=block
+	 * </pre>
+	 * @param headerValue the new header value
+	 * @throws IllegalArgumentException when headerValue is null
+	 * @since 5.8
+	 */
+	public void setHeaderValue(HeaderValue headerValue) {
+		Assert.notNull(headerValue, "headerValue cannot be null");
+		this.headerValue = headerValue;
+	}
+
+	/**
+	 * The value of the x-xss-protection header. One of: "0", "1", "1 ; mode=block"
+	 *
+	 * @author Daniel Garnier-Moiroux
+	 * @since 5.8
+	 */
+	public enum HeaderValue {
+
+		DISABLED("0"), ENABLED("1"), ENABLED_MODE_BLOCK("1; mode=block");
+
+		private final String value;
+
+		HeaderValue(String value) {
+			this.value = value;
 		}
-		this.headerValue = "1";
-		if (this.block) {
-			this.headerValue += "; mode=block";
+
+		@Override
+		public String toString() {
+			return this.value;
 		}
+
 	}
 
 	@Override

--- a/web/src/test/java/org/springframework/security/web/header/writers/XXssProtectionHeaderWriterTests.java
+++ b/web/src/test/java/org/springframework/security/web/header/writers/XXssProtectionHeaderWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,6 +92,36 @@ public class XXssProtectionHeaderWriterTests {
 		this.response.setHeader(XSS_PROTECTION_HEADER, value);
 		this.writer.writeHeaders(this.request, this.response);
 		assertThat(this.response.getHeader(XSS_PROTECTION_HEADER)).isSameAs(value);
+	}
+
+	@Test
+	void writeHeaderWhenDisabled() {
+		this.writer.setHeaderValue(XXssProtectionHeaderWriter.HeaderValue.DISABLED);
+		this.writer.writeHeaders(this.request, this.response);
+		assertThat(this.response.getHeaderNames()).hasSize(1);
+		assertThat(this.response.getHeaderValues("X-XSS-Protection")).containsOnly("0");
+	}
+
+	@Test
+	void writeHeaderWhenEnabled() {
+		this.writer.setHeaderValue(XXssProtectionHeaderWriter.HeaderValue.ENABLED);
+		this.writer.writeHeaders(this.request, this.response);
+		assertThat(this.response.getHeaderNames()).hasSize(1);
+		assertThat(this.response.getHeaderValues("X-XSS-Protection")).containsOnly("1");
+	}
+
+	@Test
+	void writeHeaderWhenEnabledModeBlock() {
+		this.writer.setHeaderValue(XXssProtectionHeaderWriter.HeaderValue.ENABLED_MODE_BLOCK);
+		this.writer.writeHeaders(this.request, this.response);
+		assertThat(this.response.getHeaderNames()).hasSize(1);
+		assertThat(this.response.getHeaderValues("X-XSS-Protection")).containsOnly("1; mode=block");
+	}
+
+	@Test
+	public void setHeaderValueNullThenThrowsIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.writer.setHeaderValue(null))
+				.withMessage("headerValue cannot be null");
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/server/header/XXssProtectionServerHttpHeadersWriterTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/header/XXssProtectionServerHttpHeadersWriterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.web.server.ServerWebExchange;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 /**
  * @author Rob Winch
@@ -36,6 +37,12 @@ public class XXssProtectionServerHttpHeadersWriterTests {
 	HttpHeaders headers = this.exchange.getResponse().getHeaders();
 
 	XXssProtectionServerHttpHeadersWriter writer = new XXssProtectionServerHttpHeadersWriter();
+
+	@Test
+	void setHeaderValueNullThenThrowsIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.writer.setHeaderValue(null))
+				.withMessage("headerValue cannot be null");
+	}
 
 	@Test
 	public void writeHeadersWhenNoHeadersThenWriteHeaders() {
@@ -68,6 +75,31 @@ public class XXssProtectionServerHttpHeadersWriterTests {
 		this.writer.writeHttpHeaders(this.exchange);
 		assertThat(this.headers).hasSize(1);
 		assertThat(this.headers.get(XXssProtectionServerHttpHeadersWriter.X_XSS_PROTECTION)).containsOnly(headerValue);
+	}
+
+	@Test
+	void writeHeadersWhenDisabledThenWriteHeaders() {
+		this.writer.setHeaderValue(XXssProtectionServerHttpHeadersWriter.HeaderValue.DISABLED);
+		this.writer.writeHttpHeaders(this.exchange);
+		assertThat(this.headers).hasSize(1);
+		assertThat(this.headers.get(XXssProtectionServerHttpHeadersWriter.X_XSS_PROTECTION)).containsOnly("0");
+	}
+
+	@Test
+	void writeHeadersWhenEnabledThenWriteHeaders() {
+		this.writer.setHeaderValue(XXssProtectionServerHttpHeadersWriter.HeaderValue.ENABLED);
+		this.writer.writeHttpHeaders(this.exchange);
+		assertThat(this.headers).hasSize(1);
+		assertThat(this.headers.get(XXssProtectionServerHttpHeadersWriter.X_XSS_PROTECTION)).containsOnly("1");
+	}
+
+	@Test
+	void writeHeadersWhenEnabledModeBlockThenWriteHeaders() {
+		this.writer.setHeaderValue(XXssProtectionServerHttpHeadersWriter.HeaderValue.ENABLED_MODE_BLOCK);
+		this.writer.writeHttpHeaders(this.exchange);
+		assertThat(this.headers).hasSize(1);
+		assertThat(this.headers.get(XXssProtectionServerHttpHeadersWriter.X_XSS_PROTECTION))
+				.containsOnly("1 ; mode=block");
 	}
 
 }


### PR DESCRIPTION
Make `X-Xss-Protection` header configurable in `ServerHttpSecurity`, re issue: gh-9631.
XSS Protection is configurable through `ServerHttpSecurity#xssProtection#headerValue`, with a `HeaderValue` enum  (DISABLED / ENABLED / ENABLED_MODE_BLOCK). This is because the state `!enabled && block` is invalid, thus we restrict the API to the three valid states only.

I ported the changes over to the Servlet stack, which has more configuration exposed in `HttpSecurity`, so the deprecations bubble up to that class too.

The idea in 6.0 is to change the default to `HeaderValue = DISABLED`, and also remove the `enabled` and `block` booleans.

---

As part of this change, I noticed that in servlet the "mode=block" header values are different in the Servlet and Reactive stacks:
- `X-Xss-Protection: 1; mode=block` in Servlet
- `X-Xss-Protection: 1 ; mode=block` in Reactive, with an extra space

Should we plan to align the Reactive header with the Servlet version?