### PR TITLE
automatically manage docs version (no collector)

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,3 +1,5 @@
-name: 'ROOT'
-version: '5.6.8'
-prerelease: '-SNAPSHOT'
+name: ROOT
+version: true
+title: Documentation
+nav:
+- modules/ROOT/nav.adoc

--- a/docs/spring-security-docs.gradle
+++ b/docs/spring-security-docs.gradle
@@ -1,6 +1,5 @@
 plugins {
 	id 'org.antora' version '1.0.0-alpha.3'
-	id 'org.springframework.antora.check-version'
 }
 
 apply plugin: 'io.spring.convention.docs'
@@ -19,6 +18,14 @@ antora {
 
 tasks.antora.dependsOn 'generateAntora'
 
+gradle.taskGraph.afterTask { task ->
+	if (task.name == 'antora') {
+		def originalAntoraYml = layout.buildDirectory.file('.antora.yml').get().asFile
+		file('antora.yml').text = originalAntoraYml.text
+		originalAntoraYml.delete()
+	}
+}
+
 tasks.register('generateAntora') {
 	group = 'Documentation'
 	description = 'Generates the antora.yml for dynamic properties'
@@ -33,21 +40,23 @@ tasks.register('generateAntora') {
 		def securityReferenceUrl = "$securityDocsUrl/reference/html5/"
 		def springFrameworkApiUrl = "https://docs.spring.io/spring-framework/docs/$springFrameworkVersion/javadoc-api/"
 		def springFrameworkReferenceUrl = "https://docs.spring.io/spring-framework/docs/$springFrameworkVersion/reference/html/"
-		def versions = resolvedVersions(project.configurations.testRuntimeClasspath)
-		def ymlVersions = ''
-		versions.call().each { name, version ->
-			ymlVersions += """
-    ${name}: ${version}"""
-		}
-		def outputFile = layout.buildDirectory.file('generateAntora/antora.yml').orNull.asFile
-		outputFile.getParentFile().mkdirs()
-		outputFile.createNewFile()
-		def antoraYmlText = file('antora.yml').text.trim()
-		outputFile.setText("""$antoraYmlText
-title: Spring Security
-start_page: ROOT:index.adoc
-nav:
-- modules/ROOT/nav.adoc
+		def ymlVersions = resolvedVersions(project.configurations.testRuntimeClasspath).call()
+			.collect(v -> "    ${v.getKey()}: ${v.getValue()}")
+            .join('\n')
+		def outputFile = layout.buildDirectory.file('generateAntora/antora.yml').get().asFile
+		mkdir(outputFile.getParentFile())
+		def (mainVersion, prerelease) = project.version.split(/(?=-)/, 2)
+		def antoraYmlText = file('antora.yml').text
+		layout.buildDirectory.file('.antora.yml').get().asFile.text = antoraYmlText
+		antoraYmlText = antoraYmlText.lines().collect(l -> {
+			if (l.startsWith('version: ')) {
+				return prerelease == null ? "version: '${mainVersion}'" : "version: '${mainVersion}'\nprerelease: '${prerelease}'"
+			}
+			if (l.startsWith('title: ')) return "title: ${project.parent.description}"
+			return l
+		}).join('\n')
+		file('antora.yml').text = antoraYmlText
+		outputFile.text = """$antoraYmlText
 asciidoc:
   attributes:
     icondir: icons
@@ -60,7 +69,7 @@ asciidoc:
     spring-framework-reference-url: $springFrameworkReferenceUrl
     spring-security-version: ${project.version}
 ${ymlVersions}
-""")
+"""
 	}
 }
 


### PR DESCRIPTION
The purpose of this PR is to remove the hard-coded version in the docs component descriptor (docs/antora.yml). This variation does this without using Antora Collector. Instead, it creates a task dependency in the Gradle build and temporarily rewrites the original component descriptor for the duration of the task execution.