### PR TITLE
automatically manage docs version (with collector)

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,3 +1,12 @@
-name: 'ROOT'
-version: '5.6.8'
-prerelease: '-SNAPSHOT'
+name: ROOT
+version: true
+title: Documentation
+nav:
+- modules/ROOT/nav.adoc
+ext:
+  collector:
+    run:
+      command: gradlew -q -PbuildSrc.skipTests=true "-Dorg.gradle.jvmargs=-Xmx3g -XX:+HeapDumpOnOutOfMemoryError" :spring-security-docs:generateAntora
+      local: true
+    scan:
+      dir: ./build/generateAntora

--- a/docs/local-antora-playbook.yml
+++ b/docs/local-antora-playbook.yml
@@ -2,6 +2,7 @@
 antora:
   extensions:
   - ./antora-linked-worktree-patch.js
+  - '@antora/collector-extension'
 site:
   title: Spring Security
   url: https://docs.spring.io/spring-security/reference
@@ -9,7 +10,7 @@ content:
   sources:
   - url: ./..
     branches: HEAD
-    start_paths: [docs, 'docs/build/generateAntora*']
+    start_path: docs
     worktrees: true
 asciidoc:
   attributes:

--- a/docs/spring-security-docs.gradle
+++ b/docs/spring-security-docs.gradle
@@ -1,6 +1,5 @@
 plugins {
 	id 'org.antora' version '1.0.0-alpha.3'
-	id 'org.springframework.antora.check-version'
 }
 
 apply plugin: 'io.spring.convention.docs'
@@ -15,9 +14,10 @@ antora {
 		'ALGOLIA_APP_ID': '244V8V9FGG',
 		'ALGOLIA_INDEX_NAME': 'security-docs'
 	]
+	dependencies = [
+		'@antora/collector-extension': '1.0.0-alpha.2'
+	]
 }
-
-tasks.antora.dependsOn 'generateAntora'
 
 tasks.register('generateAntora') {
 	group = 'Documentation'
@@ -33,21 +33,22 @@ tasks.register('generateAntora') {
 		def securityReferenceUrl = "$securityDocsUrl/reference/html5/"
 		def springFrameworkApiUrl = "https://docs.spring.io/spring-framework/docs/$springFrameworkVersion/javadoc-api/"
 		def springFrameworkReferenceUrl = "https://docs.spring.io/spring-framework/docs/$springFrameworkVersion/reference/html/"
-		def versions = resolvedVersions(project.configurations.testRuntimeClasspath)
-		def ymlVersions = ''
-		versions.call().each { name, version ->
-			ymlVersions += """
-    ${name}: ${version}"""
-		}
-		def outputFile = layout.buildDirectory.file('generateAntora/antora.yml').orNull.asFile
-		outputFile.getParentFile().mkdirs()
-		outputFile.createNewFile()
-		def antoraYmlText = file('antora.yml').text.trim()
-		outputFile.setText("""$antoraYmlText
-title: Spring Security
-start_page: ROOT:index.adoc
-nav:
-- modules/ROOT/nav.adoc
+		def ymlVersions = resolvedVersions(project.configurations.testRuntimeClasspath).call()
+			.collect(v -> "    ${v.getKey()}: ${v.getValue()}")
+			.join('\n')
+		def outputFile = layout.buildDirectory.file('generateAntora/antora.yml').get().asFile
+		mkdir(outputFile.getParentFile())
+		def (mainVersion, prerelease) = project.version.split(/(?=-)/, 2)
+		def antoraYmlText = file('antora.yml').text
+		layout.buildDirectory.file('.antora.yml').get().asFile.text = antoraYmlText
+		antoraYmlText = antoraYmlText.lines().collect { l ->
+			if (l.startsWith('version: ')) {
+				return prerelease == null ? "version: '${mainVersion}'" : "version: '${mainVersion}'\nprerelease: '${prerelease}'"
+			}
+			if (l.startsWith('title: ')) return "title: ${project.parent.description}"
+			return l == 'ext:' || l.getAt(0) == ' ' ? null : l
+		}.findAll(Objects::nonNull).join('\n')
+		outputFile.text = """$antoraYmlText
 asciidoc:
   attributes:
     icondir: icons
@@ -60,7 +61,7 @@ asciidoc:
     spring-framework-reference-url: $springFrameworkReferenceUrl
     spring-security-version: ${project.version}
 ${ymlVersions}
-""")
+"""
 	}
 }
 


### PR DESCRIPTION
The purpose of this PR is to remove the hard-coded version in the docs component descriptor (docs/antora.yml). This variation does so using Antora Collector. This approach does not rely on temporary changes to the component descriptor.