### PR TITLE
Add configurable authorities split regex

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtGrantedAuthoritiesConverter.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtGrantedAuthoritiesConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,9 +45,13 @@ public final class JwtGrantedAuthoritiesConverter implements Converter<Jwt, Coll
 
 	private static final String DEFAULT_AUTHORITY_PREFIX = "SCOPE_";
 
+	private static final String DEFAULT_AUTHORITIES_SPLIT_REGEX = " ";
+
 	private static final Collection<String> WELL_KNOWN_AUTHORITIES_CLAIM_NAMES = Arrays.asList("scope", "scp");
 
 	private String authorityPrefix = DEFAULT_AUTHORITY_PREFIX;
+
+	private String authoritiesSplitRegex = DEFAULT_AUTHORITIES_SPLIT_REGEX;
 
 	private String authoritiesClaimName;
 
@@ -75,6 +79,18 @@ public final class JwtGrantedAuthoritiesConverter implements Converter<Jwt, Coll
 	public void setAuthorityPrefix(String authorityPrefix) {
 		Assert.notNull(authorityPrefix, "authorityPrefix cannot be null");
 		this.authorityPrefix = authorityPrefix;
+	}
+
+	/**
+	 * Sets the regex to use for splitting the value of the authorities claim into
+	 * {@link GrantedAuthority authorities}. Defaults to
+	 * {@link JwtGrantedAuthoritiesConverter#DEFAULT_AUTHORITIES_SPLIT_REGEX}.
+	 * @param authoritiesSplitRegex The regex used to split the authorities
+	 * @since 6.1
+	 */
+	public void setAuthoritiesSplitRegex(String authoritiesSplitRegex) {
+		Assert.notNull(authoritiesSplitRegex, "authoritiesSplitRegex cannot be null");
+		this.authoritiesSplitRegex = authoritiesSplitRegex;
 	}
 
 	/**
@@ -113,7 +129,7 @@ public final class JwtGrantedAuthoritiesConverter implements Converter<Jwt, Coll
 		Object authorities = jwt.getClaim(claimName);
 		if (authorities instanceof String) {
 			if (StringUtils.hasText((String) authorities)) {
-				return Arrays.asList(((String) authorities).split(" "));
+				return Arrays.asList(((String) authorities).split(this.authoritiesSplitRegex));
 			}
 			return Collections.emptyList();
 		}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtGrantedAuthoritiesConverterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtGrantedAuthoritiesConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -254,6 +254,20 @@ public class JwtGrantedAuthoritiesConverterTests {
 		jwtGrantedAuthoritiesConverter.setAuthoritiesClaimName("roles");
 		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
 		assertThat(authorities).isEmpty();
+	}
+
+	@Test
+	public void convertWithCustomAuthoritiesSplitRegexWhenTokenHasScopeAttributeThenTranslatedToAuthorities() {
+		// @formatter:off
+		Jwt jwt = TestJwts.jwt()
+				.claim("scope", "message:read,message:write")
+				.build();
+		// @formatter:on
+		JwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new JwtGrantedAuthoritiesConverter();
+		jwtGrantedAuthoritiesConverter.setAuthoritiesSplitRegex(",");
+		Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(jwt);
+		assertThat(authorities).containsExactly(new SimpleGrantedAuthority("SCOPE_message:read"),
+				new SimpleGrantedAuthority("SCOPE_message:write"));
 	}
 
 }


### PR DESCRIPTION
This PR adds the ability to split the authorities claim on a configurable regex, which was previously set ot a hardcoded regex " ". The IAM solution I used provided the authorities separated by another character than ' ' and I realized that with the JwtGrantedAuthoritiesConverter I was not able to set a custom regex. The solution in this PR makes the JwtGrantedAuthoritiesConverter more flexible by supporting this use case while keeping the previous default behaviour.

I signed the individual CLA to provide this PR.
