### PR TITLE
sync local-antora-playbook.yml with antora-playbook.yml

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -3,7 +3,7 @@ antora:
   - ./lib/antora/extensions/inject-collector-config.js
   - '@antora/collector-extension'
   - ./lib/antora/extensions/version-fix.js
-  - ./lib/antora/extensions/major-minor-segment.js
+  - '@opendevise/antora-release-line-extension'
 site:
   title: Spring Security
   url: https://docs.spring.io/spring-security/reference
@@ -14,7 +14,7 @@ content:
   - url: .
     branches: [main, '5.{{6..9},{1..9}+({0..9})}.x']
     worktrees: true # automatically discovers worktrees, if present; otherwise, will use git tree
-    #tags: ['5.{{6..9},{1..9}+({0..9})}.+({0..9})?(-RC+({0..9}))', '6.+({0..9}).+({0..9})?(-{RC,M}*)']
+    tags: ['5.{{6..9},{1..9}+({0..9})}.+({0..9})?(-RC+({0..9}))', '6.+({0..9}).+({0..9})?(-{RC,M}*)']
     start_path: docs
 asciidoc:
   attributes:


### PR DESCRIPTION
When the production playbook was updated to use the new release line extension, the local playbook was not updated. This PR brings in up to date.