### PR TITLE
Log a warning when `AuthorizationGrantType` does not exactly match a pre-defined constant

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,9 +24,13 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.core.log.LogMessage;
 import org.springframework.security.core.SpringSecurityCoreVersion;
 import org.springframework.security.oauth2.core.AuthenticationMethod;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
@@ -39,6 +43,7 @@ import org.springframework.util.StringUtils;
  * Provider.
  *
  * @author Joe Grandja
+ * @author Michael Sosa
  * @since 5.0
  * @see <a target="_blank" href="https://tools.ietf.org/html/rfc6749#section-2">Section 2
  * Client Registration</a>
@@ -333,6 +338,12 @@ public final class ClientRegistration implements Serializable {
 
 		private static final long serialVersionUID = SpringSecurityCoreVersion.SERIAL_VERSION_UID;
 
+		private static final Log logger = LogFactory.getLog(Builder.class);
+
+		private static final List<AuthorizationGrantType> AUTHORIZATION_GRANT_TYPES = Arrays.asList(
+				AuthorizationGrantType.AUTHORIZATION_CODE, AuthorizationGrantType.CLIENT_CREDENTIALS,
+				AuthorizationGrantType.REFRESH_TOKEN, AuthorizationGrantType.IMPLICIT, AuthorizationGrantType.PASSWORD);
+
 		private String registrationId;
 
 		private String clientId;
@@ -622,6 +633,7 @@ public final class ClientRegistration implements Serializable {
 			else if (AuthorizationGrantType.AUTHORIZATION_CODE.equals(this.authorizationGrantType)) {
 				this.validateAuthorizationCodeGrantType();
 			}
+			this.validateAuthorizationGrantTypes();
 			this.validateScopes();
 			return this.create();
 		}
@@ -696,6 +708,17 @@ public final class ClientRegistration implements Serializable {
 			Assert.hasText(this.registrationId, "registrationId cannot be empty");
 			Assert.hasText(this.clientId, "clientId cannot be empty");
 			Assert.hasText(this.tokenUri, "tokenUri cannot be empty");
+		}
+
+		private void validateAuthorizationGrantTypes() {
+			for (AuthorizationGrantType authorizationGrantType : AUTHORIZATION_GRANT_TYPES) {
+				if (authorizationGrantType.getValue().equalsIgnoreCase(this.authorizationGrantType.getValue())
+						&& !authorizationGrantType.equals(this.authorizationGrantType)) {
+					logger.warn(LogMessage.format(
+							"AuthorizationGrantType: %s does not match the pre-defined constant %s and won't match a valid OAuth2AuthorizedClientProvider",
+							this.authorizationGrantType, authorizationGrantType));
+				}
+			}
 		}
 
 		private void validateScopes() {


### PR DESCRIPTION
This adds the warning when `AuthorizationGrantType` does not exactly match what is expected as discussed on gh-11905

