### PR TITLE
Fix SAML logout log messages

### DIFF
--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/OpenSamlLogoutRequestValidator.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/OpenSamlLogoutRequestValidator.java
@@ -126,7 +126,7 @@ public final class OpenSamlLogoutRequestValidator implements Saml2LogoutRequestV
 			RelyingPartyRegistration registration) {
 		return (errors) -> {
 			if (request.getIssuer() == null) {
-				errors.add(new Saml2Error(Saml2ErrorCodes.INVALID_ISSUER, "Failed to find issuer in LogoutResponse"));
+				errors.add(new Saml2Error(Saml2ErrorCodes.INVALID_ISSUER, "Failed to find issuer in LogoutRequest"));
 				return;
 			}
 			String issuer = request.getIssuer().getValue();
@@ -142,7 +142,7 @@ public final class OpenSamlLogoutRequestValidator implements Saml2LogoutRequestV
 		return (errors) -> {
 			if (request.getDestination() == null) {
 				errors.add(new Saml2Error(Saml2ErrorCodes.INVALID_DESTINATION,
-						"Failed to find destination in LogoutResponse"));
+						"Failed to find destination in LogoutRequest"));
 				return;
 			}
 			String destination = request.getDestination();

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2LogoutResponseFilter.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2LogoutResponseFilter.java
@@ -114,7 +114,7 @@ public final class Saml2LogoutResponseFilter extends OncePerRequestFilter {
 				logoutRequest.getRelyingPartyRegistrationId());
 		if (registration == null) {
 			this.logger
-					.trace("Did not process logout request since failed to find associated RelyingPartyRegistration");
+					.trace("Did not process logout response since failed to find associated RelyingPartyRegistration");
 			Saml2Error error = new Saml2Error(Saml2ErrorCodes.RELYING_PARTY_REGISTRATION_NOT_FOUND,
 					"Failed to find associated RelyingPartyRegistration");
 			response.sendError(HttpServletResponse.SC_BAD_REQUEST, error.toString());


### PR DESCRIPTION
Fixes SAML logout log messages incorrectly referring to logout response instead of logout request and vice versa.

Closes gh-12129

@pivotal-cla This is an Obvious Fix

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
