### PR TITLE
Fix documentation in UrlAuthorizationConfigurer

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/UrlAuthorizationConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/UrlAuthorizationConfigurer.java
@@ -49,10 +49,11 @@ import org.springframework.util.Assert;
  * </p>
  *
  * <pre>
- * protected void configure(HttpSecurity http) throws Exception {
- * 	http.apply(new UrlAuthorizationConfigurer&lt;HttpSecurity&gt;()).getRegistry()
- * 			.antMatchers(&quot;/users**&quot;, &quot;/sessions/**&quot;).hasRole(&quot;USER&quot;)
- * 			.antMatchers(&quot;/signup&quot;).hasRole(&quot;ANONYMOUS&quot;).anyRequest().hasRole(&quot;USER&quot;);
+ * @Bean
+ * public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+ * 	http.apply(new UrlAuthorizationConfigurer&lt;HttpSecurity&gt;(context)).getRegistry()
+ * 			.requestMatchers(&quot;/users**&quot;, &quot;/sessions/**&quot;).hasRole(&quot;USER&quot;)
+ * 			.requestMatchers(&quot;/signup&quot;).hasRole(&quot;ANONYMOUS&quot;).anyRequest().hasRole(&quot;USER&quot;);
  * }
  * </pre>
  *


### PR DESCRIPTION
This fixes the outdated example in javadoc for class `UrlAuthorizationConfigurer`, which still is referring to its default constructor that no longer exists.