### PR TITLE
Remove antMatcher usage from Multiple HttpSecurity docs

### DIFF
--- a/docs/modules/ROOT/pages/servlet/configuration/java.adoc
+++ b/docs/modules/ROOT/pages/servlet/configuration/java.adoc
@@ -209,7 +209,7 @@ public class MultiHttpSecurityConfig {
 	@Order(1)                                                        <2>
 	public SecurityFilterChain apiFilterChain(HttpSecurity http) throws Exception {
 		http
-			.antMatcher("/api/**")                                   <3>
+			.securityMatcher("/api/**")                                   <3>
 			.authorizeHttpRequests(authorize -> authorize
 				.anyRequest().hasRole("ADMIN")
 			)
@@ -230,7 +230,7 @@ public class MultiHttpSecurityConfig {
 ----
 <1> Configure Authentication as usual.
 <2> Create an instance of `SecurityFilterChain` that contains `@Order` to specify which `SecurityFilterChain` should be considered first.
-<3> The `http.antMatcher` states that this `HttpSecurity` is applicable only to URLs that start with `/api/`.
+<3> The `http.securityMatcher` states that this `HttpSecurity` is applicable only to URLs that start with `/api/`.
 <4> Create another instance of `SecurityFilterChain`.
 If the URL does not start with `/api/`, this configuration is used.
 This configuration is considered after `apiFilterChain`, since it has an `@Order` value after `1` (no `@Order` defaults to last).


### PR DESCRIPTION
This is a change based on 6.0.0-RC1 release documentation.

`http.antMatcher()` is not longer available and was replaced with `http.securityMatcher()`, so use this in the Java Config Multiple HttpSecurity Instances example, too.

That part of documentation was missing in https://github.com/spring-projects/spring-security/issues/11939