### PR TITLE
savedRequest classcastexception between webflux and mvc

### DIFF
--- a/web/src/main/java/org/springframework/security/web/savedrequest/HttpSessionRequestCache.java
+++ b/web/src/main/java/org/springframework/security/web/savedrequest/HttpSessionRequestCache.java
@@ -86,7 +86,12 @@ public class HttpSessionRequestCache implements RequestCache {
 	@Override
 	public SavedRequest getRequest(HttpServletRequest currentRequest, HttpServletResponse response) {
 		HttpSession session = currentRequest.getSession(false);
-		return (session != null) ? (SavedRequest) session.getAttribute(this.sessionAttrName) : null;
+		if (session != null && session.getAttribute(this.sessionAttrName) instanceof SavedRequest) {
+			return (SavedRequest) session.getAttribute(this.sessionAttrName);
+		}
+		else {
+			return null;
+		}
 	}
 
 	@Override

--- a/web/src/test/java/org/springframework/security/web/savedrequest/HttpSessionRequestCacheTests.java
+++ b/web/src/test/java/org/springframework/security/web/savedrequest/HttpSessionRequestCacheTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,6 +83,21 @@ public class HttpSessionRequestCacheTests {
 		cache.saveRequest(request, response);
 		cache.saveRequest(request, response);
 		assertThat(cache.getRequest(request, response)).isInstanceOf(CustomSavedRequest.class);
+	}
+
+	@Test
+	public void getRequestStringNoClassCastException() {
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/destination");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		HttpSessionRequestCache cache = new HttpSessionRequestCache() {
+			@Override
+			public void saveRequest(HttpServletRequest request, HttpServletResponse response) {
+				request.getSession().setAttribute(SAVED_REQUEST, "session_from_webflux_as_string");
+			}
+		};
+		cache.saveRequest(request, response);
+		cache.saveRequest(request, response);
+		assertThat(cache.getRequest(request, response)).isNull();
 	}
 
 	@Test


### PR DESCRIPTION
avoid ClassCastException in case HttpSessionRequestCache is unable to read the session attribute

closes gh-12182

