### PR TITLE
Register FilterChainProxy for All Dispatcher Types Migration Steps

### DIFF
--- a/docs/modules/ROOT/pages/migration.adoc
+++ b/docs/modules/ROOT/pages/migration.adoc
@@ -1143,7 +1143,7 @@ As such, in 6.0, Spring Security changes this default.
 
 So, finally, change your authorization rules to filter all dispatcher types.
 
-To do this, change:
+To do this, you should change:
 
 ====
 .Java
@@ -1220,6 +1220,37 @@ http {
     <!-- ... -->
     <intercept-url pattern="/**" access="denyAll"/>
 </http>
+----
+====
+
+And, the `FilterChainProxy` should be registered for all dispatcher types as well.
+If you are using Spring Boot, https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#application-properties.security.spring.security.filter.dispatcher-types[you have to change the `spring.security.filter.dispatcher-types` property] to include all dispatcher types:
+
+====
+.application.properties
+[source,properties,role="primary"]
+----
+spring.security.filter.dispatcher-types=request,async,error,forward,include
+----
+====
+
+If you are xref::servlet/configuration/java.adoc#_abstractsecuritywebapplicationinitializer[using the `AbstractSecurityWebApplicationInitializer`] you should override the `getSecurityDispatcherTypes` method and return all dispatcher types:
+
+====
+.Java
+[source,java,role="primary"]
+----
+import org.springframework.security.web.context.*;
+
+public class SecurityWebApplicationInitializer extends AbstractSecurityWebApplicationInitializer {
+
+    @Override
+    protected EnumSet<DispatcherType> getSecurityDispatcherTypes() {
+        return EnumSet.of(DispatcherType.REQUEST, DispatcherType.ERROR, DispatcherType.FORWARD,
+                DispatcherType.FORWARD, DispatcherType.INCLUDE);
+    }
+
+}
 ----
 ====
 


### PR DESCRIPTION
This PR adds more information under the _Switch to filter all dispatcher types_ section on how to register the `FilterChainProxy` to all dispatcher types

Closes gh-12186

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
