### PR TITLE
remove dry-run on sync script; replace with -c for partial build

### DIFF
--- a/.github/actions/publish-docs.sh
+++ b/.github/actions/publish-docs.sh
@@ -20,7 +20,7 @@ fi
   echo "$SSH_KNOWN_HOST" > ~/.ssh/known_hosts
   RSYNC_OPTS='-avz --delete'
   if [ -n "$BUILD_REFNAME" ]; then
-    RSYNC_OPTS="-n $RSYNC_OPTS$(find $FROM -mindepth 1 -maxdepth 1 \! -name 404.html \! -name '.*' -type f -printf ' --include /%P')"
+    RSYNC_OPTS="-c $RSYNC_OPTS$(find $FROM -mindepth 1 -maxdepth 1 \! -name 404.html \! -name '.*' -type f -printf ' --include /%P')"
     RSYNC_OPTS="$RSYNC_OPTS$(find $FROM -mindepth 1 -maxdepth 1 -type d \! -name _ -printf ' --include /%P --include /%P/**') --exclude **"
   fi
   rsync $RSYNC_OPTS -e "ssh -i $SSH_PRIVATE_KEY_PATH" $FROM/ "$HOST:$HOST_PATH"


### PR DESCRIPTION
This PR fully activates the partial docs build.