### PR TITLE
Fix Javadoc in EnableWebSocketSecurity

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/socket/EnableWebSocketSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/socket/EnableWebSocketSecurity.java
@@ -37,7 +37,7 @@ import org.springframework.context.annotation.Import;
  * public class WebSocketSecurityConfig {
  *
  * 	&#064;Bean
- * 	AuthorizationManager&lt;Message&lt;?&gt;&gt; (MessageMatcherDelegatingAuthorizationManager.Builder messages) {
+ * 	AuthorizationManager&lt;Message&lt;?&gt;&gt; authorizationManager(MessageMatcherDelegatingAuthorizationManager.Builder messages) {
  * 		messages.simpDestMatchers(&quot;/user/queue/errors&quot;).permitAll()
  * 				.simpDestMatchers(&quot;/admin/**&quot;).hasRole(&quot;ADMIN&quot;)
  * 				.anyMessage().authenticated();


### PR DESCRIPTION
Add missing method name in EnableWebSocketSecurity JavaDoc code example.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
