### PR TITLE
 Add the ability to set the SameSite policy to the CRSF Cookie

### DIFF
--- a/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
@@ -15,14 +15,15 @@
  */
 
 package org.springframework.security.web.csrf;
-
 import java.util.UUID;
+import java.util.function.Consumer;
 
-import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.web.util.WebUtils;
@@ -34,6 +35,7 @@ import org.springframework.web.util.WebUtils;
  *
  * @author Rob Winch
  * @author Steve Riesenberg
+ * @author Alex Montoya
  * @since 4.1
  */
 public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
@@ -63,7 +65,17 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 
 	private int cookieMaxAge = -1;
 
-	public CookieCsrfTokenRepository() {
+	private Consumer<ResponseCookie.ResponseCookieBuilder> cookieCustomizer = (builder) -> {};
+
+	/**
+	 * Add a {@link Consumer} for a {@code ResponseCookieBuilder} that will be invoked
+	 * for each cookie being built, just before the call to {@code build()}.
+	 * @param cookieCustomizer consumer for a cookie builder
+	 * @since 6.1
+	 */
+	public void setCookieCustomizer(Consumer<ResponseCookie.ResponseCookieBuilder> cookieCustomizer) {
+		Assert.notNull(cookieCustomizer, "cookieCustomizer must not be null");
+		this.cookieCustomizer = cookieCustomizer;
 	}
 
 	@Override
@@ -74,15 +86,17 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 	@Override
 	public void saveToken(CsrfToken token, HttpServletRequest request, HttpServletResponse response) {
 		String tokenValue = (token != null) ? token.getToken() : "";
-		Cookie cookie = new Cookie(this.cookieName, tokenValue);
-		cookie.setSecure((this.secure != null) ? this.secure : request.isSecure());
-		cookie.setPath(StringUtils.hasLength(this.cookiePath) ? this.cookiePath : this.getRequestContext(request));
-		cookie.setMaxAge((token != null) ? this.cookieMaxAge : 0);
-		cookie.setHttpOnly(this.cookieHttpOnly);
-		if (StringUtils.hasLength(this.cookieDomain)) {
-			cookie.setDomain(this.cookieDomain);
-		}
-		response.addCookie(cookie);
+
+		ResponseCookie.ResponseCookieBuilder cookieBuilder = ResponseCookie.from(this.cookieName, tokenValue)
+				.secure(this.secure != null ? this.secure : request.isSecure())
+				.path(StringUtils.hasLength(this.cookiePath) ? this.cookiePath : this.getRequestContext(request))
+				.maxAge(token != null ? this.cookieMaxAge : 0)
+				.httpOnly(this.cookieHttpOnly)
+				.domain(this.cookieDomain);
+
+		this.cookieCustomizer.accept(cookieBuilder);
+
+		response.setHeader(HttpHeaders.SET_COOKIE, cookieBuilder.build().toString());
 
 		// Set request attribute to signal that response has blank cookie value,
 		// which allows loadToken to return null when token has been removed
@@ -143,11 +157,9 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 	}
 
 	/**
-	 * Sets the HttpOnly attribute on the cookie containing the CSRF token. Defaults to
-	 * <code>true</code>.
-	 * @param cookieHttpOnly <code>true</code> sets the HttpOnly attribute,
-	 * <code>false</code> does not set it
+	 * @deprecated Use {@link #setCookieCustomizer(Consumer)} instead.
 	 */
+	@Deprecated(since = "6.1")
 	public void setCookieHttpOnly(boolean cookieHttpOnly) {
 		this.cookieHttpOnly = cookieHttpOnly;
 	}
@@ -191,51 +203,30 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 	}
 
 	/**
-	 * Sets the domain of the cookie that the expected CSRF token is saved to and read
-	 * from.
-	 * @param cookieDomain the domain of the cookie that the expected CSRF token is saved
-	 * to and read from
+	 * @deprecated Use {@link #setCookieCustomizer(Consumer)} instead.
 	 * @since 5.2
 	 */
+	@Deprecated(since = "6.1")
 	public void setCookieDomain(String cookieDomain) {
 		this.cookieDomain = cookieDomain;
 	}
 
 	/**
-	 * Sets secure flag of the cookie that the expected CSRF token is saved to and read
-	 * from. By default secure flag depends on {@link ServletRequest#isSecure()}
-	 * @param secure the secure flag of the cookie that the expected CSRF token is saved
-	 * to and read from
+	 * @deprecated Use {@link #setCookieCustomizer(Consumer)} instead.
 	 * @since 5.4
 	 */
+	@Deprecated(since = "6.1")
 	public void setSecure(Boolean secure) {
 		this.secure = secure;
 	}
 
 	/**
-	 * Sets maximum age in seconds for the cookie that the expected CSRF token is saved to
-	 * and read from. By default maximum age value is -1.
-	 *
-	 * <p>
-	 * A positive value indicates that the cookie will expire after that many seconds have
-	 * passed. Note that the value is the <i>maximum</i> age when the cookie will expire,
-	 * not the cookie's current age.
-	 *
-	 * <p>
-	 * A negative value means that the cookie is not stored persistently and will be
-	 * deleted when the Web browser exits.
-	 *
-	 * <p>
-	 * A zero value causes the cookie to be deleted immediately therefore it is not a
-	 * valid value and in that case an {@link IllegalArgumentException} will be thrown.
-	 * @param cookieMaxAge an integer specifying the maximum age of the cookie in seconds;
-	 * if negative, means the cookie is not stored; if zero, the method throws an
-	 * {@link IllegalArgumentException}
+	 * @deprecated Use {@link #setCookieCustomizer(Consumer)} instead.
 	 * @since 5.5
 	 */
+	@Deprecated(since = "6.1")
 	public void setCookieMaxAge(int cookieMaxAge) {
 		Assert.isTrue(cookieMaxAge != 0, "cookieMaxAge cannot be zero");
 		this.cookieMaxAge = cookieMaxAge;
 	}
-
 }

--- a/web/src/main/java/org/springframework/security/web/server/csrf/CookieServerCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/server/csrf/CookieServerCsrfTokenRepository.java
@@ -17,6 +17,7 @@
 package org.springframework.security.web.server.csrf;
 
 import java.util.UUID;
+import java.util.function.Consumer;
 
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -36,6 +37,7 @@ import org.springframework.web.server.ServerWebExchange;
  * @author Eric Deandrea
  * @author Thomas Vitale
  * @author Alonso Araya
+ * @author Alex Montoya
  * @since 5.1
  */
 public final class CookieServerCsrfTokenRepository implements ServerCsrfTokenRepository {
@@ -60,6 +62,19 @@ public final class CookieServerCsrfTokenRepository implements ServerCsrfTokenRep
 
 	private int cookieMaxAge = -1;
 
+	private Consumer<ResponseCookie.ResponseCookieBuilder> cookieCustomizer = (builder) -> {};
+
+	/**
+	 * Add a {@link Consumer} for a {@code ResponseCookieBuilder} that will be invoked
+	 * for each cookie being built, just before the call to {@code build()}.
+	 * @param cookieCustomizer consumer for a cookie builder
+	 * @since 6.1
+	 */
+	public void setCookieCustomizer(Consumer<ResponseCookie.ResponseCookieBuilder> cookieCustomizer) {
+		Assert.notNull(cookieCustomizer, "cookieCustomizer must not be null");
+		this.cookieCustomizer = cookieCustomizer;
+	}
+
 	/**
 	 * Factory method to conveniently create an instance that has
 	 * {@link #setCookieHttpOnly(boolean)} set to false.
@@ -82,16 +97,18 @@ public final class CookieServerCsrfTokenRepository implements ServerCsrfTokenRep
 		return Mono.fromRunnable(() -> {
 			String tokenValue = (token != null) ? token.getToken() : "";
 			// @formatter:off
-			ResponseCookie cookie = ResponseCookie
+			ResponseCookie.ResponseCookieBuilder cookieBuilder = ResponseCookie
 					.from(this.cookieName, tokenValue)
 					.domain(this.cookieDomain)
 					.httpOnly(this.cookieHttpOnly)
 					.maxAge(!tokenValue.isEmpty() ? this.cookieMaxAge : 0)
 					.path((this.cookiePath != null) ? this.cookiePath : getRequestContext(exchange.getRequest()))
-					.secure((this.secure != null) ? this.secure : (exchange.getRequest().getSslInfo() != null))
-					.build();
+					.secure((this.secure != null) ? this.secure : (exchange.getRequest().getSslInfo() != null));
+
+			this.cookieCustomizer.accept(cookieBuilder);
+
 			// @formatter:on
-			exchange.getResponse().addCookie(cookie);
+			exchange.getResponse().addCookie(cookieBuilder.build());
 		});
 	}
 
@@ -107,9 +124,9 @@ public final class CookieServerCsrfTokenRepository implements ServerCsrfTokenRep
 	}
 
 	/**
-	 * Sets the HttpOnly attribute on the cookie containing the CSRF token
-	 * @param cookieHttpOnly True to mark the cookie as http only. False otherwise.
+	 * @deprecated Use {@link #setCookieCustomizer(Consumer)} instead.
 	 */
+	@Deprecated(since = "6.1")
 	public void setCookieHttpOnly(boolean cookieHttpOnly) {
 		this.cookieHttpOnly = cookieHttpOnly;
 	}
@@ -150,44 +167,27 @@ public final class CookieServerCsrfTokenRepository implements ServerCsrfTokenRep
 	}
 
 	/**
-	 * Sets the cookie domain
-	 * @param cookieDomain The cookie domain
+	 * @deprecated Use {@link #setCookieCustomizer(Consumer)} instead.
 	 */
+	@Deprecated(since = "6.1")
 	public void setCookieDomain(String cookieDomain) {
 		this.cookieDomain = cookieDomain;
 	}
 
 	/**
-	 * Sets the cookie secure flag. If not set, the value depends on
-	 * {@link ServerHttpRequest#getSslInfo()}.
-	 * @param secure The value for the secure flag
+	 * @deprecated Use {@link #setCookieCustomizer(Consumer)} instead.
 	 * @since 5.5
 	 */
+	@Deprecated(since = "6.1")
 	public void setSecure(boolean secure) {
 		this.secure = secure;
 	}
 
 	/**
-	 * Sets maximum age in seconds for the cookie that the expected CSRF token is saved to
-	 * and read from. By default maximum age value is -1.
-	 *
-	 * <p>
-	 * A positive value indicates that the cookie will expire after that many seconds have
-	 * passed. Note that the value is the <i>maximum</i> age when the cookie will expire,
-	 * not the cookie's current age.
-	 *
-	 * <p>
-	 * A negative value means that the cookie is not stored persistently and will be
-	 * deleted when the Web browser exits.
-	 *
-	 * <p>
-	 * A zero value causes the cookie to be deleted immediately therefore it is not a
-	 * valid value and in that case an {@link IllegalArgumentException} will be thrown.
-	 * @param cookieMaxAge an integer specifying the maximum age of the cookie in seconds;
-	 * if negative, means the cookie is not stored; if zero, the method throws an
-	 * {@link IllegalArgumentException}
+	 * @deprecated Use {@link #setCookieCustomizer(Consumer)} instead.
 	 * @since 5.8
 	 */
+	@Deprecated(since = "6.1")
 	public void setCookieMaxAge(int cookieMaxAge) {
 		Assert.isTrue(cookieMaxAge != 0, "cookieMaxAge cannot be zero");
 		this.cookieMaxAge = cookieMaxAge;

--- a/web/src/test/java/org/springframework/security/web/csrf/CookieCsrfTokenRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CookieCsrfTokenRepositoryTests.java
@@ -33,7 +33,7 @@ import static org.springframework.security.web.csrf.CsrfTokenAssert.assertThatCs
  * @author Alex Montoya
  * @since 4.1
  */
-public class CookieCsrfTokenRepositoryTests {
+class CookieCsrfTokenRepositoryTests {
 
 	CookieCsrfTokenRepository repository;
 
@@ -50,7 +50,7 @@ public class CookieCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void generateToken() {
+	void generateToken() {
 		CsrfToken generateToken = this.repository.generateToken(this.request);
 		assertThat(generateToken).isNotNull();
 		assertThat(generateToken.getHeaderName()).isEqualTo(CookieCsrfTokenRepository.DEFAULT_CSRF_HEADER_NAME);
@@ -59,7 +59,7 @@ public class CookieCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void generateTokenCustom() {
+	void generateTokenCustom() {
 		String headerName = "headerName";
 		String parameterName = "paramName";
 		this.repository.setHeaderName(headerName);
@@ -72,7 +72,7 @@ public class CookieCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void saveToken() {
+	void saveToken() {
 		CsrfToken token = this.repository.generateToken(this.request);
 		this.repository.saveToken(token, this.request, this.response);
 		Cookie tokenCookie = this.response.getCookie(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
@@ -81,11 +81,11 @@ public class CookieCsrfTokenRepositoryTests {
 		assertThat(tokenCookie.getPath()).isEqualTo(this.request.getContextPath());
 		assertThat(tokenCookie.getSecure()).isEqualTo(this.request.isSecure());
 		assertThat(tokenCookie.getValue()).isEqualTo(token.getToken());
-		assertThat(tokenCookie.isHttpOnly()).isEqualTo(true);
+		assertThat(tokenCookie.isHttpOnly()).isTrue();
 	}
 
 	@Test
-	public void saveTokenSecure() {
+	void saveTokenSecure() {
 		this.request.setSecure(true);
 		CsrfToken token = this.repository.generateToken(this.request);
 		this.repository.saveToken(token, this.request, this.response);
@@ -94,7 +94,7 @@ public class CookieCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void saveTokenSecureFlagTrue() {
+	void saveTokenSecureFlagTrue() {
 		this.request.setSecure(false);
 		this.repository.setSecure(Boolean.TRUE);
 		CsrfToken token = this.repository.generateToken(this.request);
@@ -146,7 +146,7 @@ public class CookieCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void saveTokenHttpOnlyTrue() {
+	void saveTokenHttpOnlyTrue() {
 		this.repository.setCookieHttpOnly(true);
 		CsrfToken token = this.repository.generateToken(this.request);
 		this.repository.saveToken(token, this.request, this.response);
@@ -191,7 +191,7 @@ public class CookieCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void saveTokenCustomPath() {
+	void saveTokenCustomPath() {
 		String customPath = "/custompath";
 		this.repository.setCookiePath(customPath);
 		CsrfToken token = this.repository.generateToken(this.request);
@@ -201,7 +201,7 @@ public class CookieCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void saveTokenEmptyCustomPath() {
+	void saveTokenEmptyCustomPath() {
 		String customPath = "";
 		this.repository.setCookiePath(customPath);
 		CsrfToken token = this.repository.generateToken(this.request);
@@ -211,7 +211,7 @@ public class CookieCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void saveTokenNullCustomPath() {
+	void saveTokenNullCustomPath() {
 		String customPath = null;
 		this.repository.setCookiePath(customPath);
 		CsrfToken token = this.repository.generateToken(this.request);
@@ -221,7 +221,7 @@ public class CookieCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void saveTokenWithCookieDomain() {
+	void saveTokenWithCookieDomain() {
 		String domainName = "example.com";
 		this.repository.setCookieDomain(domainName);
 		CsrfToken token = this.repository.generateToken(this.request);
@@ -241,7 +241,7 @@ public class CookieCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void saveTokenWithCookieMaxAge() {
+	void saveTokenWithCookieMaxAge() {
 		int maxAge = 1200;
 		this.repository.setCookieMaxAge(maxAge);
 		CsrfToken token = this.repository.generateToken(this.request);
@@ -291,24 +291,24 @@ public class CookieCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void loadTokenNoCookiesNull() {
+	void loadTokenNoCookiesNull() {
 		assertThat(this.repository.loadToken(this.request)).isNull();
 	}
 
 	@Test
-	public void loadTokenCookieIncorrectNameNull() {
+	void loadTokenCookieIncorrectNameNull() {
 		this.request.setCookies(new Cookie("other", "name"));
 		assertThat(this.repository.loadToken(this.request)).isNull();
 	}
 
 	@Test
-	public void loadTokenCookieValueEmptyString() {
+	void loadTokenCookieValueEmptyString() {
 		this.request.setCookies(new Cookie(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME, ""));
 		assertThat(this.repository.loadToken(this.request)).isNull();
 	}
 
 	@Test
-	public void loadToken() {
+	void loadToken() {
 		CsrfToken generateToken = this.repository.generateToken(this.request);
 		this.request
 				.setCookies(new Cookie(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME, generateToken.getToken()));
@@ -320,7 +320,7 @@ public class CookieCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void loadTokenCustom() {
+	void loadTokenCustom() {
 		String cookieName = "cookieName";
 		String value = "value";
 		String headerName = "headerName";
@@ -337,7 +337,7 @@ public class CookieCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void loadDeferredTokenWhenDoesNotExistThenGeneratedAndSaved() {
+	void loadDeferredTokenWhenDoesNotExistThenGeneratedAndSaved() {
 		DeferredCsrfToken deferredCsrfToken = this.repository.loadDeferredToken(this.request, this.response);
 		CsrfToken csrfToken = deferredCsrfToken.get();
 		assertThat(csrfToken).isNotNull();
@@ -353,7 +353,7 @@ public class CookieCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void loadDeferredTokenWhenExistsAndNullSavedThenGeneratedAndSaved() {
+	void loadDeferredTokenWhenExistsAndNullSavedThenGeneratedAndSaved() {
 		CsrfToken generatedToken = this.repository.generateToken(this.request);
 		this.request
 				.setCookies(new Cookie(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME, generatedToken.getToken()));
@@ -366,7 +366,7 @@ public class CookieCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void loadDeferredTokenWhenExistsAndNullSavedAndNonNullSavedThenLoaded() {
+	void loadDeferredTokenWhenExistsAndNullSavedAndNonNullSavedThenLoaded() {
 		CsrfToken generatedToken = this.repository.generateToken(this.request);
 		this.request
 				.setCookies(new Cookie(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME, generatedToken.getToken()));
@@ -379,7 +379,7 @@ public class CookieCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void loadDeferredTokenWhenExistsThenLoaded() {
+	void loadDeferredTokenWhenExistsThenLoaded() {
 		CsrfToken generatedToken = this.repository.generateToken(this.request);
 		this.request
 				.setCookies(new Cookie(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME, generatedToken.getToken()));
@@ -412,23 +412,22 @@ public class CookieCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void setCookieNameNullIllegalArgumentException() {
+	void setCookieNameNullIllegalArgumentException() {
 		assertThatIllegalArgumentException().isThrownBy(() -> this.repository.setCookieName(null));
 	}
 
 	@Test
-	public void setParameterNameNullIllegalArgumentException() {
+	void setParameterNameNullIllegalArgumentException() {
 		assertThatIllegalArgumentException().isThrownBy(() -> this.repository.setParameterName(null));
 	}
 
 	@Test
-	public void setHeaderNameNullIllegalArgumentException() {
+	void setHeaderNameNullIllegalArgumentException() {
 		assertThatIllegalArgumentException().isThrownBy(() -> this.repository.setHeaderName(null));
 	}
 
 	@Test
-	public void setCookieMaxAgeZeroIllegalArgumentException() {
+	void setCookieMaxAgeZeroIllegalArgumentException() {
 		assertThatIllegalArgumentException().isThrownBy(() -> this.repository.setCookieMaxAge(0));
 	}
-
 }

--- a/web/src/test/java/org/springframework/security/web/server/csrf/CookieServerCsrfTokenRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/csrf/CookieServerCsrfTokenRepositoryTests.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Alex Montoya
  * @since 5.1
  */
-public class CookieServerCsrfTokenRepositoryTests {
+class CookieServerCsrfTokenRepositoryTests {
 
 	private CookieServerCsrfTokenRepository csrfTokenRepository;
 
@@ -72,54 +72,54 @@ public class CookieServerCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void generateTokenWhenDefaultThenDefaults() {
+	void generateTokenWhenDefaultThenDefaults() {
 		generateTokenAndAssertExpectedValues();
 	}
 
 	@Test
-	public void generateTokenWhenCustomHeaderThenCustomHeader() {
+	void generateTokenWhenCustomHeaderThenCustomHeader() {
 		setExpectedHeaderName("someHeader");
 		generateTokenAndAssertExpectedValues();
 	}
 
 	@Test
-	public void generateTokenWhenCustomParameterThenCustomParameter() {
+	void generateTokenWhenCustomParameterThenCustomParameter() {
 		setExpectedParameterName("someParam");
 		generateTokenAndAssertExpectedValues();
 	}
 
 	@Test
-	public void generateTokenWhenCustomHeaderAndParameterThenCustomHeaderAndParameter() {
+	void generateTokenWhenCustomHeaderAndParameterThenCustomHeaderAndParameter() {
 		setExpectedHeaderName("someHeader");
 		setExpectedParameterName("someParam");
 		generateTokenAndAssertExpectedValues();
 	}
 
 	@Test
-	public void saveTokenWhenNoSubscriptionThenNotWritten() {
+	void saveTokenWhenNoSubscriptionThenNotWritten() {
 		MockServerWebExchange exchange = MockServerWebExchange.from(this.request);
 		this.csrfTokenRepository.saveToken(exchange, createToken());
 		assertThat(exchange.getResponse().getCookies().getFirst(this.expectedCookieName)).isNull();
 	}
 
 	@Test
-	public void saveTokenWhenDefaultThenDefaults() {
+	void saveTokenWhenDefaultThenDefaults() {
 		saveAndAssertExpectedValues(createToken());
 	}
 
 	@Test
-	public void saveTokenWhenNullThenDeletes() {
+	void saveTokenWhenNullThenDeletes() {
 		saveAndAssertExpectedValues(null);
 	}
 
 	@Test
-	public void saveTokenWhenHttpOnlyFalseThenHttpOnlyFalse() {
+	void saveTokenWhenHttpOnlyFalseThenHttpOnlyFalse() {
 		setExpectedHttpOnly(false);
 		saveAndAssertExpectedValues(createToken());
 	}
 
 	@Test
-	public void saveTokenWhenCookieMaxAgeThenCookieMaxAge() {
+	void saveTokenWhenCookieMaxAgeThenCookieMaxAge() {
 		setExpectedCookieMaxAge(3600);
 		saveAndAssertExpectedValues(createToken());
 	}
@@ -131,7 +131,7 @@ public class CookieServerCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void saveTokenWhenCustomPropertiesThenCustomProperties() {
+	void saveTokenWhenCustomPropertiesThenCustomProperties() {
 		setExpectedDomain("spring.io");
 		setExpectedCookieName("csrfCookie");
 		setExpectedPath("/some/path");
@@ -188,7 +188,7 @@ public class CookieServerCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void saveTokenWhenSslInfoNullThenNotSecure() {
+	void saveTokenWhenSslInfoNullThenNotSecure() {
 		MockServerWebExchange exchange = MockServerWebExchange.from(this.request);
 		this.csrfTokenRepository.saveToken(exchange, createToken()).block();
 		ResponseCookie cookie = exchange.getResponse().getCookies().getFirst(this.expectedCookieName);
@@ -197,7 +197,7 @@ public class CookieServerCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void saveTokenWhenSecureFlagTrueThenSecure() {
+	void saveTokenWhenSecureFlagTrueThenSecure() {
 		MockServerWebExchange exchange = MockServerWebExchange.from(this.request);
 		this.csrfTokenRepository.setSecure(true);
 		this.csrfTokenRepository.saveToken(exchange, createToken()).block();
@@ -217,7 +217,7 @@ public class CookieServerCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void saveTokenWhenSecureFlagFalseThenNotSecure() {
+	void saveTokenWhenSecureFlagFalseThenNotSecure() {
 		MockServerWebExchange exchange = MockServerWebExchange.from(this.request);
 		this.csrfTokenRepository.setSecure(false);
 		this.csrfTokenRepository.saveToken(exchange, createToken()).block();
@@ -237,7 +237,7 @@ public class CookieServerCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void saveTokenWhenSecureFlagFalseAndSslInfoThenNotSecure() {
+	void saveTokenWhenSecureFlagFalseAndSslInfoThenNotSecure() {
 		MockServerWebExchange exchange = MockServerWebExchange.from(this.request);
 		this.request.sslInfo(new MockSslInfo());
 		this.csrfTokenRepository.setSecure(false);
@@ -259,12 +259,12 @@ public class CookieServerCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void loadTokenWhenCookieExistThenTokenFound() {
+	void loadTokenWhenCookieExistThenTokenFound() {
 		loadAndAssertExpectedValues();
 	}
 
 	@Test
-	public void loadTokenWhenCustomThenTokenFound() {
+	void loadTokenWhenCustomThenTokenFound() {
 		setExpectedParameterName("paramName");
 		setExpectedHeaderName("headerName");
 		setExpectedCookieName("csrfCookie");
@@ -272,20 +272,20 @@ public class CookieServerCsrfTokenRepositoryTests {
 	}
 
 	@Test
-	public void loadTokenWhenNoCookiesThenNullToken() {
+	void loadTokenWhenNoCookiesThenNullToken() {
 		MockServerWebExchange exchange = MockServerWebExchange.from(this.request);
 		CsrfToken csrfToken = this.csrfTokenRepository.loadToken(exchange).block();
 		assertThat(csrfToken).isNull();
 	}
 
 	@Test
-	public void loadTokenWhenCookieExistsWithNoValue() {
+	void loadTokenWhenCookieExistsWithNoValue() {
 		setExpectedCookieValue("");
 		loadAndAssertExpectedValues();
 	}
 
 	@Test
-	public void loadTokenWhenCookieExistsWithNullValue() {
+	void loadTokenWhenCookieExistsWithNullValue() {
 		setExpectedCookieValue(null);
 		loadAndAssertExpectedValues();
 	}


### PR DESCRIPTION
Add a customizer to CookieCsrfTokenRepository and CookieServerCsrfTokenRepository

- Mark setCookieHttpOnly, setCookieDomain, setCookieMaxAge and setSecure as deprecated.
- Add the method setCookieCustomizer which allows to set properties to the ResponseCookieBuilder without having to add new setter methods.

Closes gh-12086