### PR TITLE
NimbusJwtDecoder unknown KID scenario is not correctly tested

### DIFF
--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoderTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoderTests.java
@@ -60,6 +60,7 @@ import org.mockito.ArgumentCaptor;
 
 import org.springframework.cache.Cache;
 import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.cache.support.SimpleValueWrapper;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -700,6 +701,7 @@ public class NimbusJwtDecoderTests {
 		RestOperations restOperations = mock(RestOperations.class);
 		Cache cache = mock(Cache.class);
 		given(cache.get(eq(JWK_SET_URI), eq(String.class))).willReturn(JWK_SET);
+		given(cache.get(eq(JWK_SET_URI))).willReturn(new SimpleValueWrapper(JWK_SET));
 		given(restOperations.exchange(any(RequestEntity.class), eq(String.class)))
 				.willReturn(new ResponseEntity<>(NEW_KID_JWK_SET, HttpStatus.OK));
 


### PR DESCRIPTION
Two different methods are used for accessing the cache and only one of them is correctly mocked. This means the cache will always refresh unrelated to the unknown KID. https://github.com/spring-projects/spring-security/blob/main/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoder.java#L415
The `RemoteJWKSet` will never actually find a missing KID and do the update because of this. The code seems to be correct though and the test succeeds with the fixed mock.

Relates to this issue https://github.com/spring-projects/spring-security/issues/11621