### PR TITLE
sync and refactor docs build (main)

### DIFF
--- a/.github/workflows/rebuild-search-index.yml
+++ b/.github/workflows/rebuild-search-index.yml
@@ -6,15 +6,15 @@ on:
 permissions: read-all
 jobs:
   build:
-    runs-on: ubuntu-latest
     if: github.repository_owner == 'spring-projects'
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: docs-build
         fetch-depth: 1
     - name: Dispatch
-      run: gh workflow run --ref $(git rev-parse --abbrev-ref HEAD) rebuild-search-index.yml
       env:
         GH_TOKEN: ${{ secrets.GH_ACTIONS_REPO_TOKEN }}
+      run: gh workflow run rebuild-search-index.yml -r $(git rev-parse --abbrev-ref HEAD)

--- a/.github/workflows/release-scheduler.yml
+++ b/.github/workflows/release-scheduler.yml
@@ -1,32 +1,24 @@
 name: Release Scheduler
-
 on:
   schedule:
-    - cron: '15 15 * * MON' # Every Monday at 3:15pm UTC
+  - cron: '15 15 * * MON' # Every Monday at 3:15pm UTC
   workflow_dispatch:
-
-permissions:
-  contents: read
-
+permissions: read-all
 jobs:
   dispatch_scheduled_releases:
     name: Dispatch scheduled releases
-    if: ${{ github.repository == 'spring-projects/spring-security' }}
+    if: github.repository_owner == 'spring-projects'
     strategy:
       matrix:
-        #
         # List of active maintenance branches.
-        #
-        branch:
-          - 'main'
-          - '5.8.x'
-          - '5.7.x'
-          - '5.6.x'
+        branch: [ main, 6.0.x, 5.8.x, 5.7.x, 5.6.x ]
     runs-on: ubuntu-latest
-    env:
-      TOKEN: ${{ secrets.GH_ACTIONS_REPO_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: spring-io/spring-gradle-build-action@v1
-      - name: Trigger release workflow
-        run: ./gradlew dispatchGitHubWorkflow -Pbranch=${{ matrix.branch }} -PworkflowId=update-scheduled-release-version.yml -PgitHubAccessToken=$TOKEN
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+    - name: Dispatch
+      env:
+        GH_TOKEN: ${{ secrets.GH_ACTIONS_REPO_TOKEN }}
+      run: gh workflow run update-scheduled-release-version.yml -r ${{ matrix.branch }}


### PR DESCRIPTION
- upgrade Antora to 3.2.0-alpha.2
- remove Antora patch to support linked worktrees
- upgrade Antora Collector to latest alpha
- remove dispatch.sh script (handled by gh run workflow)
- consistently use gh run workflow to trigger workflows
- remove step to publish generated docs (no longer in use)