### PR TITLE
Fix: Replace tenantRepository with tenants

### DIFF
--- a/docs/modules/ROOT/pages/servlet/oauth2/resource-server/multitenancy.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/resource-server/multitenancy.adoc
@@ -248,7 +248,7 @@ public class TenantJWSKeySelector
 	}
 
 	private JWSKeySelector<SecurityContext> fromTenant(String tenant) {
-		return Optional.ofNullable(this.tenantRepository.findById(tenant)) <3>
+		return Optional.ofNullable(this.tenants.findById(tenant)) <3>
 		        .map(t -> t.getAttrbute("jwks_uri"))
 				.map(this::fromUri)
 				.orElseThrow(() -> new IllegalArgumentException("unknown tenant"));


### PR DESCRIPTION
Fix issue : https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/multitenancy.html

Details: 
Replace `this.tenantRepository` with `this.tenants`