### PR TITLE
Fix Delegation-based Strategy with OidcUserService/OidcReactiveOAuth2UserService examples

### DIFF
--- a/docs/modules/ROOT/pages/reactive/oauth2/login/advanced.adoc
+++ b/docs/modules/ROOT/pages/reactive/oauth2/login/advanced.adoc
@@ -453,7 +453,13 @@ public class OAuth2LoginSecurityConfig {
 						// 2) Map the authority information to one or more GrantedAuthority's and add it to mappedAuthorities
 
 						// 3) Create a copy of oidcUser but use the mappedAuthorities instead
-						oidcUser = new DefaultOidcUser(mappedAuthorities, oidcUser.getIdToken(), oidcUser.getUserInfo());
+						ProviderDetails providerDetails = userRequest.getClientRegistration().getProviderDetails();
+						String userNameAttributeName = providerDetails.getUserInfoEndpoint().getUserNameAttributeName();
+						if (StringUtils.hasText(userNameAttributeName)) {
+							oidcUser = new DefaultOidcUser(mappedAuthorities, oidcUser.getIdToken(), oidcUser.getUserInfo(), userNameAttributeName);
+						} else {
+							oidcUser = new DefaultOidcUser(mappedAuthorities, oidcUser.getIdToken(), oidcUser.getUserInfo());
+						}
 
 						return Mono.just(oidcUser);
 					});
@@ -493,7 +499,12 @@ class OAuth2LoginSecurityConfig {
                     // 1) Fetch the authority information from the protected resource using accessToken
                     // 2) Map the authority information to one or more GrantedAuthority's and add it to mappedAuthorities
                     // 3) Create a copy of oidcUser but use the mappedAuthorities instead
-                    val mappedOidcUser = DefaultOidcUser(mappedAuthorities, oidcUser.idToken, oidcUser.userInfo)
+                    val providerDetails = userRequest.getClientRegistration().getProviderDetails()
+                    val userNameAttributeName = providerDetails.getUserInfoEndpoint().getUserNameAttributeName()
+                    val mappedOidcUser = when (StringUtils.hasText(userNameAttributeName)) {
+                        true -> DefaultOidcUser(mappedAuthorities, oidcUser.idToken, oidcUser.userInfo, userNameAttributeName)
+                        false -> DefaultOidcUser(mappedAuthorities, oidcUser.idToken, oidcUser.userInfo)
+                    }
 
                     Mono.just(mappedOidcUser)
                 }

--- a/docs/modules/ROOT/pages/servlet/oauth2/login/advanced.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/login/advanced.adoc
@@ -640,7 +640,13 @@ public class OAuth2LoginSecurityConfig {
 			// 2) Map the authority information to one or more GrantedAuthority's and add it to mappedAuthorities
 
 			// 3) Create a copy of oidcUser but use the mappedAuthorities instead
-			oidcUser = new DefaultOidcUser(mappedAuthorities, oidcUser.getIdToken(), oidcUser.getUserInfo());
+			ProviderDetails providerDetails = userRequest.getClientRegistration().getProviderDetails();
+			String userNameAttributeName = providerDetails.getUserInfoEndpoint().getUserNameAttributeName();
+			if (StringUtils.hasText(userNameAttributeName)) {
+				oidcUser = new DefaultOidcUser(mappedAuthorities, oidcUser.getIdToken(), oidcUser.getUserInfo(), userNameAttributeName);
+			} else {
+				oidcUser = new DefaultOidcUser(mappedAuthorities, oidcUser.getIdToken(), oidcUser.getUserInfo());
+			}
 
 			return oidcUser;
 		};
@@ -682,7 +688,13 @@ class OAuth2LoginSecurityConfig  {
             // 1) Fetch the authority information from the protected resource using accessToken
             // 2) Map the authority information to one or more GrantedAuthority's and add it to mappedAuthorities
             // 3) Create a copy of oidcUser but use the mappedAuthorities instead
-            oidcUser = DefaultOidcUser(mappedAuthorities, oidcUser.idToken, oidcUser.userInfo)
+            val providerDetails = userRequest.getClientRegistration().getProviderDetails()
+            val userNameAttributeName = providerDetails.getUserInfoEndpoint().getUserNameAttributeName()
+            if (StringUtils.hasText(userNameAttributeName)) {
+                oidcUser = DefaultOidcUser(mappedAuthorities, oidcUser.idToken, oidcUser.userInfo, userNameAttributeName)
+            else {
+                oidcUser = DefaultOidcUser(mappedAuthorities, oidcUser.idToken, oidcUser.userInfo)
+            }
 
             oidcUser
         }


### PR DESCRIPTION
The examples for Delegation-based Strategy with `OidcUserService`/`OidcReactiveOAuth2UserService` is bugged. If the `userNameAttributeName` is overridden with `spring.security.oauth2.client.provider.<provider>.user-name-attribute`, `SecurityContextHolder.getContext().getAuthentication().getName()` will return the value of `sub` (the default username attribute) regardless of what is set.

This fixes the example by obtaining the username attribute from `OidcUserRequest` and passing it to the new `DefaultOidcUser`.

See gh-12275 for the original discussion.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
