### PR TITLE
Improve API for delegation-based strategy

### DIFF
--- a/docs/modules/ROOT/pages/reactive/oauth2/login/advanced.adoc
+++ b/docs/modules/ROOT/pages/reactive/oauth2/login/advanced.adoc
@@ -439,24 +439,21 @@ public class OAuth2LoginSecurityConfig {
 
 	@Bean
 	public ReactiveOAuth2UserService<OidcUserRequest, OidcUser> oidcUserService() {
-		final OidcReactiveOAuth2UserService delegate = new OidcReactiveOAuth2UserService();
+		return new OidcReactiveOAuth2UserService() {
+			@Override
+			protected OidcUser getUser(OidcUserRequest userRequest, OidcUserInfo userInfo, Set<GrantedAuthority> authorities) {
+				OAuth2AccessToken accessToken = userRequest.getAccessToken();
+				Set<GrantedAuthority> mappedAuthorities = new HashSet<>();
 
-		return (userRequest) -> {
-			// Delegate to the default implementation for loading a user
-			return delegate.loadUser(userRequest)
-					.flatMap((oidcUser) -> {
-						OAuth2AccessToken accessToken = userRequest.getAccessToken();
-						Set<GrantedAuthority> mappedAuthorities = new HashSet<>();
+				// TODO
+				// 1) Fetch the authority information from the protected resource using accessToken
+				// 2) Map the authority information to one or more GrantedAuthority's and add it to mappedAuthorities
 
-						// TODO
-						// 1) Fetch the authority information from the protected resource using accessToken
-						// 2) Map the authority information to one or more GrantedAuthority's and add it to mappedAuthorities
+				// Delegate to the default implementation for getting a user
+				OidcUser oidcUser = super.loadUser(userRequest, userInfo, mappedAuthorities);
 
-						// 3) Create a copy of oidcUser but use the mappedAuthorities instead
-						oidcUser = new DefaultOidcUser(mappedAuthorities, oidcUser.getIdToken(), oidcUser.getUserInfo());
-
-						return Mono.just(oidcUser);
-					});
+				return oidcUser;
+			}
 		};
 	}
 }
@@ -479,24 +476,19 @@ class OAuth2LoginSecurityConfig {
     }
 
     @Bean
-    fun oidcUserService(): ReactiveOAuth2UserService<OidcUserRequest, OidcUser> {
-        val delegate = OidcReactiveOAuth2UserService()
+    fun oidcUserService(): ReactiveOAuth2UserService<OidcUserRequest, OidcUser> = object : OidcReactiveOAuth2UserService() {
+        override fun getUser(userRequest: OidcUserRequest, userInfo: OidcUserInfo, authorities: Set<GrantedAuthority>): OidcUser {
+            val accessToken = userRequest.accessToken
+            val mappedAuthorities = mutableSetOf<GrantedAuthority>()
 
-        return ReactiveOAuth2UserService { userRequest ->
-            // Delegate to the default implementation for loading a user
-            delegate.loadUser(userRequest)
-                .flatMap { oidcUser ->
-                    val accessToken = userRequest.accessToken
-                    val mappedAuthorities = mutableSetOf<GrantedAuthority>()
+            // TODO
+            // 1) Fetch the authority information from the protected resource using accessToken
+            // 2) Map the authority information to one or more GrantedAuthority's and add it to mappedAuthorities
 
-                    // TODO
-                    // 1) Fetch the authority information from the protected resource using accessToken
-                    // 2) Map the authority information to one or more GrantedAuthority's and add it to mappedAuthorities
-                    // 3) Create a copy of oidcUser but use the mappedAuthorities instead
-                    val mappedOidcUser = DefaultOidcUser(mappedAuthorities, oidcUser.idToken, oidcUser.userInfo)
+            // Delegate to the default implementation for getting a user
+            val mappedOidcUser = super.getUser(userRequest, userInfo, mappedAuthorities)
 
-                    Mono.just(mappedOidcUser)
-                }
+            mappedOidcUser
         }
     }
 }

--- a/docs/modules/ROOT/pages/servlet/oauth2/login/advanced.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/login/advanced.adoc
@@ -626,23 +626,21 @@ public class OAuth2LoginSecurityConfig {
 	}
 
 	private OAuth2UserService<OidcUserRequest, OidcUser> oidcUserService() {
-		final OidcUserService delegate = new OidcUserService();
+		return new OidcUserService() {
+			@Override
+			protected OidcUser getUser(OidcUserRequest userRequest, OidcUserInfo userInfo, Set<GrantedAuthority> authorities) {
+				OAuth2AccessToken accessToken = userRequest.getAccessToken();
+				Set<GrantedAuthority> mappedAuthorities = new HashSet<>();
 
-		return (userRequest) -> {
-			// Delegate to the default implementation for loading a user
-			OidcUser oidcUser = delegate.loadUser(userRequest);
+				// TODO
+				// 1) Fetch the authority information from the protected resource using accessToken
+				// 2) Map the authority information to one or more GrantedAuthority's and add it to mappedAuthorities
 
-			OAuth2AccessToken accessToken = userRequest.getAccessToken();
-			Set<GrantedAuthority> mappedAuthorities = new HashSet<>();
+				// Delegate to the default implementation for getting a user
+				OidcUser oidcUser = super.getUser(userRequest, userInfo, mappedAuthorities);
 
-			// TODO
-			// 1) Fetch the authority information from the protected resource using accessToken
-			// 2) Map the authority information to one or more GrantedAuthority's and add it to mappedAuthorities
-
-			// 3) Create a copy of oidcUser but use the mappedAuthorities instead
-			oidcUser = new DefaultOidcUser(mappedAuthorities, oidcUser.getIdToken(), oidcUser.getUserInfo());
-
-			return oidcUser;
+				return oidcUser;
+			}
 		};
 	}
 }
@@ -668,21 +666,17 @@ class OAuth2LoginSecurityConfig  {
     }
 
     @Bean
-    fun oidcUserService(): OAuth2UserService<OidcUserRequest, OidcUser> {
-        val delegate = OidcUserService()
-
-        return OAuth2UserService { userRequest ->
-            // Delegate to the default implementation for loading a user
-            var oidcUser = delegate.loadUser(userRequest)
-
+    fun oidcUserService(): OAuth2UserService<OidcUserRequest, OidcUser> = object : OidcUserService() {
+        override fun getUser(userRequest: OidcUserRequest, userInfo: OidcUserInfo, authorities: Set<GrantedAuthority>): OidcUser {
             val accessToken = userRequest.accessToken
             val mappedAuthorities = HashSet<GrantedAuthority>()
 
             // TODO
             // 1) Fetch the authority information from the protected resource using accessToken
             // 2) Map the authority information to one or more GrantedAuthority's and add it to mappedAuthorities
-            // 3) Create a copy of oidcUser but use the mappedAuthorities instead
-            oidcUser = DefaultOidcUser(mappedAuthorities, oidcUser.idToken, oidcUser.userInfo)
+
+            // Delegate to the default implementation for getting a user
+            val oidcUser = super.getUser(userRequest, userInfo, mappedAuthorities)
 
             oidcUser
         }

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcReactiveOAuth2UserService.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcReactiveOAuth2UserService.java
@@ -111,15 +111,19 @@ public class OidcReactiveOAuth2UserService implements ReactiveOAuth2UserService<
 					for (String scope : token.getScopes()) {
 						authorities.add(new SimpleGrantedAuthority("SCOPE_" + scope));
 					}
-					String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
-							.getUserInfoEndpoint().getUserNameAttributeName();
-					if (StringUtils.hasText(userNameAttributeName)) {
-						return new DefaultOidcUser(authorities, userRequest.getIdToken(), userInfo,
-								userNameAttributeName);
-					}
-					return new DefaultOidcUser(authorities, userRequest.getIdToken(), userInfo);
+					return getUser(userRequest, userInfo, authorities);
 				});
 		// @formatter:on
+	}
+
+	protected OidcUser getUser(OidcUserRequest userRequest, OidcUserInfo userInfo, Set<GrantedAuthority> authorities) {
+		String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
+				.getUserInfoEndpoint().getUserNameAttributeName();
+		if (StringUtils.hasText(userNameAttributeName)) {
+			return new DefaultOidcUser(authorities, userRequest.getIdToken(), userInfo,
+					userNameAttributeName);
+		}
+		return new DefaultOidcUser(authorities, userRequest.getIdToken(), userInfo);
 	}
 
 	private Mono<OidcUserInfo> getUserInfo(OidcUserRequest userRequest) {

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcUserService.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcUserService.java
@@ -145,7 +145,7 @@ public class OidcUserService implements OAuth2UserService<OidcUserRequest, OidcU
 		return DEFAULT_CLAIM_TYPE_CONVERTER.convert(oauth2User.getAttributes());
 	}
 
-	private OidcUser getUser(OidcUserRequest userRequest, OidcUserInfo userInfo, Set<GrantedAuthority> authorities) {
+	protected OidcUser getUser(OidcUserRequest userRequest, OidcUserInfo userInfo, Set<GrantedAuthority> authorities) {
 		ProviderDetails providerDetails = userRequest.getClientRegistration().getProviderDetails();
 		String userNameAttributeName = providerDetails.getUserInfoEndpoint().getUserNameAttributeName();
 		if (StringUtils.hasText(userNameAttributeName)) {


### PR DESCRIPTION
The current API for delegation-based strategy with [OidcUserService](https://docs.spring.io/spring-security/reference/6.0/servlet/oauth2/login/advanced.html#oauth2login-advanced-map-authorities-oauth2userservice)/[OidcReactiveOAuth2UserService](https://docs.spring.io/spring-security/reference/6.0/reactive/oauth2/login/advanced.html#webflux-oauth2-login-advanced-map-authorities-reactiveoauth2userservice) is error-prone because it requires understanding the inner workings of [OidcUserService](https://github.com/daniel-shuy/spring-security/blob/77f62d8b6cc2ae6229f1345cabe303b215043ef0/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcUserService.java)/[OidcReactiveOAuth2UserService](https://github.com/daniel-shuy/spring-security/blob/77f62d8b6cc2ae6229f1345cabe303b215043ef0/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcReactiveOAuth2UserService.java) (see gh-12275 and gh-12281 for the original discussion).

This improves the API by:
- Making `OidcUserService#getUser(OidcUserRequest, OidcUserInfo, Set)` `protected`
- `OidcReactiveOAuth2UserService`: Abstract out logic to set `DefaultOidcUser` `nameAttributeKey` from `OidcUserRequest` into a new `protected` `getUser(OidcUserRequest, OidcUserInfo, Set)` method

This allows the delegation-based strategy to be massively simplified (especially for reactive).

Using the example in the doc, the configuration can be simplified from:
```java
@Bean
public ReactiveOAuth2UserService<OidcUserRequest, OidcUser> oidcUserService() {
	final OidcReactiveOAuth2UserService delegate = new OidcReactiveOAuth2UserService();

	return (userRequest) -> {
		// Delegate to the default implementation for loading a user
		return delegate.loadUser(userRequest)
				.flatMap((oidcUser) -> {
					OAuth2AccessToken accessToken = userRequest.getAccessToken();
					Set<GrantedAuthority> mappedAuthorities = new HashSet<>();

					// TODO
					// 1) Fetch the authority information from the protected resource using accessToken
					// 2) Map the authority information to one or more GrantedAuthority's and add it to mappedAuthorities

					// 3) Create a copy of oidcUser but use the mappedAuthorities instead
					ProviderDetails providerDetails = userRequest.getClientRegistration().getProviderDetails();
					String userNameAttributeName = providerDetails.getUserInfoEndpoint().getUserNameAttributeName();
					if (StringUtils.hasText(userNameAttributeName)) {
						oidcUser = new DefaultOidcUser(mappedAuthorities, oidcUser.getIdToken(), oidcUser.getUserInfo(), userNameAttributeName);
					} else {
						oidcUser = new DefaultOidcUser(mappedAuthorities, oidcUser.getIdToken(), oidcUser.getUserInfo());
					}

					return Mono.just(oidcUser);
				});
	};
}
```
to:
```java
@Bean
public ReactiveOAuth2UserService<OidcUserRequest, OidcUser> oidcUserService() {
	return new OidcReactiveOAuth2UserService() {
		@Override
		protected OidcUser getUser(OidcUserRequest userRequest, OidcUserInfo userInfo, Set<GrantedAuthority> authorities) {
			OAuth2AccessToken accessToken = userRequest.getAccessToken();
			Set<GrantedAuthority> mappedAuthorities = new HashSet<>();

			// TODO
			// 1) Fetch the authority information from the protected resource using accessToken
			// 2) Map the authority information to one or more GrantedAuthority's and add it to mappedAuthorities

			// Delegate to the default implementation for getting a user
			OidcUser oidcUser = super.loadUser(userRequest, userInfo, mappedAuthorities);

			return oidcUser;
		}
	};
}
```
