### PR TITLE
Replace deprecated set-state set-output GitHub Action's commands

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -31,15 +31,15 @@ jobs:
       runjobs: ${{ steps.continue.outputs.runjobs }}
       project_version: ${{ steps.continue.outputs.project_version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: continue
         name: Determine if should continue
         run: |
           # Run jobs if in upstream repository
-          echo "::set-output name=runjobs::true"
+          echo "runjobs=true" >>$GITHUB_OUTPUT
           # Extract version from gradle.properties
           version=$(cat gradle.properties | grep "version=" | awk -F'=' '{print $2}')
-          echo "::set-output name=project_version::$version"
+          echo "project_version=$version" >>$GITHUB_OUTPUT
   build_jdk_11:
     name: Build JDK 11
     needs: [prerequisites]
@@ -49,9 +49,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     if: needs.prerequisites.outputs.runjobs
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'adopt'
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.prerequisites.outputs.runjobs
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up gradle
         uses: spring-io/spring-gradle-build-action@v1
         with:
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.prerequisites.outputs.runjobs
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up gradle
         uses: spring-io/spring-gradle-build-action@v1
         with:
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.prerequisites.outputs.runjobs
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up gradle
         uses: spring-io/spring-gradle-build-action@v1
         with:
@@ -130,7 +130,7 @@ jobs:
     needs: [build_jdk_11, snapshot_tests, check_samples, check_tangles]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up gradle
         uses: spring-io/spring-gradle-build-action@v1
         with:
@@ -154,7 +154,7 @@ jobs:
     needs: [build_jdk_11, snapshot_tests, check_samples, check_tangles]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up gradle
         uses: spring-io/spring-gradle-build-action@v1
         with:
@@ -175,7 +175,7 @@ jobs:
     needs: [build_jdk_11, snapshot_tests, check_samples, check_tangles]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up gradle
         uses: spring-io/spring-gradle-build-action@v1
         with:
@@ -205,7 +205,7 @@ jobs:
       TOKEN: ${{ github.token }}
       VERSION: ${{ needs.prerequisites.outputs.project_version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_ACTIONS_REPO_TOKEN }}
       - name: Set up gradle
@@ -286,7 +286,7 @@ jobs:
       TOKEN: ${{ github.token }}
       VERSION: ${{ needs.prerequisites.outputs.project_version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up gradle
         uses: spring-io/spring-gradle-build-action@v1
         with:

--- a/.github/workflows/pr-build-workflow.yml
+++ b/.github/workflows/pr-build-workflow.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'spring-projects/spring-security' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up gradle
         uses: spring-io/spring-gradle-build-action@v1
         with:

--- a/.github/workflows/update-scheduled-release-version.yml
+++ b/.github/workflows/update-scheduled-release-version.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - id: checkout-source
         name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_ACTIONS_REPO_TOKEN }}
       - name: Set up gradle
@@ -38,7 +38,7 @@ jobs:
           export GRADLE_ENTERPRISE_CACHE_PASSWORD="$GRADLE_ENTERPRISE_CACHE_PASSWORD"
           export GRADLE_ENTERPRISE_ACCESS_KEY="$GRADLE_ENTERPRISE_SECRET_ACCESS_KEY"
           ./gradlew gitHubCheckNextVersionDueToday
-          echo "::set-output name=is_due_today::$(cat build/github/milestones/is-due-today)"
+          echo "is_due_today=$(cat build/github/milestones/is-due-today)" >>$GITHUB_OUTPUT
       - id: check-open-issues
         name: Check for open issues
         if: steps.check-release-due.outputs.is_due_today == 'true'
@@ -47,7 +47,7 @@ jobs:
           export GRADLE_ENTERPRISE_CACHE_PASSWORD="$GRADLE_ENTERPRISE_CACHE_PASSWORD"
           export GRADLE_ENTERPRISE_ACCESS_KEY="$GRADLE_ENTERPRISE_SECRET_ACCESS_KEY"
           ./gradlew gitHubCheckMilestoneHasNoOpenIssues
-          echo "::set-output name=is_open_issues::$(cat build/github/milestones/is-open-issues)"
+          echo "is_open_issues=$(cat build/github/milestones/is-open-issues)" >>$GITHUB_OUTPUT
       - id: validate-release-state
         name: Validate State of Release
         if: steps.check-release-due.outputs.is_due_today == 'true' && steps.check-open-issues.outputs.is_open_issues == 'true'


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
The save-state, set-output command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Closes gh-12032