### PR TITLE
Prepare for upgrade to reactor-core:3.5.0

### DIFF
--- a/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -3039,7 +3039,7 @@ public class ServerHttpSecurity {
 
 		@Override
 		public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
-			return chain.filter(exchange).subscriberContext(Context.of(ServerWebExchange.class, exchange));
+			return chain.filter(exchange).contextWrite(Context.of(ServerWebExchange.class, exchange));
 		}
 
 	}

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/EnableReactiveMethodSecurityTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/EnableReactiveMethodSecurityTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,8 +97,7 @@ public class EnableReactiveMethodSecurityTests {
 	@Test
 	public void monoPreAuthorizeHasRoleWhenGrantedThenSuccess() {
 		given(this.delegate.monoPreAuthorizeHasRoleFindById(1L)).willReturn(Mono.just("result"));
-		Mono<String> findById = this.messageService.monoPreAuthorizeHasRoleFindById(1L)
-				.subscriberContext(this.withAdmin);
+		Mono<String> findById = this.messageService.monoPreAuthorizeHasRoleFindById(1L).contextWrite(this.withAdmin);
 		StepVerifier.create(findById).expectNext("result").verifyComplete();
 	}
 
@@ -113,8 +112,7 @@ public class EnableReactiveMethodSecurityTests {
 	@Test
 	public void monoPreAuthorizeHasRoleWhenNotAuthorizedThenDenied() {
 		given(this.delegate.monoPreAuthorizeHasRoleFindById(1L)).willReturn(Mono.from(this.result));
-		Mono<String> findById = this.messageService.monoPreAuthorizeHasRoleFindById(1L)
-				.subscriberContext(this.withUser);
+		Mono<String> findById = this.messageService.monoPreAuthorizeHasRoleFindById(1L).contextWrite(this.withUser);
 		StepVerifier.create(findById).expectError(AccessDeniedException.class).verify();
 		this.result.assertNoSubscribers();
 	}
@@ -122,7 +120,7 @@ public class EnableReactiveMethodSecurityTests {
 	@Test
 	public void monoPreAuthorizeBeanWhenGrantedThenSuccess() {
 		given(this.delegate.monoPreAuthorizeBeanFindById(2L)).willReturn(Mono.just("result"));
-		Mono<String> findById = this.messageService.monoPreAuthorizeBeanFindById(2L).subscriberContext(this.withAdmin);
+		Mono<String> findById = this.messageService.monoPreAuthorizeBeanFindById(2L).contextWrite(this.withAdmin);
 		StepVerifier.create(findById).expectNext("result").verifyComplete();
 	}
 
@@ -144,7 +142,7 @@ public class EnableReactiveMethodSecurityTests {
 	@Test
 	public void monoPreAuthorizeBeanWhenNotAuthorizedThenDenied() {
 		given(this.delegate.monoPreAuthorizeBeanFindById(1L)).willReturn(Mono.from(this.result));
-		Mono<String> findById = this.messageService.monoPreAuthorizeBeanFindById(1L).subscriberContext(this.withUser);
+		Mono<String> findById = this.messageService.monoPreAuthorizeBeanFindById(1L).contextWrite(this.withUser);
 		StepVerifier.create(findById).expectError(AccessDeniedException.class).verify();
 		this.result.assertNoSubscribers();
 	}
@@ -152,21 +150,21 @@ public class EnableReactiveMethodSecurityTests {
 	@Test
 	public void monoPostAuthorizeWhenAuthorizedThenSuccess() {
 		given(this.delegate.monoPostAuthorizeFindById(1L)).willReturn(Mono.just("user"));
-		Mono<String> findById = this.messageService.monoPostAuthorizeFindById(1L).subscriberContext(this.withUser);
+		Mono<String> findById = this.messageService.monoPostAuthorizeFindById(1L).contextWrite(this.withUser);
 		StepVerifier.create(findById).expectNext("user").verifyComplete();
 	}
 
 	@Test
 	public void monoPostAuthorizeWhenNotAuthorizedThenDenied() {
 		given(this.delegate.monoPostAuthorizeBeanFindById(1L)).willReturn(Mono.just("not-authorized"));
-		Mono<String> findById = this.messageService.monoPostAuthorizeBeanFindById(1L).subscriberContext(this.withUser);
+		Mono<String> findById = this.messageService.monoPostAuthorizeBeanFindById(1L).contextWrite(this.withUser);
 		StepVerifier.create(findById).expectError(AccessDeniedException.class).verify();
 	}
 
 	@Test
 	public void monoPostAuthorizeWhenBeanAndAuthorizedThenSuccess() {
 		given(this.delegate.monoPostAuthorizeBeanFindById(2L)).willReturn(Mono.just("user"));
-		Mono<String> findById = this.messageService.monoPostAuthorizeBeanFindById(2L).subscriberContext(this.withUser);
+		Mono<String> findById = this.messageService.monoPostAuthorizeBeanFindById(2L).contextWrite(this.withUser);
 		StepVerifier.create(findById).expectNext("user").verifyComplete();
 	}
 
@@ -180,7 +178,7 @@ public class EnableReactiveMethodSecurityTests {
 	@Test
 	public void monoPostAuthorizeWhenBeanAndNotAuthorizedThenDenied() {
 		given(this.delegate.monoPostAuthorizeBeanFindById(1L)).willReturn(Mono.just("not-authorized"));
-		Mono<String> findById = this.messageService.monoPostAuthorizeBeanFindById(1L).subscriberContext(this.withUser);
+		Mono<String> findById = this.messageService.monoPostAuthorizeBeanFindById(1L).contextWrite(this.withUser);
 		StepVerifier.create(findById).expectError(AccessDeniedException.class).verify();
 	}
 
@@ -201,8 +199,7 @@ public class EnableReactiveMethodSecurityTests {
 	@Test
 	public void fluxPreAuthorizeHasRoleWhenGrantedThenSuccess() {
 		given(this.delegate.fluxPreAuthorizeHasRoleFindById(1L)).willReturn(Flux.just("result"));
-		Flux<String> findById = this.messageService.fluxPreAuthorizeHasRoleFindById(1L)
-				.subscriberContext(this.withAdmin);
+		Flux<String> findById = this.messageService.fluxPreAuthorizeHasRoleFindById(1L).contextWrite(this.withAdmin);
 		StepVerifier.create(findById).consumeNextWith((s) -> assertThat(s).isEqualTo("result")).verifyComplete();
 	}
 
@@ -217,8 +214,7 @@ public class EnableReactiveMethodSecurityTests {
 	@Test
 	public void fluxPreAuthorizeHasRoleWhenNotAuthorizedThenDenied() {
 		given(this.delegate.fluxPreAuthorizeHasRoleFindById(1L)).willReturn(Flux.from(this.result));
-		Flux<String> findById = this.messageService.fluxPreAuthorizeHasRoleFindById(1L)
-				.subscriberContext(this.withUser);
+		Flux<String> findById = this.messageService.fluxPreAuthorizeHasRoleFindById(1L).contextWrite(this.withUser);
 		StepVerifier.create(findById).expectError(AccessDeniedException.class).verify();
 		this.result.assertNoSubscribers();
 	}
@@ -226,7 +222,7 @@ public class EnableReactiveMethodSecurityTests {
 	@Test
 	public void fluxPreAuthorizeBeanWhenGrantedThenSuccess() {
 		given(this.delegate.fluxPreAuthorizeBeanFindById(2L)).willReturn(Flux.just("result"));
-		Flux<String> findById = this.messageService.fluxPreAuthorizeBeanFindById(2L).subscriberContext(this.withAdmin);
+		Flux<String> findById = this.messageService.fluxPreAuthorizeBeanFindById(2L).contextWrite(this.withAdmin);
 		StepVerifier.create(findById).expectNext("result").verifyComplete();
 	}
 
@@ -248,7 +244,7 @@ public class EnableReactiveMethodSecurityTests {
 	@Test
 	public void fluxPreAuthorizeBeanWhenNotAuthorizedThenDenied() {
 		given(this.delegate.fluxPreAuthorizeBeanFindById(1L)).willReturn(Flux.from(this.result));
-		Flux<String> findById = this.messageService.fluxPreAuthorizeBeanFindById(1L).subscriberContext(this.withUser);
+		Flux<String> findById = this.messageService.fluxPreAuthorizeBeanFindById(1L).contextWrite(this.withUser);
 		StepVerifier.create(findById).expectError(AccessDeniedException.class).verify();
 		this.result.assertNoSubscribers();
 	}
@@ -256,21 +252,21 @@ public class EnableReactiveMethodSecurityTests {
 	@Test
 	public void fluxPostAuthorizeWhenAuthorizedThenSuccess() {
 		given(this.delegate.fluxPostAuthorizeFindById(1L)).willReturn(Flux.just("user"));
-		Flux<String> findById = this.messageService.fluxPostAuthorizeFindById(1L).subscriberContext(this.withUser);
+		Flux<String> findById = this.messageService.fluxPostAuthorizeFindById(1L).contextWrite(this.withUser);
 		StepVerifier.create(findById).expectNext("user").verifyComplete();
 	}
 
 	@Test
 	public void fluxPostAuthorizeWhenNotAuthorizedThenDenied() {
 		given(this.delegate.fluxPostAuthorizeBeanFindById(1L)).willReturn(Flux.just("not-authorized"));
-		Flux<String> findById = this.messageService.fluxPostAuthorizeBeanFindById(1L).subscriberContext(this.withUser);
+		Flux<String> findById = this.messageService.fluxPostAuthorizeBeanFindById(1L).contextWrite(this.withUser);
 		StepVerifier.create(findById).expectError(AccessDeniedException.class).verify();
 	}
 
 	@Test
 	public void fluxPostAuthorizeWhenBeanAndAuthorizedThenSuccess() {
 		given(this.delegate.fluxPostAuthorizeBeanFindById(2L)).willReturn(Flux.just("user"));
-		Flux<String> findById = this.messageService.fluxPostAuthorizeBeanFindById(2L).subscriberContext(this.withUser);
+		Flux<String> findById = this.messageService.fluxPostAuthorizeBeanFindById(2L).contextWrite(this.withUser);
 		StepVerifier.create(findById).expectNext("user").verifyComplete();
 	}
 
@@ -284,7 +280,7 @@ public class EnableReactiveMethodSecurityTests {
 	@Test
 	public void fluxPostAuthorizeWhenBeanAndNotAuthorizedThenDenied() {
 		given(this.delegate.fluxPostAuthorizeBeanFindById(1L)).willReturn(Flux.just("not-authorized"));
-		Flux<String> findById = this.messageService.fluxPostAuthorizeBeanFindById(1L).subscriberContext(this.withUser);
+		Flux<String> findById = this.messageService.fluxPostAuthorizeBeanFindById(1L).contextWrite(this.withUser);
 		StepVerifier.create(findById).expectError(AccessDeniedException.class).verify();
 	}
 
@@ -306,7 +302,7 @@ public class EnableReactiveMethodSecurityTests {
 	public void publisherPreAuthorizeHasRoleWhenGrantedThenSuccess() {
 		given(this.delegate.publisherPreAuthorizeHasRoleFindById(1L)).willReturn(publisherJust("result"));
 		Publisher<String> findById = Flux.from(this.messageService.publisherPreAuthorizeHasRoleFindById(1L))
-				.subscriberContext(this.withAdmin);
+				.contextWrite(this.withAdmin);
 		StepVerifier.create(findById).consumeNextWith((s) -> assertThat(s).isEqualTo("result")).verifyComplete();
 	}
 
@@ -322,7 +318,7 @@ public class EnableReactiveMethodSecurityTests {
 	public void publisherPreAuthorizeHasRoleWhenNotAuthorizedThenDenied() {
 		given(this.delegate.publisherPreAuthorizeHasRoleFindById(1L)).willReturn(this.result);
 		Publisher<String> findById = Flux.from(this.messageService.publisherPreAuthorizeHasRoleFindById(1L))
-				.subscriberContext(this.withUser);
+				.contextWrite(this.withUser);
 		StepVerifier.create(findById).expectError(AccessDeniedException.class).verify();
 		this.result.assertNoSubscribers();
 	}
@@ -331,7 +327,7 @@ public class EnableReactiveMethodSecurityTests {
 	public void publisherPreAuthorizeBeanWhenGrantedThenSuccess() {
 		given(this.delegate.publisherPreAuthorizeBeanFindById(2L)).willReturn(publisherJust("result"));
 		Publisher<String> findById = Flux.from(this.messageService.publisherPreAuthorizeBeanFindById(2L))
-				.subscriberContext(this.withAdmin);
+				.contextWrite(this.withAdmin);
 		StepVerifier.create(findById).expectNext("result").verifyComplete();
 	}
 
@@ -354,7 +350,7 @@ public class EnableReactiveMethodSecurityTests {
 	public void publisherPreAuthorizeBeanWhenNotAuthorizedThenDenied() {
 		given(this.delegate.publisherPreAuthorizeBeanFindById(1L)).willReturn(this.result);
 		Publisher<String> findById = Flux.from(this.messageService.publisherPreAuthorizeBeanFindById(1L))
-				.subscriberContext(this.withUser);
+				.contextWrite(this.withUser);
 		StepVerifier.create(findById).expectError(AccessDeniedException.class).verify();
 		this.result.assertNoSubscribers();
 	}
@@ -363,7 +359,7 @@ public class EnableReactiveMethodSecurityTests {
 	public void publisherPostAuthorizeWhenAuthorizedThenSuccess() {
 		given(this.delegate.publisherPostAuthorizeFindById(1L)).willReturn(publisherJust("user"));
 		Publisher<String> findById = Flux.from(this.messageService.publisherPostAuthorizeFindById(1L))
-				.subscriberContext(this.withUser);
+				.contextWrite(this.withUser);
 		StepVerifier.create(findById).expectNext("user").verifyComplete();
 	}
 
@@ -371,7 +367,7 @@ public class EnableReactiveMethodSecurityTests {
 	public void publisherPostAuthorizeWhenNotAuthorizedThenDenied() {
 		given(this.delegate.publisherPostAuthorizeBeanFindById(1L)).willReturn(publisherJust("not-authorized"));
 		Publisher<String> findById = Flux.from(this.messageService.publisherPostAuthorizeBeanFindById(1L))
-				.subscriberContext(this.withUser);
+				.contextWrite(this.withUser);
 		StepVerifier.create(findById).expectError(AccessDeniedException.class).verify();
 	}
 
@@ -379,7 +375,7 @@ public class EnableReactiveMethodSecurityTests {
 	public void publisherPostAuthorizeWhenBeanAndAuthorizedThenSuccess() {
 		given(this.delegate.publisherPostAuthorizeBeanFindById(2L)).willReturn(publisherJust("user"));
 		Publisher<String> findById = Flux.from(this.messageService.publisherPostAuthorizeBeanFindById(2L))
-				.subscriberContext(this.withUser);
+				.contextWrite(this.withUser);
 		StepVerifier.create(findById).expectNext("user").verifyComplete();
 	}
 
@@ -394,7 +390,7 @@ public class EnableReactiveMethodSecurityTests {
 	public void publisherPostAuthorizeWhenBeanAndNotAuthorizedThenDenied() {
 		given(this.delegate.publisherPostAuthorizeBeanFindById(1L)).willReturn(publisherJust("not-authorized"));
 		Publisher<String> findById = Flux.from(this.messageService.publisherPostAuthorizeBeanFindById(1L))
-				.subscriberContext(this.withUser);
+				.contextWrite(this.withUser);
 		StepVerifier.create(findById).expectError(AccessDeniedException.class).verify();
 	}
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configuration/SecurityReactorContextConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configuration/SecurityReactorContextConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -200,7 +200,7 @@ public class SecurityReactorContextConfigurationTests {
 		SecurityContextHolder.getContext().setAuthentication(this.authentication);
 		ClientResponse clientResponseOk = ClientResponse.create(HttpStatus.OK).build();
 		// @formatter:off
-		ExchangeFilterFunction filter = (req, next) -> Mono.subscriberContext()
+		ExchangeFilterFunction filter = (req, next) -> Mono.deferContextual(Mono::just)
 				.filter((ctx) -> ctx.hasKey(SecurityReactorContextSubscriber.SECURITY_CONTEXT_ATTRIBUTES))
 				.map((ctx) -> ctx.get(SecurityReactorContextSubscriber.SECURITY_CONTEXT_ATTRIBUTES))
 				.cast(Map.class)

--- a/config/src/test/java/org/springframework/security/config/web/server/ServerHttpSecurityTests.java
+++ b/config/src/test/java/org/springframework/security/config/web/server/ServerHttpSecurityTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -557,7 +557,7 @@ public class ServerHttpSecurityTests {
 
 		@GetMapping("/**")
 		Mono<String> pathWithinApplicationFromContext() {
-			return Mono.subscriberContext().filter((c) -> c.hasKey(ServerWebExchange.class))
+			return Mono.deferContextual(Mono::just).filter((c) -> c.hasKey(ServerWebExchange.class))
 					.map((c) -> c.get(ServerWebExchange.class))
 					.map((e) -> e.getRequest().getPath().pathWithinApplication().value());
 		}

--- a/core/src/main/java/org/springframework/security/core/context/ReactiveSecurityContextHolder.java
+++ b/core/src/main/java/org/springframework/security/core/context/ReactiveSecurityContextHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.function.Function;
 
 import reactor.core.publisher.Mono;
 import reactor.util.context.Context;
+import reactor.util.context.ContextView;
 
 import org.springframework.security.core.Authentication;
 
@@ -37,23 +38,23 @@ public final class ReactiveSecurityContextHolder {
 	}
 
 	/**
-	 * Gets the {@code Mono<SecurityContext>} from Reactor {@link Context}
+	 * Gets the {@code Mono<SecurityContext>} from Reactor {@link ContextView}
 	 * @return the {@code Mono<SecurityContext>}
 	 */
 	public static Mono<SecurityContext> getContext() {
 		// @formatter:off
-		return Mono.subscriberContext()
+		return Mono.deferContextual(Mono::just)
 				.filter(ReactiveSecurityContextHolder::hasSecurityContext)
 				.flatMap(ReactiveSecurityContextHolder::getSecurityContext);
 		// @formatter:on
 	}
 
-	private static boolean hasSecurityContext(Context context) {
-		return context.hasKey(SECURITY_CONTEXT_KEY);
+	private static boolean hasSecurityContext(ContextView contextView) {
+		return contextView.hasKey(SECURITY_CONTEXT_KEY);
 	}
 
-	private static Mono<SecurityContext> getSecurityContext(Context context) {
-		return context.<Mono<SecurityContext>>get(SECURITY_CONTEXT_KEY);
+	private static Mono<SecurityContext> getSecurityContext(ContextView contextView) {
+		return contextView.<Mono<SecurityContext>>get(SECURITY_CONTEXT_KEY);
 	}
 
 	/**

--- a/core/src/test/java/org/springframework/security/core/context/ReactiveSecurityContextHolderTests.java
+++ b/core/src/test/java/org/springframework/security/core/context/ReactiveSecurityContextHolderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,9 +42,9 @@ public class ReactiveSecurityContextHolderTests {
 	public void setContextAndGetContextThenEmitsContext() {
 		SecurityContext expectedContext = new SecurityContextImpl(
 				new TestingAuthenticationToken("user", "password", "ROLE_USER"));
-		Mono<SecurityContext> context = Mono.subscriberContext()
+		Mono<SecurityContext> context = Mono.deferContextual(Mono::just)
 				.flatMap((c) -> ReactiveSecurityContextHolder.getContext())
-				.subscriberContext(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(expectedContext)));
+				.contextWrite(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(expectedContext)));
 		// @formatter:off
 		StepVerifier.create(context)
 				.expectNext(expectedContext)
@@ -60,7 +60,7 @@ public class ReactiveSecurityContextHolderTests {
 				.map(SecurityContext::getAuthentication)
 				.map(Authentication::getName)
 				.flatMap(this::findMessageByUsername)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(authentication));
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication));
 		StepVerifier.create(messageByUsername)
 				.expectNext("Hi user")
 				.verifyComplete();
@@ -76,10 +76,10 @@ public class ReactiveSecurityContextHolderTests {
 		SecurityContext expectedContext = new SecurityContextImpl(
 				new TestingAuthenticationToken("user", "password", "ROLE_USER"));
 		// @formatter:off
-		Mono<SecurityContext> context = Mono.subscriberContext()
+		Mono<SecurityContext> context = Mono.deferContextual(Mono::just)
 				.flatMap((c) -> ReactiveSecurityContextHolder.getContext())
-				.subscriberContext(ReactiveSecurityContextHolder.clearContext())
-				.subscriberContext(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(expectedContext)));
+				.contextWrite(ReactiveSecurityContextHolder.clearContext())
+				.contextWrite(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(expectedContext)));
 		StepVerifier.create(context)
 				.verifyComplete();
 		// @formatter:on
@@ -89,10 +89,10 @@ public class ReactiveSecurityContextHolderTests {
 	public void setAuthenticationAndGetContextThenEmitsContext() {
 		Authentication expectedAuthentication = new TestingAuthenticationToken("user", "password", "ROLE_USER");
 		// @formatter:off
-		Mono<Authentication> authentication = Mono.subscriberContext()
+		Mono<Authentication> authentication = Mono.deferContextual(Mono::just)
 				.flatMap((c) -> ReactiveSecurityContextHolder.getContext())
 				.map(SecurityContext::getAuthentication)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(expectedAuthentication));
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(expectedAuthentication));
 		StepVerifier.create(authentication)
 				.expectNext(expectedAuthentication)
 				.verifyComplete();

--- a/messaging/src/test/java/org/springframework/security/messaging/context/SecurityContextChannelInterceptorTests.java
+++ b/messaging/src/test/java/org/springframework/security/messaging/context/SecurityContextChannelInterceptorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -197,8 +197,8 @@ public class SecurityContextChannelInterceptorTests {
 	public void restoresOriginalContextNestedThreeDeep() {
 		AnonymousAuthenticationToken anonymous = new AnonymousAuthenticationToken("key", "anonymous",
 				AuthorityUtils.createAuthorityList("ROLE_USER"));
-		TestingAuthenticationToken origional = new TestingAuthenticationToken("original", "origional", "ROLE_USER");
-		SecurityContextHolder.getContext().setAuthentication(origional);
+		TestingAuthenticationToken original = new TestingAuthenticationToken("original", "original", "ROLE_USER");
+		SecurityContextHolder.getContext().setAuthentication(original);
 		this.messageBuilder.setHeader(SimpMessageHeaderAccessor.USER_HEADER, this.authentication);
 		this.interceptor.beforeHandle(this.messageBuilder.build(), this.channel, this.handler);
 		assertThat(SecurityContextHolder.getContext().getAuthentication()).isSameAs(this.authentication);
@@ -210,7 +210,7 @@ public class SecurityContextChannelInterceptorTests {
 		assertThat(SecurityContextHolder.getContext().getAuthentication()).isSameAs(this.authentication);
 		// end send websocket
 		this.interceptor.afterMessageHandled(this.messageBuilder.build(), this.channel, this.handler, null);
-		assertThat(SecurityContextHolder.getContext().getAuthentication()).isSameAs(origional);
+		assertThat(SecurityContextHolder.getContext().getAuthentication()).isSameAs(original);
 	}
 
 	private void assertAnonymous() {

--- a/messaging/src/test/java/org/springframework/security/messaging/handler/invocation/reactive/AuthenticationPrincipalArgumentResolverTests.java
+++ b/messaging/src/test/java/org/springframework/security/messaging/handler/invocation/reactive/AuthenticationPrincipalArgumentResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public class AuthenticationPrincipalArgumentResolverTests {
 		// @formatter:off
 		Mono<UserDetails> result = (Mono<UserDetails>) this.resolver
 				.resolveArgument(arg0("authenticationPrincipalOnMonoUserDetails"), null)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(authentication))
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication))
 				.block();
 		// @formatter:on
 		assertThat(result.block()).isEqualTo(authentication.getPrincipal());
@@ -79,7 +79,7 @@ public class AuthenticationPrincipalArgumentResolverTests {
 		// @formatter:off
 		Mono<UserDetails> result = (Mono<UserDetails>) this.resolver
 				.resolveArgument(arg0("currentUserOnMonoUserDetails"), null)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(authentication))
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication))
 				.block();
 		// @formatter:on
 		assertThat(result.block()).isEqualTo(authentication.getPrincipal());
@@ -95,7 +95,7 @@ public class AuthenticationPrincipalArgumentResolverTests {
 		// @formatter:off
 		Mono<String> result = (Mono<String>) this.resolver
 				.resolveArgument(arg0("authenticationPrincipalExpression"), null)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(authentication))
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication))
 				.block();
 		// @formatter:on
 		assertThat(result.block()).isEqualTo(authentication.getName());
@@ -112,7 +112,7 @@ public class AuthenticationPrincipalArgumentResolverTests {
 		// @formatter:off
 		Mono<Object> result = this.resolver
 				.resolveArgument(arg0("authenticationPrincipalExpressionPrimitive"), null)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(new TestingAuthenticationToken(principal, "password", "ROLE_USER")));
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(new TestingAuthenticationToken(principal, "password", "ROLE_USER")));
 		// @formatter:on
 		assertThat(result.block()).isEqualTo(principal.id);
 	}

--- a/messaging/src/test/java/org/springframework/security/messaging/handler/invocation/reactive/CurrentSecurityContextArgumentResolverTests.java
+++ b/messaging/src/test/java/org/springframework/security/messaging/handler/invocation/reactive/CurrentSecurityContextArgumentResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public class CurrentSecurityContextArgumentResolverTests {
 		Authentication authentication = TestAuthentication.authenticatedUser();
 		Mono<SecurityContext> result = (Mono<SecurityContext>) this.resolver
 				.resolveArgument(arg0("currentSecurityContextOnMonoSecurityContext"), null)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(authentication)).block();
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication)).block();
 		assertThat(result.block().getAuthentication()).isEqualTo(authentication);
 	}
 
@@ -76,7 +76,7 @@ public class CurrentSecurityContextArgumentResolverTests {
 		Authentication authentication = TestAuthentication.authenticatedUser();
 		Mono<UserDetails> result = (Mono<UserDetails>) this.resolver
 				.resolveArgument(arg0("currentUserOnMonoUserDetails"), null)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(authentication)).block();
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication)).block();
 		assertThat(result.block()).isEqualTo(authentication.getPrincipal());
 	}
 
@@ -89,7 +89,7 @@ public class CurrentSecurityContextArgumentResolverTests {
 		Authentication authentication = TestAuthentication.authenticatedUser();
 		Mono<String> result = (Mono<String>) this.resolver
 				.resolveArgument(arg0("authenticationPrincipalExpression"), null)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(authentication)).block();
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication)).block();
 		assertThat(result.block()).isEqualTo(authentication.getName());
 	}
 

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/DefaultReactiveOAuth2AuthorizedClientManager.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/DefaultReactiveOAuth2AuthorizedClientManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,7 +103,7 @@ public final class DefaultReactiveOAuth2AuthorizedClientManager implements React
 	// @formatter:on
 
 	// @formatter:off
-	private static final Mono<ServerWebExchange> currentServerWebExchangeMono = Mono.subscriberContext()
+	private static final Mono<ServerWebExchange> currentServerWebExchangeMono = Mono.deferContextual(Mono::just)
 			.filter((c) -> c.hasKey(ServerWebExchange.class))
 			.map((c) -> c.get(ServerWebExchange.class));
 	// @formatter:on

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServerOAuth2AuthorizedClientExchangeFilterFunction.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServerOAuth2AuthorizedClientExchangeFilterFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -139,7 +139,7 @@ public final class ServerOAuth2AuthorizedClientExchangeFilterFunction implements
 	// @formatter:on
 
 	// @formatter:off
-	private final Mono<ServerWebExchange> currentServerWebExchangeMono = Mono.subscriberContext()
+	private final Mono<ServerWebExchange> currentServerWebExchangeMono = Mono.deferContextual(Mono::just)
 			.filter((c) -> c.hasKey(ServerWebExchange.class))
 			.map((c) -> c.get(ServerWebExchange.class));
 	// @formatter:on

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/reactive/result/method/annotation/OAuth2AuthorizedClientArgumentResolver.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/reactive/result/method/annotation/OAuth2AuthorizedClientArgumentResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -141,7 +141,7 @@ public final class OAuth2AuthorizedClientArgumentResolver implements HandlerMeth
 
 	private Mono<ServerWebExchange> currentServerWebExchange() {
 		// @formatter:off
-		return Mono.subscriberContext()
+		return Mono.deferContextual(Mono::just)
 				.filter((c) -> c.hasKey(ServerWebExchange.class))
 				.map((c) -> c.get(ServerWebExchange.class));
 		// @formatter:on

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/DefaultReactiveOAuth2AuthorizedClientManagerTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/DefaultReactiveOAuth2AuthorizedClientManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -194,7 +194,7 @@ public class DefaultReactiveOAuth2AuthorizedClientManagerTests {
 		OAuth2AuthorizeRequest authorizeRequest = OAuth2AuthorizeRequest
 				.withClientRegistrationId("invalid-registration-id").principal(this.principal).build();
 		assertThatIllegalArgumentException().isThrownBy(
-				() -> this.authorizedClientManager.authorize(authorizeRequest).subscriberContext(this.context).block())
+				() -> this.authorizedClientManager.authorize(authorizeRequest).contextWrite(this.context).block())
 				.withMessage("Could not find ClientRegistration with id 'invalid-registration-id'");
 	}
 
@@ -207,7 +207,7 @@ public class DefaultReactiveOAuth2AuthorizedClientManagerTests {
 				.withClientRegistrationId(this.clientRegistration.getRegistrationId()).principal(this.principal)
 				.build();
 		OAuth2AuthorizedClient authorizedClient = this.authorizedClientManager.authorize(authorizeRequest)
-				.subscriberContext(this.context).block();
+				.contextWrite(this.context).block();
 		verify(this.authorizedClientProvider).authorize(this.authorizationContextCaptor.capture());
 		verify(this.contextAttributesMapper).apply(eq(authorizeRequest));
 		OAuth2AuthorizationContext authorizationContext = this.authorizationContextCaptor.getValue();
@@ -230,7 +230,7 @@ public class DefaultReactiveOAuth2AuthorizedClientManagerTests {
 				.withClientRegistrationId(this.clientRegistration.getRegistrationId()).principal(this.principal)
 				.build();
 		OAuth2AuthorizedClient authorizedClient = this.authorizedClientManager.authorize(authorizeRequest)
-				.subscriberContext(this.context).block();
+				.contextWrite(this.context).block();
 		verify(this.authorizedClientProvider).authorize(this.authorizationContextCaptor.capture());
 		verify(this.contextAttributesMapper).apply(eq(authorizeRequest));
 		OAuth2AuthorizationContext authorizationContext = this.authorizationContextCaptor.getValue();
@@ -258,7 +258,7 @@ public class DefaultReactiveOAuth2AuthorizedClientManagerTests {
 		this.authorizedClientManager.setAuthorizationSuccessHandler(
 				(client, principal, attributes) -> authorizationSuccessHandlerProbe.mono());
 		OAuth2AuthorizedClient authorizedClient = this.authorizedClientManager.authorize(authorizeRequest)
-				.subscriberContext(this.context).block();
+				.contextWrite(this.context).block();
 		verify(this.authorizedClientProvider).authorize(this.authorizationContextCaptor.capture());
 		verify(this.contextAttributesMapper).apply(eq(authorizeRequest));
 		OAuth2AuthorizationContext authorizationContext = this.authorizationContextCaptor.getValue();
@@ -285,7 +285,7 @@ public class DefaultReactiveOAuth2AuthorizedClientManagerTests {
 		given(this.authorizedClientProvider.authorize(any(OAuth2AuthorizationContext.class)))
 				.willReturn(Mono.error(exception));
 		assertThatExceptionOfType(ClientAuthorizationException.class).isThrownBy(
-				() -> this.authorizedClientManager.authorize(authorizeRequest).subscriberContext(this.context).block())
+				() -> this.authorizedClientManager.authorize(authorizeRequest).contextWrite(this.context).block())
 				.isEqualTo(exception);
 		verify(this.authorizedClientProvider).authorize(this.authorizationContextCaptor.capture());
 		verify(this.contextAttributesMapper).apply(eq(authorizeRequest));
@@ -313,7 +313,7 @@ public class DefaultReactiveOAuth2AuthorizedClientManagerTests {
 		given(this.authorizedClientProvider.authorize(any(OAuth2AuthorizationContext.class)))
 				.willReturn(Mono.error(exception));
 		assertThatExceptionOfType(ClientAuthorizationException.class).isThrownBy(
-				() -> this.authorizedClientManager.authorize(authorizeRequest).subscriberContext(this.context).block())
+				() -> this.authorizedClientManager.authorize(authorizeRequest).contextWrite(this.context).block())
 				.isEqualTo(exception);
 		verify(this.authorizedClientProvider).authorize(this.authorizationContextCaptor.capture());
 		verify(this.contextAttributesMapper).apply(eq(authorizeRequest));
@@ -341,7 +341,7 @@ public class DefaultReactiveOAuth2AuthorizedClientManagerTests {
 		given(this.authorizedClientProvider.authorize(any(OAuth2AuthorizationContext.class)))
 				.willReturn(Mono.error(exception));
 		assertThatExceptionOfType(ClientAuthorizationException.class).isThrownBy(
-				() -> this.authorizedClientManager.authorize(authorizeRequest).subscriberContext(this.context).block())
+				() -> this.authorizedClientManager.authorize(authorizeRequest).contextWrite(this.context).block())
 				.isEqualTo(exception);
 		verify(this.authorizedClientProvider).authorize(this.authorizationContextCaptor.capture());
 		verify(this.contextAttributesMapper).apply(eq(authorizeRequest));
@@ -366,7 +366,7 @@ public class DefaultReactiveOAuth2AuthorizedClientManagerTests {
 		given(this.authorizedClientProvider.authorize(any(OAuth2AuthorizationContext.class)))
 				.willReturn(Mono.error(exception));
 		assertThatExceptionOfType(OAuth2AuthorizationException.class).isThrownBy(
-				() -> this.authorizedClientManager.authorize(authorizeRequest).subscriberContext(this.context).block())
+				() -> this.authorizedClientManager.authorize(authorizeRequest).contextWrite(this.context).block())
 				.isEqualTo(exception);
 		verify(this.authorizedClientProvider).authorize(this.authorizationContextCaptor.capture());
 		verify(this.contextAttributesMapper).apply(eq(authorizeRequest));
@@ -394,7 +394,7 @@ public class DefaultReactiveOAuth2AuthorizedClientManagerTests {
 		this.authorizedClientManager.setAuthorizationFailureHandler(
 				(client, principal, attributes) -> authorizationFailureHandlerProbe.mono());
 		assertThatExceptionOfType(OAuth2AuthorizationException.class).isThrownBy(
-				() -> this.authorizedClientManager.authorize(authorizeRequest).subscriberContext(this.context).block())
+				() -> this.authorizedClientManager.authorize(authorizeRequest).contextWrite(this.context).block())
 				.isEqualTo(exception);
 		verify(this.authorizedClientProvider).authorize(this.authorizationContextCaptor.capture());
 		verify(this.contextAttributesMapper).apply(eq(authorizeRequest));
@@ -423,7 +423,7 @@ public class DefaultReactiveOAuth2AuthorizedClientManagerTests {
 				.withClientRegistrationId(this.clientRegistration.getRegistrationId()).principal(this.principal)
 				.build();
 		OAuth2AuthorizedClient authorizedClient = this.authorizedClientManager.authorize(authorizeRequest)
-				.subscriberContext(this.context).block();
+				.contextWrite(this.context).block();
 		verify(this.authorizedClientProvider).authorize(this.authorizationContextCaptor.capture());
 		verify(this.contextAttributesMapper).apply(any());
 		OAuth2AuthorizationContext authorizationContext = this.authorizationContextCaptor.getValue();
@@ -460,7 +460,7 @@ public class DefaultReactiveOAuth2AuthorizedClientManagerTests {
 		OAuth2AuthorizeRequest authorizeRequest = OAuth2AuthorizeRequest
 				.withClientRegistrationId(this.clientRegistration.getRegistrationId()).principal(this.principal)
 				.build();
-		this.authorizedClientManager.authorize(authorizeRequest).subscriberContext(this.context).block();
+		this.authorizedClientManager.authorize(authorizeRequest).contextWrite(this.context).block();
 		verify(this.authorizedClientProvider).authorize(this.authorizationContextCaptor.capture());
 		OAuth2AuthorizationContext authorizationContext = this.authorizationContextCaptor.getValue();
 		String username = authorizationContext.getAttribute(OAuth2AuthorizationContext.USERNAME_ATTRIBUTE_NAME);
@@ -475,7 +475,7 @@ public class DefaultReactiveOAuth2AuthorizedClientManagerTests {
 		OAuth2AuthorizeRequest reauthorizeRequest = OAuth2AuthorizeRequest.withAuthorizedClient(this.authorizedClient)
 				.principal(this.principal).build();
 		OAuth2AuthorizedClient authorizedClient = this.authorizedClientManager.authorize(reauthorizeRequest)
-				.subscriberContext(this.context).block();
+				.contextWrite(this.context).block();
 		verify(this.authorizedClientProvider).authorize(this.authorizationContextCaptor.capture());
 		verify(this.contextAttributesMapper).apply(eq(reauthorizeRequest));
 		OAuth2AuthorizationContext authorizationContext = this.authorizationContextCaptor.getValue();
@@ -496,7 +496,7 @@ public class DefaultReactiveOAuth2AuthorizedClientManagerTests {
 		OAuth2AuthorizeRequest reauthorizeRequest = OAuth2AuthorizeRequest.withAuthorizedClient(this.authorizedClient)
 				.principal(this.principal).build();
 		OAuth2AuthorizedClient authorizedClient = this.authorizedClientManager.authorize(reauthorizeRequest)
-				.subscriberContext(this.context).block();
+				.contextWrite(this.context).block();
 		verify(this.authorizedClientProvider).authorize(this.authorizationContextCaptor.capture());
 		verify(this.contextAttributesMapper).apply(eq(reauthorizeRequest));
 		OAuth2AuthorizationContext authorizationContext = this.authorizationContextCaptor.getValue();
@@ -524,7 +524,7 @@ public class DefaultReactiveOAuth2AuthorizedClientManagerTests {
 		this.context = Context.of(ServerWebExchange.class, this.serverWebExchange);
 		OAuth2AuthorizeRequest reauthorizeRequest = OAuth2AuthorizeRequest.withAuthorizedClient(this.authorizedClient)
 				.principal(this.principal).build();
-		this.authorizedClientManager.authorize(reauthorizeRequest).subscriberContext(this.context).block();
+		this.authorizedClientManager.authorize(reauthorizeRequest).contextWrite(this.context).block();
 		verify(this.authorizedClientProvider).authorize(this.authorizationContextCaptor.capture());
 		OAuth2AuthorizationContext authorizationContext = this.authorizationContextCaptor.getValue();
 		String[] requestScopeAttribute = authorizationContext
@@ -533,7 +533,7 @@ public class DefaultReactiveOAuth2AuthorizedClientManagerTests {
 	}
 
 	private Mono<ServerWebExchange> currentServerWebExchange() {
-		return Mono.subscriberContext().filter((c) -> c.hasKey(ServerWebExchange.class))
+		return Mono.deferContextual(Mono::just).filter((c) -> c.hasKey(ServerWebExchange.class))
 				.map((c) -> c.get(ServerWebExchange.class));
 	}
 

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServerOAuth2AuthorizedClientExchangeFilterFunctionITests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServerOAuth2AuthorizedClientExchangeFilterFunctionITests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -156,8 +156,8 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionITests {
 						.clientRegistrationId(clientRegistration.getRegistrationId()))
 				.retrieve()
 				.bodyToMono(String.class)
-				.subscriberContext(Context.of(ServerWebExchange.class, this.exchange))
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(this.authentication))
+				.contextWrite(Context.of(ServerWebExchange.class, this.exchange))
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(this.authentication))
 				.block();
 		// @formatter:on
 		assertThat(this.server.getRequestCount()).isEqualTo(2);
@@ -199,9 +199,8 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionITests {
 		this.webClient.get().uri(this.serverUrl)
 				.attributes(ServletOAuth2AuthorizedClientExchangeFilterFunction
 						.clientRegistrationId(clientRegistration.getRegistrationId()))
-				.retrieve().bodyToMono(String.class)
-				.subscriberContext(Context.of(ServerWebExchange.class, this.exchange))
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(this.authentication)).block();
+				.retrieve().bodyToMono(String.class).contextWrite(Context.of(ServerWebExchange.class, this.exchange))
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(this.authentication)).block();
 		assertThat(this.server.getRequestCount()).isEqualTo(2);
 		ArgumentCaptor<OAuth2AuthorizedClient> authorizedClientCaptor = ArgumentCaptor
 				.forClass(OAuth2AuthorizedClient.class);
@@ -254,8 +253,8 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionITests {
 						.retrieve()
 						.bodyToMono(String.class)
 				)
-				.subscriberContext(Context.of(ServerWebExchange.class, this.exchange))
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(this.authentication))
+				.contextWrite(Context.of(ServerWebExchange.class, this.exchange))
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(this.authentication))
 				.block();
 		// @formatter:on
 		assertThat(this.server.getRequestCount()).isEqualTo(4);
@@ -306,8 +305,8 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionITests {
 						.clientRegistrationId(clientRegistration.getRegistrationId()))
 				.retrieve()
 				.bodyToMono(String.class)
-				.subscriberContext(Context.of(ServerWebExchange.class, this.exchange))
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
+				.contextWrite(Context.of(ServerWebExchange.class, this.exchange))
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
 		// @formatter:on
 		// first try should fail, and remove the cached authorized client
 		// @formatter:off

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServerOAuth2AuthorizedClientExchangeFilterFunctionTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServerOAuth2AuthorizedClientExchangeFilterFunctionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -249,7 +249,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				.attributes(ServerOAuth2AuthorizedClientExchangeFilterFunction.oauth2AuthorizedClient(authorizedClient))
 				.build();
 		// @formatter:off
-		this.function.filter(request, this.exchange).subscriberContext(serverWebExchange())
+		this.function.filter(request, this.exchange).contextWrite(serverWebExchange())
 				.block();
 		// @formatter:on
 		assertThat(this.exchange.getRequest().headers().getFirst(HttpHeaders.AUTHORIZATION))
@@ -266,7 +266,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				.attributes(ServerOAuth2AuthorizedClientExchangeFilterFunction.oauth2AuthorizedClient(authorizedClient))
 				.build();
 		// @formatter:on
-		this.function.filter(request, this.exchange).subscriberContext(serverWebExchange()).block();
+		this.function.filter(request, this.exchange).contextWrite(serverWebExchange()).block();
 		HttpHeaders headers = this.exchange.getRequest().headers();
 		assertThat(headers.get(HttpHeaders.AUTHORIZATION)).containsOnly("Bearer " + this.accessToken.getTokenValue());
 	}
@@ -296,8 +296,8 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				.attributes(ServerOAuth2AuthorizedClientExchangeFilterFunction.oauth2AuthorizedClient(authorizedClient))
 				.build();
 		this.function.filter(request, this.exchange)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(authentication))
-				.subscriberContext(serverWebExchange())
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication))
+				.contextWrite(serverWebExchange())
 				.block();
 		// @formatter:on
 		verify(this.clientCredentialsTokenResponseClient).getTokenResponse(any());
@@ -322,8 +322,8 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				.attributes(ServerOAuth2AuthorizedClientExchangeFilterFunction.oauth2AuthorizedClient(authorizedClient))
 				.build();
 		this.function.filter(request, this.exchange)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(authentication))
-				.subscriberContext(serverWebExchange())
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication))
+				.contextWrite(serverWebExchange())
 				.block();
 		// @formatter:on
 		verify(this.clientCredentialsTokenResponseClient, never()).getTokenResponse(any());
@@ -357,8 +357,8 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 		TestingAuthenticationToken authentication = new TestingAuthenticationToken("test", "this");
 		// @formatter:off
 		this.function.filter(request, this.exchange)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(authentication))
-				.subscriberContext(serverWebExchange())
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication))
+				.contextWrite(serverWebExchange())
 				.block();
 		// @formatter:on
 		verify(this.refreshTokenTokenResponseClient).getTokenResponse(any());
@@ -394,7 +394,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				.attributes(ServerOAuth2AuthorizedClientExchangeFilterFunction.oauth2AuthorizedClient(authorizedClient))
 				.build();
 		this.function.filter(request, this.exchange)
-				.subscriberContext(serverWebExchange())
+				.contextWrite(serverWebExchange())
 				.block();
 		// @formatter:on
 		verify(this.refreshTokenTokenResponseClient).getTokenResponse(any());
@@ -436,8 +436,8 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				.build();
 		// @formatter:on
 		this.function.filter(request, this.exchange)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(jwtAuthentication))
-				.subscriberContext(serverWebExchange()).block();
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(jwtAuthentication))
+				.contextWrite(serverWebExchange()).block();
 		verify(this.jwtBearerTokenResponseClient).getTokenResponse(any());
 		verify(this.authorizedClientRepository).loadAuthorizedClient(eq(registration.getRegistrationId()),
 				eq(jwtAuthentication), any());
@@ -460,7 +460,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				.attributes(ServerOAuth2AuthorizedClientExchangeFilterFunction.oauth2AuthorizedClient(authorizedClient))
 				.build();
 		this.function.filter(request, this.exchange)
-				.subscriberContext(serverWebExchange())
+				.contextWrite(serverWebExchange())
 				.block();
 		// @formatter:on
 		List<ClientRequest> requests = this.exchange.getRequests();
@@ -482,7 +482,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				.attributes(ServerOAuth2AuthorizedClientExchangeFilterFunction.oauth2AuthorizedClient(authorizedClient))
 				.build();
 		this.function.filter(request, this.exchange)
-				.subscriberContext(serverWebExchange())
+				.contextWrite(serverWebExchange())
 				.block();
 		// @formatter:on
 		List<ClientRequest> requests = this.exchange.getRequests();
@@ -510,7 +510,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				.build();
 		// @formatter:on
 		given(this.exchange.getResponse().rawStatusCode()).willReturn(HttpStatus.UNAUTHORIZED.value());
-		this.function.filter(request, this.exchange).subscriberContext(serverWebExchange()).block();
+		this.function.filter(request, this.exchange).contextWrite(serverWebExchange()).block();
 		assertThat(publisherProbe.wasSubscribed()).isTrue();
 		verify(this.authorizationFailureHandler).onAuthorizationFailure(this.authorizationExceptionCaptor.capture(),
 				this.authenticationCaptor.capture(), this.attributesCaptor.capture());
@@ -547,7 +547,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 		assertThatExceptionOfType(WebClientResponseException.class)
 				.isThrownBy(() -> this.function
 					.filter(request, throwingExchangeFunction)
-						.subscriberContext(serverWebExchange())
+						.contextWrite(serverWebExchange())
 						.block()
 				)
 				.isEqualTo(exception);
@@ -585,7 +585,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				.build();
 		// @formatter:on
 		given(this.exchange.getResponse().rawStatusCode()).willReturn(HttpStatus.FORBIDDEN.value());
-		this.function.filter(request, this.exchange).subscriberContext(serverWebExchange()).block();
+		this.function.filter(request, this.exchange).contextWrite(serverWebExchange()).block();
 		assertThat(publisherProbe.wasSubscribed()).isTrue();
 		verify(this.authorizationFailureHandler).onAuthorizationFailure(this.authorizationExceptionCaptor.capture(),
 				this.authenticationCaptor.capture(), this.attributesCaptor.capture());
@@ -620,7 +620,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 		assertThatExceptionOfType(WebClientResponseException.class)
 				.isThrownBy(() -> this.function
 					.filter(request, throwingExchangeFunction)
-					.subscriberContext(serverWebExchange())
+					.contextWrite(serverWebExchange())
 					.block()
 				)
 				.isEqualTo(exception);
@@ -659,7 +659,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 		given(headers.header(eq(HttpHeaders.WWW_AUTHENTICATE)))
 				.willReturn(Collections.singletonList(wwwAuthenticateHeader));
 		given(this.exchange.getResponse().headers()).willReturn(headers);
-		this.function.filter(request, this.exchange).subscriberContext(serverWebExchange()).block();
+		this.function.filter(request, this.exchange).contextWrite(serverWebExchange()).block();
 		assertThat(publisherProbe.wasSubscribed()).isTrue();
 		verify(this.authorizationFailureHandler).onAuthorizationFailure(this.authorizationExceptionCaptor.capture(),
 				this.authenticationCaptor.capture(), this.attributesCaptor.capture());
@@ -693,8 +693,8 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 		OAuth2AuthorizationException exception = new OAuth2AuthorizationException(
 				new OAuth2Error(OAuth2ErrorCodes.INVALID_TOKEN, null, null));
 		ExchangeFunction throwingExchangeFunction = (r) -> Mono.error(exception);
-		assertThatExceptionOfType(OAuth2AuthorizationException.class).isThrownBy(() -> this.function
-				.filter(request, throwingExchangeFunction).subscriberContext(serverWebExchange()).block())
+		assertThatExceptionOfType(OAuth2AuthorizationException.class).isThrownBy(
+				() -> this.function.filter(request, throwingExchangeFunction).contextWrite(serverWebExchange()).block())
 				.isEqualTo(exception);
 		assertThat(publisherProbe.wasSubscribed()).isTrue();
 		verify(this.authorizationFailureHandler).onAuthorizationFailure(this.authorizationExceptionCaptor.capture(),
@@ -716,7 +716,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				.attributes(ServerOAuth2AuthorizedClientExchangeFilterFunction.oauth2AuthorizedClient(authorizedClient))
 				.build();
 		given(this.exchange.getResponse().rawStatusCode()).willReturn(HttpStatus.BAD_REQUEST.value());
-		this.function.filter(request, this.exchange).subscriberContext(serverWebExchange()).block();
+		this.function.filter(request, this.exchange).contextWrite(serverWebExchange()).block();
 		verify(this.authorizationFailureHandler, never()).onAuthorizationFailure(any(), any(), any());
 	}
 
@@ -754,8 +754,8 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 						.clientRegistrationId(registration.getRegistrationId()))
 				.build();
 		this.function.filter(request, this.exchange)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(authentication))
-				.subscriberContext(serverWebExchange()).block();
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication))
+				.contextWrite(serverWebExchange()).block();
 		verify(this.passwordTokenResponseClient).getTokenResponse(any());
 		verify(this.authorizedClientRepository).saveAuthorizedClient(any(), eq(authentication), any());
 		List<ClientRequest> requests = this.exchange.getRequests();
@@ -778,7 +778,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				.attributes(ServerOAuth2AuthorizedClientExchangeFilterFunction
 						.clientRegistrationId(this.registration.getRegistrationId()))
 				.build();
-		this.function.filter(request, this.exchange).subscriberContext(serverWebExchange()).block();
+		this.function.filter(request, this.exchange).contextWrite(serverWebExchange()).block();
 		List<ClientRequest> requests = this.exchange.getRequests();
 		assertThat(requests).hasSize(1);
 		ClientRequest request0 = requests.get(0);
@@ -797,7 +797,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 		given(this.authorizedClientRepository.loadAuthorizedClient(any(), any(), any()))
 				.willReturn(Mono.just(authorizedClient));
 		ClientRequest request = ClientRequest.create(HttpMethod.GET, URI.create("https://example.com")).build();
-		this.function.filter(request, this.exchange).subscriberContext(serverWebExchange()).block();
+		this.function.filter(request, this.exchange).contextWrite(serverWebExchange()).block();
 		List<ClientRequest> requests = this.exchange.getRequests();
 		assertThat(requests).hasSize(1);
 		ClientRequest request0 = requests.get(0);
@@ -821,8 +821,8 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 		OAuth2AuthenticationToken authentication = new OAuth2AuthenticationToken(user, user.getAuthorities(),
 				"client-id");
 		this.function.filter(request, this.exchange)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(authentication))
-				.subscriberContext(serverWebExchange()).block();
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication))
+				.contextWrite(serverWebExchange()).block();
 		List<ClientRequest> requests = this.exchange.getRequests();
 		assertThat(requests).hasSize(1);
 		ClientRequest request0 = requests.get(0);
@@ -841,7 +841,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				"client-id");
 		// @formatter:off
 		this.function.filter(request, this.exchange)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(authentication))
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication))
 				.block();
 		// @formatter:on
 		List<ClientRequest> requests = this.exchange.getRequests();
@@ -861,7 +861,7 @@ public class ServerOAuth2AuthorizedClientExchangeFilterFunctionTests {
 				.attributes(ServerOAuth2AuthorizedClientExchangeFilterFunction.clientRegistrationId(this.registration.getRegistrationId()))
 				.build();
 		this.function.filter(request, this.exchange)
-				.subscriberContext(serverWebExchange())
+				.contextWrite(serverWebExchange())
 				.block();
 		// @formatter:on
 		verify(this.authorizedClientRepository).loadAuthorizedClient(eq(this.registration.getRegistrationId()), any(),

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServletOAuth2AuthorizedClientExchangeFilterFunctionITests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServletOAuth2AuthorizedClientExchangeFilterFunctionITests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -265,7 +265,7 @@ public class ServletOAuth2AuthorizedClientExchangeFilterFunctionITests {
 					.retrieve()
 					.bodyToMono(String.class)
 				)
-				.subscriberContext(context())
+				.contextWrite(context())
 				.block();
 		// @formatter:on
 		assertThat(this.server.getRequestCount()).isEqualTo(4);

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServletOAuth2AuthorizedClientExchangeFilterFunctionTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/function/client/ServletOAuth2AuthorizedClientExchangeFilterFunctionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -658,8 +658,7 @@ public class ServletOAuth2AuthorizedClientExchangeFilterFunctionTests {
 		final ClientRequest request2 = ClientRequest.create(HttpMethod.GET, URI.create("https://example2.com")).build();
 		Context context = context(servletRequest, servletResponse, authentication);
 		this.function.filter(request1, this.exchange)
-				.flatMap((response) -> this.function.filter(request2, this.exchange)).subscriberContext(context)
-				.block();
+				.flatMap((response) -> this.function.filter(request2, this.exchange)).contextWrite(context).block();
 		List<ClientRequest> requests = this.exchange.getRequests();
 		assertThat(requests).hasSize(2);
 		ClientRequest request = requests.get(0);

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/result/method/annotation/OAuth2AuthorizedClientArgumentResolverTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/reactive/result/method/annotation/OAuth2AuthorizedClientArgumentResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -187,9 +187,9 @@ public class OAuth2AuthorizedClientArgumentResolverTests {
 
 	private Object resolveArgument(MethodParameter methodParameter) {
 		return this.argumentResolver.resolveArgument(methodParameter, null, null)
-				.subscriberContext((this.authentication != null)
+				.contextWrite((this.authentication != null)
 						? ReactiveSecurityContextHolder.withAuthentication(this.authentication) : Context.empty())
-				.subscriberContext(serverWebExchange()).block();
+				.contextWrite(serverWebExchange()).block();
 	}
 
 	private Context serverWebExchange() {

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/reactive/function/client/ServerBearerExchangeFilterFunctionTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/reactive/function/client/ServerBearerExchangeFilterFunctionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ public class ServerBearerExchangeFilterFunctionTests {
 	public void filterWhenAuthenticatedThenAuthorizationHeaderNull() throws Exception {
 		ClientRequest request = ClientRequest.create(HttpMethod.GET, URI.create("https://example.com")).build();
 		this.function.filter(request, this.exchange)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(this.authentication)).block();
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(this.authentication)).block();
 		assertThat(this.exchange.getRequest().headers().getFirst(HttpHeaders.AUTHORIZATION))
 				.isEqualTo("Bearer " + this.accessToken.getTokenValue());
 	}
@@ -80,7 +80,7 @@ public class ServerBearerExchangeFilterFunctionTests {
 		ClientRequest request = ClientRequest.create(HttpMethod.GET, URI.create("https://example.com")).build();
 		TestingAuthenticationToken token = new TestingAuthenticationToken("user", "pass");
 		this.function.filter(request, this.exchange)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(token)).block();
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(token)).block();
 		assertThat(this.exchange.getRequest().headers().getFirst(HttpHeaders.AUTHORIZATION)).isNull();
 	}
 
@@ -89,7 +89,7 @@ public class ServerBearerExchangeFilterFunctionTests {
 		ClientRequest request = ClientRequest.create(HttpMethod.GET, URI.create("https://example.com"))
 				.header(HttpHeaders.AUTHORIZATION, "Existing").build();
 		this.function.filter(request, this.exchange)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(this.authentication)).block();
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(this.authentication)).block();
 		HttpHeaders headers = this.exchange.getRequest().headers();
 		assertThat(headers.get(HttpHeaders.AUTHORIZATION)).containsOnly("Bearer " + this.accessToken.getTokenValue());
 	}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/reactive/function/client/ServletBearerExchangeFilterFunctionTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/reactive/function/client/ServletBearerExchangeFilterFunctionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,14 +74,14 @@ public class ServletBearerExchangeFilterFunctionTests {
 	public void filterWhenAuthenticatedWithOtherTokenThenAuthorizationHeaderNull() {
 		TestingAuthenticationToken token = new TestingAuthenticationToken("user", "pass");
 		ClientRequest request = ClientRequest.create(HttpMethod.GET, URI.create("https://example.com")).build();
-		this.function.filter(request, this.exchange).subscriberContext(context(token)).block();
+		this.function.filter(request, this.exchange).contextWrite(context(token)).block();
 		assertThat(this.exchange.getRequest().headers().getFirst(HttpHeaders.AUTHORIZATION)).isNull();
 	}
 
 	@Test
 	public void filterWhenAuthenticatedThenAuthorizationHeader() {
 		ClientRequest request = ClientRequest.create(HttpMethod.GET, URI.create("https://example.com")).build();
-		this.function.filter(request, this.exchange).subscriberContext(context(this.authentication)).block();
+		this.function.filter(request, this.exchange).contextWrite(context(this.authentication)).block();
 		assertThat(this.exchange.getRequest().headers().getFirst(HttpHeaders.AUTHORIZATION))
 				.isEqualTo("Bearer " + this.accessToken.getTokenValue());
 	}
@@ -90,7 +90,7 @@ public class ServletBearerExchangeFilterFunctionTests {
 	public void filterWhenExistingAuthorizationThenSingleAuthorizationHeader() {
 		ClientRequest request = ClientRequest.create(HttpMethod.GET, URI.create("https://example.com"))
 				.header(HttpHeaders.AUTHORIZATION, "Existing").build();
-		this.function.filter(request, this.exchange).subscriberContext(context(this.authentication)).block();
+		this.function.filter(request, this.exchange).contextWrite(context(this.authentication)).block();
 		HttpHeaders headers = this.exchange.getRequest().headers();
 		assertThat(headers.get(HttpHeaders.AUTHORIZATION)).containsOnly("Bearer " + this.accessToken.getTokenValue());
 	}

--- a/rsocket/src/main/java/org/springframework/security/rsocket/authentication/AnonymousPayloadInterceptor.java
+++ b/rsocket/src/main/java/org/springframework/security/rsocket/authentication/AnonymousPayloadInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,8 +84,7 @@ public class AnonymousPayloadInterceptor implements PayloadInterceptor, Ordered 
 		return ReactiveSecurityContextHolder.getContext().switchIfEmpty(Mono.defer(() -> {
 			AnonymousAuthenticationToken authentication = new AnonymousAuthenticationToken(this.key, this.principal,
 					this.authorities);
-			return chain.next(exchange)
-					.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(authentication))
+			return chain.next(exchange).contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication))
 					.then(Mono.empty());
 		})).flatMap((securityContext) -> chain.next(exchange));
 	}

--- a/rsocket/src/main/java/org/springframework/security/rsocket/authentication/AuthenticationPayloadInterceptor.java
+++ b/rsocket/src/main/java/org/springframework/security/rsocket/authentication/AuthenticationPayloadInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ public class AuthenticationPayloadInterceptor implements PayloadInterceptor, Ord
 	}
 
 	private Mono<Void> onAuthenticationSuccess(Mono<Void> payload, Authentication authentication) {
-		return payload.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(authentication));
+		return payload.contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication));
 	}
 
 }

--- a/rsocket/src/test/java/org/springframework/security/rsocket/authentication/AnonymousPayloadInterceptorTests.java
+++ b/rsocket/src/test/java/org/springframework/security/rsocket/authentication/AnonymousPayloadInterceptorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ public class AnonymousPayloadInterceptorTests {
 		AuthenticationPayloadInterceptorChain chain = new AuthenticationPayloadInterceptorChain();
 		TestingAuthenticationToken expected = new TestingAuthenticationToken("test", "password");
 		this.interceptor.intercept(this.exchange, chain)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(expected)).block();
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(expected)).block();
 		Authentication authentication = chain.getAuthentication();
 		assertThat(authentication).isEqualTo(expected);
 	}

--- a/rsocket/src/test/java/org/springframework/security/rsocket/authorization/AuthorizationPayloadInterceptorTests.java
+++ b/rsocket/src/test/java/org/springframework/security/rsocket/authorization/AuthorizationPayloadInterceptorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ public class AuthorizationPayloadInterceptorTests {
 				AuthorityReactiveAuthorizationManager.hasRole("USER"));
 		Context userContext = ReactiveSecurityContextHolder
 				.withAuthentication(new TestingAuthenticationToken("user", "password"));
-		Mono<Void> intercept = interceptor.intercept(this.exchange, this.chain).subscriberContext(userContext);
+		Mono<Void> intercept = interceptor.intercept(this.exchange, this.chain).contextWrite(userContext);
 		StepVerifier.create(intercept).then(() -> this.chainResult.assertWasNotSubscribed())
 				.verifyError(AccessDeniedException.class);
 	}
@@ -95,7 +95,7 @@ public class AuthorizationPayloadInterceptorTests {
 				AuthenticatedReactiveAuthorizationManager.authenticated());
 		Context userContext = ReactiveSecurityContextHolder
 				.withAuthentication(new TestingAuthenticationToken("user", "password", "ROLE_USER"));
-		Mono<Void> intercept = interceptor.intercept(this.exchange, this.chain).subscriberContext(userContext);
+		Mono<Void> intercept = interceptor.intercept(this.exchange, this.chain).contextWrite(userContext);
 		StepVerifier.create(intercept).then(() -> this.chainResult.assertWasSubscribed()).verifyComplete();
 	}
 

--- a/rsocket/src/test/java/org/springframework/security/rsocket/core/PayloadInterceptorRSocketTests.java
+++ b/rsocket/src/test/java/org/springframework/security/rsocket/core/PayloadInterceptorRSocketTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -471,7 +471,7 @@ public class PayloadInterceptorRSocketTests {
 			PayloadInterceptorChain c = (PayloadInterceptorChain) invocation.getArguments()[1];
 			return c.next(new DefaultPayloadExchange(PayloadExchangeType.REQUEST_CHANNEL, this.payload,
 					this.metadataMimeType, this.dataMimeType))
-					.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(authentication));
+					.contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication));
 		};
 	}
 

--- a/rsocket/src/test/java/org/springframework/security/rsocket/core/PayloadSocketAcceptorTests.java
+++ b/rsocket/src/test/java/org/springframework/security/rsocket/core/PayloadSocketAcceptorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -155,7 +155,7 @@ public class PayloadSocketAcceptorTests {
 		PayloadInterceptor authenticateInterceptor = (exchange, chain) -> {
 			Context withSecurityContext = ReactiveSecurityContextHolder
 					.withSecurityContext(Mono.just(expectedSecurityContext));
-			return chain.next(exchange).subscriberContext(withSecurityContext);
+			return chain.next(exchange).contextWrite(withSecurityContext);
 		};
 		List<PayloadInterceptor> interceptors = Arrays.asList(authenticateInterceptor);
 		this.acceptor = new PayloadSocketAcceptor(captureSecurityContext, interceptors);

--- a/test/src/main/java/org/springframework/security/test/web/reactive/server/SecurityMockServerConfigurers.java
+++ b/test/src/main/java/org/springframework/security/test/web/reactive/server/SecurityMockServerConfigurers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -432,7 +432,7 @@ public final class SecurityMockServerConfigurers {
 			if (context != null) {
 				exchange.getAttributes().remove(ATTRIBUTE_NAME);
 				return webFilterChain.filter(exchange)
-						.subscriberContext(ReactiveSecurityContextHolder.withSecurityContext(context.get()));
+						.contextWrite(ReactiveSecurityContextHolder.withSecurityContext(context.get()));
 			}
 			return webFilterChain.filter(exchange);
 		}

--- a/test/src/test/java/org/springframework/security/test/context/support/ReactorContextTestExecutionListenerTests.java
+++ b/test/src/test/java/org/springframework/security/test/context/support/ReactorContextTestExecutionListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ public class ReactorContextTestExecutionListenerTests {
 		this.listener.beforeTestMethod(this.testContext);
 		Mono<Authentication> authentication = Mono.just("any")
 				.flatMap((s) -> ReactiveSecurityContextHolder.getContext().map(SecurityContext::getAuthentication))
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(expectedAuthentication));
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(expectedAuthentication));
 		StepVerifier.create(authentication).expectNext(expectedAuthentication).verifyComplete();
 	}
 
@@ -115,7 +115,7 @@ public class ReactorContextTestExecutionListenerTests {
 		this.listener.beforeTestMethod(this.testContext);
 		Mono<Authentication> authentication = Mono.just("any")
 				.flatMap((s) -> ReactiveSecurityContextHolder.getContext().map(SecurityContext::getAuthentication))
-				.subscriberContext(ReactiveSecurityContextHolder.clearContext());
+				.contextWrite(ReactiveSecurityContextHolder.clearContext());
 		StepVerifier.create(authentication).verifyComplete();
 	}
 
@@ -129,7 +129,7 @@ public class ReactorContextTestExecutionListenerTests {
 	public void afterTestMethodWhenSetupThenReactorContextNull() throws Exception {
 		beforeTestMethodWhenAuthenticationThenReactorContextHasAuthentication();
 		this.listener.afterTestMethod(this.testContext);
-		assertThat(Mono.subscriberContext().block().isEmpty()).isTrue();
+		assertThat(Mono.deferContextual(Mono::just).block().isEmpty()).isTrue();
 	}
 
 	@Test
@@ -137,7 +137,7 @@ public class ReactorContextTestExecutionListenerTests {
 		Object obj = new Object();
 		Hooks.onLastOperator("CUSTOM_HOOK", (p) -> Mono.just(obj));
 		this.listener.afterTestMethod(this.testContext);
-		Object result = Mono.subscriberContext().block();
+		Object result = Mono.deferContextual(Mono::just).block();
 		assertThat(result).isEqualTo(obj);
 	}
 

--- a/web/src/main/java/org/springframework/security/web/server/authentication/AnonymousAuthenticationWebFilter.java
+++ b/web/src/main/java/org/springframework/security/web/server/authentication/AnonymousAuthenticationWebFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ public class AnonymousAuthenticationWebFilter implements WebFilter {
 			SecurityContext securityContext = new SecurityContextImpl(authentication);
 			logger.debug(LogMessage.format("Populated SecurityContext with anonymous token: '%s'", authentication));
 			return chain.filter(exchange)
-					.subscriberContext(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(securityContext)))
+					.contextWrite(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(securityContext)))
 					.then(Mono.empty());
 		})).flatMap((securityContext) -> {
 			logger.debug(LogMessage.format("SecurityContext contains anonymous token: '%s'",

--- a/web/src/main/java/org/springframework/security/web/server/authentication/AuthenticationWebFilter.java
+++ b/web/src/main/java/org/springframework/security/web/server/authentication/AuthenticationWebFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,7 +133,7 @@ public class AuthenticationWebFilter implements WebFilter {
 		securityContext.setAuthentication(authentication);
 		return this.securityContextRepository.save(exchange, securityContext)
 				.then(this.authenticationSuccessHandler.onAuthenticationSuccess(webFilterExchange, authentication))
-				.subscriberContext(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(securityContext)));
+				.contextWrite(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(securityContext)));
 	}
 
 	/**

--- a/web/src/main/java/org/springframework/security/web/server/authentication/SwitchUserWebFilter.java
+++ b/web/src/main/java/org/springframework/security/web/server/authentication/SwitchUserWebFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -238,7 +238,7 @@ public class SwitchUserWebFilter implements WebFilter {
 		return this.securityContextRepository.save(exchange, securityContext)
 				.doOnSuccess((v) -> this.logger.debug(LogMessage.format("Switched user to %s", authentication)))
 				.then(this.successHandler.onAuthenticationSuccess(webFilterExchange, authentication))
-				.subscriberContext(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(securityContext)));
+				.contextWrite(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(securityContext)));
 	}
 
 	private Mono<Void> onAuthenticationFailure(AuthenticationException exception, WebFilterExchange webFilterExchange) {

--- a/web/src/main/java/org/springframework/security/web/server/authentication/logout/LogoutWebFilter.java
+++ b/web/src/main/java/org/springframework/security/web/server/authentication/logout/LogoutWebFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ public class LogoutWebFilter implements WebFilter {
 		logger.debug(LogMessage.format("Logging out user '%s' and transferring to logout destination", authentication));
 		return this.logoutHandler.logout(webFilterExchange, authentication)
 				.then(this.logoutSuccessHandler.onLogoutSuccess(webFilterExchange, authentication))
-				.subscriberContext(ReactiveSecurityContextHolder.clearContext());
+				.contextWrite(ReactiveSecurityContextHolder.clearContext());
 	}
 
 	/**

--- a/web/src/main/java/org/springframework/security/web/server/context/ReactorContextWebFilter.java
+++ b/web/src/main/java/org/springframework/security/web/server/context/ReactorContextWebFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,13 +44,13 @@ public class ReactorContextWebFilter implements WebFilter {
 
 	@Override
 	public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
-		return chain.filter(exchange).subscriberContext(
+		return chain.filter(exchange).contextWrite(
 				(context) -> context.hasKey(SecurityContext.class) ? context : withSecurityContext(context, exchange));
 	}
 
 	private Context withSecurityContext(Context mainContext, ServerWebExchange exchange) {
-		return mainContext
-				.putAll(this.repository.load(exchange).as(ReactiveSecurityContextHolder::withSecurityContext));
+		return mainContext.putAll(
+				this.repository.load(exchange).as(ReactiveSecurityContextHolder::withSecurityContext).readOnly());
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/reactive/result/method/annotation/AuthenticationPrincipalArgumentResolverTests.java
+++ b/web/src/test/java/org/springframework/security/web/reactive/result/method/annotation/AuthenticationPrincipalArgumentResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ public class AuthenticationPrincipalArgumentResolverTests {
 		MethodParameter parameter = this.authenticationPrincipal.arg(String.class);
 		given(this.authentication.getPrincipal()).willReturn("user");
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
 		assertThat(argument.block()).isEqualTo(this.authentication.getPrincipal());
 	}
 
@@ -114,7 +114,7 @@ public class AuthenticationPrincipalArgumentResolverTests {
 		MethodParameter parameter = this.authenticationPrincipal.arg(Mono.class, String.class);
 		given(this.authentication.getPrincipal()).willReturn("user");
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
 		assertThat(argument.cast(Mono.class).block().block()).isEqualTo(this.authentication.getPrincipal());
 	}
 
@@ -124,7 +124,7 @@ public class AuthenticationPrincipalArgumentResolverTests {
 				.arg(Mono.class);
 		given(this.authentication.getPrincipal()).willReturn("user");
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
 		assertThat(argument.cast(Mono.class).block().block()).isEqualTo(this.authentication.getPrincipal());
 	}
 
@@ -134,7 +134,7 @@ public class AuthenticationPrincipalArgumentResolverTests {
 		MethodParameter parameter = this.spel.arg(Long.class);
 		given(this.authentication.getPrincipal()).willReturn(user);
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
 		assertThat(argument.block()).isEqualTo(user.getId());
 	}
 
@@ -144,7 +144,7 @@ public class AuthenticationPrincipalArgumentResolverTests {
 		MethodParameter parameter = this.spelPrimitive.arg(int.class);
 		given(this.authentication.getPrincipal()).willReturn(user);
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
 		assertThat(argument.block()).isEqualTo(user.getId());
 	}
 
@@ -155,7 +155,7 @@ public class AuthenticationPrincipalArgumentResolverTests {
 		given(this.authentication.getPrincipal()).willReturn(user);
 		given(this.beanResolver.resolve(any(), eq("beanName"))).willReturn(new Bean());
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
 		assertThat(argument.block()).isEqualTo(user.getId());
 	}
 
@@ -164,7 +164,7 @@ public class AuthenticationPrincipalArgumentResolverTests {
 		MethodParameter parameter = this.meta.arg(String.class);
 		given(this.authentication.getPrincipal()).willReturn("user");
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
 		assertThat(argument.block()).isEqualTo("user");
 	}
 
@@ -174,7 +174,7 @@ public class AuthenticationPrincipalArgumentResolverTests {
 				.arg(Integer.class);
 		given(this.authentication.getPrincipal()).willReturn("user");
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
 		assertThat(argument.block()).isNull();
 	}
 
@@ -184,7 +184,7 @@ public class AuthenticationPrincipalArgumentResolverTests {
 				.arg(Integer.class);
 		given(this.authentication.getPrincipal()).willReturn("user");
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
 		assertThat(argument.block()).isNull();
 	}
 
@@ -194,7 +194,7 @@ public class AuthenticationPrincipalArgumentResolverTests {
 				.arg(Integer.class);
 		given(this.authentication.getPrincipal()).willReturn("user");
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange)
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(this.authentication));
 		assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> argument.block());
 	}
 

--- a/web/src/test/java/org/springframework/security/web/reactive/result/method/annotation/CurrentSecurityContextArgumentResolverTests.java
+++ b/web/src/test/java/org/springframework/security/web/reactive/result/method/annotation/CurrentSecurityContextArgumentResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ public class CurrentSecurityContextArgumentResolverTests {
 				SecurityContext.class);
 		Context context = ReactiveSecurityContextHolder.withSecurityContext(Mono.empty());
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange);
-		Object obj = argument.subscriberContext(context).block();
+		Object obj = argument.contextWrite(context).block();
 		assertThat(obj).isNull();
 		ReactiveSecurityContextHolder.clearContext();
 	}
@@ -111,7 +111,7 @@ public class CurrentSecurityContextArgumentResolverTests {
 		Authentication auth = buildAuthenticationWithPrincipal("hello");
 		Context context = ReactiveSecurityContextHolder.withAuthentication(auth);
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange);
-		SecurityContext securityContext = (SecurityContext) argument.subscriberContext(context).cast(Mono.class).block()
+		SecurityContext securityContext = (SecurityContext) argument.contextWrite(context).cast(Mono.class).block()
 				.block();
 		assertThat(securityContext.getAuthentication()).isSameAs(auth);
 		ReactiveSecurityContextHolder.clearContext();
@@ -124,8 +124,8 @@ public class CurrentSecurityContextArgumentResolverTests {
 		Authentication auth = buildAuthenticationWithPrincipal("hello");
 		Context context = ReactiveSecurityContextHolder.withSecurityContext(Mono.just(new CustomSecurityContext(auth)));
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange);
-		CustomSecurityContext securityContext = (CustomSecurityContext) argument.subscriberContext(context)
-				.cast(Mono.class).block().block();
+		CustomSecurityContext securityContext = (CustomSecurityContext) argument.contextWrite(context).cast(Mono.class)
+				.block().block();
 		assertThat(securityContext.getAuthentication()).isSameAs(auth);
 		ReactiveSecurityContextHolder.clearContext();
 	}
@@ -137,7 +137,7 @@ public class CurrentSecurityContextArgumentResolverTests {
 		Authentication auth = null;
 		Context context = ReactiveSecurityContextHolder.withAuthentication(auth);
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange);
-		SecurityContext securityContext = (SecurityContext) argument.subscriberContext(context).cast(Mono.class).block()
+		SecurityContext securityContext = (SecurityContext) argument.contextWrite(context).cast(Mono.class).block()
 				.block();
 		assertThat(securityContext.getAuthentication()).isNull();
 		ReactiveSecurityContextHolder.clearContext();
@@ -150,7 +150,7 @@ public class CurrentSecurityContextArgumentResolverTests {
 		Authentication auth = null;
 		Context context = ReactiveSecurityContextHolder.withAuthentication(auth);
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange);
-		Mono<Object> r = (Mono<Object>) argument.subscriberContext(context).block();
+		Mono<Object> r = (Mono<Object>) argument.contextWrite(context).block();
 		assertThat(r.block()).isNull();
 		ReactiveSecurityContextHolder.clearContext();
 	}
@@ -162,7 +162,7 @@ public class CurrentSecurityContextArgumentResolverTests {
 		Authentication auth = buildAuthenticationWithPrincipal("authentication1");
 		Context context = ReactiveSecurityContextHolder.withAuthentication(auth);
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange);
-		Mono<Authentication> auth1 = (Mono<Authentication>) argument.subscriberContext(context).block();
+		Mono<Authentication> auth1 = (Mono<Authentication>) argument.contextWrite(context).block();
 		assertThat(auth1.block()).isSameAs(auth);
 		ReactiveSecurityContextHolder.clearContext();
 	}
@@ -174,7 +174,7 @@ public class CurrentSecurityContextArgumentResolverTests {
 		Authentication auth = null;
 		Context context = ReactiveSecurityContextHolder.withAuthentication(auth);
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange);
-		Mono<Object> obj = (Mono<Object>) argument.subscriberContext(context).block();
+		Mono<Object> obj = (Mono<Object>) argument.contextWrite(context).block();
 		assertThat(obj.block()).isNull();
 		ReactiveSecurityContextHolder.clearContext();
 	}
@@ -186,7 +186,7 @@ public class CurrentSecurityContextArgumentResolverTests {
 		Authentication auth = buildAuthenticationWithPrincipal("auth_optional");
 		Context context = ReactiveSecurityContextHolder.withAuthentication(auth);
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange);
-		Mono<Object> obj = (Mono<Object>) argument.subscriberContext(context).block();
+		Mono<Object> obj = (Mono<Object>) argument.contextWrite(context).block();
 		assertThat(obj.block()).isEqualTo("auth_optional");
 		ReactiveSecurityContextHolder.clearContext();
 	}
@@ -199,7 +199,7 @@ public class CurrentSecurityContextArgumentResolverTests {
 		Context context = ReactiveSecurityContextHolder.withAuthentication(auth);
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange);
 		assertThatExceptionOfType(SpelEvaluationException.class)
-				.isThrownBy(() -> argument.subscriberContext(context).block());
+				.isThrownBy(() -> argument.contextWrite(context).block());
 		ReactiveSecurityContextHolder.clearContext();
 	}
 
@@ -210,7 +210,7 @@ public class CurrentSecurityContextArgumentResolverTests {
 		Authentication auth = buildAuthenticationWithPrincipal("auth_string");
 		Context context = ReactiveSecurityContextHolder.withAuthentication(auth);
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange);
-		Mono<String> obj = (Mono<String>) argument.subscriberContext(context).block();
+		Mono<String> obj = (Mono<String>) argument.contextWrite(context).block();
 		assertThat(obj.block()).isEqualTo("auth_string");
 		ReactiveSecurityContextHolder.clearContext();
 	}
@@ -222,7 +222,7 @@ public class CurrentSecurityContextArgumentResolverTests {
 		Authentication auth = buildAuthenticationWithPrincipal("invalid_type_implicit");
 		Context context = ReactiveSecurityContextHolder.withAuthentication(auth);
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange);
-		Mono<String> obj = (Mono<String>) argument.subscriberContext(context).block();
+		Mono<String> obj = (Mono<String>) argument.contextWrite(context).block();
 		assertThat(obj.block()).isNull();
 		ReactiveSecurityContextHolder.clearContext();
 	}
@@ -234,7 +234,7 @@ public class CurrentSecurityContextArgumentResolverTests {
 		Authentication auth = buildAuthenticationWithPrincipal("error_on_invalid_type_explicit_false");
 		Context context = ReactiveSecurityContextHolder.withAuthentication(auth);
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange);
-		Mono<String> obj = (Mono<String>) argument.subscriberContext(context).block();
+		Mono<String> obj = (Mono<String>) argument.contextWrite(context).block();
 		assertThat(obj.block()).isNull();
 		ReactiveSecurityContextHolder.clearContext();
 	}
@@ -246,8 +246,7 @@ public class CurrentSecurityContextArgumentResolverTests {
 		Authentication auth = buildAuthenticationWithPrincipal("error_on_invalid_type_explicit_true");
 		Context context = ReactiveSecurityContextHolder.withAuthentication(auth);
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange);
-		assertThatExceptionOfType(ClassCastException.class)
-				.isThrownBy(() -> argument.subscriberContext(context).block());
+		assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> argument.contextWrite(context).block());
 		ReactiveSecurityContextHolder.clearContext();
 	}
 
@@ -258,7 +257,7 @@ public class CurrentSecurityContextArgumentResolverTests {
 		Authentication auth = buildAuthenticationWithPrincipal("current_custom_security_context");
 		Context context = ReactiveSecurityContextHolder.withAuthentication(auth);
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange);
-		SecurityContext securityContext = (SecurityContext) argument.subscriberContext(context).cast(Mono.class).block()
+		SecurityContext securityContext = (SecurityContext) argument.contextWrite(context).cast(Mono.class).block()
 				.block();
 		assertThat(securityContext.getAuthentication()).isSameAs(auth);
 		ReactiveSecurityContextHolder.clearContext();
@@ -271,7 +270,7 @@ public class CurrentSecurityContextArgumentResolverTests {
 		Authentication auth = buildAuthenticationWithPrincipal("current_authentication");
 		Context context = ReactiveSecurityContextHolder.withAuthentication(auth);
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange);
-		Authentication authentication = (Authentication) argument.subscriberContext(context).cast(Mono.class).block()
+		Authentication authentication = (Authentication) argument.contextWrite(context).cast(Mono.class).block()
 				.block();
 		assertThat(authentication).isSameAs(auth);
 		ReactiveSecurityContextHolder.clearContext();
@@ -284,7 +283,7 @@ public class CurrentSecurityContextArgumentResolverTests {
 		Authentication auth = buildAuthenticationWithPrincipal("current_security_with_error_on_invalid_type");
 		Context context = ReactiveSecurityContextHolder.withAuthentication(auth);
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange);
-		SecurityContext securityContext = (SecurityContext) argument.subscriberContext(context).cast(Mono.class).block()
+		SecurityContext securityContext = (SecurityContext) argument.contextWrite(context).cast(Mono.class).block()
 				.block();
 		assertThat(securityContext.getAuthentication()).isSameAs(auth);
 		ReactiveSecurityContextHolder.clearContext();
@@ -298,7 +297,7 @@ public class CurrentSecurityContextArgumentResolverTests {
 		Context context = ReactiveSecurityContextHolder.withAuthentication(auth);
 		Mono<Object> argument = this.resolver.resolveArgument(parameter, this.bindingContext, this.exchange);
 		assertThatExceptionOfType(ClassCastException.class)
-				.isThrownBy(() -> argument.subscriberContext(context).cast(Mono.class).block().block());
+				.isThrownBy(() -> argument.contextWrite(context).cast(Mono.class).block().block());
 		ReactiveSecurityContextHolder.clearContext();
 	}
 

--- a/web/src/test/java/org/springframework/security/web/server/authentication/SwitchUserWebFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/authentication/SwitchUserWebFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,8 +119,7 @@ public class SwitchUserWebFilterTests {
 		given(this.successHandler.onAuthenticationSuccess(any(WebFilterExchange.class), any(Authentication.class)))
 				.willReturn(Mono.empty());
 		this.switchUserWebFilter.filter(exchange, chain)
-				.subscriberContext(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(securityContext)))
-				.block();
+				.contextWrite(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(securityContext))).block();
 		verifyNoInteractions(chain);
 		verify(this.userDetailsService).findByUsername(targetUsername);
 		final ArgumentCaptor<SecurityContext> securityContextCaptor = ArgumentCaptor.forClass(SecurityContext.class);
@@ -161,8 +160,7 @@ public class SwitchUserWebFilterTests {
 		given(this.userDetailsService.findByUsername(targetUsername))
 				.willReturn(Mono.just(switchUserDetails(targetUsername, true)));
 		this.switchUserWebFilter.filter(exchange, chain)
-				.subscriberContext(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(securityContext)))
-				.block();
+				.contextWrite(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(securityContext))).block();
 		final ArgumentCaptor<Authentication> authenticationCaptor = ArgumentCaptor.forClass(Authentication.class);
 		verify(this.successHandler).onAuthenticationSuccess(any(WebFilterExchange.class),
 				authenticationCaptor.capture());
@@ -183,7 +181,7 @@ public class SwitchUserWebFilterTests {
 		assertThatIllegalArgumentException().isThrownBy(() -> {
 			Context securityContextHolder = ReactiveSecurityContextHolder
 					.withSecurityContext(Mono.just(securityContext));
-			this.switchUserWebFilter.filter(exchange, chain).subscriberContext(securityContextHolder).block();
+			this.switchUserWebFilter.filter(exchange, chain).contextWrite(securityContextHolder).block();
 		}).withMessage("The userName can not be null.");
 		verifyNoInteractions(chain);
 	}
@@ -200,8 +198,7 @@ public class SwitchUserWebFilterTests {
 		given(this.failureHandler.onAuthenticationFailure(any(WebFilterExchange.class), any(DisabledException.class)))
 				.willReturn(Mono.empty());
 		this.switchUserWebFilter.filter(exchange, chain)
-				.subscriberContext(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(securityContext)))
-				.block();
+				.contextWrite(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(securityContext))).block();
 		verify(this.failureHandler).onAuthenticationFailure(any(WebFilterExchange.class), any(DisabledException.class));
 		verifyNoInteractions(chain);
 	}
@@ -219,7 +216,7 @@ public class SwitchUserWebFilterTests {
 		assertThatExceptionOfType(DisabledException.class).isThrownBy(() -> {
 			Context securityContextHolder = ReactiveSecurityContextHolder
 					.withSecurityContext(Mono.just(securityContext));
-			this.switchUserWebFilter.filter(exchange, chain).subscriberContext(securityContextHolder).block();
+			this.switchUserWebFilter.filter(exchange, chain).contextWrite(securityContextHolder).block();
 		});
 		verifyNoInteractions(chain);
 	}
@@ -241,8 +238,7 @@ public class SwitchUserWebFilterTests {
 		given(this.successHandler.onAuthenticationSuccess(any(WebFilterExchange.class), any(Authentication.class)))
 				.willReturn(Mono.empty());
 		this.switchUserWebFilter.filter(exchange, chain)
-				.subscriberContext(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(securityContext)))
-				.block();
+				.contextWrite(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(securityContext))).block();
 		final ArgumentCaptor<SecurityContext> securityContextCaptor = ArgumentCaptor.forClass(SecurityContext.class);
 		verify(this.serverSecurityContextRepository).save(eq(exchange), securityContextCaptor.capture());
 		final SecurityContext savedSecurityContext = securityContextCaptor.getValue();
@@ -266,7 +262,7 @@ public class SwitchUserWebFilterTests {
 		assertThatExceptionOfType(AuthenticationCredentialsNotFoundException.class).isThrownBy(() -> {
 			Context securityContextHolder = ReactiveSecurityContextHolder
 					.withSecurityContext(Mono.just(securityContext));
-			this.switchUserWebFilter.filter(exchange, chain).subscriberContext(securityContextHolder).block();
+			this.switchUserWebFilter.filter(exchange, chain).contextWrite(securityContextHolder).block();
 		}).withMessage("Could not find original Authentication object");
 		verifyNoInteractions(chain);
 	}

--- a/web/src/test/java/org/springframework/security/web/server/authorization/AuthorizationWebFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/authorization/AuthorizationWebFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,8 +65,8 @@ public class AuthorizationWebFilterTests {
 		given(this.chain.filter(this.exchange)).willReturn(this.chainResult.mono());
 		AuthorizationWebFilter filter = new AuthorizationWebFilter(
 				(a, e) -> a.flatMap((auth) -> Mono.error(new AccessDeniedException("Denied"))));
-		Mono<Void> result = filter.filter(this.exchange, this.chain).subscriberContext(
-				ReactiveSecurityContextHolder.withSecurityContext(Mono.just(new SecurityContextImpl())));
+		Mono<Void> result = filter.filter(this.exchange, this.chain)
+				.contextWrite(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(new SecurityContextImpl())));
 		StepVerifier.create(result).expectError(AccessDeniedException.class).verify();
 		this.chainResult.assertWasNotSubscribed();
 	}
@@ -76,7 +76,7 @@ public class AuthorizationWebFilterTests {
 		given(this.chain.filter(this.exchange)).willReturn(this.chainResult.mono());
 		AuthorizationWebFilter filter = new AuthorizationWebFilter(
 				(a, e) -> Mono.error(new AccessDeniedException("Denied")));
-		Mono<Void> result = filter.filter(this.exchange, this.chain).subscriberContext(
+		Mono<Void> result = filter.filter(this.exchange, this.chain).contextWrite(
 				ReactiveSecurityContextHolder.withAuthentication(new TestingAuthenticationToken("a", "b", "R")));
 		StepVerifier.create(result).expectError(AccessDeniedException.class).verify();
 		this.chainResult.assertWasNotSubscribed();
@@ -89,7 +89,7 @@ public class AuthorizationWebFilterTests {
 		AuthorizationWebFilter filter = new AuthorizationWebFilter(
 				(a, e) -> Mono.error(new AccessDeniedException("Denied")));
 		Mono<Void> result = filter.filter(this.exchange, this.chain)
-				.subscriberContext(ReactiveSecurityContextHolder.withSecurityContext(context.mono()));
+				.contextWrite(ReactiveSecurityContextHolder.withSecurityContext(context.mono()));
 		StepVerifier.create(result).expectError(AccessDeniedException.class).verify();
 		this.chainResult.assertWasNotSubscribed();
 		context.assertWasNotSubscribed();
@@ -102,7 +102,7 @@ public class AuthorizationWebFilterTests {
 		AuthorizationWebFilter filter = new AuthorizationWebFilter(
 				(a, e) -> Mono.just(new AuthorizationDecision(true)));
 		Mono<Void> result = filter.filter(this.exchange, this.chain)
-				.subscriberContext(ReactiveSecurityContextHolder.withSecurityContext(context.mono()));
+				.contextWrite(ReactiveSecurityContextHolder.withSecurityContext(context.mono()));
 		StepVerifier.create(result).verifyComplete();
 		this.chainResult.assertWasSubscribed();
 		context.assertWasNotSubscribed();
@@ -115,7 +115,7 @@ public class AuthorizationWebFilterTests {
 		AuthorizationWebFilter filter = new AuthorizationWebFilter((a, e) -> a
 				.map((auth) -> new AuthorizationDecision(true)).defaultIfEmpty(new AuthorizationDecision(true)));
 		Mono<Void> result = filter.filter(this.exchange, this.chain)
-				.subscriberContext(ReactiveSecurityContextHolder.withSecurityContext(context.mono()));
+				.contextWrite(ReactiveSecurityContextHolder.withSecurityContext(context.mono()));
 		StepVerifier.create(result).verifyComplete();
 		this.chainResult.assertWasSubscribed();
 		context.assertWasSubscribed();

--- a/web/src/test/java/org/springframework/security/web/server/context/ReactorContextWebFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/context/ReactorContextWebFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,7 +108,7 @@ public class ReactorContextWebFilterTests {
 	public void filterWhenMainContextThenDoesNotOverride() {
 		given(this.repository.load(any())).willReturn(this.securityContext.mono());
 		String contextKey = "main";
-		WebFilter mainContextWebFilter = (e, c) -> c.filter(e).subscriberContext(Context.of(contextKey, true));
+		WebFilter mainContextWebFilter = (e, c) -> c.filter(e).contextWrite(Context.of(contextKey, true));
 		WebFilterChain chain = new DefaultWebFilterChain((e) -> Mono.empty(), mainContextWebFilter, this.filter);
 		Mono<Void> filter = chain.filter(MockServerWebExchange.from(this.exchange.build()));
 		StepVerifier.create(filter).expectAccessibleContext().hasKey(contextKey).then().verifyComplete();

--- a/web/src/test/java/org/springframework/security/web/server/context/SecurityContextServerWebExchangeWebFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/context/SecurityContextServerWebExchangeWebFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,10 +47,10 @@ public class SecurityContextServerWebExchangeWebFilterTests {
 		Mono<Void> result = this.filter
 				.filter(this.exchange, new DefaultWebFilterChain((e) -> e.getPrincipal()
 						.doOnSuccess((contextPrincipal) -> assertThat(contextPrincipal).isEqualTo(this.principal))
-						.flatMap((contextPrincipal) -> Mono.subscriberContext())
+						.flatMap((contextPrincipal) -> Mono.deferContextual(Mono::just))
 						.doOnSuccess((context) -> assertThat(context.<String>get("foo")).isEqualTo("bar")).then()))
-				.subscriberContext((context) -> context.put("foo", "bar"))
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(this.principal));
+				.contextWrite((context) -> context.put("foo", "bar"))
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(this.principal));
 		StepVerifier.create(result).verifyComplete();
 	}
 
@@ -62,7 +62,7 @@ public class SecurityContextServerWebExchangeWebFilterTests {
 								.doOnSuccess(
 										(contextPrincipal) -> assertThat(contextPrincipal).isEqualTo(this.principal))
 								.then()))
-				.subscriberContext(ReactiveSecurityContextHolder.withAuthentication(this.principal));
+				.contextWrite(ReactiveSecurityContextHolder.withAuthentication(this.principal));
 		StepVerifier.create(result).verifyComplete();
 	}
 


### PR DESCRIPTION
As per the `reactor-core:3.5.0` [release notes](https://github.com/reactor/reactor-core/releases/tag/v3.5.0) some deprecated methods were removed. This PR removes the usage of these methods.

Closes gh-12291

_Note:_ I have signed the CLA.