### PR TITLE
Fix securityMatchers code sample

### DIFF
--- a/docs/modules/ROOT/pages/migration/servlet/config.adoc
+++ b/docs/modules/ROOT/pages/migration/servlet/config.adoc
@@ -409,7 +409,9 @@ import static org.springframework.security.web.util.matcher.AntPathRequestMatche
 @Bean
 public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http
-        .securityMatcher(antMatcher("/api/**"), antMatcher("/app/**"))
+        .securityMatchers((matchers) -> matchers
+            .requestMatchers(antMatcher("/api/**"), antMatcher("/app/**"))
+        )
         .authorizeHttpRequests((authz) -> authz
             .requestMatchers(antMatcher("/api/admin/**")).hasRole("ADMIN")
             .anyRequest().authenticated()


### PR DESCRIPTION
`http.securityMatcher(antMatcher("/api/**"), antMatcher("/app/**"))` is not possible at the moment. There is no `public HttpSecurity securityMatcher(RequestMatcher... requestMatcher)` method only a `public HttpSecurity securityMatcher(RequestMatcher requestMatcher)` method (no varargs) is available. The correct alternative is `http.securityMatchers().requestMatchers(antMatcher("/api/**"), antMatcher("/app/**"))`

Fixes gh-12296
