### PR TITLE
Add a new Saml2MetadataFilter constructor 

### DIFF
--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/Saml2MetadataFilter.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/Saml2MetadataFilter.java
@@ -29,6 +29,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.saml2.provider.service.metadata.Saml2MetadataResolver;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
+import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrationRepository;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
@@ -60,6 +61,11 @@ public final class Saml2MetadataFilter extends OncePerRequestFilter {
 		Assert.notNull(saml2MetadataResolver, "saml2MetadataResolver cannot be null");
 		this.relyingPartyRegistrationResolver = relyingPartyRegistrationResolver;
 		this.saml2MetadataResolver = saml2MetadataResolver;
+	}
+
+	public Saml2MetadataFilter(RelyingPartyRegistrationRepository relyingPartyRegistrationRepository,
+			Saml2MetadataResolver saml2MetadataResolver) {
+		this(new DefaultRelyingPartyRegistrationResolver(relyingPartyRegistrationRepository), saml2MetadataResolver);
 	}
 
 	@Override


### PR DESCRIPTION
This PR adds a new constructor for Saml2MetadataFilter for RelyingPartyRegistrationRepository and resolves the issue https://github.com/spring-projects/spring-security/issues/11815