### PR TITLE
SecuredAuthorizationManager should cache annotation's value

### DIFF
--- a/core/src/main/java/org/springframework/security/authorization/AuthorityAuthorizationManager.java
+++ b/core/src/main/java/org/springframework/security/authorization/AuthorityAuthorizationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 package org.springframework.security.authorization;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -43,7 +41,7 @@ public final class AuthorityAuthorizationManager<T> implements AuthorizationMana
 	private final Set<String> authorities;
 
 	private AuthorityAuthorizationManager(String... authorities) {
-		this.authorities = new HashSet<>(Arrays.asList(authorities));
+		this.authorities = Set.of(authorities);
 	}
 
 	/**

--- a/core/src/test/java/org/springframework/security/authorization/AuthoritiesAuthorizationManagerTests.java
+++ b/core/src/test/java/org/springframework/security/authorization/AuthoritiesAuthorizationManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,14 +74,14 @@ class AuthoritiesAuthorizationManagerTests {
 	}
 
 	@Test
-	void hasRoleWhenRoleHierarchySetThenGreaterRoleTakesPrecedence() {
+	void checkWhenRoleHierarchySetThenGreaterRoleTakesPrecedence() {
 		AuthoritiesAuthorizationManager manager = new AuthoritiesAuthorizationManager();
 		RoleHierarchyImpl roleHierarchy = new RoleHierarchyImpl();
 		roleHierarchy.setHierarchy("ROLE_ADMIN > ROLE_USER");
 		manager.setRoleHierarchy(roleHierarchy);
 		Supplier<Authentication> authentication = () -> new TestingAuthenticationToken("user", "password",
 				"ROLE_ADMIN");
-		assertThat(manager.check(authentication, Collections.singleton("ROLE_ADMIN")).isGranted()).isTrue();
+		assertThat(manager.check(authentication, Collections.singleton("ROLE_USER")).isGranted()).isTrue();
 	}
 
 }


### PR DESCRIPTION
Closes gh-12232

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
