### PR TITLE
add Asciidoctor Tabs, tabs migration, code chomping & code folding to prod

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -6,6 +6,10 @@ antora:
   - ./lib/antora/extensions/version-fix.js
   - '@antora/atlas-extension'
   - '@opendevise/antora-release-line-extension'
+  - require: '@springio/asciidoctor-extensions/tabs-migration-antora-extension'
+    # uncomment this option to save the migrated content to the worktree
+    #save_result: true
+    unwrap_example_block: always
 site:
   title: Spring Security
   url: https://docs.spring.io/spring-security/reference
@@ -22,6 +26,10 @@ asciidoc:
   attributes:
     page-pagination: ''
     hide-uri-scheme: '@'
+    tabs-sync-option: '@'
+  extensions:
+  - '@asciidoctor/tabs'
+  - '@springio/asciidoctor-extensions'
 urls:
   latest_version_segment_strategy: redirect:to
   latest_version_segment: ''

--- a/build.gradle
+++ b/build.gradle
@@ -9,11 +9,13 @@ antora {
 	environment = [
 		'ALGOLIA_API_KEY': '82c7ead946afbac3cf98c32446154691',
 		'ALGOLIA_APP_ID': '244V8V9FGG',
-		'ALGOLIA_INDEX_NAME': 'security-docs'
+		'ALGOLIA_INDEX_NAME': 'security-docs',
     ]
 	dependencies = [
 		'@antora/atlas-extension': '1.0.0-alpha.1',
 		'@antora/collector-extension': '1.0.0-alpha.2',
-		'@opendevise/antora-release-line-extension': '1.0.0-alpha.2'
+		'@asciidoctor/tabs': '1.0.0-alpha.8',
+		'@opendevise/antora-release-line-extension': '1.0.0-alpha.2',
+		'@springio/asciidoctor-extensions': '1.0.0-alpha.4',
 	]
 }

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -4,6 +4,10 @@ antora:
   - '@antora/collector-extension'
   - ./lib/antora/extensions/version-fix.js
   - '@opendevise/antora-release-line-extension'
+  - require: '@springio/asciidoctor-extensions/tabs-migration-antora-extension'
+    # uncomment this option to save the migrated content to the worktree
+    #save_result: true
+    unwrap_example_block: always
 site:
   title: Spring Security
   url: https://docs.spring.io/spring-security/reference
@@ -12,7 +16,7 @@ git:
 content:
   sources:
   - url: .
-    branches: [main, '5.{{6..9},{1..9}+({0..9})}.x']
+    branches: [main, '5.{{6..9},{1..9}+({0..9})}.x', '6.+({0..9}).x']
     worktrees: true # automatically discovers worktrees, if present; otherwise, will use git tree
     tags: ['5.{{6..9},{1..9}+({0..9})}.+({0..9})?(-RC+({0..9}))', '6.+({0..9}).+({0..9})?(-{RC,M}*)']
     start_path: docs
@@ -20,6 +24,10 @@ asciidoc:
   attributes:
     page-pagination: ''
     hide-uri-scheme: '@'
+    tabs-sync-option: '@'
+  extensions:
+  - '@asciidoctor/tabs'
+  - '@springio/asciidoctor-extensions'
 urls:
   latest_version_segment: ''
 ui:


### PR DESCRIPTION
This pull request updates the production build to use the following extensions / behaviors:

* Asciidoctor Tabs
* automated / runtime migration from Spring Tabs to Asciidoctor Tabs
* code chomping (active, but not current used)
* code folding

There are still some improvements we're working on in Asciidoctor Tabs and the Spring.io Asciidoctor extensions, so I'd like to hold off adding these changes to the software branches until we are comfortable with how it works in production.

Once we submit the PR to add these extensions to the software branches, it will be possible to save the result of the tabs migration and commit it to the branch. After that point, the tabs migration will continue to run indefinitely on tags.