### PR TITLE
Relax visibility of JwtDecoders.withProviderConfiguration

### DIFF
--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoders.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoders.java
@@ -105,7 +105,7 @@ public final class JwtDecoders {
 	 * "https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a>
 	 * @return {@link JwtDecoder}
 	 */
-	private static JwtDecoder withProviderConfiguration(Map<String, Object> configuration, String issuer) {
+	public static JwtDecoder withProviderConfiguration(Map<String, Object> configuration, String issuer) {
 		JwtDecoderProviderConfigurationUtils.validateIssuer(configuration, issuer);
 		OAuth2TokenValidator<Jwt> jwtValidator = JwtValidators.createDefaultWithIssuer(issuer);
 		String jwkSetUri = configuration.get("jwks_uri").toString();


### PR DESCRIPTION
For my configured server, it doesn't have oauth handle like `https:/my-company/.well-known/oauth-authorization-server/ISSUER`, which is need in `JwtDecoderProviderConfigurationUtils.getConfigurationForIssuerLocation(issuer) -> oauth(uri)`.
The second problem with it is it generates JWT where issuer is just string, not url.

So it's helpful for me to just create JwtDecoder with issuer and `jwks_uri` provided by myself. 

For more context:
I am adapting this manual https://curity.io/resources/learn/spring-boot-api/
Why don't I just copy the entire `JwtDecoders.withProviderConfiguration` ? because in `JwtDecoderProviderConfigurationUtils::addJWSAlgorithms` both class and method are not public.
I think it's OK to just relax visibility.


PTAL @jzheaux 