### PR TITLE
Introduce JwtDecoders.fromIssuerAndJwksUri

### DIFF
--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoders.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoders.java
@@ -95,6 +95,26 @@ public final class JwtDecoders {
 	}
 
 	/**
+	 * Creates a {@link JwtDecoder} using the provided
+	 * <a href= "https://tools.ietf.org/html/rfc7519#section-4.1.1">Issuer</a> an jwksUri.
+	 *
+	 * Note that this method is useful for cases when JWT token has {@code iss} param
+	 * which is not an uri
+	 * @param issuer an issuer from
+	 * <a href="https://tools.ietf.org/html/rfc7519#section-4.1.1">JWT</a>
+	 * @param jwksUri <a href="https://tools.ietf.org/html/rfc7517#section-5">JWK Set</a>
+	 * uri
+	 * @return a {@link JwtDecoder} that was initialized by provided issuer and jwksUri
+	 */
+	public static JwtDecoder fromIssuerAndJwksUri(String issuer, String jwksUri) {
+		OAuth2TokenValidator<Jwt> jwtValidator = JwtValidators.createDefaultWithIssuer(issuer);
+		NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder.withJwkSetUri(jwksUri)
+				.jwtProcessorCustomizer(JwtDecoderProviderConfigurationUtils::addJWSAlgorithms).build();
+		jwtDecoder.setJwtValidator(jwtValidator);
+		return jwtDecoder;
+	}
+
+	/**
 	 * Validate provided issuer and build {@link JwtDecoder} from <a href=
 	 * "https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse">OpenID
 	 * Provider Configuration Response</a> and

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtDecodersTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtDecodersTests.java
@@ -165,6 +165,17 @@ public class JwtDecodersTests {
 	}
 
 	@Test
+	public void issuerAndJwksUri() {
+		String providedIssuer = "COMPANYNAME";
+		String jwksUri = jwks();
+		Map<String, MockResponse> responses = new HashMap<>();
+		responses.put(jwksUri, response(JWK_SET));
+		prepareConfigurationResponses(responses);
+		JwtDecoder jwtDecoder = JwtDecoders.fromIssuerAndJwksUri(providedIssuer, jwksUri);
+		assertThat(jwtDecoder).isNotNull();
+	}
+
+	@Test
 	public void issuerWhenResponseIsNonCompliantThenThrowsRuntimeException() {
 		prepareConfigurationResponse("{ \"missing_required_keys\" : \"and_values\" }");
 		assertThatExceptionOfType(RuntimeException.class)


### PR DESCRIPTION
For my configured server, it doesn't have OAuth2 handle like `https:/my-company/.well-known/oauth-authorization-server/ISSUER`, which is need in `JwtDecoderProviderConfigurationUtils.getConfigurationForIssuerLocation(issuer) -> oauth(uri)`.
The second problem with it is it generates JWT where issuer (`iss`) is just string, not url, according https://www.rfc-editor.org/rfc/rfc7519#section-4.1.1.

So it's helpful for me to just create JwtDecoder with issuer and `jwks_uri` provided by myself. 

For more context:
I am adapting this manual https://curity.io/resources/learn/spring-boot-api/
Why don't I just copy the entire `JwtDecoders.withProviderConfiguration` ? because in `JwtDecoderProviderConfigurationUtils::addJWSAlgorithms` both class and method are not public.

PTAL @jzheaux 

---
Actually, it's better variant of https://github.com/spring-projects/spring-security/pull/12348.
