### PR TITLE
Fix typo in OAuth 2.0 testing docs

### DIFF
--- a/docs/modules/ROOT/pages/servlet/test/mockmvc/oauth2.adoc
+++ b/docs/modules/ROOT/pages/servlet/test/mockmvc/oauth2.adoc
@@ -296,7 +296,7 @@ fun foo(@AuthenticationPrincipal oauth2User: OAuth2User): String? {
 ----
 ====
 
-In that case, we can tell Spring Security to include a default `OAuth2User` using the `oauth2User` xref:servlet/test/mockmvc/request-post-processors.adoc[`RequestPostProcessor`], like so:
+In that case, we can tell Spring Security to include a default `OAuth2User` using the `oauth2Login` xref:servlet/test/mockmvc/request-post-processors.adoc[`RequestPostProcessor`], like so:
 
 ====
 .Java


### PR DESCRIPTION
The `RequestPostProcessor` that takes no arguments is `oauth2Login`, which is what this paragraph describes.

This should be forward-ported up to 6.0.x.