### PR TITLE
show build-refname value in Deploy Docs workflow name

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,4 +1,5 @@
 name: Deploy Docs
+run-name: ${{ format('{0} ({1})', github.workflow, github.event.inputs.build-refname || 'all') }}
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This change makes it possible to see which refname is being built by the Deploy Docs workflow from the GitHub Actions screen.