### PR TITLE
Adjusts setRequestHandler javadoc in CsrfFilter

### DIFF
--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
@@ -170,7 +170,7 @@ public final class CsrfFilter extends OncePerRequestFilter {
 	 * {@link CsrfToken} available as a request attribute.
 	 *
 	 * <p>
-	 * The default is {@link CsrfTokenRequestAttributeHandler}.
+	 * The default is {@link XorCsrfTokenRequestAttributeHandler}.
 	 * </p>
 	 * @param requestHandler the {@link CsrfTokenRequestHandler} to use
 	 * @since 5.8


### PR DESCRIPTION
Adjusts setRequestHandler method javadoc in CsrfFilter class to reflect changes in 6.0.

In 6.0, the default CsrfTokenRequestHandler changed to XorCsrfTokenRequestAttributeHandler, however, the javadoc for the setRequestHandler method still said it was CsrfTokenRequestAttributeHandler.

This change adjusts the information to make it more accurate, because, although XorCsrfTokenRequestAttributeHandler is a subclass of CsrfTokenRequestAttributeHandler, the behavior is quite different.

Closes gh-12464

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
