### PR TITLE
Update multitenancy.adoc

### DIFF
--- a/docs/modules/ROOT/pages/servlet/oauth2/resource-server/multitenancy.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/resource-server/multitenancy.adoc
@@ -418,7 +418,7 @@ Now that we have a tenant-aware processor and a tenant-aware validator, we can p
 JwtDecoder jwtDecoder(JWTProcessor jwtProcessor, OAuth2TokenValidator<Jwt> jwtValidator) {
 	NimbusJwtDecoder decoder = new NimbusJwtDecoder(processor);
 	OAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<>
-			(JwtValidators.createDefault(), this.jwtValidator);
+			(JwtValidators.createDefault(), jwtValidator);
 	decoder.setJwtValidator(validator);
 	return decoder;
 }


### PR DESCRIPTION
The Java example at line 421 should use the injected `jwtValidator` and not from the current class referenced by `this. jwtValidator`.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
