### PR TITLE
turn off scheduler for Deploy Docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,8 +5,8 @@ on:
     tags: '**'
   repository_dispatch:
     types: request-build-reference # legacy
-  schedule:
-  - cron: '0 10 * * *' # Once per day at 10am UTC
+  #schedule:
+  #- cron: '0 10 * * *' # Once per day at 10am UTC
   workflow_dispatch:
 permissions: read-all
 jobs:


### PR DESCRIPTION
This need is already filled by the push trigger. When a commit is pushed to a branch, the workflow automatically kicks off a partial build for that branch/version. A full build of the site occurs when a release is made or on demand. There's no reason to run this workflow otherwise.