### PR TITLE
Get userInfo, if scopes in token is empty

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcUserRequestUtils.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcUserRequestUtils.java
@@ -60,7 +60,8 @@ final class OidcUserRequestUtils {
 		if (AuthorizationGrantType.AUTHORIZATION_CODE.equals(clientRegistration.getAuthorizationGrantType())) {
 			// Return true if there is at least one match between the authorized scope(s)
 			// and UserInfo scope(s)
-			return CollectionUtils.containsAny(userRequest.getAccessToken().getScopes(),
+			return CollectionUtils.isEmpty(userRequest.getAccessToken().getScopes())
+				|| CollectionUtils.containsAny(userRequest.getAccessToken().getScopes(),
 					userRequest.getClientRegistration().getScopes());
 		}
 		return false;


### PR DESCRIPTION
In a WebFlux app, with OIDC authentication, the userInfo request is handled here: https://github.com/spring-projects/spring-security/blob/556891b4fa8e6b2e32be5b8dcadae485283d761a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcReactiveOAuth2UserService.java#L125-L128

Here, we call the `OidcUserRequestUtils.shouldRetrieveUserInfo` static function, to determine if we should do `userInfo`. In this function, we check if the scopes in the token, and the configured scopes match: https://github.com/spring-projects/spring-security/blob/556891b4fa8e6b2e32be5b8dcadae485283d761a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcUserRequestUtils.java#L60-L65

Now consider this check for a non-Webflux (non-reactive) OIDC authentication: https://github.com/spring-projects/spring-security/blob/556891b4fa8e6b2e32be5b8dcadae485283d761a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/userinfo/OidcUserService.java#L172-L184

We can see two major differences:

1. The non-Webflux flow, when it encounters missing scope field, or empty scope field, it _will_ call the `userInfo` endpoint. Whereas the Webflux flow _will not_.

2. The non-Webflux flow, also checks `this.accessibleScopes.isEmpty()`. Overriding this `accessibleScopes` has been [recommended](https://github.com/spring-projects/spring-security/issues/10143#issuecomment-888605197), to handle cases like missing scope in token. But this affordance is missing in the Webflux flow.

So, when using Webflux, I don't see a way out. Can we add these (at least the first) one, to the Webflux's flow as well? That's what this PR does. If the scopes are missing/empty in the token, _do_ call the `userInfo` endpoint.

Thank you for your time.
