### PR TITLE
Index Latest Patch Only

### DIFF
--- a/.github/actions/docsearch-config.json.hbs
+++ b/.github/actions/docsearch-config.json.hbs
@@ -3,6 +3,7 @@
   "start_urls": [
     {{#each components}}
     {{#each versions}}
+    {{#unless (eq ./activeVersionSegment ./version)}}
     {
       "url": "{{{@root.site.url}}}/{{#if (eq ./activeVersionSegment '')}}(?:$|index.html$|[a-z].*){{else}}{{{./activeVersionSegment}}}/{{/if}}",
       "extra_attributes": {
@@ -11,6 +12,7 @@
         "version_rank": {{#if (eq this ../latest)}}1{{else}}2{{/if}}
       }
     }{{#unless (and @last @../last)}},{{/unless}}
+    {{/unless}}
     {{/each}}
     {{/each}}
   ],


### PR DESCRIPTION
Rather than index every version, we should index only the latest patch release of each major.minor to avoid overwhelming users with redundant results.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
