### PR TITLE
only index pages from the latest version in each release line

### DIFF
--- a/.github/actions/docsearch-config.json.hbs
+++ b/.github/actions/docsearch-config.json.hbs
@@ -1,17 +1,15 @@
 {
   "index_name": "spring-security-docs",
   "start_urls": [
-    {{#each components}}
-    {{#each versions}}
+    {{#each latestVersions}}
     {
       "url": "{{{@root.site.url}}}/{{#if (eq ./activeVersionSegment '')}}(?:$|index.html$|[a-z].*){{else}}{{{./activeVersionSegment}}}/{{/if}}",
       "extra_attributes": {
-        "component": "{{#if (eq ./name 'ROOT')}}spring-security{{else}}{{{./name}}}{{/if}}",
+        "component": "{{#if (eq ./name 'ROOT')}}security{{else}}{{{./name}}}{{/if}}",
         "version": "{{{./version}}}",
-        "version_rank": {{#if (eq this ../latest)}}1{{else}}2{{/if}}
+        "version_rank": {{#if (eq ./activeVersionSegment '')}}1{{else}}2{{/if}}
       }
-    }{{#unless (and @last @../last)}},{{/unless}}
-    {{/each}}
+    }{{#unless @last}},{{/unless}}
     {{/each}}
   ],
   "sitemap_urls": [

--- a/lib/antora/extensions/publish-docsearch-config.js
+++ b/lib/antora/extensions/publish-docsearch-config.js
@@ -18,11 +18,14 @@ module.exports.register = function ({ config: { templatePath = './docsearch/conf
     const templateSrc = await fsp.readFile(templatePath, 'utf8')
     const templateBasename = ospath.basename(templatePath)
     const template = handlebars.compile(templateSrc, { noEscape: true, preventIndent: true, srcName: templateBasename })
-    const components = contentCatalog.getComponentsSortedBy('name').filter((component) => component.latest.version)
+    const latestVersions = contentCatalog.getComponentsSortedBy('name').reduce((accum, component) => {
+      component.versions.forEach((version) => version.versionSegment !== undefined && accum.push(version))
+      return accum
+    }, [])
     const stopPages = contentCatalog.getPages((page) => {
       return page.out && ('page-archived' in page.asciidoc.attributes || 'page-noindex' in page.asciidoc.attributes)
     })
-    const compiled = template({ components, site: playbook.site, stopPages })
+    const compiled = template({ latestVersions, site: playbook.site, stopPages })
     siteCatalog.addFile({ contents: Buffer.from(compiled), out: { path: 'docsearch-config.json' } })
   })
 }


### PR DESCRIPTION
This change should drastically reduce the number of search records and get the rollout of the search enhancements moving again.