### PR TITLE
use single gradle command/daemon for production docs build

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,24 +18,21 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 5
-    - name: Set Up Gradle
-      uses: spring-io/spring-gradle-build-action@v1
-      with:
-        java-version: '17'
-        distribution: temurin
-    - name: Scrub Gradle Cache
-      # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
-      # Restoring these files from a GitHub Actions cache might cause problems for future builds.
-      run: |
-        rm -f /home/runner/.gradle/caches/modules-2/modules-2.lock
-        rm -f /home/runner/.gradle/caches/modules-2/gc.properties
     - name: Set up refname build
       if: github.event.inputs.build-refname
       run: |
-        git fetch --depth 1 https://github.com/$GITHUB_REPOSITORY ${{ github.event.inputs.build-refname }}
+        git fetch --depth 1 $GITHUB_SERVER_URL/$GITHUB_REPOSITORY ${{ github.event.inputs.build-refname }}
         echo BUILD_REFNAME=${{ github.event.inputs.build-refname }} >> $GITHUB_ENV
         echo BUILD_VERSION=$(git cat-file --textconv FETCH_HEAD:gradle.properties | sed -n '/^version=/ { s/^version=//;p }') >> $GITHUB_ENV
-    - name: Run Antora
-      run: ./gradlew antora
+    - name: Install Java
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: '17'
+    - name: Install Gradle and Run Antora
+      uses: gradle/gradle-build-action@v2
+      with:
+        gradle-version: '7.5.1'
+        arguments: antora
     - name: Publish Docs
       run: $GITHUB_WORKSPACE/.github/actions/publish-docs.sh "${{ secrets.DOCS_USERNAME }}@${{ secrets.DOCS_HOST }}" /opt/www/domains/spring.io/docs/htdocs/spring-security/reference/ "${{ secrets.DOCS_SSH_KEY }}" "${{ secrets.DOCS_SSH_HOST_KEY }}" "${{ secrets.CLOUDFLARE_ZONE_ID }}" "${{ secrets.CLOUDFLARE_CACHE_TOKEN }}"

--- a/lib/antora/extensions/inject-collector-config.js
+++ b/lib/antora/extensions/inject-collector-config.js
@@ -1,26 +1,30 @@
 'use strict'
 
-const BASE_COMMAND = 'gradlew -q -PbuildSrc.skipTests=true'
+const GRADLE_ARGS = '-q -PbuildSrc.skipTests=true'
 const JVM_ARGS='-Xmx3g -XX:+HeapDumpOnOutOfMemoryError'
-const REPO_URL = 'https://github.com/spring-projects/spring-security'
 const TASK_NAME=':spring-security-docs:generateAntora'
 
 module.exports.register = function () {
-  this.once('contentAggregated', ({ contentAggregate }) => {
+  this.once('contentAggregated', ({ playbook, contentAggregate }) => {
+    const gradle = playbook.env.GRADLE || 'gradle'
+    const repositoryUrl = playbook.env.BUILD_REPOSITORY
+      ? playbook.env.BUILD_REPOSITORY
+      : playbook.env.GITHUB_REPOSITORY
+        ? `${playbook.env.GITHUB_SERVER_URL}/${playbook.env.GITHUB_REPOSITORY}`
+        : require('child_process').execSync('git remote get-url origin').toString().trimEnd()
     for (const { origins } of contentAggregate) {
       for (const origin of origins) {
-        if (origin.url === REPO_URL && origin.descriptor.ext?.collector === undefined) {
+        if (origin.url !== repositoryUrl) continue
+        let collector, run
+        if ((collector = origin.descriptor.ext?.collector) === undefined) {
           origin.descriptor.ext = {
             collector: {
-              run: {
-                command: `${BASE_COMMAND} "-Dorg.gradle.jvmargs=${JVM_ARGS}" ${TASK_NAME}`,
-                local: true,
-              },
-              scan: {
-                dir: './build/generateAntora',
-              },
+              run: { command: `${gradle} ${GRADLE_ARGS} "-Dorg.gradle.jvmargs=${JVM_ARGS}" ${TASK_NAME}` },
+              scan: { dir: './build/generateAntora' },
             }
           }
+        } else if ((run = collector.run) && run.command?.startsWith('gradlew ')) {
+          Object.assign(run, { command: `${gradle} ${run.command.slice(8)}`, local: false })
         }
       }
     }


### PR DESCRIPTION
I'm not requesting that you merge this right away, but to consider it. This PR reconfigures the production docs build to use the same gradle command/daemon throughout the build. It first installs Gradle onto the PATH. Then it rewrites the collector commands to use that gradle command instead of gradlew. By doing so, the build does not have to keep downloading Gradle for each reference where a different version is requested by gradlew.

Right now, this works across all references. If there comes a time when it does not, it would be possible to reconfigure the extension to leave those references alone and only use the shared gradle command for ones where it does work.