### PR TITLE
enable fetch option in Antora unless Gradle is running in offline mode

### DIFF
--- a/docs/spring-security-docs.gradle
+++ b/docs/spring-security-docs.gradle
@@ -13,7 +13,7 @@ antora {
 		path = 'lib/antora/templates/per-branch-antora-playbook.yml'
 		checkLocalBranch = true
 	}
-	options = [clean: true, stacktrace: true]
+	options = [clean: true, fetch: !project.gradle.startParameter.offline, stacktrace: true]
 }
 
 tasks.register('generateAntora') {


### PR DESCRIPTION
This will allow Antora to retrieve updates to the UI when Gradle is permitted access to the internet.