### PR TITLE
Extend jackson allow list

### DIFF
--- a/core/src/main/java/org/springframework/security/jackson2/SecurityJackson2Modules.java
+++ b/core/src/main/java/org/springframework/security/jackson2/SecurityJackson2Modules.java
@@ -204,10 +204,12 @@ public final class SecurityJackson2Modules {
 		static {
 			Set<String> names = new HashSet<>();
 			names.add("java.util.ArrayList");
+			names.add("java.util.Collections$EmptySet");
 			names.add("java.util.Collections$EmptyList");
 			names.add("java.util.Collections$EmptyMap");
 			names.add("java.util.Collections$UnmodifiableRandomAccessList");
 			names.add("java.util.Collections$SingletonList");
+			names.add("java.lang.Long");
 			names.add("java.util.Date");
 			names.add("java.time.Instant");
 			names.add("java.net.URL");


### PR DESCRIPTION
Fix for this issue https://github.com/spring-projects/spring-security/issues/12294
This exception occurs when session is stored in redis and `RedisIndexedSessionConfiguration` is used.
Also I faced with similar problem when put `Collection.emptySet()` in user's authorities, so I added it to allow list too.