### PR TITLE
upgrade Gradle Antora Plugin to 1.0.0 (docs build)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,6 @@
 plugins {
 	id 'base'
-	id 'org.antora' version '1.0.0-alpha.7'
-}
-
-node {
-	version = '19.4.0'
+	id 'org.antora' version '1.0.0'
 }
 
 antora {


### PR DESCRIPTION
This PR also removes the node version since it is now managed automatically by the plugin.