### PR TITLE
Update javadoc in EnableWebSecurity

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configuration/EnableWebSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configuration/EnableWebSecurity.java
@@ -46,7 +46,7 @@ import org.springframework.security.web.SecurityFilterChain;
  *
  * 	&#064;Bean
  * 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
- * 		http.authorizeRequests().requestMatchers(&quot;/public/**&quot;).permitAll().anyRequest()
+ * 		http.authorizeHttpRequests().requestMatchers(&quot;/public/**&quot;).permitAll().anyRequest()
  * 				.hasRole(&quot;USER&quot;).and()
  * 				// Possibly more configuration ...
  * 				.formLogin() // enable form based log in


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->
This PR fixes the explanation in the javadoc of the `@EnableWebSecurity`, which was using a deprecated method to set up the `SecurityFilterChain` as a `@Bean`.
<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
