### PR TITLE
Fix NPE in HttpSecurity#addFilterBefore, HttpSecurity#addFilterAfter

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -3254,7 +3254,12 @@ public final class HttpSecurity extends AbstractConfiguredSecurityBuilder<Defaul
 	}
 
 	private HttpSecurity addFilterAtOffsetOf(Filter filter, int offset, Class<? extends Filter> registeredFilter) {
-		int order = this.filterOrders.getOrder(registeredFilter) + offset;
+		Integer registeredFilterOrder = this.filterOrders.getOrder(registeredFilter);
+		if (registeredFilterOrder == null) {
+			throw new IllegalArgumentException(
+					"The Filter class " + registeredFilter.getName() + " does not have a registered order");
+		}
+		int order = registeredFilterOrder + offset;
 		this.filters.add(new OrderedFilter(filter, order));
 		this.filterOrders.put(filter.getClass(), order);
 		return this;


### PR DESCRIPTION
Before the fix, these methods would throw a NPE in case when the filter class passed as the second parameter, is not registered yet.

In particular, this exception can occur when mixing standard and custom DSL to register filters.

The fix doesn't change the situation that standard DSL for registration of filters cannot refer to filters that are registered via custom DSL even though those calls were done earlier.

It just provides more user-friendly error handling for this and most likely other scenarios of calls of HttpSecurity#addFilterBefore, HttpSecurity#addFilterAfter.

The error handling is implemented similarly to HttpSecurity#addFilter.

Closes gh-12637