### PR TITLE
FIX gh-12662

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/PrePostMethodSecurityConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/PrePostMethodSecurityConfigurationTests.java
@@ -45,6 +45,8 @@ import org.springframework.security.access.annotation.ExpressionProtectedBusines
 import org.springframework.security.access.annotation.Jsr250BusinessServiceImpl;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationEventPublisher;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -416,6 +418,26 @@ public class PrePostMethodSecurityConfigurationTests {
 		assertThat(this.spring.getContext().containsBean("postAuthorizeAspect$0")).isTrue();
 		assertThat(this.spring.getContext().containsBean("securedAspect$0")).isTrue();
 		assertThat(this.spring.getContext().containsBean("annotationSecurityAspect$0")).isFalse();
+	}
+
+	// gh-12662
+	@Test
+	@WithMockUser(username = "robert",roles = "SUPER_ADMIN")
+	public void testRoleHierarchy() {
+		this.spring.register(RoleHierarchyConfiguration.class, BusinessServiceConfig.class).autowire();
+		businessService.onlyPreAuthorizeAdminMethod();
+	}
+
+	@Configuration
+	static class RoleHierarchyConfiguration {
+
+		@Bean
+		public RoleHierarchy myRoleHierarchy() {
+			RoleHierarchyImpl roleHierarchy = new RoleHierarchyImpl();
+			roleHierarchy.setHierarchy("ROLE_SUPER_ADMIN > ROLE_ADMIN");
+			return roleHierarchy;
+		}
+
 	}
 
 	@Configuration

--- a/core/src/test/java/org/springframework/security/access/annotation/BusinessService.java
+++ b/core/src/test/java/org/springframework/security/access/annotation/BusinessService.java
@@ -35,6 +35,9 @@ public interface BusinessService extends Serializable {
 	@PreAuthorize("hasRole('ROLE_ADMIN')")
 	void someAdminMethod();
 
+	@PreAuthorize("hasRole('ROLE_ADMIN')")
+	void onlyPreAuthorizeAdminMethod();
+
 	@Secured({ "ROLE_USER", "ROLE_ADMIN" })
 	@RolesAllowed({ "ROLE_USER", "ROLE_ADMIN" })
 	void someUserAndAdminMethod();

--- a/core/src/test/java/org/springframework/security/access/annotation/BusinessServiceImpl.java
+++ b/core/src/test/java/org/springframework/security/access/annotation/BusinessServiceImpl.java
@@ -18,6 +18,7 @@ package org.springframework.security.access.annotation;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 /**
  * @author Joe Scalise
@@ -42,6 +43,12 @@ public class BusinessServiceImpl<E extends Entity> implements BusinessService {
 	@Override
 	@Secured({ "ROLE_ADMIN" })
 	public void someAdminMethod() {
+	}
+
+	@Override
+	@PreAuthorize("hasRole('ROLE_ADMIN')")
+	public void onlyPreAuthorizeAdminMethod() {
+
 	}
 
 	public E someUserMethod3(final E entity) {

--- a/core/src/test/java/org/springframework/security/access/annotation/ExpressionProtectedBusinessServiceImpl.java
+++ b/core/src/test/java/org/springframework/security/access/annotation/ExpressionProtectedBusinessServiceImpl.java
@@ -30,6 +30,12 @@ public class ExpressionProtectedBusinessServiceImpl implements BusinessService {
 	}
 
 	@Override
+	@PreAuthorize("hasRole('ROLE_ADMIN')")
+	public void onlyPreAuthorizeAdminMethod() {
+
+	}
+
+	@Override
 	public int someOther(String s) {
 		return 0;
 	}

--- a/core/src/test/java/org/springframework/security/access/annotation/Jsr250BusinessServiceImpl.java
+++ b/core/src/test/java/org/springframework/security/access/annotation/Jsr250BusinessServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 /**
  * @author Luke Taylor

--- a/core/src/test/java/org/springframework/security/access/annotation/Jsr250BusinessServiceImpl.java
+++ b/core/src/test/java/org/springframework/security/access/annotation/Jsr250BusinessServiceImpl.java
@@ -49,6 +49,12 @@ public class Jsr250BusinessServiceImpl implements BusinessService {
 	}
 
 	@Override
+	@PreAuthorize("hasRole('ROLE_ADMIN')")
+	public void onlyPreAuthorizeAdminMethod() {
+
+	}
+
+	@Override
 	public int someOther(String input) {
 		return 0;
 	}


### PR DESCRIPTION
Initialize as complete the default MethodSecurityExpressionHandler object as possible to ensure migration from @EnableGlobalMethodSecurity to @EnableMethodSecurity will work
see https://github.com/spring-projects/spring-security/issues/12662