### PR TITLE
Fix .access(...) parameter

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authorization/expression-based.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/expression-based.adoc
@@ -210,7 +210,7 @@ You could then refer to the method as follows:
 ----
 http
 	.authorizeHttpRequests(authorize -> authorize
-		.requestMatchers("/user/{userId}/**").access("@webSecurity.checkUserId(authentication,#userId)")
+		.requestMatchers("/user/{userId}/**").access(new WebExpressionAuthorizationManager("@webSecurity.checkUserId(authentication,#userId)"))
 		...
 	);
 ----


### PR DESCRIPTION
[This commit](https://github.com/spring-projects/spring-security/commit/d2b33a25839955e4f56379cc356b14dc007a3c73#diff-d5e1c4625ffca3f882dd1372f8f4ae140a75cc92b70352d95d628936305c56a5) fixed first example but not the second one (`.access(...)` parameter's class is `AuthorizationManager`, not `String`)