### PR TITLE
Remove the related introduce in reference docs `SecurityContextPersistenceFilter` which has be Deprecated. 

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/architecture.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/architecture.adoc
@@ -248,8 +248,7 @@ image:{icondir}/number_4.png[] If authentication is successful, then __Success__
 * `SessionAuthenticationStrategy` is notified of a new login.
 See the {security-api-url}org/springframework/security/web/authentication/session/SessionAuthenticationStrategy.html[`SessionAuthenticationStrategy`] interface.
 * The <<servlet-authentication-authentication>> is set on the <<servlet-authentication-securitycontextholder>>.
-Later, the `SecurityContextPersistenceFilter` saves the `SecurityContext` to the `HttpSession`.
-See the {security-api-url}org/springframework/security/web/context/SecurityContextPersistenceFilter.html[`SecurityContextPersistenceFilter`] class.
+Later, if you neeed to save `SecurityContext` , `SecurityContextRepository#saveContext` must be explicitly invoked.See the {security-api-url}org/springframework/security/web/context/SecurityContextHolderFilter.html[`SecurityContextHolderFilter`] class.
 * `RememberMeServices.loginSuccess` is invoked.
 If remember me is not configured, this is a no-op.
 See the {security-api-url}org/springframework/security/web/authentication/rememberme/package-frame.html[`rememberme`] package.


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->
Remove `SecurityContextPersistenceFilter` which has be Deprecated. And introduce `SecurityContextHolderFilter`

https://docs.spring.io/spring-security/reference/servlet/authentication/architecture.html#servlet-authentication-abstractprocessingfilter:~:text=.%20Later%2C%20the-,SecurityContextPersistenceFilter,-saves%20the%20SecurityContext
<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
