### PR TITLE
Fixed test in DefaultLoginPageGeneratingFilterTests

### DIFF
--- a/web/src/test/java/org/springframework/security/web/authentication/DefaultLoginPageGeneratingFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/DefaultLoginPageGeneratingFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,12 +132,14 @@ public class DefaultLoginPageGeneratingFilterTests {
 		DefaultLoginPageGeneratingFilter filter = new DefaultLoginPageGeneratingFilter(
 				new UsernamePasswordAuthenticationFilter());
 		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/login");
-		request.addParameter("login_error", "true");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		request.setQueryString("error");
 		MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
 		String message = messages.getMessage("AbstractUserDetailsAuthenticationProvider.badCredentials",
 				"Bad credentials", Locale.KOREA);
 		request.getSession().setAttribute(WebAttributes.AUTHENTICATION_EXCEPTION, new BadCredentialsException(message));
-		filter.doFilter(request, new MockHttpServletResponse(), this.chain);
+		filter.doFilter(request, response, this.chain);
+		assertThat(response.getContentAsString()).contains(message);
 	}
 
 	// gh-5394


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->
In the existing `handlesNonIso8859CharsInErrorMessage` method of `DefaultLoginPageGeneratingFilterTests`, 
it only retrieved a `Korean ISO-8859` message but did not verify whether it was properly included in the HTML document that is actually returned as the response. 
Therefore, a verification logic was added.
<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
