### PR TITLE
Add test to SimpleUrlAuthenticationSuccessHandlerTests

### DIFF
--- a/web/src/test/java/org/springframework/security/web/authentication/SimpleUrlAuthenticationSuccessHandlerTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/SimpleUrlAuthenticationSuccessHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,16 @@
 
 package org.springframework.security.web.authentication;
 
+import javax.servlet.http.HttpSession;
+
 import org.junit.jupiter.api.Test;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.WebAttributes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -106,6 +111,22 @@ public class SimpleUrlAuthenticationSuccessHandlerTests {
 		SimpleUrlAuthenticationSuccessHandler ash = new SimpleUrlAuthenticationSuccessHandler();
 		assertThatIllegalArgumentException().isThrownBy(() -> ash.setTargetUrlParameter(""));
 		assertThatIllegalArgumentException().isThrownBy(() -> ash.setTargetUrlParameter("   "));
+	}
+
+	@Test
+	public void shouldRemoveAuthenticationAttributeWhenOnAuthenticationSuccess() throws Exception {
+		SimpleUrlAuthenticationSuccessHandler ash = new SimpleUrlAuthenticationSuccessHandler();
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		HttpSession session = request.getSession();
+		assertThat(session).isNotNull();
+		session.setAttribute(WebAttributes.AUTHENTICATION_EXCEPTION,
+				new BadCredentialsException("Invalid credentials"));
+		assertThat(session.getAttribute(WebAttributes.AUTHENTICATION_EXCEPTION)).isNotNull();
+		assertThat(session.getAttribute(WebAttributes.AUTHENTICATION_EXCEPTION))
+				.isInstanceOf(AuthenticationException.class);
+		ash.onAuthenticationSuccess(request, response, mock(Authentication.class));
+		assertThat(session.getAttribute(WebAttributes.AUTHENTICATION_EXCEPTION)).isNull();
 	}
 
 }


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->
In the `onAuthenticationSuccess` method of the `SimpleUrlAuthenticationSuccessHandler`, the `clearAuthenticationAttributes` method is used to remove `AuthenticationException` objects that may be left in the session.

However, since there was no verification of whether this logic was working properly in test cases of `SimpleUrlAuthenticationSuccessHandler`, I added tests to verify it.
<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
