### PR TITLE
Fix hard-coded error message in LoginPageGeneratingWebFilter

### DIFF
--- a/config/src/integration-test/java/org/springframework/security/config/annotation/rsocket/RSocketMessageHandlerITests.java
+++ b/config/src/integration-test/java/org/springframework/security/config/annotation/rsocket/RSocketMessageHandlerITests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,11 +35,13 @@ import reactor.core.publisher.Mono;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.rsocket.RSocketRequester;
 import org.springframework.messaging.rsocket.RSocketStrategies;
 import org.springframework.messaging.rsocket.annotation.support.RSocketMessageHandler;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.core.SpringSecurityMessageSource;
 import org.springframework.security.core.userdetails.MapReactiveUserDetailsService;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -73,6 +75,8 @@ public class RSocketMessageHandlerITests {
 	private CloseableChannel server;
 
 	private RSocketRequester requester;
+
+	private MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
 
 	@BeforeEach
 	public void setup() {
@@ -120,6 +124,7 @@ public class RSocketMessageHandlerITests {
 	public void retrieveMonoWhenAuthenticationFailedThenException() throws Exception {
 		String data = "rob";
 		UsernamePasswordMetadata credentials = new UsernamePasswordMetadata("invalid", "password");
+		String message = this.messages.getMessage("AbstractUserDetailsAuthenticationProvider.badCredentials");
 		// @formatter:off
 		assertThatExceptionOfType(ApplicationErrorException.class)
 			.isThrownBy(() -> this.requester.route("secure.retrieve-mono")
@@ -127,7 +132,7 @@ public class RSocketMessageHandlerITests {
 				.retrieveMono(String.class)
 				.block()
 			)
-			.withMessageContaining("Invalid Credentials");
+			.withMessageContaining(message);
 		// @formatter:on
 		assertThat(this.controller.payloads).isEmpty();
 	}

--- a/config/src/test/java/org/springframework/security/config/web/server/LogoutSpecTests.java
+++ b/config/src/test/java/org/springframework/security/config/web/server/LogoutSpecTests.java
@@ -64,7 +64,7 @@ public class LogoutSpecTests {
 				.username("user")
 				.password("invalid")
 				.submit(FormLoginTests.DefaultLoginPage.class)
-				.assertError();
+				.assertBadCredentialsError();
 		FormLoginTests.HomePage homePage = loginPage.loginForm()
 				.username("user")
 				.password("password")
@@ -101,7 +101,7 @@ public class LogoutSpecTests {
 					.username("user")
 					.password("invalid")
 					.submit(FormLoginTests.DefaultLoginPage.class)
-				.assertError();
+				.assertBadCredentialsError();
 		FormLoginTests.HomePage homePage = loginPage.loginForm()
 				.username("user")
 				.password("password")
@@ -138,7 +138,7 @@ public class LogoutSpecTests {
 				.username("user")
 				.password("invalid")
 				.submit(FormLoginTests.DefaultLoginPage.class)
-				.assertError();
+				.assertBadCredentialsError();
 		FormLoginTests.HomePage homePage = loginPage.loginForm()
 				.username("user").password("password")
 				.submit(FormLoginTests.HomePage.class);

--- a/core/src/main/java/org/springframework/security/authentication/AbstractUserDetailsReactiveAuthenticationManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/AbstractUserDetailsReactiveAuthenticationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,7 +99,9 @@ public abstract class AbstractUserDetailsReactiveAuthenticationManager
 				.doOnNext(this.preAuthenticationChecks::check)
 				.publishOn(this.scheduler)
 				.filter((userDetails) -> this.passwordEncoder.matches(presentedPassword, userDetails.getPassword()))
-				.switchIfEmpty(Mono.defer(() -> Mono.error(new BadCredentialsException("Invalid Credentials"))))
+				.switchIfEmpty(Mono.defer(() -> Mono.error(new BadCredentialsException(
+						this.messages.getMessage("AbstractUserDetailsAuthenticationProvider.badCredentials", "Bad credentials")
+				))))
 				.flatMap((userDetails) -> upgradeEncodingIfNecessary(userDetails, presentedPassword))
 				.doOnNext(this.postAuthenticationChecks::check)
 				.map(this::createUsernamePasswordAuthenticationToken);

--- a/web/src/main/java/org/springframework/security/web/server/authentication/RedirectServerAuthenticationFailureHandler.java
+++ b/web/src/main/java/org/springframework/security/web/server/authentication/RedirectServerAuthenticationFailureHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.net.URI;
 import reactor.core.publisher.Mono;
 
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.WebAttributes;
 import org.springframework.security.web.server.DefaultServerRedirectStrategy;
 import org.springframework.security.web.server.ServerRedirectStrategy;
 import org.springframework.security.web.server.WebFilterExchange;
@@ -58,7 +59,9 @@ public class RedirectServerAuthenticationFailureHandler implements ServerAuthent
 
 	@Override
 	public Mono<Void> onAuthenticationFailure(WebFilterExchange webFilterExchange, AuthenticationException exception) {
-		return this.redirectStrategy.sendRedirect(webFilterExchange.getExchange(), this.location);
+		return webFilterExchange.getExchange().getSession()
+				.doOnNext((session) -> session.getAttributes().put(WebAttributes.AUTHENTICATION_EXCEPTION, exception))
+				.flatMap((s) -> this.redirectStrategy.sendRedirect(webFilterExchange.getExchange(), this.location));
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/server/authentication/RedirectServerAuthenticationSuccessHandlerTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/authentication/RedirectServerAuthenticationSuccessHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,21 +17,26 @@
 package org.springframework.security.web.server.authentication;
 
 import java.net.URI;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
 import reactor.test.publisher.PublisherProbe;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.WebAttributes;
 import org.springframework.security.web.server.ServerRedirectStrategy;
 import org.springframework.security.web.server.WebFilterExchange;
-import org.springframework.web.server.ServerWebExchange;
-import org.springframework.web.server.WebFilterChain;
+import org.springframework.web.server.WebSession;
+import org.springframework.web.server.handler.DefaultWebFilterChain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -47,11 +52,7 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 public class RedirectServerAuthenticationSuccessHandlerTests {
 
-	@Mock
-	private ServerWebExchange exchange;
-
-	@Mock
-	private WebFilterChain chain;
+	private WebFilterExchange exchange;
 
 	@Mock
 	private ServerRedirectStrategy redirectStrategy;
@@ -70,19 +71,18 @@ public class RedirectServerAuthenticationSuccessHandlerTests {
 
 	@Test
 	public void successWhenNoSubscribersThenNoActions() {
-		this.exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
-		this.handler.onAuthenticationSuccess(new WebFilterExchange(this.exchange, this.chain), this.authentication);
-		assertThat(this.exchange.getResponse().getHeaders().getLocation()).isNull();
-		assertThat(this.exchange.getSession().block().isStarted()).isFalse();
+		this.exchange = createExchange();
+		this.handler.onAuthenticationSuccess(this.exchange, this.authentication);
+		assertThat(this.exchange.getExchange().getResponse().getHeaders().getLocation()).isNull();
+		assertThat(this.exchange.getExchange().getSession().block().isStarted()).isFalse();
 	}
 
 	@Test
 	public void successWhenSubscribeThenStatusAndLocationSet() {
-		this.exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
-		this.handler.onAuthenticationSuccess(new WebFilterExchange(this.exchange, this.chain), this.authentication)
-				.block();
-		assertThat(this.exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FOUND);
-		assertThat(this.exchange.getResponse().getHeaders().getLocation()).isEqualTo(this.location);
+		this.exchange = createExchange();
+		this.handler.onAuthenticationSuccess(this.exchange, this.authentication).block();
+		assertThat(this.exchange.getExchange().getResponse().getStatusCode()).isEqualTo(HttpStatus.FOUND);
+		assertThat(this.exchange.getExchange().getResponse().getHeaders().getLocation()).isEqualTo(this.location);
 	}
 
 	@Test
@@ -90,9 +90,8 @@ public class RedirectServerAuthenticationSuccessHandlerTests {
 		PublisherProbe<Void> redirectResult = PublisherProbe.empty();
 		given(this.redirectStrategy.sendRedirect(any(), any())).willReturn(redirectResult.mono());
 		this.handler.setRedirectStrategy(this.redirectStrategy);
-		this.exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
-		this.handler.onAuthenticationSuccess(new WebFilterExchange(this.exchange, this.chain), this.authentication)
-				.block();
+		this.exchange = createExchange();
+		this.handler.onAuthenticationSuccess(this.exchange, this.authentication).block();
 		redirectResult.assertWasSubscribed();
 		verify(this.redirectStrategy).sendRedirect(any(), eq(this.location));
 	}
@@ -105,6 +104,23 @@ public class RedirectServerAuthenticationSuccessHandlerTests {
 	@Test
 	public void setLocationWhenNullThenException() {
 		assertThatIllegalArgumentException().isThrownBy(() -> this.handler.setLocation(null));
+	}
+
+	@Test
+	public void shouldRemoveAuthenticationAttributeWhenOnAuthenticationSuccess() {
+		this.exchange = createExchange();
+		WebSession session = this.exchange.getExchange().getSession().block();
+		assertThat(session).isNotNull();
+		AuthenticationException exception = new BadCredentialsException("Invalid credentials");
+		session.getAttributes().put(WebAttributes.AUTHENTICATION_EXCEPTION, exception);
+		this.handler.onAuthenticationSuccess(this.exchange, this.authentication).block();
+		AuthenticationException authAttribute = session.getAttribute(WebAttributes.AUTHENTICATION_EXCEPTION);
+		assertThat(authAttribute).isNull();
+	}
+
+	private WebFilterExchange createExchange() {
+		return new WebFilterExchange(MockServerWebExchange.from(MockServerHttpRequest.get("/").build()),
+				new DefaultWebFilterChain((e) -> Mono.empty(), Collections.emptyList()));
 	}
 
 }


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->
Fix hard coded error message in default login page on web flux security
Closes #12743 

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
