### PR TITLE
Make Saml2LogoutRequest#encoder transient

### DIFF
--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/Saml2LogoutRequest.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/Saml2LogoutRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ public final class Saml2LogoutRequest implements Serializable {
 
 	private final String relyingPartyRegistrationId;
 
-	private Function<Map<String, String>, String> encoder;
+	private transient Function<Map<String, String>, String> encoder;
 
 	private Saml2LogoutRequest(String location, Saml2MessageBinding binding, Map<String, String> parameters, String id,
 			String relyingPartyRegistrationId) {


### PR DESCRIPTION
`Saml2LogoutRequest` was not able to serialize/deserialize , changes are made to `Saml2LogoutRequest` class to made the `encoder` a transient variable , unit tests are added under `HttpSessionLogoutRequestRepositoryTests`

**previous PR #12638 created against the latest main is now closed as this fix goes under 5.8.x**
