### PR TITLE
Correct deprecated description in docs

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/architecture.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/architecture.adoc
@@ -248,8 +248,9 @@ image:{icondir}/number_4.png[] If authentication is successful, then __Success__
 * `SessionAuthenticationStrategy` is notified of a new login.
 See the {security-api-url}org/springframework/security/web/authentication/session/SessionAuthenticationStrategy.html[`SessionAuthenticationStrategy`] interface.
 * The <<servlet-authentication-authentication>> is set on the <<servlet-authentication-securitycontextholder>>.
-Later, the `SecurityContextPersistenceFilter` saves the `SecurityContext` to the `HttpSession`.
-See the {security-api-url}org/springframework/security/web/context/SecurityContextPersistenceFilter.html[`SecurityContextPersistenceFilter`] class.
+Later, if you need to save the `SecurityContext` so that it can be automatically set on future requests, `SecurityContextRepository#saveContext` must be explicitly invoked.
+See the {security-api-url}org/springframework/security/web/context/SecurityContextHolderFilter.html[`SecurityContextHolderFilter`] class.
+
 * `RememberMeServices.loginSuccess` is invoked.
 If remember me is not configured, this is a no-op.
 See the {security-api-url}org/springframework/security/web/authentication/rememberme/package-frame.html[`rememberme`] package.


### PR DESCRIPTION
Remove deprecated SecurityContextPersistenceFilter from docs.
related to #12690 

