### PR TITLE
fix missing semi-colon java example in observability documentation

### DIFF
--- a/docs/modules/ROOT/pages/reactive/integrations/observability.adoc
+++ b/docs/modules/ROOT/pages/reactive/integrations/observability.adoc
@@ -192,8 +192,8 @@ Instead, you can alter the provided `ObservationRegistry` with an `ObservationPr
 ----
 @Bean
 ObservationRegistryCustomizer<ObservationRegistry> noSpringSecurityObservations() {
-	ObservationPredicate predicate = (name, context) -> !name.startsWith("spring.security.")
-	return (registry) -> registry.observationConfig().observationPredicate(predicate)
+	ObservationPredicate predicate = (name, context) -> !name.startsWith("spring.security.");
+	return (registry) -> registry.observationConfig().observationPredicate(predicate);
 }
 ----
 

--- a/docs/modules/ROOT/pages/servlet/integrations/observability.adoc
+++ b/docs/modules/ROOT/pages/servlet/integrations/observability.adoc
@@ -198,7 +198,7 @@ Instead, you can alter the provided `ObservationRegistry` with an `ObservationPr
 @Bean
 ObservationRegistryCustomizer<ObservationRegistry> noSpringSecurityObservations() {
 	ObservationPredicate predicate = (name, context) -> !name.startsWith("spring.security.");
-	return (registry) -> registry.observationConfig().observationPredicate(predicate)
+	return (registry) -> registry.observationConfig().observationPredicate(predicate);
 }
 ----
 


### PR DESCRIPTION
Fix java example in the following pages documentation : 
- https://docs.spring.io/spring-security/reference/servlet/integrations/observability.html
- https://docs.spring.io/spring-security/reference/reactive/integrations/observability.html
