### PR TITLE
Fix typo in SecurityMockMvcResultMatchers.java

### DIFF
--- a/test/src/main/java/org/springframework/security/test/web/servlet/response/SecurityMockMvcResultMatchers.java
+++ b/test/src/main/java/org/springframework/security/test/web/servlet/response/SecurityMockMvcResultMatchers.java
@@ -140,11 +140,11 @@ public final class SecurityMockMvcResultMatchers {
 
 		/**
 		 * Allows for any validating the authentication with arbitrary assertions
-		 * @param assesrtAuthentication the Consumer which validates the authentication
+		 * @param assertAuthentication the Consumer which validates the authentication
 		 * @return the AuthenticatedMatcher to perform additional assertions
 		 */
-		public AuthenticatedMatcher withAuthentication(Consumer<Authentication> assesrtAuthentication) {
-			this.assertAuthentication = assesrtAuthentication;
+		public AuthenticatedMatcher withAuthentication(Consumer<Authentication> assertAuthentication) {
+			this.assertAuthentication = assertAuthentication;
 			return this;
 		}
 


### PR DESCRIPTION
Change the first parameter's name of the `AuthenticatedMatcher.withAuthentication()` method from `assesrtAuthentication` to `assertAuthentication`

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
