### PR TITLE
Make it possible to take servlet context path into account and ensure HTTP method is preserved on redirect to requested URL

### DIFF
--- a/web/src/main/java/org/springframework/security/web/session/RequestedUrlRedirectInvalidSessionStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/session/RequestedUrlRedirectInvalidSessionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.security.web.DefaultRedirectStrategy;
 import org.springframework.security.web.RedirectStrategy;
+import org.springframework.util.Assert;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 /**
@@ -32,12 +33,13 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
  * detected by the {@code SessionManagementFilter}.
  *
  * @author Craig Andrews
+ * @author Mark Chesney
  */
 public final class RequestedUrlRedirectInvalidSessionStrategy implements InvalidSessionStrategy {
 
 	private final Log logger = LogFactory.getLog(getClass());
 
-	private final RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
+	private RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
 
 	private boolean createNewSession = true;
 
@@ -66,6 +68,16 @@ public final class RequestedUrlRedirectInvalidSessionStrategy implements Invalid
 	 */
 	public void setCreateNewSession(boolean createNewSession) {
 		this.createNewSession = createNewSession;
+	}
+
+	/**
+	 * Sets the redirect strategy to use. The default is {@link DefaultRedirectStrategy}.
+	 * @param redirectStrategy the redirect strategy to use.
+	 * @since 6.2
+	 */
+	public void setRedirectStrategy(RedirectStrategy redirectStrategy) {
+		Assert.notNull(redirectStrategy, "redirectStrategy cannot be null");
+		this.redirectStrategy = redirectStrategy;
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/DefaultRedirectStrategyTests.java
+++ b/web/src/test/java/org/springframework/security/web/DefaultRedirectStrategyTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.security.web;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -26,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 
 /**
  * @author Luke Taylor
+ * @author Mark Chesney
  * @since 3.0
  */
 public class DefaultRedirectStrategyTests {
@@ -62,6 +64,23 @@ public class DefaultRedirectStrategyTests {
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> rds.sendRedirect(request, response, "https://redirectme.somewhere.else"));
+	}
+
+	@Test
+	public void statusCodeIsHandledCorrectly() throws Exception {
+		// given
+		DefaultRedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
+		redirectStrategy.setStatusCode(HttpStatus.TEMPORARY_REDIRECT);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		// when
+		redirectStrategy.sendRedirect(request, response, "/requested");
+
+		// then
+		assertThat(response.isCommitted()).isTrue();
+		assertThat(response.getRedirectedUrl()).isEqualTo("/requested");
+		assertThat(response.getStatus()).isEqualTo(307);
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/session/SessionManagementFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/session/SessionManagementFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.mock.web.MockFilterChain;
@@ -29,6 +30,7 @@ import org.springframework.security.authentication.AuthenticationTrustResolver;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.DefaultRedirectStrategy;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.session.SessionAuthenticationException;
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
@@ -46,9 +48,11 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 /**
  * @author Luke Taylor
  * @author Rob Winch
+ * @author Mark Chesney
  */
 public class SessionManagementFilterTests {
 
+	@BeforeEach
 	@AfterEach
 	public void clearContext() {
 		SecurityContextHolder.clearContext();
@@ -172,6 +176,38 @@ public class SessionManagementFilterTests {
 		filter.doFilter(request, response, fc);
 		verifyNoMoreInteractions(fc);
 		assertThat(response.getRedirectedUrl()).isEqualTo("/requested");
+	}
+
+	@Test
+	public void responseIsRedirectedToRequestedUrlIfContextPathIsSetAndSessionIsInvalid() throws Exception {
+		// given
+		DefaultRedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
+		redirectStrategy.setContextRelative(true);
+		RequestedUrlRedirectInvalidSessionStrategy invalidSessionStrategy = new RequestedUrlRedirectInvalidSessionStrategy();
+		invalidSessionStrategy.setCreateNewSession(true);
+		invalidSessionStrategy.setRedirectStrategy(redirectStrategy);
+		SecurityContextRepository securityContextRepository = mock(SecurityContextRepository.class);
+		SessionAuthenticationStrategy sessionAuthenticationStrategy = mock(SessionAuthenticationStrategy.class);
+		SessionManagementFilter filter = new SessionManagementFilter(securityContextRepository,
+				sessionAuthenticationStrategy);
+		filter.setInvalidSessionStrategy(invalidSessionStrategy);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setContextPath("/context");
+		request.setRequestedSessionId("xxx");
+		request.setRequestedSessionIdValid(false);
+		request.setRequestURI("/context/requested");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain chain = mock(FilterChain.class);
+
+		// when
+		filter.doFilter(request, response, chain);
+
+		// then
+		verify(securityContextRepository).containsContext(request);
+		verifyNoMoreInteractions(securityContextRepository, sessionAuthenticationStrategy, chain);
+		assertThat(response.isCommitted()).isTrue();
+		assertThat(response.getRedirectedUrl()).isEqualTo("/context/requested");
+		assertThat(response.getStatus()).isEqualTo(302);
 	}
 
 	@Test


### PR DESCRIPTION
* Makes it possible to customize the redirect strategy of `RequestedUrlRedirectInvalidSessionStrategy`, so that the servlet context path can be taken into account if desired.
* Makes the HTTP status code used by `DefaultRedirectStrategy` configurable, so that `307 Temporary Redirect` can be chosen if desired.

Closes gh-12795
Closes gh-12797