### PR TITLE
Updated core.adoc to fix Issue #12824

### DIFF
--- a/docs/modules/ROOT/pages/servlet/oauth2/login/core.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/login/core.adoc
@@ -5,7 +5,7 @@
 
 Spring Boot 2.x brings full auto-configuration capabilities for OAuth 2.0 Login.
 
-This section shows how to configure the {gh-samples-url}/boot/oauth2login[*OAuth 2.0 Login sample*] by using _Google_ as the _Authentication Provider_ and covers the following topics:
+This section shows how to configure the {gh-samples-url}/servlet/spring-boot/java/oauth2/login[*OAuth 2.0 Login sample*] by using _Google_ as the _Authentication Provider_ and covers the following topics:
 
 * <<oauth2login-sample-initial-setup>>
 * <<oauth2login-sample-redirect-uri>>


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
This PR fixes gh-12824, which currently redirects to a non-existent page. Instead, it will now redirect to [the actual page](https://github.com/spring-projects/spring-security-samples/tree/main/servlet/spring-boot/java/oauth2/login).