### PR TITLE
Add matchers and fix typo in RequestCacheConfigurer

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurer.java
@@ -112,7 +112,7 @@ public final class RequestCacheConfigurer<H extends HttpSecurityBuilder<H>>
 	 * {@link #requestCache(org.springframework.security.web.savedrequest.RequestCache)},
 	 * then it is used. Otherwise, an attempt to find a {@link RequestCache} shared object
 	 * is made. If that fails, an {@link HttpSessionRequestCache} is used
-	 * @param http the {@link HttpSecurity} to attempt to fined the shared object
+	 * @param http the {@link HttpSecurity} to attempt to find the shared object
 	 * @return the {@link RequestCache} to use
 	 */
 	private RequestCache getRequestCache(H http) {

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,6 +72,8 @@ import org.springframework.web.accept.HeaderContentNegotiationStrategy;
  */
 public final class RequestCacheConfigurer<H extends HttpSecurityBuilder<H>>
 		extends AbstractHttpConfigurer<RequestCacheConfigurer<H>, H> {
+
+	private static final MediaType TEXT_CSS = new MediaType("text", "css");
 
 	public RequestCacheConfigurer() {
 	}
@@ -154,6 +156,7 @@ public final class RequestCacheConfigurer<H extends HttpSecurityBuilder<H>>
 			matchers.add(0, getRequests);
 		}
 		matchers.add(notFavIcon);
+		matchers.add(notMatchingMediaType(http, TEXT_CSS));
 		matchers.add(notMatchingMediaType(http, MediaType.APPLICATION_JSON));
 		matchers.add(notXRequestedWith);
 		matchers.add(notMatchingMediaType(http, MediaType.MULTIPART_FORM_DATA));


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->
This PR fixes an issue where, if the CSS file of a page's static resources was last blocked before login, the user would be redirected to that CSS file after logging in(#12656).
And fix some typo.
<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
