### PR TITLE
Add new DaoAuthenticationProvider constructor

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/dao/DaoAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/dao/DaoAuthenticationProvider.java
@@ -61,7 +61,11 @@ public class DaoAuthenticationProvider extends AbstractUserDetailsAuthentication
 	private UserDetailsPasswordService userDetailsPasswordService;
 
 	public DaoAuthenticationProvider() {
-		setPasswordEncoder(PasswordEncoderFactories.createDelegatingPasswordEncoder());
+		this(PasswordEncoderFactories.createDelegatingPasswordEncoder());
+	}
+
+	public DaoAuthenticationProvider(PasswordEncoder passwordEncoder) {
+		setPasswordEncoder(passwordEncoder);
 	}
 
 	@Override


### PR DESCRIPTION
Add a new constructor to the DaoAuthenticationProvider, which allows providing a custom PasswordEncoder to prevent instantiation of the default delegating PasswordEncoder in the default constructor.

This provides a way to instantiate the DaoAuthenticationProvider on JDKs where the default delegating PasswordEncoder cannot be instantiated due to limited JCE providers for compliance reasons (e.g., FIPS).

Closes gh-12873

@pivotal-cla This is an Obvious Fix