### PR TITLE
chore: typo, removed extra "s" in word implementationss

### DIFF
--- a/docs/modules/ROOT/pages/servlet/saml2/login/overview.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/login/overview.adoc
@@ -151,7 +151,7 @@ To achieve this, any interfaces or classes where Spring Security uses OpenSAML i
 This makes it possible for you to switch out OpenSAML for some other library or an unsupported version of OpenSAML.
 
 As a natural outcome of these two goals, Spring Security's SAML API is quite small relative to other modules.
-Instead, such classes as `OpenSamlAuthenticationRequestFactory` and `OpenSamlAuthenticationProvider` expose `Converter` implementationss that customize various steps in the authentication process.
+Instead, such classes as `OpenSamlAuthenticationRequestFactory` and `OpenSamlAuthenticationProvider` expose `Converter` implementations that customize various steps in the authentication process.
 
 For example, once your application receives a `SAMLResponse` and delegates to `Saml2WebSsoAuthenticationFilter`, the filter delegates to `OpenSamlAuthenticationProvider`:
 


### PR DESCRIPTION
found a typo in the documentation of saml2.

introduced in commit 2fb056b5c1, specifically here:

https://github.com/spring-projects/spring-security/commit/2fb056b5c1aeae06027252ef7888ca946cfbae8b#diff-c1f73d72d06f3dcee2e96352cb2f9f1a1b3a19f7ad73f02d2a0b343c435c9684R153