### PR TITLE
Make eclipse/vscode project import work

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"java.import.gradle.enabled": false
+}

--- a/buildSrc/src/main/groovy/io/spring/gradle/convention/AbstractSpringJavaPlugin.groovy
+++ b/buildSrc/src/main/groovy/io/spring/gradle/convention/AbstractSpringJavaPlugin.groovy
@@ -54,6 +54,7 @@ public abstract class AbstractSpringJavaPlugin implements Plugin<Project> {
 		pluginManager.apply("io.spring.convention.javadoc-options");
 		pluginManager.apply("io.spring.convention.checkstyle");
 		pluginManager.apply(CopyPropertiesPlugin);
+		pluginManager.apply("io.spring.convention.eclipse");
 
 		project.jar {
 			manifest.attributes["Created-By"] =

--- a/buildSrc/src/main/groovy/io/spring/gradle/convention/EclipsePlugin.groovy
+++ b/buildSrc/src/main/groovy/io/spring/gradle/convention/EclipsePlugin.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.spring.gradle.convention
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.plugins.ide.eclipse.EclipsePlugin
+
+/**
+ * Plugin to tweak .classpath settings so that eclipse/sts/vscode can
+ * be imported cleanly.
+ *
+ * @author Janne Valkealahti
+ */
+class EclipsePlugin implements Plugin<Project> {
+
+	@Override
+	void apply(Project project) {
+		project.plugins.apply(EclipsePlugin)
+
+		project.eclipse {
+			classpath {
+				file {
+					whenMerged {
+						// for aspects gradle eclipse integration wrongly creates lib entries for
+						// aspects/build/classes/java/main and aspects/build/resources/main which
+						// never has anything. eclipse/sts don't care, vscode language server
+						// complains about missing folders. So remove those from a .classpath
+						entries.removeAll {
+							entry -> entry.kind == 'lib' && (entry.path.contains('aspects/build/classes/java/main') || entry.path.contains('aspects/build/resources/main'))
+						}
+						// there are cycles and then dependencies between projects main sources and
+						// test sources. Looks like gradle eclipse integration is getting confused.
+						// thus just relax rules so that projects always sees everything from
+						// dependant project.
+						entries
+							.findAll { entry -> entry instanceof org.gradle.plugins.ide.eclipse.model.ProjectDependency }
+							.each {
+								it.entryAttributes['without_test_code'] = 'false'
+								it.entryAttributes['test'] = 'false'
+							}
+					}
+				}
+			}
+			jdt {
+				file {
+					withProperties { properties ->
+						// there are cycles and then dependencies between projects main sources and
+						// test sources. Relax those from error to warning
+						properties['org.eclipse.jdt.core.circularClasspath'] = 'warning'
+						properties['org.eclipse.jdt.core.incompleteClasspath'] = 'warning'
+					}
+				}
+			}
+		}
+	}
+
+}

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/io.spring.convention.eclipse.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/io.spring.convention.eclipse.properties
@@ -1,0 +1,1 @@
+implementation-class=io.spring.gradle.convention.EclipsePlugin

--- a/config/spring-security-config.gradle
+++ b/config/spring-security-config.gradle
@@ -68,6 +68,7 @@ dependencies {
 	testImplementation 'ldapsdk:ldapsdk:4.1'
 	testImplementation('net.sourceforge.htmlunit:htmlunit') {
 		exclude group: 'commons-logging', module: 'commons-logging'
+		exclude group: 'xml-apis', module: 'xml-apis'
 	}
 	testImplementation "org.apache.directory.server:apacheds-core"
 	testImplementation "org.apache.directory.server:apacheds-core-entry"
@@ -83,6 +84,7 @@ dependencies {
 	testImplementation "org.mockito:mockito-inline"
 	testImplementation('org.seleniumhq.selenium:htmlunit-driver') {
 		exclude group: 'commons-logging', module: 'commons-logging'
+		exclude group: 'xml-apis', module: 'xml-apis'
 	}
 	testImplementation('org.seleniumhq.selenium:selenium-java') {
 		exclude group: 'commons-logging', module: 'commons-logging'


### PR DESCRIPTION
- Gradle projects contain cycles which comes from dependencies to test sources which is not a problem in gradle but eclipse metadata generation is getting confused. Thus we need settings to relax errors org.eclipse.jdt.core.circularClasspath=warning org.eclipse.jdt.core.incompleteClasspath=warning
- Additionally .classpath entries needs to be changes having without_test_code=false test=false
- Aspects end up getting source dirs `build/classes/java/main` and `build/resources/main` which never have sources. Vscode complains about that, eclipse is fine. Remove those from entries.
- In tests `htmlunit` depends on `xml-apis`. `xml-apis` are now part of jdk and eclipse complains about that. Excluse these in a gradle build.
- Both eclipse and vscode don't currently work with buildship, due to project cycles and buildship cannot be configured. It's possible to create metadata from `eclipse` task manually which then can be imported. For this we need to disable automatic import in vscode using buildship. This goes to `.vscode/settings.json` workspace config.
- Then with these changes user can do something like git clean -fxd && ./gradlew clean build cleanEclipse eclipse -x checkstyleNohttp -x test -x integrationTest and import projects manually.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
