### PR TITLE
TestingAuthenticationToken takes broader collection type

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/TestingAuthenticationToken.java
+++ b/core/src/main/java/org/springframework/security/authentication/TestingAuthenticationToken.java
@@ -47,7 +47,7 @@ public class TestingAuthenticationToken extends AbstractAuthenticationToken {
 		this(principal, credentials, AuthorityUtils.createAuthorityList(authorities));
 	}
 
-	public TestingAuthenticationToken(Object principal, Object credentials, List<GrantedAuthority> authorities) {
+	public TestingAuthenticationToken(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
 		super(authorities);
 		this.principal = principal;
 		this.credentials = credentials;


### PR DESCRIPTION
So that callers do not have to cast.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
