### PR TITLE
Add missing null-check

### DIFF
--- a/web/src/main/java/org/springframework/security/web/firewall/StrictHttpFirewall.java
+++ b/web/src/main/java/org/springframework/security/web/firewall/StrictHttpFirewall.java
@@ -734,7 +734,9 @@ public class StrictHttpFirewall implements HttpFirewall {
 				@Override
 				public String nextElement() {
 					String value = headers.nextElement();
-					validateAllowedHeaderValue(value);
+					if (value != null) {
+						validateAllowedHeaderValue(value);
+					}
 					return value;
 				}
 


### PR DESCRIPTION
Following the behaviour of getHeader(String name), avoid call to validateAllowedHeaderValue with a null value (which results in an exception).

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
