### PR TITLE
Fix javadoc for migration from WebSecurityConfigurerAdapter

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurerAdapter.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,7 +103,7 @@ import org.springframework.web.accept.HeaderContentNegotiationStrategy;
  *     }
  *
  *    &#64;Bean
- *    public WebSecurityCustomizer webSecurityCustomizer(WebSecurity web) {
+ *    public WebSecurityCustomizer webSecurityCustomizer() {
  *        return (web) -> web.ignoring().antMatchers("/resources/**");
  *    }
  * </pre> See the <a href=


### PR DESCRIPTION
This PR just fixes the code sample in javadocs that errorneously uses `WebSecurity` parameter in a bean-creation method that doesn't need to have any parameters, as `WebSecurity` parameter is already provided in `WebSecurityCustomizer.customize(WebSecurity web)` functional method. Moreover, the sample doesn't even compile because of parameter names collision (the bean factory paramter and lambda parameter).

This fix could also be backported to 5.7.x branch.