### PR TITLE
Store HttpServletResponse used by LazyCsrfTokenRepository in an appropriately prefixed request attribute

### DIFF
--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/CsrfDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/CsrfDslTests.kt
@@ -43,6 +43,7 @@ import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler
 import org.springframework.security.web.csrf.CsrfTokenRequestHandler
 import org.springframework.security.web.csrf.DefaultCsrfToken
 import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository
+import org.springframework.security.web.csrf.LazyCsrfTokenRepository
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
@@ -317,7 +318,7 @@ class CsrfDslTests {
             val request: HttpServletRequest = firstArg()
             val response: HttpServletResponse = secondArg()
             // Required for LazyCsrfTokenRepository
-            request.setAttribute(HttpServletResponse::class.java.name, response)
+            request.setAttribute(LazyCsrfTokenRepository.HTTP_RESPONSE_ATTR, response)
         }
         every { RequestHandlerConfig.HANDLER.resolveCsrfTokenValue(any(), any()) } returns "token"
 

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRequestAttributeHandler.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfTokenRequestAttributeHandler.java
@@ -54,7 +54,7 @@ public class CsrfTokenRequestAttributeHandler implements CsrfTokenRequestHandler
 		Assert.notNull(response, "response cannot be null");
 		Assert.notNull(deferredCsrfToken, "deferredCsrfToken cannot be null");
 
-		request.setAttribute(HttpServletResponse.class.getName(), response);
+		request.setAttribute(LazyCsrfTokenRepository.HTTP_RESPONSE_ATTR, response);
 		CsrfToken csrfToken = new SupplierCsrfToken(deferredCsrfToken);
 		request.setAttribute(CsrfToken.class.getName(), csrfToken);
 		String csrfAttrName = (this.csrfRequestAttributeName != null) ? this.csrfRequestAttributeName

--- a/web/src/main/java/org/springframework/security/web/csrf/LazyCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/LazyCsrfTokenRepository.java
@@ -38,7 +38,8 @@ public final class LazyCsrfTokenRepository implements CsrfTokenRepository {
 	 * The {@link HttpServletRequest} attribute name that the {@link HttpServletResponse}
 	 * must be on.
 	 */
-	private static final String HTTP_RESPONSE_ATTR = HttpServletResponse.class.getName();
+	public static final String HTTP_RESPONSE_ATTR = LazyCsrfTokenRepository.class.getSimpleName()
+			+ ".HTTP_SERVLET_RESPONSE";
 
 	private final CsrfTokenRepository delegate;
 
@@ -67,7 +68,7 @@ public final class LazyCsrfTokenRepository implements CsrfTokenRepository {
 	 * Generates a new token
 	 * @param request the {@link HttpServletRequest} to use. The
 	 * {@link HttpServletRequest} must have the {@link HttpServletResponse} as an
-	 * attribute with the name of <code>HttpServletResponse.class.getName()</code>
+	 * attribute with the name of {@link #HTTP_RESPONSE_ATTR}
 	 */
 	@Override
 	public CsrfToken generateToken(HttpServletRequest request) {

--- a/web/src/test/java/org/springframework/security/web/csrf/CsrfAuthenticationStrategyTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CsrfAuthenticationStrategyTests.java
@@ -63,7 +63,7 @@ public class CsrfAuthenticationStrategyTests {
 	public void setup() {
 		this.response = new MockHttpServletResponse();
 		this.request = new MockHttpServletRequest();
-		this.request.setAttribute(HttpServletResponse.class.getName(), this.response);
+		this.request.setAttribute(LazyCsrfTokenRepository.HTTP_RESPONSE_ATTR, this.response);
 		this.strategy = new CsrfAuthenticationStrategy(this.csrfTokenRepository);
 		this.existingToken = new DefaultCsrfToken("_csrf", "_csrf", "1");
 		this.generatedToken = new DefaultCsrfToken("_csrf", "_csrf", "2");

--- a/web/src/test/java/org/springframework/security/web/csrf/CsrfFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CsrfFilterTests.java
@@ -279,7 +279,7 @@ public class CsrfFilterTests {
 		assertThatCsrfToken(this.request.getAttribute(CsrfToken.class.getName())).isNotNull();
 		assertThat(this.request.getAttribute(DeferredCsrfToken.class.getName())).isSameAs(deferredCsrfToken);
 		// LazyCsrfTokenRepository requires the response as an attribute
-		assertThat(this.request.getAttribute(HttpServletResponse.class.getName())).isEqualTo(this.response);
+		assertThat(this.request.getAttribute(LazyCsrfTokenRepository.HTTP_RESPONSE_ATTR)).isEqualTo(this.response);
 		verify(this.filterChain).doFilter(this.request, this.response);
 		verifyNoMoreInteractions(this.deniedHandler);
 	}

--- a/web/src/test/java/org/springframework/security/web/csrf/LazyCsrfTokenRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/LazyCsrfTokenRepositoryTests.java
@@ -72,7 +72,7 @@ public class LazyCsrfTokenRepositoryTests {
 	@Test
 	public void generateTokenGetTokenSavesToken() {
 		given(this.delegate.generateToken(this.request)).willReturn(this.token);
-		given(this.request.getAttribute(HttpServletResponse.class.getName())).willReturn(this.response);
+		given(this.request.getAttribute(LazyCsrfTokenRepository.HTTP_RESPONSE_ATTR)).willReturn(this.response);
 		CsrfToken newToken = this.repository.generateToken(this.request);
 		newToken.getToken();
 		verify(this.delegate).saveToken(this.token, this.request, this.response);


### PR DESCRIPTION
This PR closes gh-6452 by storing the `HttpServletResponse` in a non-reserved request attribute.