### PR TITLE
Update architecture.adoc

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authorization/architecture.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/architecture.adoc
@@ -197,7 +197,7 @@ A typical configuration might look like this:
 ----
 @Bean
 static RoleHierarchy roleHierarchy() {
-    RoleHierarchy hierarchy = new RoleHierarchyImpl();
+    var hierarchy = new RoleHierarchyImpl();
     hierarchy.setHierarchy("ROLE_ADMIN > ROLE_STAFF\n" +
             "ROLE_STAFF > ROLE_USER\n" +
             "ROLE_USER > ROLE_GUEST");


### PR DESCRIPTION
`RoleHierarchy` doesn't have the `setHierarchy` method, so the snippet doesn't work as is. The method is declared inside `RoleHierarchyImpl`

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
