### PR TITLE
TestCsrfTokenRepository should delegate to the configured CsrfTokenRepository

### DIFF
--- a/test/src/main/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessors.java
+++ b/test/src/main/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessors.java
@@ -98,7 +98,6 @@ import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.security.web.csrf.CsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRequestHandler;
 import org.springframework.security.web.csrf.DeferredCsrfToken;
-import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
@@ -518,7 +517,7 @@ public final class SecurityMockMvcRequestPostProcessors {
 			CsrfTokenRepository repository = WebTestUtils.getCsrfTokenRepository(request);
 			CsrfTokenRequestHandler handler = WebTestUtils.getCsrfTokenRequestHandler(request);
 			if (!(repository instanceof TestCsrfTokenRepository)) {
-				repository = new TestCsrfTokenRepository(new HttpSessionCsrfTokenRepository());
+				repository = new TestCsrfTokenRepository(repository);
 				WebTestUtils.setCsrfTokenRepository(request, repository);
 			}
 			TestCsrfTokenRepository.enable(request);


### PR DESCRIPTION
I'm creating this as a draft, because there are some failing tests I need to fix before this can be merged.

`CsrfRequestPostProcessor` currently reconfigures `CsrfFilter` with a `TestCsrfTokenRepository` that delegates to a newly created `HttpSessionCsrfTokenRepository`. This is fine as long as the configured `CsrfTokenRepository` is a `HttpSessionCsrfTokenRepository` as well, because it accesses the same session attribute.

However, if the configured `CsrfTokenRepository` is not a `HttpSessionCsrfTokenRepository`, this change affects (and may break) any test that uses the same cached `ApplicationContext`, because it now basically uses a `HttpSessionCsrfTokenRepository` instead of the configured `CsrfTokenRepository`.

`TestCsrfTokenRepository` should delegate to the configured `CsrfTokenRepository` to avoid affecting unrelated tests.