### PR TITLE
Suggestion: Deprecate XContentTypeOptionsServerHttpHeadersWriter

### DIFF
--- a/web/src/main/java/org/springframework/security/web/server/header/XContentTypeOptionsServerHttpHeadersWriter.java
+++ b/web/src/main/java/org/springframework/security/web/server/header/XContentTypeOptionsServerHttpHeadersWriter.java
@@ -25,7 +25,9 @@ import org.springframework.web.server.ServerWebExchange;
  *
  * @author Rob Winch
  * @since 5.0
+ * @deprecated For removal in 7.0. Use {@link ContentTypeOptionsServerHttpHeadersWriter} instead.
  */
+@Deprecated(since = "6.2", forRemoval = true)
 public class XContentTypeOptionsServerHttpHeadersWriter implements ServerHttpHeadersWriter {
 
 	public static final String X_CONTENT_OPTIONS = "X-Content-Options";


### PR DESCRIPTION
- Deprecation of XContentTypeOptionsServerHttpHeadersWriter as duplicate of ContentTypeOptionsServerHttpHeadersWriter
- XContentTypeOptionsServerHttpHeadersWriter#X_CONTENT_OPTIONS defines "X-Content-Options", instead of "X-Content-Type-Options"
- X-Content-Options does seem to be listed. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers

Following the recommendation by marcusdacoregio on the original request: https://github.com/spring-projects/spring-security/pull/13070
