### PR TITLE
Add meta-annotation support for EnableMethodSecurity

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/MethodSecuritySelector.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/MethodSecuritySelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,8 @@ final class MethodSecuritySelector implements ImportSelector {
 
 	@Override
 	public String[] selectImports(@NonNull AnnotationMetadata importMetadata) {
-		if (!importMetadata.hasAnnotation(EnableMethodSecurity.class.getName())) {
+		if (!importMetadata.hasAnnotation(EnableMethodSecurity.class.getName())
+				&& !importMetadata.hasMetaAnnotation(EnableMethodSecurity.class.getName())) {
 			return new String[0];
 		}
 		EnableMethodSecurity annotation = importMetadata.getAnnotations().get(EnableMethodSecurity.class).synthesize();

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/EnableCustomMethodSecurity.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/EnableCustomMethodSecurity.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.config.annotation.method.configuration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.AdviceMode;
+import org.springframework.core.annotation.AliasFor;
+
+/**
+ * @author Evgeniy Cheban
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@EnableMethodSecurity
+public @interface EnableCustomMethodSecurity {
+
+	@AliasFor(annotation = EnableMethodSecurity.class, attribute = "proxyTargetClass")
+	boolean proxyTargetClass() default false;
+
+	@AliasFor(annotation = EnableMethodSecurity.class, attribute = "mode")
+	AdviceMode mode() default AdviceMode.PROXY;
+
+}

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/PrePostMethodSecurityConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/PrePostMethodSecurityConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,6 +91,21 @@ public class PrePostMethodSecurityConfigurationTests {
 
 	@Autowired(required = false)
 	BusinessService businessService;
+
+	@WithMockUser
+	@Test
+	public void customMethodSecurityPreAuthorizeAdminWhenRoleUserThenAccessDeniedException() {
+		this.spring.register(CustomMethodSecurityServiceConfig.class).autowire();
+		assertThatExceptionOfType(AccessDeniedException.class).isThrownBy(this.methodSecurityService::preAuthorizeAdmin)
+				.withMessage("Access Denied");
+	}
+
+	@WithMockUser(roles = "ADMIN")
+	@Test
+	public void customMethodSecurityPreAuthorizeAdminWhenRoleAdminThenPasses() {
+		this.spring.register(CustomMethodSecurityServiceConfig.class).autowire();
+		this.methodSecurityService.preAuthorizeAdmin();
+	}
 
 	@WithMockUser(roles = "ADMIN")
 	@Test
@@ -416,6 +431,17 @@ public class PrePostMethodSecurityConfigurationTests {
 		assertThat(this.spring.getContext().containsBean("postAuthorizeAspect$0")).isTrue();
 		assertThat(this.spring.getContext().containsBean("securedAspect$0")).isTrue();
 		assertThat(this.spring.getContext().containsBean("annotationSecurityAspect$0")).isFalse();
+	}
+
+	@Configuration
+	@EnableCustomMethodSecurity
+	static class CustomMethodSecurityServiceConfig {
+
+		@Bean
+		MethodSecurityService methodSecurityService() {
+			return new MethodSecurityServiceImpl();
+		}
+
 	}
 
 	@Configuration


### PR DESCRIPTION
EnableMethodSecurity annotation does not get imported when defined as a meta-annotation

Closes gh-12870

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
