### PR TITLE
Address CVE-2023-1370

### DIFF
--- a/dependencies/spring-security-dependencies.gradle
+++ b/dependencies/spring-security-dependencies.gradle
@@ -20,7 +20,7 @@ dependencies {
 		api "ch.qos.logback:logback-classic:1.2.12"
 		api "com.google.inject:guice:3.0"
 		api "com.nimbusds:nimbus-jose-jwt:9.24.4"
-		api "com.nimbusds:oauth2-oidc-sdk:9.43.1"
+		api "com.nimbusds:oauth2-oidc-sdk:9.43.2"
 		api "com.squareup.okhttp3:mockwebserver:3.14.9"
 		api "com.squareup.okhttp3:okhttp:3.14.9"
 		api "com.unboundid:unboundid-ldapsdk:4.0.14"


### PR DESCRIPTION
Bump oauth2-oidc-sdk to 10.7.1 to update json-smart to 2.4.10

`oauth2-oidc-sdk:9.43.1` uses `json-smart-2.4.8` which is vulnerable to the following [CVE-2023-1370](https://nvd.nist.gov/vuln/detail/CVE-2023-1370)

Updated the version to `10.7.1` to use `json-smart-2.4.10` to fix the vulnerability