### PR TITLE
Ignore synthetic methods when checking for duplicate annotations

### DIFF
--- a/core/src/main/java/org/springframework/security/authorization/method/AuthorizationAnnotationUtils.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/AuthorizationAnnotationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/springframework/security/authorization/method/AuthorizationAnnotationUtils.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/AuthorizationAnnotationUtils.java
@@ -17,6 +17,7 @@
 package org.springframework.security.authorization.method;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 
 import org.springframework.core.annotation.AnnotationConfigurationException;
@@ -96,6 +97,10 @@ final class AuthorizationAnnotationUtils {
 			Class<A> annotationType) {
 		boolean alreadyFound = false;
 		for (MergedAnnotation<Annotation> mergedAnnotation : mergedAnnotations) {
+			if (isSynthetic(mergedAnnotation.getSource())) {
+				continue;
+			}
+
 			if (mergedAnnotation.getType() == annotationType) {
 				if (alreadyFound) {
 					return true;
@@ -103,6 +108,14 @@ final class AuthorizationAnnotationUtils {
 				alreadyFound = true;
 			}
 		}
+		return false;
+	}
+
+	private static boolean isSynthetic(Object object) {
+		if (object instanceof Executable) {
+			return ((Executable) object).isSynthetic();
+		}
+
 		return false;
 	}
 

--- a/core/src/test/java/org/springframework/security/authorization/method/AuthorizationAnnotationUtilsTests.java
+++ b/core/src/test/java/org/springframework/security/authorization/method/AuthorizationAnnotationUtilsTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.security.authorization.method;
 
 import java.lang.reflect.Method;
@@ -5,6 +21,7 @@ import java.lang.reflect.Proxy;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+
 import org.springframework.security.access.prepost.PreAuthorize;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -15,11 +32,10 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 class AuthorizationAnnotationUtilsTests {
 
 	@Test // gh-13132
-	public void annotationsOnSyntheticMethodsShouldNotTriggerAnnotationConfigurationException()
-			throws NoSuchMethodException {
-		StringRepository proxy =
-				(StringRepository) Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(),
-						new Class[] {StringRepository.class}, (p, m, args) -> null);
+	void annotationsOnSyntheticMethodsShouldNotTriggerAnnotationConfigurationException() throws NoSuchMethodException {
+		StringRepository proxy = (StringRepository) Proxy.newProxyInstance(
+				Thread.currentThread().getContextClassLoader(), new Class[] { StringRepository.class },
+				(p, m, args) -> null);
 		Method method = proxy.getClass().getDeclaredMethod("findAll");
 		assertThatNoException()
 				.isThrownBy(() -> AuthorizationAnnotationUtils.findUniqueAnnotation(method, PreAuthorize.class));
@@ -28,6 +44,7 @@ class AuthorizationAnnotationUtilsTests {
 	private interface BaseRepository<T> {
 
 		Iterable<T> findAll();
+
 	}
 
 	private interface StringRepository extends BaseRepository<String> {
@@ -35,5 +52,7 @@ class AuthorizationAnnotationUtilsTests {
 		@Override
 		@PreAuthorize("hasRole('someRole')")
 		List<String> findAll();
+
 	}
+
 }

--- a/core/src/test/java/org/springframework/security/authorization/method/AuthorizationAnnotationUtilsTests.java
+++ b/core/src/test/java/org/springframework/security/authorization/method/AuthorizationAnnotationUtilsTests.java
@@ -1,0 +1,39 @@
+package org.springframework.security.authorization.method;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+/**
+ * Tests for {@link AuthorizationAnnotationUtils}
+ */
+class AuthorizationAnnotationUtilsTests {
+
+	@Test // gh-13132
+	public void annotationsOnSyntheticMethodsShouldNotTriggerAnnotationConfigurationException()
+			throws NoSuchMethodException {
+		StringRepository proxy =
+				(StringRepository) Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(),
+						new Class[] {StringRepository.class}, (p, m, args) -> null);
+		Method method = proxy.getClass().getDeclaredMethod("findAll");
+		assertThatNoException()
+				.isThrownBy(() -> AuthorizationAnnotationUtils.findUniqueAnnotation(method, PreAuthorize.class));
+	}
+
+	private interface BaseRepository<T> {
+
+		Iterable<T> findAll();
+	}
+
+	private interface StringRepository extends BaseRepository<String> {
+
+		@Override
+		@PreAuthorize("hasRole('someRole')")
+		List<String> findAll();
+	}
+}


### PR DESCRIPTION
Closes gh-13132

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
