### PR TITLE
Use consistent list of micrometer tags in web observation handler

### DIFF
--- a/web/src/main/java/org/springframework/security/web/ObservationFilterChainDecorator.java
+++ b/web/src/main/java/org/springframework/security/web/ObservationFilterChainDecorator.java
@@ -37,6 +37,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.core.log.LogMessage;
+import org.springframework.util.StringUtils;
 
 /**
  * A {@link org.springframework.security.web.FilterChainProxy.FilterChainDecorator} that
@@ -519,8 +520,8 @@ public final class ObservationFilterChainDecorator implements FilterChainProxy.F
 			return KeyValues.of(CHAIN_SIZE_NAME, String.valueOf(context.getChainSize()))
 					.and(CHAIN_POSITION_NAME, String.valueOf(context.getChainPosition()))
 					.and(FILTER_SECTION_NAME, context.getFilterSection())
-					.and(FILTER_NAME, (context.getFilterName() != null && !context.getFilterName().isEmpty())
-							? context.getFilterName() : KeyValue.NONE_VALUE);
+					.and(FILTER_NAME, (StringUtils.hasText(context.getFilterName())) ? context.getFilterName()
+							: KeyValue.NONE_VALUE);
 		}
 
 		@Override

--- a/web/src/main/java/org/springframework/security/web/ObservationFilterChainDecorator.java
+++ b/web/src/main/java/org/springframework/security/web/ObservationFilterChainDecorator.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationConvention;
@@ -515,13 +516,11 @@ public final class ObservationFilterChainDecorator implements FilterChainProxy.F
 
 		@Override
 		public KeyValues getLowCardinalityKeyValues(FilterChainObservationContext context) {
-			KeyValues kv = KeyValues.of(CHAIN_SIZE_NAME, String.valueOf(context.getChainSize()))
+			return KeyValues.of(CHAIN_SIZE_NAME, String.valueOf(context.getChainSize()))
 					.and(CHAIN_POSITION_NAME, String.valueOf(context.getChainPosition()))
-					.and(FILTER_SECTION_NAME, context.getFilterSection());
-			if (context.getFilterName() != null) {
-				kv = kv.and(FILTER_NAME, context.getFilterName());
-			}
-			return kv;
+					.and(FILTER_SECTION_NAME, context.getFilterSection())
+					.and(FILTER_NAME, (context.getFilterName() != null && !context.getFilterName().isEmpty())
+							? context.getFilterName() : KeyValue.NONE_VALUE);
 		}
 
 		@Override

--- a/web/src/main/java/org/springframework/security/web/server/ObservationWebFilterChainDecorator.java
+++ b/web/src/main/java/org/springframework/security/web/server/ObservationWebFilterChainDecorator.java
@@ -34,6 +34,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
@@ -689,8 +690,8 @@ public final class ObservationWebFilterChainDecorator implements WebFilterChainP
 			return KeyValues.of(CHAIN_SIZE_NAME, String.valueOf(context.getChainSize()))
 					.and(CHAIN_POSITION_NAME, String.valueOf(context.getChainPosition()))
 					.and(FILTER_SECTION_NAME, context.getFilterSection())
-					.and(FILTER_NAME, (context.getFilterName() != null && !context.getFilterName().isEmpty())
-							? context.getFilterName() : KeyValue.NONE_VALUE);
+					.and(FILTER_NAME, (StringUtils.hasText(context.getFilterName())) ? context.getFilterName()
+							: KeyValue.NONE_VALUE);
 		}
 
 		@Override

--- a/web/src/main/java/org/springframework/security/web/server/ObservationWebFilterChainDecorator.java
+++ b/web/src/main/java/org/springframework/security/web/server/ObservationWebFilterChainDecorator.java
@@ -686,13 +686,11 @@ public final class ObservationWebFilterChainDecorator implements WebFilterChainP
 
 		@Override
 		public KeyValues getLowCardinalityKeyValues(WebFilterChainObservationContext context) {
-			KeyValues kv = KeyValues.of(CHAIN_SIZE_NAME, String.valueOf(context.getChainSize()))
+			return KeyValues.of(CHAIN_SIZE_NAME, String.valueOf(context.getChainSize()))
 					.and(CHAIN_POSITION_NAME, String.valueOf(context.getChainPosition()))
-					.and(FILTER_SECTION_NAME, context.getFilterSection());
-			if (context.getFilterName() != null) {
-				kv = kv.and(FILTER_NAME, context.getFilterName());
-			}
-			return kv;
+					.and(FILTER_SECTION_NAME, context.getFilterSection())
+					.and(FILTER_NAME, (context.getFilterName() != null && !context.getFilterName().isEmpty())
+							? context.getFilterName() : KeyValue.NONE_VALUE);
 		}
 
 		@Override


### PR DESCRIPTION
The tag `spring.security.reached.filter.name` is only set if a filter-name is available, otherwise the tag is omitted entirely. This leads to issues with metric-exporters that don't support dynamic tags, but rather expect tag-names of a metric to be always the same. The most prominent example is the Prometheus-exporter.

Instead of omitting the tag if no filer-name is set, a none-value is applied instead, making the tag-list consistent in all cases
