### PR TITLE
Remove LazyCsrfTokenRepository usage

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurer.java
@@ -40,7 +40,6 @@ import org.springframework.security.web.csrf.CsrfLogoutHandler;
 import org.springframework.security.web.csrf.CsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRequestHandler;
 import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository;
-import org.springframework.security.web.csrf.LazyCsrfTokenRepository;
 import org.springframework.security.web.csrf.MissingCsrfTokenException;
 import org.springframework.security.web.session.InvalidSessionAccessDeniedHandler;
 import org.springframework.security.web.session.InvalidSessionStrategy;
@@ -83,7 +82,7 @@ import org.springframework.util.Assert;
 public final class CsrfConfigurer<H extends HttpSecurityBuilder<H>>
 		extends AbstractHttpConfigurer<CsrfConfigurer<H>, H> {
 
-	private CsrfTokenRepository csrfTokenRepository = new LazyCsrfTokenRepository(new HttpSessionCsrfTokenRepository());
+	private CsrfTokenRepository csrfTokenRepository = new HttpSessionCsrfTokenRepository();
 
 	private RequestMatcher requireCsrfProtectionMatcher = CsrfFilter.DEFAULT_CSRF_MATCHER;
 
@@ -105,7 +104,7 @@ public final class CsrfConfigurer<H extends HttpSecurityBuilder<H>>
 
 	/**
 	 * Specify the {@link CsrfTokenRepository} to use. The default is an
-	 * {@link HttpSessionCsrfTokenRepository} wrapped by {@link LazyCsrfTokenRepository}.
+	 * {@link HttpSessionCsrfTokenRepository}.
 	 * @param csrfTokenRepository the {@link CsrfTokenRepository} to use
 	 * @return the {@link CsrfConfigurer} for further customizations
 	 */

--- a/config/src/main/java/org/springframework/security/config/http/CsrfBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/http/CsrfBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@ import org.springframework.security.web.csrf.CsrfAuthenticationStrategy;
 import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.csrf.CsrfLogoutHandler;
 import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository;
-import org.springframework.security.web.csrf.LazyCsrfTokenRepository;
 import org.springframework.security.web.csrf.MissingCsrfTokenException;
 import org.springframework.security.web.servlet.support.csrf.CsrfRequestDataValueProcessor;
 import org.springframework.security.web.session.InvalidSessionAccessDeniedHandler;
@@ -109,13 +108,12 @@ public class CsrfBeanDefinitionParser implements BeanDefinitionParser {
 			this.requestHandlerRef = element.getAttribute(ATT_REQUEST_HANDLER);
 		}
 		if (!StringUtils.hasText(this.csrfRepositoryRef)) {
-			RootBeanDefinition csrfTokenRepository = new RootBeanDefinition(HttpSessionCsrfTokenRepository.class);
-			BeanDefinitionBuilder lazyTokenRepository = BeanDefinitionBuilder
-					.rootBeanDefinition(LazyCsrfTokenRepository.class);
-			lazyTokenRepository.addConstructorArgValue(csrfTokenRepository);
-			this.csrfRepositoryRef = pc.getReaderContext().generateBeanName(lazyTokenRepository.getBeanDefinition());
-			pc.registerBeanComponent(
-					new BeanComponentDefinition(lazyTokenRepository.getBeanDefinition(), this.csrfRepositoryRef));
+			BeanDefinitionBuilder httpSessionCsrfTokenRepository = BeanDefinitionBuilder
+					.rootBeanDefinition(HttpSessionCsrfTokenRepository.class);
+			this.csrfRepositoryRef = pc.getReaderContext()
+					.generateBeanName(httpSessionCsrfTokenRepository.getBeanDefinition());
+			pc.registerBeanComponent(new BeanComponentDefinition(httpSessionCsrfTokenRepository.getBeanDefinition(),
+					this.csrfRepositoryRef));
 		}
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(CsrfFilter.class);
 		builder.addConstructorArgReference(this.csrfRepositoryRef);

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
@@ -51,9 +51,9 @@ import org.springframework.web.filter.OncePerRequestFilter;
  *
  * <p>
  * Typically the {@link CsrfTokenRepository} implementation chooses to store the
- * {@link CsrfToken} in {@link HttpSession} with {@link HttpSessionCsrfTokenRepository}
- * wrapped by a {@link LazyCsrfTokenRepository}. This is preferred to storing the token in
- * a cookie which can be modified by a client application.
+ * {@link CsrfToken} in {@link HttpSession} with {@link HttpSessionCsrfTokenRepository}.
+ * This is preferred to storing the token in a cookie which can be modified by a client
+ * application.
  * </p>
  *
  * @author Rob Winch
@@ -72,7 +72,7 @@ public final class CsrfFilter extends OncePerRequestFilter {
 	/**
 	 * The attribute name to use when marking a given request as one that should not be
 	 * filtered.
-	 *
+	 * <p>
 	 * To use, set the attribute on your {@link HttpServletRequest}: <pre>
 	 * 	CsrfFilter.skipRequest(request);
 	 * </pre>


### PR DESCRIPTION
Remove usage of deprecated `LazyCsrfTokenRepository` from  `CsrfConfigurer.java` and  `CsrfBeanDefinitionParser.java`
as `CsrfFilter` uses `CsrfTokenRepository`.

Closes gh-13194

