### PR TITLE
Update JavaDoc of BasicAuthenticationFilter (gh-13231)

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilter.java
@@ -80,9 +80,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * <p>
  * Basic authentication is an attractive protocol because it is simple and widely
  * deployed. However, it still transmits a password in clear text and as such is
- * undesirable in many situations. Digest authentication is also provided by Spring
- * Security and should be used instead of Basic authentication wherever possible. See
- * {@link org.springframework.security.web.authentication.www.DigestAuthenticationFilter}.
+ * undesirable in many situations.
  * <p>
  * Note that if a {@link RememberMeServices} is set, this filter will automatically send
  * back remember-me details to the client. Therefore, subsequent requests will not need to


### PR DESCRIPTION
Remove deprecated hint to use Digest Auth in favor of Basic Auth.

Closes gh-13231