### PR TITLE
The current version breaks backwards compatibility

### DIFF
--- a/core/src/main/java/org/springframework/security/core/userdetails/User.java
+++ b/core/src/main/java/org/springframework/security/core/userdetails/User.java
@@ -441,6 +441,7 @@ public class User implements UserDetails, CredentialsContainer {
 		 */
 		public UserBuilder authorities(Collection<? extends GrantedAuthority> authorities) {
 			Assert.notNull(authorities, "authorities cannot be null");
+			this.authorities.clear();
 			this.authorities.addAll(authorities);
 			return this;
 		}


### PR DESCRIPTION
Broken backwards compatibility. There is currently no way to reset the `this.authorities` list.
For example, the code will not work correctly,

```java
final User.UserBuilder builder = User.withUserDetails(userDetails);
if (CollectionUtils.isEmpty(authorities)) {
  builder.authorities(Collections.emptyList());
} else {
  builder.authorities(authorities.toArray(String[]::new));
}
userDetailsManager.updateUser(builder.build());
```
it will always merge new and old authorities, but the previous version will overwrite them
