### PR TITLE
Fix method typo in Gh3409Tests (gh-3409)

### DIFF
--- a/test/src/test/java/org/springframework/security/test/web/servlet/response/Gh3409Tests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/response/Gh3409Tests.java
@@ -78,7 +78,7 @@ public class Gh3409Tests {
 	}
 
 	@Test
-	public void unauthenticatedNullAuthenitcation() throws Exception {
+	public void unauthenticatedNullAuthentication() throws Exception {
 		// @formatter:off
 		this.mockMvc
 			.perform(get("/")


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->

Fix method typo `unauthenticatedNullAuthenitcation()` to `unauthenticatedNullAuthentication()`.

It seems like change for this review request was omitted: https://github.com/spring-projects/spring-security/pull/3818#discussion_r60294118.