### PR TITLE
fix String comparison

### DIFF
--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
@@ -188,11 +188,11 @@ public final class CsrfFilter extends OncePerRequestFilter {
 	 * @return
 	 */
 	private static boolean equalsConstantTime(String expected, String actual) {
-		if (expected == actual) {
-			return true;
-		}
 		if (expected == null || actual == null) {
 			return false;
+		}
+		if (expected.equals(actual)) {
+			return true;
 		}
 		// Encode after ensure that the string is not null
 		byte[] expectedBytes = Utf8.encode(expected);


### PR DESCRIPTION
It seems to me that the original author intended to return early without executing the `Utf8...` part if the values of two tokens are the same. However, even if the values are the same, the `Utf8...` part is executed because the `==` operator is used.

