### PR TITLE
Enabled all `*JwtDecoderBuilder`s to set a custom JWT validator

### DIFF
--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoders.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoders.java
@@ -89,9 +89,8 @@ public final class JwtDecoders {
 	@SuppressWarnings("unchecked")
 	public static <T extends JwtDecoder> T fromIssuerLocation(String issuer) {
 		Assert.hasText(issuer, "issuer cannot be empty");
-		NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder.withIssuerLocation(issuer).build();
 		OAuth2TokenValidator<Jwt> jwtValidator = JwtValidators.createDefaultWithIssuer(issuer);
-		jwtDecoder.setJwtValidator(jwtValidator);
+		NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder.withIssuerLocation(issuer).jwtValidator(jwtValidator).build();
 		return (T) jwtDecoder;
 	}
 
@@ -110,10 +109,9 @@ public final class JwtDecoders {
 		JwtDecoderProviderConfigurationUtils.validateIssuer(configuration, issuer);
 		OAuth2TokenValidator<Jwt> jwtValidator = JwtValidators.createDefaultWithIssuer(issuer);
 		String jwkSetUri = configuration.get("jwks_uri").toString();
-		NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder.withJwkSetUri(jwkSetUri)
-				.jwtProcessorCustomizer(JwtDecoderProviderConfigurationUtils::addJWSAlgorithms).build();
-		jwtDecoder.setJwtValidator(jwtValidator);
-		return jwtDecoder;
+		return NimbusJwtDecoder.withJwkSetUri(jwkSetUri)
+				.jwtProcessorCustomizer(JwtDecoderProviderConfigurationUtils::addJWSAlgorithms)
+				.jwtValidator(jwtValidator).build();
 	}
 
 }

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoder.java
@@ -274,6 +274,8 @@ public final class NimbusJwtDecoder implements JwtDecoder {
 
 		private Consumer<ConfigurableJWTProcessor<SecurityContext>> jwtProcessorCustomizer;
 
+		private OAuth2TokenValidator<Jwt> jwtValidator = JwtValidators.createDefault();
+
 		private JwkSetUriJwtDecoderBuilder(String jwkSetUri) {
 			Assert.hasText(jwkSetUri, "jwkSetUri cannot be empty");
 			this.jwkSetUri = (rest) -> jwkSetUri;
@@ -395,11 +397,25 @@ public final class NimbusJwtDecoder implements JwtDecoder {
 		}
 
 		/**
+		 * Configure the built {@link NimbusJwtDecoder} to use the given
+		 * {@link OAuth2TokenValidator} when validating incoming {@link Jwt}s.
+		 * @param jwtValidator the {@link OAuth2TokenValidator} to use
+		 * @return a {@link JwkSetUriJwtDecoderBuilder} for further configurations
+		 */
+		public JwkSetUriJwtDecoderBuilder jwtValidator(OAuth2TokenValidator<Jwt> jwtValidator) {
+			Assert.notNull(jwtValidator, "jwtValidator cannot be null");
+			this.jwtValidator = jwtValidator;
+			return this;
+		}
+
+		/**
 		 * Build the configured {@link NimbusJwtDecoder}.
 		 * @return the configured {@link NimbusJwtDecoder}
 		 */
 		public NimbusJwtDecoder build() {
-			return new NimbusJwtDecoder(processor());
+			NimbusJwtDecoder jwtDecoder = new NimbusJwtDecoder(processor());
+			jwtDecoder.setJwtValidator(this.jwtValidator);
+			return jwtDecoder;
 		}
 
 		private static URL toURL(String url) {
@@ -504,6 +520,8 @@ public final class NimbusJwtDecoder implements JwtDecoder {
 
 		private Consumer<ConfigurableJWTProcessor<SecurityContext>> jwtProcessorCustomizer;
 
+		private OAuth2TokenValidator<Jwt> jwtValidator = JwtValidators.createDefault();
+
 		private PublicKeyJwtDecoderBuilder(RSAPublicKey key) {
 			Assert.notNull(key, "key cannot be null");
 			this.jwsAlgorithm = JWSAlgorithm.RS256;
@@ -559,11 +577,25 @@ public final class NimbusJwtDecoder implements JwtDecoder {
 		}
 
 		/**
+		 * Configure the built {@link NimbusJwtDecoder} to use the given
+		 * {@link OAuth2TokenValidator} when validating incoming {@link Jwt}s.
+		 * @param jwtValidator the {@link OAuth2TokenValidator} to use
+		 * @return a {@link PublicKeyJwtDecoderBuilder} for further configurations
+		 */
+		public PublicKeyJwtDecoderBuilder jwtValidator(OAuth2TokenValidator<Jwt> jwtValidator) {
+			Assert.notNull(jwtValidator, "jwtValidator cannot be null");
+			this.jwtValidator = jwtValidator;
+			return this;
+		}
+
+		/**
 		 * Build the configured {@link NimbusJwtDecoder}.
 		 * @return the configured {@link NimbusJwtDecoder}
 		 */
 		public NimbusJwtDecoder build() {
-			return new NimbusJwtDecoder(processor());
+			NimbusJwtDecoder jwtDecoder = new NimbusJwtDecoder(processor());
+			jwtDecoder.setJwtValidator(this.jwtValidator);
+			return jwtDecoder;
 		}
 
 	}
@@ -579,6 +611,8 @@ public final class NimbusJwtDecoder implements JwtDecoder {
 		private JWSAlgorithm jwsAlgorithm = JWSAlgorithm.HS256;
 
 		private Consumer<ConfigurableJWTProcessor<SecurityContext>> jwtProcessorCustomizer;
+
+		private OAuth2TokenValidator<Jwt> jwtValidator = JwtValidators.createDefault();
 
 		private SecretKeyJwtDecoderBuilder(SecretKey secretKey) {
 			Assert.notNull(secretKey, "secretKey cannot be null");
@@ -620,11 +654,25 @@ public final class NimbusJwtDecoder implements JwtDecoder {
 		}
 
 		/**
+		 * Configure the built {@link NimbusJwtDecoder} to use the given
+		 * {@link OAuth2TokenValidator} when validating incoming {@link Jwt}s.
+		 * @param jwtValidator the {@link OAuth2TokenValidator} to use
+		 * @return a {@link SecretKeyJwtDecoderBuilder} for further configurations
+		 */
+		public SecretKeyJwtDecoderBuilder jwtValidator(OAuth2TokenValidator<Jwt> jwtValidator) {
+			Assert.notNull(jwtValidator, "jwtValidator cannot be null");
+			this.jwtValidator = jwtValidator;
+			return this;
+		}
+
+		/**
 		 * Build the configured {@link NimbusJwtDecoder}.
 		 * @return the configured {@link NimbusJwtDecoder}
 		 */
 		public NimbusJwtDecoder build() {
-			return new NimbusJwtDecoder(processor());
+			NimbusJwtDecoder jwtDecoder = new NimbusJwtDecoder(processor());
+			jwtDecoder.setJwtValidator(this.jwtValidator);
+			return jwtDecoder;
 		}
 
 		JWTProcessor<SecurityContext> processor() {

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
@@ -320,6 +320,8 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 
 		private BiFunction<ReactiveRemoteJWKSource, ConfigurableJWTProcessor<JWKSecurityContext>, Mono<ConfigurableJWTProcessor<JWKSecurityContext>>> jwtProcessorCustomizer;
 
+		private OAuth2TokenValidator<Jwt> jwtValidator = JwtValidators.createDefault();
+
 		private JwkSetUriReactiveJwtDecoderBuilder(String jwkSetUri) {
 			Assert.hasText(jwkSetUri, "jwkSetUri cannot be empty");
 			this.jwkSetUri = (web) -> Mono.just(jwkSetUri);
@@ -403,11 +405,25 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 		}
 
 		/**
+		 * Configure the built {@link NimbusReactiveJwtDecoder} to use the given
+		 * {@link OAuth2TokenValidator} when validating incoming {@link Jwt}s.
+		 * @param jwtValidator the {@link OAuth2TokenValidator} to use
+		 * @return a {@link JwkSetUriReactiveJwtDecoderBuilder} for further configurations
+		 */
+		public JwkSetUriReactiveJwtDecoderBuilder jwtValidator(OAuth2TokenValidator<Jwt> jwtValidator) {
+			Assert.notNull(jwtValidator, "jwtValidator cannot be null");
+			this.jwtValidator = jwtValidator;
+			return this;
+		}
+
+		/**
 		 * Build the configured {@link NimbusReactiveJwtDecoder}.
 		 * @return the configured {@link NimbusReactiveJwtDecoder}
 		 */
 		public NimbusReactiveJwtDecoder build() {
-			return new NimbusReactiveJwtDecoder(processor());
+			NimbusReactiveJwtDecoder jwtDecoder = new NimbusReactiveJwtDecoder(processor());
+			jwtDecoder.setJwtValidator(this.jwtValidator);
+			return jwtDecoder;
 		}
 
 		Mono<JWSKeySelector<JWKSecurityContext>> jwsKeySelector(ReactiveRemoteJWKSource source) {
@@ -480,6 +496,8 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 
 		private Consumer<ConfigurableJWTProcessor<SecurityContext>> jwtProcessorCustomizer;
 
+		private OAuth2TokenValidator<Jwt> jwtValidator = JwtValidators.createDefault();
+
 		private PublicKeyReactiveJwtDecoderBuilder(RSAPublicKey key) {
 			Assert.notNull(key, "key cannot be null");
 			this.key = key;
@@ -519,11 +537,25 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 		}
 
 		/**
+		 * Configure the built {@link NimbusReactiveJwtDecoder} to use the given
+		 * {@link OAuth2TokenValidator} when validating incoming {@link Jwt}s.
+		 * @param jwtValidator the {@link OAuth2TokenValidator} to use
+		 * @return a {@link PublicKeyReactiveJwtDecoderBuilder} for further configurations
+		 */
+		public PublicKeyReactiveJwtDecoderBuilder jwtValidator(OAuth2TokenValidator<Jwt> jwtValidator) {
+			Assert.notNull(jwtValidator, "jwtValidator cannot be null");
+			this.jwtValidator = jwtValidator;
+			return this;
+		}
+
+		/**
 		 * Build the configured {@link NimbusReactiveJwtDecoder}.
 		 * @return the configured {@link NimbusReactiveJwtDecoder}
 		 */
 		public NimbusReactiveJwtDecoder build() {
-			return new NimbusReactiveJwtDecoder(processor());
+			NimbusReactiveJwtDecoder jwtDecoder = new NimbusReactiveJwtDecoder(processor());
+			jwtDecoder.setJwtValidator(this.jwtValidator);
+			return jwtDecoder;
 		}
 
 		Converter<JWT, Mono<JWTClaimsSet>> processor() {
@@ -555,6 +587,8 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 		private JWSAlgorithm jwsAlgorithm = JWSAlgorithm.HS256;
 
 		private Consumer<ConfigurableJWTProcessor<SecurityContext>> jwtProcessorCustomizer;
+
+		private OAuth2TokenValidator<Jwt> jwtValidator = JwtValidators.createDefault();
 
 		private SecretKeyReactiveJwtDecoderBuilder(SecretKey secretKey) {
 			Assert.notNull(secretKey, "secretKey cannot be null");
@@ -596,11 +630,25 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 		}
 
 		/**
+		 * Configure the built {@link NimbusReactiveJwtDecoder} to use the given
+		 * {@link OAuth2TokenValidator} when validating incoming {@link Jwt}s.
+		 * @param jwtValidator the {@link OAuth2TokenValidator} to use
+		 * @return a {@link SecretKeyReactiveJwtDecoderBuilder} for further configurations
+		 */
+		public SecretKeyReactiveJwtDecoderBuilder jwtValidator(OAuth2TokenValidator<Jwt> jwtValidator) {
+			Assert.notNull(jwtValidator, "jwtValidator cannot be null");
+			this.jwtValidator = jwtValidator;
+			return this;
+		}
+
+		/**
 		 * Build the configured {@link NimbusReactiveJwtDecoder}.
 		 * @return the configured {@link NimbusReactiveJwtDecoder}
 		 */
 		public NimbusReactiveJwtDecoder build() {
-			return new NimbusReactiveJwtDecoder(processor());
+			NimbusReactiveJwtDecoder jwtDecoder = new NimbusReactiveJwtDecoder(processor());
+			jwtDecoder.setJwtValidator(this.jwtValidator);
+			return jwtDecoder;
 		}
 
 		Converter<JWT, Mono<JWTClaimsSet>> processor() {
@@ -629,6 +677,8 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 		private JWSAlgorithm jwsAlgorithm = JWSAlgorithm.RS256;
 
 		private Consumer<ConfigurableJWTProcessor<JWKSecurityContext>> jwtProcessorCustomizer;
+
+		private OAuth2TokenValidator<Jwt> jwtValidator = JwtValidators.createDefault();
 
 		private JwkSourceReactiveJwtDecoderBuilder(Function<SignedJWT, Flux<JWK>> jwkSource) {
 			Assert.notNull(jwkSource, "jwkSource cannot be null");
@@ -666,11 +716,25 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 		}
 
 		/**
+		 * Configure the built {@link NimbusReactiveJwtDecoder} to use the given
+		 * {@link OAuth2TokenValidator} when validating incoming {@link Jwt}s.
+		 * @param jwtValidator the {@link OAuth2TokenValidator} to use
+		 * @return a {@link JwkSourceReactiveJwtDecoderBuilder} for further configurations
+		 */
+		public JwkSourceReactiveJwtDecoderBuilder jwtValidator(OAuth2TokenValidator<Jwt> jwtValidator) {
+			Assert.notNull(jwtValidator, "jwtValidator cannot be null");
+			this.jwtValidator = jwtValidator;
+			return this;
+		}
+
+		/**
 		 * Build the configured {@link NimbusReactiveJwtDecoder}.
 		 * @return the configured {@link NimbusReactiveJwtDecoder}
 		 */
 		public NimbusReactiveJwtDecoder build() {
-			return new NimbusReactiveJwtDecoder(processor());
+			NimbusReactiveJwtDecoder jwtDecoder = new NimbusReactiveJwtDecoder(processor());
+			jwtDecoder.setJwtValidator(this.jwtValidator);
+			return jwtDecoder;
 		}
 
 		Converter<JWT, Mono<JWTClaimsSet>> processor() {

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/ReactiveJwtDecoders.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/ReactiveJwtDecoders.java
@@ -107,10 +107,9 @@ public final class ReactiveJwtDecoders {
 		JwtDecoderProviderConfigurationUtils.validateIssuer(configuration, issuer);
 		OAuth2TokenValidator<Jwt> jwtValidator = JwtValidators.createDefaultWithIssuer(issuer);
 		String jwkSetUri = configuration.get("jwks_uri").toString();
-		NimbusReactiveJwtDecoder jwtDecoder = NimbusReactiveJwtDecoder.withJwkSetUri(jwkSetUri)
-				.jwtProcessorCustomizer(ReactiveJwtDecoderProviderConfigurationUtils::addJWSAlgorithms).build();
-		jwtDecoder.setJwtValidator(jwtValidator);
-		return jwtDecoder;
+		return NimbusReactiveJwtDecoder.withJwkSetUri(jwkSetUri)
+				.jwtProcessorCustomizer(ReactiveJwtDecoderProviderConfigurationUtils::addJWSAlgorithms)
+				.jwtValidator(jwtValidator).build();
 	}
 
 }


### PR DESCRIPTION
This was discussed briefly as an example to make a point in #13366, but as per a suggestion there, I went ahead and added a `jwtValidator(...)` method to all the `*JwtDecoderBuilder`s to enable customizing the `JwtDecoder` and `ReactiveJwtDecoder` further without having to resort to awkward temporary variables:

```java
@Bean
ReactiveJwtDecoder jwtDecoder(/* ... */) {
    return NimbusReactiveJwtDecoder
            .withIssuerLocation(...)
            .webClient(...)
            .jwtValidator(...)
            .build();
}
```
as opposed to this:
```java
@Bean
ReactiveJwtDecoder jwtDecoder(/* ... */) {
    var jwtDecoder = NimbusReactiveJwtDecoder
            .withIssuerLocation(...)
            .webClient(...)
            .build();
    jwtDecoder.setJwtValidator(...);
    return jwtDecoder;
}
```

Disclaimer: I recognize that I was never given a "go ahead" in #13366 to do this, so I understand if this addition is not the desired direction for the project.