### PR TITLE
Allow JWT issuer AuthenticationManagerResolvers to accept predicate issuer validator

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
@@ -227,8 +227,7 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 				return authenticationManager;
 			}
 			else {
-				this.logger.debug(LogMessage
-						.format("Did not resolve AuthenticationManager since issuer is not trusted", issuer));
+				this.logger.debug("Did not resolve AuthenticationManager since issuer is not trusted");
 			}
 			return null;
 		}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
@@ -91,6 +91,7 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 	 * Construct a {@link JwtIssuerAuthenticationManagerResolver} using the provided
 	 * parameters
 	 * @param trustedIssuers an array of trusted issuers
+	 * @since 6.2
 	 */
 	public static JwtIssuerAuthenticationManagerResolver fromTrustedIssuers(String... trustedIssuers) {
 		return fromTrustedIssuers(Set.of(trustedIssuers));
@@ -100,6 +101,7 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 	 * Construct a {@link JwtIssuerAuthenticationManagerResolver} using the provided
 	 * parameters
 	 * @param trustedIssuers a collection of trusted issuers
+	 * @since 6.2
 	 */
 	public static JwtIssuerAuthenticationManagerResolver fromTrustedIssuers(Collection<String> trustedIssuers) {
 		Assert.notEmpty(trustedIssuers, "trustedIssuers cannot be empty");
@@ -110,6 +112,7 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 	 * Construct a {@link JwtIssuerAuthenticationManagerResolver} using the provided
 	 * parameters
 	 * @param trustedIssuers a predicate to validate issuers
+	 * @since 6.2
 	 */
 	public static JwtIssuerAuthenticationManagerResolver fromTrustedIssuers(Predicate<String> trustedIssuers) {
 		Assert.notNull(trustedIssuers, "trustedIssuers cannot be null");
@@ -225,7 +228,7 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 			}
 			else {
 				this.logger.debug(LogMessage
-						.format("Did not resolve AuthenticationManager since issuer '%s' is not trusted", issuer));
+						.format("Did not resolve AuthenticationManager since issuer is not trusted", issuer));
 			}
 			return null;
 		}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
@@ -67,7 +67,9 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 	 * Construct a {@link JwtIssuerAuthenticationManagerResolver} using the provided
 	 * parameters
 	 * @param trustedIssuers an array of trusted issuers
+	 * @deprecated use {@link #fromTrustedIssuers(String...)}
 	 */
+	@Deprecated(since = "6.2", forRemoval = true)
 	public JwtIssuerAuthenticationManagerResolver(String... trustedIssuers) {
 		this(Set.of(trustedIssuers));
 	}
@@ -76,11 +78,43 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 	 * Construct a {@link JwtIssuerAuthenticationManagerResolver} using the provided
 	 * parameters
 	 * @param trustedIssuers a collection of trusted issuers
+	 * @deprecated use {@link #fromTrustedIssuers(Collection)}
 	 */
+	@Deprecated(since = "6.2", forRemoval = true)
 	public JwtIssuerAuthenticationManagerResolver(Collection<String> trustedIssuers) {
 		Assert.notEmpty(trustedIssuers, "trustedIssuers cannot be empty");
 		this.authenticationManager = new ResolvingAuthenticationManager(
 				new TrustedIssuerJwtAuthenticationManagerResolver(Set.copyOf(trustedIssuers)::contains));
+	}
+
+	/**
+	 * Construct a {@link JwtIssuerAuthenticationManagerResolver} using the provided
+	 * parameters
+	 * @param trustedIssuers an array of trusted issuers
+	 */
+	public static JwtIssuerAuthenticationManagerResolver fromTrustedIssuers(String... trustedIssuers) {
+		return fromTrustedIssuers(Set.of(trustedIssuers));
+	}
+
+	/**
+	 * Construct a {@link JwtIssuerAuthenticationManagerResolver} using the provided
+	 * parameters
+	 * @param trustedIssuers a collection of trusted issuers
+	 */
+	public static JwtIssuerAuthenticationManagerResolver fromTrustedIssuers(Collection<String> trustedIssuers) {
+		Assert.notEmpty(trustedIssuers, "trustedIssuers cannot be empty");
+		return fromTrustedIssuers(Set.copyOf(trustedIssuers)::contains);
+	}
+
+	/**
+	 * Construct a {@link JwtIssuerAuthenticationManagerResolver} using the provided
+	 * parameters
+	 * @param trustedIssuers a predicate to validate issuers
+	 */
+	public static JwtIssuerAuthenticationManagerResolver fromTrustedIssuers(Predicate<String> trustedIssuers) {
+		Assert.notNull(trustedIssuers, "trustedIssuers cannot be null");
+		return new JwtIssuerAuthenticationManagerResolver(
+				new TrustedIssuerJwtAuthenticationManagerResolver(trustedIssuers));
 	}
 
 	/**

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
@@ -47,10 +47,10 @@ import org.springframework.util.Assert;
  * "https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a> in
  * a signed JWT (JWS).
  *
- * To use, this class must be able to determine whether or not the `iss` claim is trusted.
- * Recall that anyone can stand up an authorization server and issue valid tokens to a
- * resource server. The simplest way to achieve this is to supply a list of trusted
- * issuers in the constructor.
+ * To use, this class must be able to determine whether the `iss` claim is trusted. Recall
+ * that anyone can stand up an authorization server and issue valid tokens to a resource
+ * server. The simplest way to achieve this is to supply a list of trusted issuers in the
+ * constructor.
  *
  * This class derives the Issuer from the `iss` claim found in the
  * {@link HttpServletRequest}'s
@@ -67,7 +67,7 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 	/**
 	 * Construct a {@link JwtIssuerAuthenticationManagerResolver} using the provided
 	 * parameters
-	 * @param trustedIssuers a list of trusted issuers
+	 * @param trustedIssuers an array of trusted issuers
 	 */
 	public JwtIssuerAuthenticationManagerResolver(String... trustedIssuers) {
 		this(Arrays.asList(trustedIssuers));
@@ -76,7 +76,7 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 	/**
 	 * Construct a {@link JwtIssuerAuthenticationManagerResolver} using the provided
 	 * parameters
-	 * @param trustedIssuers a list of trusted issuers
+	 * @param trustedIssuers a collection of trusted issuers
 	 */
 	public JwtIssuerAuthenticationManagerResolver(Collection<String> trustedIssuers) {
 		Assert.notEmpty(trustedIssuers, "trustedIssuers cannot be empty");
@@ -90,8 +90,8 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 	 * parameters
 	 *
 	 * Note that the {@link AuthenticationManagerResolver} provided in this constructor
-	 * will need to verify that the issuer is trusted. This should be done via an
-	 * allowlist.
+	 * will need to verify that the issuer is trusted. This should be done via an allowed
+	 * list of issuers.
 	 *
 	 * One way to achieve this is with a {@link Map} where the keys are the known issuers:
 	 * <pre>

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
@@ -192,7 +192,8 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 				return authenticationManager;
 			}
 			else {
-				this.logger.debug("Did not resolve AuthenticationManager since issuer is not trusted");
+				this.logger.debug(LogMessage
+						.format("Did not resolve AuthenticationManager since issuer '%s' is not trusted", issuer));
 			}
 			return null;
 		}

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
@@ -16,10 +16,9 @@
 
 package org.springframework.security.oauth2.server.resource.authentication;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 
@@ -49,7 +48,7 @@ import org.springframework.util.Assert;
  *
  * To use, this class must be able to determine whether the `iss` claim is trusted. Recall
  * that anyone can stand up an authorization server and issue valid tokens to a resource
- * server. The simplest way to achieve this is to supply a list of trusted issuers in the
+ * server. The simplest way to achieve this is to supply a set of trusted issuers in the
  * constructor.
  *
  * This class derives the Issuer from the `iss` claim found in the
@@ -70,7 +69,7 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 	 * @param trustedIssuers an array of trusted issuers
 	 */
 	public JwtIssuerAuthenticationManagerResolver(String... trustedIssuers) {
-		this(Arrays.asList(trustedIssuers));
+		this(Set.of(trustedIssuers));
 	}
 
 	/**
@@ -81,8 +80,7 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 	public JwtIssuerAuthenticationManagerResolver(Collection<String> trustedIssuers) {
 		Assert.notEmpty(trustedIssuers, "trustedIssuers cannot be empty");
 		this.authenticationManager = new ResolvingAuthenticationManager(
-				new TrustedIssuerJwtAuthenticationManagerResolver(
-						Collections.unmodifiableCollection(trustedIssuers)::contains));
+				new TrustedIssuerJwtAuthenticationManagerResolver(Set.copyOf(trustedIssuers)::contains));
 	}
 
 	/**
@@ -91,7 +89,7 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 	 *
 	 * Note that the {@link AuthenticationManagerResolver} provided in this constructor
 	 * will need to verify that the issuer is trusted. This should be done via an allowed
-	 * list of issuers.
+	 * set of issuers.
 	 *
 	 * One way to achieve this is with a {@link Map} where the keys are the known issuers:
 	 * <pre>

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
@@ -46,10 +46,10 @@ import org.springframework.web.server.ServerWebExchange;
  * "https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a> in
  * a signed JWT (JWS).
  *
- * To use, this class must be able to determine whether or not the `iss` claim is trusted.
- * Recall that anyone can stand up an authorization server and issue valid tokens to a
- * resource server. The simplest way to achieve this is to supply a list of trusted
- * issuers in the constructor.
+ * To use, this class must be able to determine whether the `iss` claim is trusted. Recall
+ * that anyone can stand up an authorization server and issue valid tokens to a resource
+ * server. The simplest way to achieve this is to supply a list of trusted issuers in the
+ * constructor.
  *
  * This class derives the Issuer from the `iss` claim found in the
  * {@link ServerWebExchange}'s
@@ -68,7 +68,7 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 	/**
 	 * Construct a {@link JwtIssuerReactiveAuthenticationManagerResolver} using the
 	 * provided parameters
-	 * @param trustedIssuers a list of trusted issuers
+	 * @param trustedIssuers an array of trusted issuers
 	 */
 	public JwtIssuerReactiveAuthenticationManagerResolver(String... trustedIssuers) {
 		this(Arrays.asList(trustedIssuers));

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
@@ -221,8 +221,7 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 		@Override
 		public Mono<ReactiveAuthenticationManager> resolve(String issuer) {
 			if (!this.trustedIssuer.test(issuer)) {
-				this.logger.debug(LogMessage
-						.format("Did not resolve AuthenticationManager since issuer is not trusted", issuer));
+				this.logger.debug("Did not resolve AuthenticationManager since issuer is not trusted");
 				return Mono.empty();
 			}
 			// @formatter:off

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
@@ -17,10 +17,9 @@
 package org.springframework.security.oauth2.server.resource.authentication;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 
@@ -51,7 +50,7 @@ import org.springframework.web.server.ServerWebExchange;
  *
  * To use, this class must be able to determine whether the `iss` claim is trusted. Recall
  * that anyone can stand up an authorization server and issue valid tokens to a resource
- * server. The simplest way to achieve this is to supply a list of trusted issuers in the
+ * server. The simplest way to achieve this is to supply a set of trusted issuers in the
  * constructor.
  *
  * This class derives the Issuer from the `iss` claim found in the
@@ -74,7 +73,7 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 	 * @param trustedIssuers an array of trusted issuers
 	 */
 	public JwtIssuerReactiveAuthenticationManagerResolver(String... trustedIssuers) {
-		this(Arrays.asList(trustedIssuers));
+		this(Set.of(trustedIssuers));
 	}
 
 	/**
@@ -85,7 +84,7 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 	public JwtIssuerReactiveAuthenticationManagerResolver(Collection<String> trustedIssuers) {
 		Assert.notEmpty(trustedIssuers, "trustedIssuers cannot be empty");
 		this.authenticationManager = new ResolvingAuthenticationManager(
-				new TrustedIssuerJwtAuthenticationManagerResolver(new ArrayList<>(trustedIssuers)::contains));
+				new TrustedIssuerJwtAuthenticationManagerResolver(Set.copyOf(trustedIssuers)::contains));
 	}
 
 	/**
@@ -94,7 +93,7 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 	 *
 	 * Note that the {@link ReactiveAuthenticationManagerResolver} provided in this
 	 * constructor will need to verify that the issuer is trusted. This should be done via
-	 * an allowed list of issuers.
+	 * an allowed set of issuers.
 	 *
 	 * One way to achieve this is with a {@link Map} where the keys are the known issuers:
 	 * <pre>

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
@@ -95,6 +95,7 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 	 * Construct a {@link JwtIssuerReactiveAuthenticationManagerResolver} using the
 	 * provided parameters
 	 * @param trustedIssuers an array of trusted issuers
+	 * @since 6.2
 	 */
 	public static JwtIssuerReactiveAuthenticationManagerResolver fromTrustedIssuers(String... trustedIssuers) {
 		return fromTrustedIssuers(Set.of(trustedIssuers));
@@ -104,6 +105,7 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 	 * Construct a {@link JwtIssuerReactiveAuthenticationManagerResolver} using the
 	 * provided parameters
 	 * @param trustedIssuers a collection of trusted issuers
+	 * @since 6.2
 	 */
 	public static JwtIssuerReactiveAuthenticationManagerResolver fromTrustedIssuers(Collection<String> trustedIssuers) {
 		Assert.notEmpty(trustedIssuers, "trustedIssuers cannot be empty");
@@ -114,6 +116,7 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 	 * Construct a {@link JwtIssuerReactiveAuthenticationManagerResolver} using the
 	 * provided parameters
 	 * @param trustedIssuers a predicate to validate issuers
+	 * @since 6.2
 	 */
 	public static JwtIssuerReactiveAuthenticationManagerResolver fromTrustedIssuers(Predicate<String> trustedIssuers) {
 		Assert.notNull(trustedIssuers, "trustedIssuers cannot be null");
@@ -219,7 +222,7 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 		public Mono<ReactiveAuthenticationManager> resolve(String issuer) {
 			if (!this.trustedIssuer.test(issuer)) {
 				this.logger.debug(LogMessage
-						.format("Did not resolve AuthenticationManager since issuer '%s' is not trusted", issuer));
+						.format("Did not resolve AuthenticationManager since issuer is not trusted", issuer));
 				return Mono.empty();
 			}
 			// @formatter:off

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolver.java
@@ -71,7 +71,9 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 	 * Construct a {@link JwtIssuerReactiveAuthenticationManagerResolver} using the
 	 * provided parameters
 	 * @param trustedIssuers an array of trusted issuers
+	 * @deprecated use {@link #fromTrustedIssuers(String...)}
 	 */
+	@Deprecated(since = "6.2", forRemoval = true)
 	public JwtIssuerReactiveAuthenticationManagerResolver(String... trustedIssuers) {
 		this(Set.of(trustedIssuers));
 	}
@@ -80,11 +82,43 @@ public final class JwtIssuerReactiveAuthenticationManagerResolver
 	 * Construct a {@link JwtIssuerReactiveAuthenticationManagerResolver} using the
 	 * provided parameters
 	 * @param trustedIssuers a collection of trusted issuers
+	 * @deprecated use {@link #fromTrustedIssuers(Collection)}
 	 */
+	@Deprecated(since = "6.2", forRemoval = true)
 	public JwtIssuerReactiveAuthenticationManagerResolver(Collection<String> trustedIssuers) {
 		Assert.notEmpty(trustedIssuers, "trustedIssuers cannot be empty");
 		this.authenticationManager = new ResolvingAuthenticationManager(
 				new TrustedIssuerJwtAuthenticationManagerResolver(Set.copyOf(trustedIssuers)::contains));
+	}
+
+	/**
+	 * Construct a {@link JwtIssuerReactiveAuthenticationManagerResolver} using the
+	 * provided parameters
+	 * @param trustedIssuers an array of trusted issuers
+	 */
+	public static JwtIssuerReactiveAuthenticationManagerResolver fromTrustedIssuers(String... trustedIssuers) {
+		return fromTrustedIssuers(Set.of(trustedIssuers));
+	}
+
+	/**
+	 * Construct a {@link JwtIssuerReactiveAuthenticationManagerResolver} using the
+	 * provided parameters
+	 * @param trustedIssuers a collection of trusted issuers
+	 */
+	public static JwtIssuerReactiveAuthenticationManagerResolver fromTrustedIssuers(Collection<String> trustedIssuers) {
+		Assert.notEmpty(trustedIssuers, "trustedIssuers cannot be empty");
+		return fromTrustedIssuers(Set.copyOf(trustedIssuers)::contains);
+	}
+
+	/**
+	 * Construct a {@link JwtIssuerReactiveAuthenticationManagerResolver} using the
+	 * provided parameters
+	 * @param trustedIssuers a predicate to validate issuers
+	 */
+	public static JwtIssuerReactiveAuthenticationManagerResolver fromTrustedIssuers(Predicate<String> trustedIssuers) {
+		Assert.notNull(trustedIssuers, "trustedIssuers cannot be null");
+		return new JwtIssuerReactiveAuthenticationManagerResolver(
+				new TrustedIssuerJwtAuthenticationManagerResolver(trustedIssuers));
 	}
 
 	/**

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolverDeprecatedTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolverDeprecatedTests.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Predicate;
 
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
@@ -51,7 +50,8 @@ import static org.mockito.BDDMockito.verify;
 /**
  * Tests for {@link JwtIssuerAuthenticationManagerResolver}
  */
-public class JwtIssuerAuthenticationManagerResolverTests {
+@Deprecated
+public class JwtIssuerAuthenticationManagerResolverDeprecatedTests {
 
 	private static final String DEFAULT_RESPONSE_TEMPLATE = "{\n" + "    \"issuer\": \"%s\", \n"
 			+ "    \"jwks_uri\": \"%s/.well-known/jwks.json\" \n" + "}";
@@ -86,8 +86,8 @@ public class JwtIssuerAuthenticationManagerResolverTests {
 			JWSObject jws = new JWSObject(new JWSHeader(JWSAlgorithm.RS256),
 					new Payload(new JSONObject(Collections.singletonMap(JwtClaimNames.ISS, issuer))));
 			jws.sign(new RSASSASigner(TestKeys.DEFAULT_PRIVATE_KEY));
-			JwtIssuerAuthenticationManagerResolver authenticationManagerResolver = JwtIssuerAuthenticationManagerResolver
-					.fromTrustedIssuers(issuer);
+			JwtIssuerAuthenticationManagerResolver authenticationManagerResolver = new JwtIssuerAuthenticationManagerResolver(
+					issuer);
 			Authentication token = withBearerToken(jws.serialize());
 			AuthenticationManager authenticationManager = authenticationManagerResolver.resolve(null);
 			assertThat(authenticationManager).isNotNull();
@@ -118,8 +118,8 @@ public class JwtIssuerAuthenticationManagerResolverTests {
 			JWSObject jws = new JWSObject(new JWSHeader(JWSAlgorithm.RS256),
 					new Payload(new JSONObject(Collections.singletonMap(JwtClaimNames.ISS, issuer))));
 			jws.sign(new RSASSASigner(TestKeys.DEFAULT_PRIVATE_KEY));
-			JwtIssuerAuthenticationManagerResolver authenticationManagerResolver = JwtIssuerAuthenticationManagerResolver
-					.fromTrustedIssuers(issuer);
+			JwtIssuerAuthenticationManagerResolver authenticationManagerResolver = new JwtIssuerAuthenticationManagerResolver(
+					issuer);
 			Authentication token = withBearerToken(jws.serialize());
 			AuthenticationManager authenticationManager = authenticationManagerResolver.resolve(null);
 			assertThat(authenticationManager).isNotNull();
@@ -148,8 +148,8 @@ public class JwtIssuerAuthenticationManagerResolverTests {
 
 	@Test
 	public void resolveWhenUsingUntrustedIssuerThenException() {
-		JwtIssuerAuthenticationManagerResolver authenticationManagerResolver = JwtIssuerAuthenticationManagerResolver
-				.fromTrustedIssuers("other", "issuers");
+		JwtIssuerAuthenticationManagerResolver authenticationManagerResolver = new JwtIssuerAuthenticationManagerResolver(
+				"other", "issuers");
 		Authentication token = withBearerToken(this.jwt);
 		// @formatter:off
 		assertThatExceptionOfType(OAuth2AuthenticationException.class)
@@ -193,8 +193,8 @@ public class JwtIssuerAuthenticationManagerResolverTests {
 
 	@Test
 	public void resolveWhenBearerTokenMalformedThenException() {
-		JwtIssuerAuthenticationManagerResolver authenticationManagerResolver = JwtIssuerAuthenticationManagerResolver
-				.fromTrustedIssuers("trusted");
+		JwtIssuerAuthenticationManagerResolver authenticationManagerResolver = new JwtIssuerAuthenticationManagerResolver(
+				"trusted");
 		Authentication token = withBearerToken("jwt");
 		// @formatter:off
 		assertThatExceptionOfType(OAuth2AuthenticationException.class)
@@ -205,8 +205,8 @@ public class JwtIssuerAuthenticationManagerResolverTests {
 
 	@Test
 	public void resolveWhenBearerTokenNoIssuerThenException() {
-		JwtIssuerAuthenticationManagerResolver authenticationManagerResolver = JwtIssuerAuthenticationManagerResolver
-				.fromTrustedIssuers("trusted");
+		JwtIssuerAuthenticationManagerResolver authenticationManagerResolver = new JwtIssuerAuthenticationManagerResolver(
+				"trusted");
 		Authentication token = withBearerToken(this.noIssuer);
 		// @formatter:off
 		assertThatExceptionOfType(OAuth2AuthenticationException.class)
@@ -217,8 +217,8 @@ public class JwtIssuerAuthenticationManagerResolverTests {
 
 	@Test
 	public void resolveWhenBearerTokenEvilThenGenericException() {
-		JwtIssuerAuthenticationManagerResolver authenticationManagerResolver = JwtIssuerAuthenticationManagerResolver
-				.fromTrustedIssuers("trusted");
+		JwtIssuerAuthenticationManagerResolver authenticationManagerResolver = new JwtIssuerAuthenticationManagerResolver(
+				"trusted");
 		Authentication token = withBearerToken(this.evil);
 		// @formatter:off
 		assertThatExceptionOfType(OAuth2AuthenticationException.class)
@@ -232,11 +232,9 @@ public class JwtIssuerAuthenticationManagerResolverTests {
 	@Test
 	public void constructorWhenNullOrEmptyIssuersThenException() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> JwtIssuerAuthenticationManagerResolver.fromTrustedIssuers((Predicate<String>) null));
+				.isThrownBy(() -> new JwtIssuerAuthenticationManagerResolver((Collection) null));
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> JwtIssuerAuthenticationManagerResolver.fromTrustedIssuers((Collection<String>) null));
-		assertThatIllegalArgumentException()
-				.isThrownBy(() -> JwtIssuerAuthenticationManagerResolver.fromTrustedIssuers(Collections.emptyList()));
+				.isThrownBy(() -> new JwtIssuerAuthenticationManagerResolver(Collections.emptyList()));
 	}
 
 	@Test

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolverTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolverTests.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
@@ -83,8 +84,8 @@ public class JwtIssuerReactiveAuthenticationManagerResolverTests {
 			JWSObject jws = new JWSObject(new JWSHeader(JWSAlgorithm.RS256),
 					new Payload(new JSONObject(Collections.singletonMap(JwtClaimNames.ISS, issuer))));
 			jws.sign(new RSASSASigner(TestKeys.DEFAULT_PRIVATE_KEY));
-			JwtIssuerReactiveAuthenticationManagerResolver authenticationManagerResolver = new JwtIssuerReactiveAuthenticationManagerResolver(
-					issuer);
+			JwtIssuerReactiveAuthenticationManagerResolver authenticationManagerResolver = JwtIssuerReactiveAuthenticationManagerResolver
+					.fromTrustedIssuers(issuer);
 			ReactiveAuthenticationManager authenticationManager = authenticationManagerResolver.resolve(null).block();
 			assertThat(authenticationManager).isNotNull();
 			BearerTokenAuthenticationToken token = withBearerToken(jws.serialize());
@@ -110,8 +111,8 @@ public class JwtIssuerReactiveAuthenticationManagerResolverTests {
 			JWSObject jws = new JWSObject(new JWSHeader(JWSAlgorithm.RS256),
 					new Payload(new JSONObject(Collections.singletonMap(JwtClaimNames.ISS, issuer))));
 			jws.sign(new RSASSASigner(TestKeys.DEFAULT_PRIVATE_KEY));
-			JwtIssuerReactiveAuthenticationManagerResolver authenticationManagerResolver = new JwtIssuerReactiveAuthenticationManagerResolver(
-					issuer);
+			JwtIssuerReactiveAuthenticationManagerResolver authenticationManagerResolver = JwtIssuerReactiveAuthenticationManagerResolver
+					.fromTrustedIssuers(issuer);
 			ReactiveAuthenticationManager authenticationManager = authenticationManagerResolver.resolve(null).block();
 			assertThat(authenticationManager).isNotNull();
 			Authentication token = withBearerToken(jws.serialize());
@@ -140,8 +141,8 @@ public class JwtIssuerReactiveAuthenticationManagerResolverTests {
 
 	@Test
 	public void resolveWhenUsingUntrustedIssuerThenException() {
-		JwtIssuerReactiveAuthenticationManagerResolver authenticationManagerResolver = new JwtIssuerReactiveAuthenticationManagerResolver(
-				"other", "issuers");
+		JwtIssuerReactiveAuthenticationManagerResolver authenticationManagerResolver = JwtIssuerReactiveAuthenticationManagerResolver
+				.fromTrustedIssuers("other", "issuers");
 		Authentication token = withBearerToken(this.jwt);
 		// @formatter:off
 		assertThatExceptionOfType(OAuth2AuthenticationException.class)
@@ -190,8 +191,8 @@ public class JwtIssuerReactiveAuthenticationManagerResolverTests {
 
 	@Test
 	public void resolveWhenBearerTokenMalformedThenException() {
-		JwtIssuerReactiveAuthenticationManagerResolver authenticationManagerResolver = new JwtIssuerReactiveAuthenticationManagerResolver(
-				"trusted");
+		JwtIssuerReactiveAuthenticationManagerResolver authenticationManagerResolver = JwtIssuerReactiveAuthenticationManagerResolver
+				.fromTrustedIssuers("trusted");
 		Authentication token = withBearerToken("jwt");
 		// @formatter:off
 		assertThatExceptionOfType(OAuth2AuthenticationException.class)
@@ -204,8 +205,8 @@ public class JwtIssuerReactiveAuthenticationManagerResolverTests {
 
 	@Test
 	public void resolveWhenBearerTokenNoIssuerThenException() {
-		JwtIssuerReactiveAuthenticationManagerResolver authenticationManagerResolver = new JwtIssuerReactiveAuthenticationManagerResolver(
-				"trusted");
+		JwtIssuerReactiveAuthenticationManagerResolver authenticationManagerResolver = JwtIssuerReactiveAuthenticationManagerResolver
+				.fromTrustedIssuers("trusted");
 		Authentication token = withBearerToken(this.noIssuer);
 		assertThatExceptionOfType(OAuth2AuthenticationException.class)
 				.isThrownBy(() -> authenticationManagerResolver.resolve(null)
@@ -215,8 +216,8 @@ public class JwtIssuerReactiveAuthenticationManagerResolverTests {
 
 	@Test
 	public void resolveWhenBearerTokenEvilThenGenericException() {
-		JwtIssuerReactiveAuthenticationManagerResolver authenticationManagerResolver = new JwtIssuerReactiveAuthenticationManagerResolver(
-				"trusted");
+		JwtIssuerReactiveAuthenticationManagerResolver authenticationManagerResolver = JwtIssuerReactiveAuthenticationManagerResolver
+				.fromTrustedIssuers("trusted");
 		Authentication token = withBearerToken(this.evil);
 		// @formatter:off
 		assertThatExceptionOfType(OAuth2AuthenticationException.class)
@@ -229,10 +230,12 @@ public class JwtIssuerReactiveAuthenticationManagerResolverTests {
 
 	@Test
 	public void constructorWhenNullOrEmptyIssuersThenException() {
-		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new JwtIssuerReactiveAuthenticationManagerResolver((Collection) null));
-		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new JwtIssuerReactiveAuthenticationManagerResolver(Collections.emptyList()));
+		assertThatIllegalArgumentException().isThrownBy(
+				() -> JwtIssuerReactiveAuthenticationManagerResolver.fromTrustedIssuers((Predicate<String>) null));
+		assertThatIllegalArgumentException().isThrownBy(
+				() -> JwtIssuerReactiveAuthenticationManagerResolver.fromTrustedIssuers((Collection<String>) null));
+		assertThatIllegalArgumentException().isThrownBy(
+				() -> JwtIssuerReactiveAuthenticationManagerResolver.fromTrustedIssuers(Collections.emptyList()));
 	}
 
 	@Test


### PR DESCRIPTION
Close #13427

* Make `TrustedIssuerJwtAuthenticationManagerResolver` public so constructors to validate issuer with a predicate can be used.
* Makes the servlet and reactive versions a little more consistent (i.e. logging)
* Use `Set` instead of `ArrayList`; it has O(1) time complexity for look ups.


<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
