### PR TITLE
Return content-type from saved request

### DIFF
--- a/web/src/main/java/org/springframework/security/web/savedrequest/SavedRequestAwareWrapper.java
+++ b/web/src/main/java/org/springframework/security/web/savedrequest/SavedRequestAwareWrapper.java
@@ -58,10 +58,7 @@ class SavedRequestAwareWrapper extends HttpServletRequestWrapper {
 
 	protected static final TimeZone GMT_ZONE = TimeZone.getTimeZone("GMT");
 
-	/** The default Locale if none are specified. */
-	protected static Locale defaultLocale = Locale.getDefault();
-
-	protected SavedRequest savedRequest = null;
+	protected SavedRequest savedRequest;
 
 	/**
 	 * The set of SimpleDateFormat formats to use in getDateHeader(). Notice that because
@@ -102,14 +99,12 @@ class SavedRequestAwareWrapper extends HttpServletRequestWrapper {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public Enumeration getHeaderNames() {
+	public Enumeration<String> getHeaderNames() {
 		return new Enumerator<>(this.savedRequest.getHeaderNames());
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public Enumeration getHeaders(String name) {
+	public Enumeration<String> getHeaders(String name) {
 		return new Enumerator<>(this.savedRequest.getHeaderValues(name));
 	}
 
@@ -126,8 +121,7 @@ class SavedRequestAwareWrapper extends HttpServletRequestWrapper {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public Enumeration getLocales() {
+	public Enumeration<Locale> getLocales() {
 		List<Locale> locales = this.savedRequest.getLocales();
 		if (locales.isEmpty()) {
 			// Fall back to default locale
@@ -171,8 +165,7 @@ class SavedRequestAwareWrapper extends HttpServletRequestWrapper {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public Map getParameterMap() {
+	public Map<String, String[]> getParameterMap() {
 		Set<String> names = getCombinedParameterNames();
 		Map<String, String[]> parameterMap = new HashMap<>(names.size());
 		for (String name : names) {
@@ -181,7 +174,6 @@ class SavedRequestAwareWrapper extends HttpServletRequestWrapper {
 		return parameterMap;
 	}
 
-	@SuppressWarnings("unchecked")
 	private Set<String> getCombinedParameterNames() {
 		Set<String> names = new HashSet<>();
 		names.addAll(super.getParameterMap().keySet());
@@ -190,9 +182,8 @@ class SavedRequestAwareWrapper extends HttpServletRequestWrapper {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public Enumeration getParameterNames() {
-		return new Enumerator(getCombinedParameterNames());
+	public Enumeration<String> getParameterNames() {
+		return new Enumerator<>(getCombinedParameterNames());
 	}
 
 	@Override

--- a/web/src/main/java/org/springframework/security/web/savedrequest/SavedRequestAwareWrapper.java
+++ b/web/src/main/java/org/springframework/security/web/savedrequest/SavedRequestAwareWrapper.java
@@ -32,6 +32,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.http.HttpHeaders;
 
 /**
  * Provides request parameters, headers and cookies from either an original request or a
@@ -139,6 +140,11 @@ class SavedRequestAwareWrapper extends HttpServletRequestWrapper {
 	@Override
 	public String getMethod() {
 		return this.savedRequest.getMethod();
+	}
+
+	@Override
+	public String getContentType() {
+		return getHeader(HttpHeaders.CONTENT_TYPE);
 	}
 
 	/**

--- a/web/src/test/java/org/springframework/security/web/savedrequest/SavedRequestAwareWrapperTests.java
+++ b/web/src/test/java/org/springframework/security/web/savedrequest/SavedRequestAwareWrapperTests.java
@@ -24,6 +24,7 @@ import java.util.Locale;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.web.PortResolverImpl;
 
@@ -167,6 +168,15 @@ public class SavedRequestAwareWrapperTests {
 		SavedRequestAwareWrapper wrapper = createWrapper(request, new MockHttpServletRequest());
 		assertThat(wrapper.getIntHeader("header")).isEqualTo(999);
 		assertThat(wrapper.getIntHeader("nonexistent")).isEqualTo(-1);
+	}
+
+	@Test
+	public void correctContentTypeIsReturned() {
+		MockHttpServletRequest request = new MockHttpServletRequest("PUT", "/notused");
+		request.setContentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE);
+
+		SavedRequestAwareWrapper wrapper = createWrapper(request, new MockHttpServletRequest("GET", "/notused"));
+		assertThat(wrapper.getContentType()).isEqualTo(MediaType.APPLICATION_FORM_URLENCODED_VALUE);
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/savedrequest/SavedRequestAwareWrapperTests.java
+++ b/web/src/test/java/org/springframework/security/web/savedrequest/SavedRequestAwareWrapperTests.java
@@ -43,22 +43,21 @@ public class SavedRequestAwareWrapperTests {
 	@Test
 	public void savedRequestCookiesAreIgnored() {
 		MockHttpServletRequest newRequest = new MockHttpServletRequest();
-		newRequest.setCookies(new Cookie[] { new Cookie("cookie", "fromnew") });
+		newRequest.setCookies(new Cookie("cookie", "fromnew"));
 		MockHttpServletRequest savedRequest = new MockHttpServletRequest();
-		savedRequest.setCookies(new Cookie[] { new Cookie("cookie", "fromsaved") });
+		savedRequest.setCookies(new Cookie("cookie", "fromsaved"));
 		SavedRequestAwareWrapper wrapper = createWrapper(savedRequest, newRequest);
 		assertThat(wrapper.getCookies()).hasSize(1);
 		assertThat(wrapper.getCookies()[0].getValue()).isEqualTo("fromnew");
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void savedRequesthHeaderIsReturnedIfSavedRequestIsSet() {
 		MockHttpServletRequest savedRequest = new MockHttpServletRequest();
 		savedRequest.addHeader("header", "savedheader");
 		SavedRequestAwareWrapper wrapper = createWrapper(savedRequest, new MockHttpServletRequest());
 		assertThat(wrapper.getHeader("nonexistent")).isNull();
-		Enumeration headers = wrapper.getHeaders("nonexistent");
+		Enumeration<String> headers = wrapper.getHeaders("nonexistent");
 		assertThat(headers.hasMoreElements()).isFalse();
 		assertThat(wrapper.getHeader("Header")).isEqualTo("savedheader");
 		headers = wrapper.getHeaders("heaDer");
@@ -98,7 +97,7 @@ public class SavedRequestAwareWrapperTests {
 		SavedRequestAwareWrapper wrapper = createWrapper(savedRequest, wrappedRequest);
 		assertThat(wrapper.getParameterValues("action")).hasSize(1);
 		assertThat(wrapper.getParameterMap()).hasSize(1);
-		assertThat(((String[]) wrapper.getParameterMap().get("action"))).hasSize(1);
+		assertThat(wrapper.getParameterMap().get("action")).hasSize(1);
 	}
 
 	@Test
@@ -128,7 +127,7 @@ public class SavedRequestAwareWrapperTests {
 		wrappedRequest.setParameter("action", "bar");
 		assertThat(wrapper.getParameterValues("action")).isEqualTo(new Object[] { "bar", "foo" });
 		// Check map is consistent
-		String[] valuesFromMap = (String[]) wrapper.getParameterMap().get("action");
+		String[] valuesFromMap = wrapper.getParameterMap().get("action");
 		assertThat(valuesFromMap).hasSize(2);
 		assertThat(valuesFromMap[0]).isEqualTo("bar");
 	}


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->

We detected an issue in the process of handling the original request, after redirecting the Browser to the authenticated entry point: As the `SavedRequestAwareWrapper` is not exposing the content-type of the original request, Spring cannot resolve the handler method correctly, if it specifies a `consumes` parameter (see attached example: [post-redirect.zip](https://github.com/spring-projects/spring-security/files/11915298/post-redirect.zip)).

```
@PostMapping(path = "example-post", consumes = {
        MediaType.APPLICATION_FORM_URLENCODED_VALUE,
        MediaType.ALL_VALUE // only needed if browser has been redirected to the authentication entry point
})
public String exampleHandler() {
    ...
}
```
