### PR TITLE
Added a note about the fact that if the CSRF protection is disabled in configuration, no logout confirmation page is shown to the user and the logout is performed directly.

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/logout.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/logout.adoc
@@ -24,7 +24,7 @@ When you include {spring-boot-reference-url}using.html#using.build-systems.start
 If you request `GET /logout`, then Spring Security displays a logout confirmation page.
 Aside from providing a valuable double-checking mechanism for the user, it also provides a simple way to provide xref:servlet/exploits/csrf.adoc[the needed CSRF token] to `POST /logout`.
 
-Please note that if xref:servlet/exploits/csrf.adoc[the CSRF protection] is disabled in configuration, no logout confirmation page is shown to the user and the logout is performed direclty.
+Please note that if xref:servlet/exploits/csrf.adoc[CSRF protection] is disabled in configuration, no logout confirmation page is shown to the user and the logout is performed directly.
 
 [TIP]
 In your application it is not necessary to use `GET /logout` to perform a logout.


### PR DESCRIPTION
Added a note about the fact that if the CSRF protection is disabled in configuration, no logout confirmation page is shown to the user and the logout is performed directly.