### PR TITLE
Fix Adapeter to Adapter

### DIFF
--- a/docs/modules/ROOT/pages/migration/servlet/config.adoc
+++ b/docs/modules/ROOT/pages/migration/servlet/config.adoc
@@ -692,7 +692,7 @@ open class SecurityConfiguration {
 
 === Publish an `AuthenticationManager` Bean
 
-As part of `WebSecurityConfigurerAdapeter` removal, `configure(AuthenticationManagerBuilder)` is also removed.
+As part of `WebSecurityConfigurerAdapter` removal, `configure(AuthenticationManagerBuilder)` is also removed.
 Preparing for its removal will differ based on your reason for using it.
 
 ==== LDAP Authentication


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->

Changed WebSecurityConfigurerAdapeter to WebSecurityConfigurerAdapter in Spring docs 5.8.x
