### PR TITLE
Fixing ArrayIndexOutOfBoundsException in XorCsrfTokenRequestAttribute…

### DIFF
--- a/web/src/main/java/org/springframework/security/web/csrf/XorCsrfTokenRequestAttributeHandler.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/XorCsrfTokenRequestAttributeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/main/java/org/springframework/security/web/csrf/XorCsrfTokenRequestAttributeHandler.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/XorCsrfTokenRequestAttributeHandler.java
@@ -97,7 +97,7 @@ public final class XorCsrfTokenRequestAttributeHandler extends CsrfTokenRequestA
 		System.arraycopy(actualBytes, randomBytesSize, xoredCsrf, 0, tokenSize);
 
 		byte[] csrfBytes = xorCsrf(randomBytes, xoredCsrf);
-		return Utf8.decode(csrfBytes);
+		return (csrfBytes != null) ? Utf8.decode(csrfBytes) : null;
 	}
 
 	private static String createXoredCsrfToken(SecureRandom secureRandom, String token) {
@@ -114,6 +114,9 @@ public final class XorCsrfTokenRequestAttributeHandler extends CsrfTokenRequestA
 	}
 
 	private static byte[] xorCsrf(byte[] randomBytes, byte[] csrfBytes) {
+		if (csrfBytes.length < randomBytes.length) {
+			return null;
+		}
 		int len = Math.min(randomBytes.length, csrfBytes.length);
 		byte[] xoredCsrf = new byte[len];
 		System.arraycopy(csrfBytes, 0, xoredCsrf, 0, csrfBytes.length);

--- a/web/src/main/java/org/springframework/security/web/server/csrf/XorServerCsrfTokenRequestAttributeHandler.java
+++ b/web/src/main/java/org/springframework/security/web/server/csrf/XorServerCsrfTokenRequestAttributeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ public final class XorServerCsrfTokenRequestAttributeHandler extends ServerCsrfT
 		System.arraycopy(actualBytes, randomBytesSize, xoredCsrf, 0, tokenSize);
 
 		byte[] csrfBytes = xorCsrf(randomBytes, xoredCsrf);
-		return Utf8.decode(csrfBytes);
+		return (csrfBytes != null) ? Utf8.decode(csrfBytes) : null;
 	}
 
 	private static String createXoredCsrfToken(SecureRandom secureRandom, String token) {
@@ -105,6 +105,9 @@ public final class XorServerCsrfTokenRequestAttributeHandler extends ServerCsrfT
 	}
 
 	private static byte[] xorCsrf(byte[] randomBytes, byte[] csrfBytes) {
+		if (csrfBytes.length < randomBytes.length) {
+			return null;
+		}
 		int len = Math.min(randomBytes.length, csrfBytes.length);
 		byte[] xoredCsrf = new byte[len];
 		System.arraycopy(csrfBytes, 0, xoredCsrf, 0, csrfBytes.length);

--- a/web/src/test/java/org/springframework/security/web/csrf/XorCsrfTokenRequestAttributeHandlerTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/XorCsrfTokenRequestAttributeHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/web/src/test/java/org/springframework/security/web/csrf/XorCsrfTokenRequestAttributeHandlerTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/XorCsrfTokenRequestAttributeHandlerTests.java
@@ -208,6 +208,14 @@ public class XorCsrfTokenRequestAttributeHandlerTests {
 		assertThat(tokenValue).isEqualTo(this.token.getToken());
 	}
 
+	@Test
+	public void resolveCsrfTokenIsInvalidThenReturnsNull() {
+		this.request.setParameter(this.token.getParameterName(), XOR_CSRF_TOKEN_VALUE);
+		CsrfToken csrfToken = new DefaultCsrfToken("headerName", "paramName", "a");
+		String tokenValue = this.handler.resolveCsrfTokenValue(this.request, csrfToken);
+		assertThat(tokenValue).isNull();
+	}
+
 	private static Answer<Void> fillByteArray() {
 		return (invocation) -> {
 			byte[] bytes = invocation.getArgument(0);

--- a/web/src/test/java/org/springframework/security/web/server/csrf/XorServerCsrfTokenRequestAttributeHandlerTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/csrf/XorServerCsrfTokenRequestAttributeHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -180,6 +180,16 @@ public class XorServerCsrfTokenRequestAttributeHandlerTests {
 				.body(this.token.getParameterName() + "=" + XOR_CSRF_TOKEN_VALUE)).build();
 		Mono<String> csrfToken = this.handler.resolveCsrfTokenValue(this.exchange, this.token);
 		StepVerifier.create(csrfToken).expectNext(this.token.getToken()).verifyComplete();
+	}
+
+	@Test
+	public void resolveCsrfTokenIsInvalidThenReturnsNull() {
+		this.exchange = MockServerWebExchange.builder(MockServerHttpRequest.post("/")
+				.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+				.body(this.token.getParameterName() + "=" + XOR_CSRF_TOKEN_VALUE)).build();
+		CsrfToken token = new DefaultCsrfToken("headerName", "paramName", "a");
+		Mono<String> csrfToken = this.handler.resolveCsrfTokenValue(this.exchange, token);
+		assertThat(csrfToken.block()).isNull();
 	}
 
 	private static Answer<Void> fillByteArray() {


### PR DESCRIPTION
## Issue Description: https://github.com/spring-projects/spring-security/issues/13310
ArrayIndexOutOfBoundsException in XorCsrfTokenRequestAttributeHandler


![SecurityIssue](https://github.com/spring-projects/spring-security/assets/19582910/01e4a2a5-c7c5-4218-ac02-9fb568ed5c7c)

## Steps to reproduce the issue

1. Modify the CSRF token value from the client side.
2. Submit the request with the modified token value.


## Expected behaviour:
The underlying method getTokenValue should validate the encoded token length and return null if the value is incorrect. Generating stack traces for exceptions is much more expensive and may impact performance.

## Change Details:

1. Handle the ArrayIndexOutOfBoundsException.
2. Added the test case.