### PR TITLE
Set NullRequestCache when session management disabled

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
@@ -358,6 +358,12 @@ public final class SessionManagementConfigurer<H extends HttpSecurityBuilder<H>>
 	}
 
 	@Override
+	public H disable() {
+		getBuilder().setSharedObject(RequestCache.class, new NullRequestCache());
+		return super.disable();
+	}
+
+	@Override
 	public void init(H http) {
 		SecurityContextRepository securityContextRepository = http.getSharedObject(SecurityContextRepository.class);
 		boolean stateless = isStateless();


### PR DESCRIPTION
```java
  @Bean
  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

    http
        .authorizeHttpRequests(request -> request.anyRequest().authenticated())
        .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS));

    return http.build();
  }

```

When I configure `sessionManagement` to `STATELESS` like upper code, spring-security sets`RequestCache` of `ExceptionTranslationFilter` to `NullRequestCache` like next image.

![image](https://github.com/spring-projects/spring-security/assets/59705184/fcb51ce5-4b22-48e9-b4b7-c8434457a473)



```java
  @Bean
  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

    http
        .authorizeHttpRequests(request -> request.anyRequest().authenticated())
        .sessionManagement(AbstractHttpConfigurer::disable);

    return http.build();
  }

```
But when I configure `sessionManagement` disabled, `RequestCache` of `ExceptionTranslationFilter` is `HttpSessionRequestCache`. Please see image and output from Spring Security debug mode.

![image](https://github.com/spring-projects/spring-security/assets/59705184/c784c7db-fee0-4fc9-bad3-c542f2029b3c)


![image](https://github.com/spring-projects/spring-security/assets/59705184/9d7d2a43-6f50-4d11-b990-5cbec5c118c5)

I think that `RequestCache` should be `NullRequestCache`.