### PR TITLE
Update links in adocs

### DIFF
--- a/docs/modules/ROOT/pages/features/exploits/http.adoc
+++ b/docs/modules/ROOT/pages/features/exploits/http.adoc
@@ -25,7 +25,7 @@ Without proper configuration, the application server can not know that the load 
 
 To fix this, you can use https://tools.ietf.org/html/rfc7239[RFC 7239] to specify that a load balancer is being used.
 To make the application aware of this, you need to configure your application server to be aware of the X-Forwarded headers.
-For example, Tomcat uses https://tomcat.apache.org/tomcat-8.0-doc/api/org/apache/catalina/valves/RemoteIpValve.html[`RemoteIpValve`] and Jetty uses https://download.eclipse.org/jetty/stable-9/apidocs/org/eclipse/jetty/server/ForwardedRequestCustomizer.html[`ForwardedRequestCustomizer`].
+For example, Tomcat uses https://tomcat.apache.org/tomcat-10.1-doc/api/org/apache/catalina/valves/RemoteIpValve.html[`RemoteIpValve`] and Jetty uses https://eclipse.dev/jetty/javadoc/jetty-11/org/eclipse/jetty/server/ForwardedRequestCustomizer.html[`ForwardedRequestCustomizer`].
 Alternatively, Spring users can use https://github.com/spring-projects/spring-framework/blob/v4.3.3.RELEASE/spring-web/src/main/java/org/springframework/web/filter/ForwardedHeaderFilter.java[`ForwardedHeaderFilter`].
 
 Spring Boot users can use the `server.use-forward-headers` property to configure the application.

--- a/docs/modules/ROOT/pages/servlet/appendix/proxy-server.adoc
+++ b/docs/modules/ROOT/pages/servlet/appendix/proxy-server.adoc
@@ -7,7 +7,7 @@ Without proper configuration, the application server will not know that the load
 
 To fix this you can use https://tools.ietf.org/html/rfc7239[RFC 7239] to specify that a load balancer is being used.
 To make the application aware of this, you need to either configure your application server aware of the X-Forwarded headers.
-For example Tomcat uses the https://tomcat.apache.org/tomcat-8.0-doc/api/org/apache/catalina/valves/RemoteIpValve.html[RemoteIpValve] and Jetty uses https://www.eclipse.org/jetty/javadoc/jetty-9/org/eclipse/jetty/server/ForwardedRequestCustomizer.html[ForwardedRequestCustomizer].
+For example Tomcat uses the https://tomcat.apache.org/tomcat-10.1-doc/api/org/apache/catalina/valves/RemoteIpValve.html[RemoteIpValve] and Jetty uses https://eclipse.dev/jetty/javadoc/jetty-11/org/eclipse/jetty/server/ForwardedRequestCustomizer.html[ForwardedRequestCustomizer].
 Alternatively, Spring 4.3+ users can leverage https://github.com/spring-projects/spring-framework/blob/v4.3.3.RELEASE/spring-web/src/main/java/org/springframework/web/filter/ForwardedHeaderFilter.java[ForwardedHeaderFilter].
 
 Spring Boot users may use the `server.use-forward-headers` property to configure the application.

--- a/docs/modules/ROOT/pages/servlet/authentication/x509.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/x509.adoc
@@ -13,7 +13,7 @@ It maps the certificate to an application user and loads that user's set of gran
 
 You can also use SSL with "`mutual authentication`". The server then requests a valid certificate from the client as part of the SSL handshake.
 The server authenticates the client by checking that its certificate is signed by an acceptable authority.
-For example, if you use Tomcat, you should read the https://tomcat.apache.org/tomcat-9.0-doc/ssl-howto.html[Tomcat SSL instructions].
+For example, if you use Tomcat, you should read the https://tomcat.apache.org/tomcat-10.1-doc/ssl-howto.html[Tomcat SSL instructions].
 You should get this working before trying it out with Spring Security.
 
 


### PR DESCRIPTION
Spring Security 6.0 requires Spring 6.0 as a minimum and Spring 6.0 requires a minimum of Tomcat 10/Jetty 11