### PR TITLE
Simplify Request Authorization Path Extraction

### DIFF
--- a/core/src/test/java/org/springframework/security/authentication/TestAuthentication.java
+++ b/core/src/test/java/org/springframework/security/authentication/TestAuthentication.java
@@ -35,14 +35,14 @@ public class TestAuthentication extends PasswordEncodedUser {
 			AuthorityUtils.createAuthorityList("ROLE_USER"));
 
 	public static Authentication authenticatedAdmin() {
-		return autheticated(admin());
+		return authenticated(admin());
 	}
 
 	public static Authentication authenticatedUser() {
-		return autheticated(user());
+		return authenticated(user());
 	}
 
-	public static Authentication autheticated(UserDetails user) {
+	public static Authentication authenticated(UserDetails user) {
 		return UsernamePasswordAuthenticationToken.authenticated(user, null, user.getAuthorities());
 	}
 


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
It is a great pleasure to write first PR on Spring Security.
This PR closes gh-13256

- Implement `hasVariable` and `equalTo` to simplify request authorization path extraction.
- I wonder if this is the best way.