### PR TITLE
Dependencies are resolved from appropriate repositories

### DIFF
--- a/buildSrc/src/main/groovy/io/spring/gradle/convention/RepositoryConventionPlugin.groovy
+++ b/buildSrc/src/main/groovy/io/spring/gradle/convention/RepositoryConventionPlugin.groovy
@@ -34,6 +34,14 @@ class RepositoryConventionPlugin implements Plugin<Project> {
 			if (forceMavenRepositories?.contains('local')) {
 				mavenLocal()
 			}
+			maven {
+				name = 'shibboleth'
+				url = 'https://build.shibboleth.net/nexus/content/repositories/releases/'
+				content {
+					includeGroup('org.opensaml')
+					includeGroup('net.shibboleth.utilities')
+				}
+			}
 			mavenCentral()
 			if (isSnapshot) {
 				maven {
@@ -67,11 +75,10 @@ class RepositoryConventionPlugin implements Plugin<Project> {
 						password project.artifactoryPassword
 					}
 				}
+				content {
+					excludeGroup('net.minidev')
+				}
 				url = 'https://repo.spring.io/release/'
-			}
-			maven {
-				name = 'shibboleth'
-				url = 'https://build.shibboleth.net/nexus/content/repositories/releases/'
 			}
 		}
 	}

--- a/buildSrc/src/test/java/io/spring/gradle/convention/RepositoryConventionPluginTests.java
+++ b/buildSrc/src/test/java/io/spring/gradle/convention/RepositoryConventionPluginTests.java
@@ -125,27 +125,27 @@ public class RepositoryConventionPluginTests {
 
 	private void assertSnapshotRepository(RepositoryHandler repositories) {
 		assertThat(repositories).extracting(ArtifactRepository::getName).hasSize(5);
-		assertThat(((MavenArtifactRepository) repositories.get(0)).getUrl().toString())
-				.isEqualTo("https://repo.maven.apache.org/maven2/");
 		assertThat(((MavenArtifactRepository) repositories.get(1)).getUrl().toString())
-				.isEqualTo("https://repo.spring.io/snapshot/");
+				.isEqualTo("https://repo.maven.apache.org/maven2/");
 		assertThat(((MavenArtifactRepository) repositories.get(2)).getUrl().toString())
+				.isEqualTo("https://repo.spring.io/snapshot/");
+		assertThat(((MavenArtifactRepository) repositories.get(3)).getUrl().toString())
 				.isEqualTo("https://repo.spring.io/milestone/");
 	}
 
 	private void assertMilestoneRepository(RepositoryHandler repositories) {
 		assertThat(repositories).extracting(ArtifactRepository::getName).hasSize(4);
-		assertThat(((MavenArtifactRepository) repositories.get(0)).getUrl().toString())
-				.isEqualTo("https://repo.maven.apache.org/maven2/");
 		assertThat(((MavenArtifactRepository) repositories.get(1)).getUrl().toString())
+				.isEqualTo("https://repo.maven.apache.org/maven2/");
+		assertThat(((MavenArtifactRepository) repositories.get(2)).getUrl().toString())
 				.isEqualTo("https://repo.spring.io/milestone/");
 	}
 
 	private void assertReleaseRepository(RepositoryHandler repositories) {
 		assertThat(repositories).extracting(ArtifactRepository::getName).hasSize(3);
-		assertThat(((MavenArtifactRepository) repositories.get(0)).getUrl().toString())
-				.isEqualTo("https://repo.maven.apache.org/maven2/");
 		assertThat(((MavenArtifactRepository) repositories.get(1)).getUrl().toString())
+				.isEqualTo("https://repo.maven.apache.org/maven2/");
+		assertThat(((MavenArtifactRepository) repositories.get(2)).getUrl().toString())
 				.isEqualTo("https://repo.spring.io/release/");
 	}
 

--- a/config/spring-security-config.gradle
+++ b/config/spring-security-config.gradle
@@ -4,10 +4,6 @@ apply plugin: 'io.spring.convention.spring-module'
 apply plugin: 'trang'
 apply plugin: 'kotlin'
 
-repositories {
-	maven { url "https://build.shibboleth.net/nexus/content/repositories/releases/" }
-}
-
 dependencies {
 	management platform(project(":spring-security-dependencies"))
 	// NB: Don't add other compile time dependencies to the config module as this breaks tooling

--- a/docs/spring-security-docs.gradle
+++ b/docs/spring-security-docs.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id 'org.antora' version '1.0.0'
 	id 'io.spring.antora.generate-antora-yml' version '0.0.1'
+	id 'io.spring.convention.repository'
 }
 
 apply plugin: 'io.spring.convention.docs'
@@ -60,11 +61,4 @@ def resolvedVersions(Configuration configuration) {
 	return configuration.resolvedConfiguration
 				.resolvedArtifacts
 				.collectEntries { [(it.name + '-version'): it.moduleVersion.id.version] }
-}
-
-repositories {
-	mavenCentral()
-	maven { url 'https://repo.spring.io/release' }
-	maven { url 'https://repo.spring.io/milestone' }
-	maven { url 'https://repo.spring.io/snapshot' }
 }


### PR DESCRIPTION
This change applies repository content filtering to configured repositories, reducing time spent during dependency resolution.

Previously, attempts would be made to resolve dependencies for `org.opensaml.*`, `net.shibboleth.utilities.*`, and `net.minidev.*` from the Spring releases repository, resulting in [numerous failed requests during dependency resolution](https://ge.solutions-team.gradle.com/s/26ikjapeyxxxm/performance/network-activity) and prolonged resolution times. 

This was particularly noticeable during IDE sync times. With these changes, my [IDE sync time is ~3s](https://ge.solutions-team.gradle.com/s/2qpmv4aukpqpi/performance/build#build-time-total) whereas previously it was [consistently above 40s](https://ge.solutions-team.gradle.com/s/26ikjapeyxxxm/performance/build#build-time-total).