### PR TITLE
Improve StrictHttpFirewall error messaging

### DIFF
--- a/web/src/main/java/org/springframework/security/web/firewall/StrictHttpFirewall.java
+++ b/web/src/main/java/org/springframework/security/web/firewall/StrictHttpFirewall.java
@@ -713,7 +713,7 @@ public class StrictHttpFirewall implements HttpFirewall {
 			}
 			String value = super.getHeader(name);
 			if (value != null) {
-				validateAllowedHeaderValue(value);
+				validateAllowedHeaderValue(name, value);
 			}
 			return value;
 		}
@@ -734,7 +734,7 @@ public class StrictHttpFirewall implements HttpFirewall {
 				@Override
 				public String nextElement() {
 					String value = headers.nextElement();
-					validateAllowedHeaderValue(value);
+					validateAllowedHeaderValue(name, value);
 					return value;
 				}
 
@@ -768,7 +768,7 @@ public class StrictHttpFirewall implements HttpFirewall {
 			}
 			String value = super.getParameter(name);
 			if (value != null) {
-				validateAllowedParameterValue(value);
+				validateAllowedParameterValue(name, value);
 			}
 			return value;
 		}
@@ -781,7 +781,7 @@ public class StrictHttpFirewall implements HttpFirewall {
 				String[] values = entry.getValue();
 				validateAllowedParameterName(name);
 				for (String value : values) {
-					validateAllowedParameterValue(value);
+					validateAllowedParameterValue(name, value);
 				}
 			}
 			return parameterMap;
@@ -815,7 +815,7 @@ public class StrictHttpFirewall implements HttpFirewall {
 			String[] values = super.getParameterValues(name);
 			if (values != null) {
 				for (String value : values) {
-					validateAllowedParameterValue(value);
+					validateAllowedParameterValue(name, value);
 				}
 			}
 			return values;
@@ -828,10 +828,10 @@ public class StrictHttpFirewall implements HttpFirewall {
 			}
 		}
 
-		private void validateAllowedHeaderValue(String value) {
+		private void validateAllowedHeaderValue(String name, String value) {
 			if (!StrictHttpFirewall.this.allowedHeaderValues.test(value)) {
 				throw new RequestRejectedException(
-						"The request was rejected because the header value \"" + value + "\" is not allowed.");
+						"The request was rejected because the header: \"" + name + " \" has a value \"" + value + "\" that is not allowed.");
 			}
 		}
 
@@ -842,10 +842,10 @@ public class StrictHttpFirewall implements HttpFirewall {
 			}
 		}
 
-		private void validateAllowedParameterValue(String value) {
+		private void validateAllowedParameterValue(String name, String value) {
 			if (!StrictHttpFirewall.this.allowedParameterValues.test(value)) {
 				throw new RequestRejectedException(
-						"The request was rejected because the parameter value \"" + value + "\" is not allowed.");
+						"The request was rejected because the parameter: \"" + name + " \" has a value \"" + value + "\" that is not allowed.");
 			}
 		}
 

--- a/web/src/main/java/org/springframework/security/web/firewall/StrictHttpFirewall.java
+++ b/web/src/main/java/org/springframework/security/web/firewall/StrictHttpFirewall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2021 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -830,8 +830,8 @@ public class StrictHttpFirewall implements HttpFirewall {
 
 		private void validateAllowedHeaderValue(String name, String value) {
 			if (!StrictHttpFirewall.this.allowedHeaderValues.test(value)) {
-				throw new RequestRejectedException(
-						"The request was rejected because the header: \"" + name + " \" has a value \"" + value + "\" that is not allowed.");
+				throw new RequestRejectedException("The request was rejected because the header: \"" + name
+						+ " \" has a value \"" + value + "\" that is not allowed.");
 			}
 		}
 
@@ -844,8 +844,8 @@ public class StrictHttpFirewall implements HttpFirewall {
 
 		private void validateAllowedParameterValue(String name, String value) {
 			if (!StrictHttpFirewall.this.allowedParameterValues.test(value)) {
-				throw new RequestRejectedException(
-						"The request was rejected because the parameter: \"" + name + " \" has a value \"" + value + "\" that is not allowed.");
+				throw new RequestRejectedException("The request was rejected because the parameter: \"" + name
+						+ " \" has a value \"" + value + "\" that is not allowed.");
 			}
 		}
 


### PR DESCRIPTION
Better error strings for invalid header and parameter values.

This PR was created because we have had an outstanding ticket with Cloudflare (https://support.cloudflare.com/hc/en-us/requests/2858014?page=1) for over a month where we have been trying to get to the bottom of what / who is sending an illegal header value. because StrictHttpFirewall doesn't tell us what the header name is, it's been a guessing game.

Work done: Updated exception strings to include the header / parameter name for when the value is invalid.