### PR TITLE
add java doc warning comment into ipAddressMatcher for potential DNS resolution

### DIFF
--- a/web/src/main/java/org/springframework/security/web/util/matcher/IpAddressMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/IpAddressMatcher.java
@@ -44,7 +44,7 @@ public final class IpAddressMatcher implements RequestMatcher {
 	 * Takes a specific IP address or a range specified using the IP/Netmask (e.g.
 	 * 192.168.1.0/24 or 202.24.0.0/14).
 	 * @param ipAddress the address or range of addresses from which the request must
-	 * come.
+	 * come. Note: ipAddress should not be a hostname to avoid the DNS resolution for potential security issue
 	 */
 	public IpAddressMatcher(String ipAddress) {
 		if (ipAddress.indexOf('/') > 0) {
@@ -65,6 +65,10 @@ public final class IpAddressMatcher implements RequestMatcher {
 		return matches(request.getRemoteAddr());
 	}
 
+	/**
+	 * match whether address is in the range of ipAddress
+	 * @param address which is for Ip range check. Note: address should not be a hostname to avoid the DNS resolution for potential security issue
+	 */
 	public boolean matches(String address) {
 		InetAddress remoteAddress = parseAddress(address);
 		if (!this.requiredAddress.getClass().equals(remoteAddress.getClass())) {


### PR DESCRIPTION
- In our use case,  our api gateway used `ipAddressMatcher` util to check whether a request's ip is in the ip-black list, but sometimes, the `remoteAddress` or `X-Forwarded-For` is in a bad format(maybe malicious requests) as following.  They're not Ip, but hostname. ipAddressMatcher calls the  `InetAddress#getByNam`e  which causes a DNS resolution, then the cloud vm alarms with this behavior.
  > remoteAddress:cj3gg4k0jvnb2t86jq6gi8twr36r38hzd.oast.fun:44194, X-Forwarded
  -For:"cj3gg4k0jvnb2t86jq6gi8twr36r38hzd.oast.fun, 1.2.3.4, 1.4.5.6"

- This PR just adds java doc warning comment, If your guys prefer the implementation by removing using the `InetAddress#getByName` and check ipv4/ipv6 inside, I will create another PR to rewrite it.
