### PR TITLE
fix EvaluationContext creation for DefaultMethodSecurityExpressionHandler

### DIFF
--- a/core/src/main/java/org/springframework/security/access/expression/method/DefaultMethodSecurityExpressionHandler.java
+++ b/core/src/main/java/org/springframework/security/access/expression/method/DefaultMethodSecurityExpressionHandler.java
@@ -52,6 +52,7 @@ import org.springframework.util.Assert;
  *
  * @author Luke Taylor
  * @author Evgeniy Cheban
+ * @author Ivan Shapoval
  * @since 3.0
  */
 public class DefaultMethodSecurityExpressionHandler extends AbstractSecurityExpressionHandler<MethodInvocation>
@@ -81,7 +82,7 @@ public class DefaultMethodSecurityExpressionHandler extends AbstractSecurityExpr
 
 	@Override
 	public EvaluationContext createEvaluationContext(Supplier<Authentication> authentication, MethodInvocation mi) {
-		MethodSecurityExpressionOperations root = createSecurityExpressionRoot(authentication, mi);
+		MethodSecurityExpressionOperations root = createSecurityExpressionRoot(authentication.get(), mi);
 		MethodSecurityEvaluationContext ctx = new MethodSecurityEvaluationContext(root, mi,
 				getParameterNameDiscoverer());
 		ctx.setBeanResolver(getBeanResolver());


### PR DESCRIPTION
Current implementation a bit strange and probably that it was just a mistake but now I can not override behavior  for `DefaultMethodSecurityExpressionHandler`
So we have the next method that used for creation `EvaluationContext`

```
@Override
public EvaluationContext createEvaluationContext(Supplier<Authentication> authentication, MethodInvocation mi) {
	MethodSecurityExpressionOperations root = createSecurityExpressionRoot(authentication, mi);
	MethodSecurityEvaluationContext ctx = new MethodSecurityEvaluationContext(root, mi, getParameterNameDiscoverer());
	ctx.setBeanResolver(getBeanResolver());
	return ctx;
}
```

And I want to use my custom `MethodSecurityExpressionOperations` for this `EvaluationContext` but I can not do despite what we have the next method 
```
@Override
protected MethodSecurityExpressionOperations createSecurityExpressionRoot(Authentication authentication,
		MethodInvocation invocation) {
	return createSecurityExpressionRoot(() -> authentication, invocation);
}
```
The problem is that inside `createEvaluationContext` used internal/private method. And public method that allowed to override not used at all.
```
private MethodSecurityExpressionOperations createSecurityExpressionRoot(Supplier<Authentication> authentication,
			MethodInvocation invocation) {
	MethodSecurityExpressionRoot root = new MethodSecurityExpressionRoot(authentication);
	root.setThis(invocation.getThis());
	root.setPermissionEvaluator(getPermissionEvaluator());
	root.setTrustResolver(getTrustResolver());
	root.setRoleHierarchy(getRoleHierarchy());
	root.setDefaultRolePrefix(getDefaultRolePrefix());
	return root;
}
```
P.S this is the best fix that I found without big refactoring but I really want to see this fix it in the next release. :)

