### PR TITLE
No implicit or explicit dependency on `rncToXsd` task causes caching to be disabled for some tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import io.spring.gradle.IncludeRepoTask
+import trang.RncToXsd
 
 buildscript {
 	dependencies {
@@ -174,7 +175,7 @@ if (hasProperty('buildScan')) {
 
 nohttp {
 	source.exclude "buildSrc/build/**"
-
+	source.builtBy(project(':spring-security-config').tasks.withType(RncToXsd))
 }
 
 tasks.register('cloneSamples', IncludeRepoTask) {

--- a/config/spring-security-config.gradle
+++ b/config/spring-security-config.gradle
@@ -122,6 +122,14 @@ tasks.named('rncToXsd', RncToXsd).configure {
 	xslFile = new File(rncDir, 'spring-security.xsl')
 }
 
+sourceSets {
+	main {
+		resources {
+			srcDir(tasks.named('rncToXsd'))
+		}
+	}
+}
+
 tasks.withType(KotlinCompile).configureEach {
 	kotlinOptions {
 		languageVersion = "1.7"
@@ -130,5 +138,3 @@ tasks.withType(KotlinCompile).configureEach {
 		jvmTarget = "17"
 	}
 }
-
-build.dependsOn rncToXsd

--- a/config/spring-security-config.gradle
+++ b/config/spring-security-config.gradle
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import trang.RncToXsd
 
 apply plugin: 'io.spring.convention.spring-module'
 apply plugin: 'trang'
@@ -115,8 +116,7 @@ dependencies {
 	testRuntimeOnly 'org.hsqldb:hsqldb'
 }
 
-
-rncToXsd {
+tasks.named('rncToXsd', RncToXsd).configure {
 	rncDir = file('src/main/resources/org/springframework/security/config/')
 	xsdDir = rncDir
 	xslFile = new File(rncDir, 'spring-security.xsl')


### PR DESCRIPTION
This change addresses a deprecation warning causing caching to be disabled for some tasks. The deprecation is caused by `rncToXsd` writing files to `src/main/resources` of the `spring-security-config` project. That directory is used as an input to several tasks, so there is ambiguity when computing the task graph. Gradle must therefore disable caching for these tasks.

Prior to this change, a build scan would show us that [caching for `rncToXsd` is disabled to ensure correctness](https://ge.solutions-team.gradle.com/s/n47ptcl7m4bks/timeline?cacheability=cacheable,overlapping-outputs,validation-failure&details=vmram3ft2bm3s&outcome=success,failed&sort=longest). We can also see the [corresponding deprecation warnings](https://ge.solutions-team.gradle.com/s/n47ptcl7m4bks/deprecations). To resolve this, the output of `rncToXsd` is wired to the main resources source set. This informs Gradle that it must execute `rncToXsd` before any task using the main resources as an input. 

Resolving this deprecation warning caused the [same issue for the `checkstyleNohttp` task of the root project](https://ge.solutions-team.gradle.com/s/77vxtbmempp4q/timeline?cacheability=cacheable,overlapping-outputs,validation-failure&details=z56sfccjdrmfs&outcome=success,failed&sort=longest). To address this, the `checkstyleNohttp` task is made aware of the output of the `rncToXsd` task from `spring-security-config`. This makes sure the `rncToXsd` task is executed before running the `checkstyleNohttp` task.

Now with these changes, we can see [caching is never disabled to ensure correctness](https://ge.solutions-team.gradle.com/s/qbqk2wkfjgpae/timeline?cacheability=validation-failure&outcome=success,failed&sort=longest) and the [deprecation warnings are gone](https://ge.solutions-team.gradle.com/s/qbqk2wkfjgpae/deprecations). It's worth noting these deprecation warnings prevented the upgrade to Gradle 8.0. Only 2 deprecation warnings remain preventing the upgrade. 