### PR TITLE
Allow instantiation with a custom webclient

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractWebClientReactiveOAuth2AccessTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractWebClientReactiveOAuth2AccessTokenResponseClient.java
@@ -69,7 +69,7 @@ import org.springframework.web.reactive.function.client.WebClient.RequestHeaders
 public abstract class AbstractWebClientReactiveOAuth2AccessTokenResponseClient<T extends AbstractOAuth2AuthorizationGrantRequest>
 		implements ReactiveOAuth2AccessTokenResponseClient<T> {
 
-	private WebClient webClient = WebClient.builder().build();
+	private WebClient webClient;
 
 	private Converter<T, RequestHeadersSpec<?>> requestEntityConverter = this::validatingPopulateRequest;
 
@@ -81,6 +81,11 @@ public abstract class AbstractWebClientReactiveOAuth2AccessTokenResponseClient<T
 			.oauth2AccessTokenResponse();
 
 	AbstractWebClientReactiveOAuth2AccessTokenResponseClient() {
+		this.webClient = WebClient.builder().build();
+	}
+
+	AbstractWebClientReactiveOAuth2AccessTokenResponseClient(WebClient webClient) {
+		this.webClient = webClient;
 	}
 
 	@Override

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveAuthorizationCodeTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveAuthorizationCodeTokenResponseClient.java
@@ -26,6 +26,7 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResp
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
 import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
 
 /**
  * An implementation of a {@link ReactiveOAuth2AccessTokenResponseClient} that
@@ -54,6 +55,14 @@ import org.springframework.web.reactive.function.BodyInserters;
  */
 public class WebClientReactiveAuthorizationCodeTokenResponseClient
 		extends AbstractWebClientReactiveOAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> {
+
+	public WebClientReactiveAuthorizationCodeTokenResponseClient() {
+		super();
+	}
+
+	public WebClientReactiveAuthorizationCodeTokenResponseClient(WebClient webClient) {
+		super(webClient);
+	}
 
 	@Override
 	ClientRegistration clientRegistration(OAuth2AuthorizationCodeGrantRequest grantRequest) {

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveClientCredentialsTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveClientCredentialsTokenResponseClient.java
@@ -20,6 +20,7 @@ import java.util.Set;
 
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.web.reactive.function.client.WebClient;
 
 /**
  * An implementation of a {@link ReactiveOAuth2AccessTokenResponseClient} that
@@ -43,6 +44,14 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenRespon
  */
 public class WebClientReactiveClientCredentialsTokenResponseClient
 		extends AbstractWebClientReactiveOAuth2AccessTokenResponseClient<OAuth2ClientCredentialsGrantRequest> {
+
+	public WebClientReactiveClientCredentialsTokenResponseClient() {
+		super();
+	}
+
+	public WebClientReactiveClientCredentialsTokenResponseClient(WebClient webClient) {
+		super(webClient);
+	}
 
 	@Override
 	ClientRegistration clientRegistration(OAuth2ClientCredentialsGrantRequest grantRequest) {

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveJwtBearerTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveJwtBearerTokenResponseClient.java
@@ -44,6 +44,14 @@ import org.springframework.web.reactive.function.client.WebClient;
 public final class WebClientReactiveJwtBearerTokenResponseClient
 		extends AbstractWebClientReactiveOAuth2AccessTokenResponseClient<JwtBearerGrantRequest> {
 
+	public WebClientReactiveJwtBearerTokenResponseClient() {
+		super();
+	}
+
+	public WebClientReactiveJwtBearerTokenResponseClient(WebClient webClient) {
+		super(webClient);
+	}
+
 	@Override
 	ClientRegistration clientRegistration(JwtBearerGrantRequest grantRequest) {
 		return grantRequest.getClientRegistration();

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/WebClientReactivePasswordTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/WebClientReactivePasswordTokenResponseClient.java
@@ -51,6 +51,14 @@ import org.springframework.web.reactive.function.client.WebClient;
 public final class WebClientReactivePasswordTokenResponseClient
 		extends AbstractWebClientReactiveOAuth2AccessTokenResponseClient<OAuth2PasswordGrantRequest> {
 
+	public WebClientReactivePasswordTokenResponseClient() {
+		super();
+	}
+
+	public WebClientReactivePasswordTokenResponseClient(WebClient webClient) {
+		super(webClient);
+	}
+
 	@Override
 	ClientRegistration clientRegistration(OAuth2PasswordGrantRequest grantRequest) {
 		return grantRequest.getClientRegistration();

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveRefreshTokenTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveRefreshTokenTokenResponseClient.java
@@ -43,6 +43,14 @@ import org.springframework.web.reactive.function.client.WebClient;
 public final class WebClientReactiveRefreshTokenTokenResponseClient
 		extends AbstractWebClientReactiveOAuth2AccessTokenResponseClient<OAuth2RefreshTokenGrantRequest> {
 
+	public WebClientReactiveRefreshTokenTokenResponseClient() {
+		super();
+	}
+
+	public WebClientReactiveRefreshTokenTokenResponseClient(WebClient webClient) {
+		super(webClient);
+	}
+
 	@Override
 	ClientRegistration clientRegistration(OAuth2RefreshTokenGrantRequest grantRequest) {
 		return grantRequest.getClientRegistration();

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveAuthorizationCodeTokenResponseClientTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveAuthorizationCodeTokenResponseClientTests.java
@@ -522,4 +522,25 @@ public class WebClientReactiveAuthorizationCodeTokenResponseClientTests {
 				.isThrownBy(() -> this.tokenResponseClient.getTokenResponse(authorizationCodeGrantRequest).block());
 	}
 
+	@Test
+	public void instantiateWithCustomWebClientThenCustomClientIsUsed() {
+		WebClient customClient = mock(WebClient.class);
+		WebClientReactiveAuthorizationCodeTokenResponseClient tokenResponseClientWithCustomWebClient = new WebClientReactiveAuthorizationCodeTokenResponseClient(
+				customClient);
+		given(customClient.post()).willReturn(WebClient.builder().build().post());
+		// @formatter:off
+		String accessTokenSuccessResponse = "{\n"
+				+ "   \"access_token\": \"access-token-1234\",\n"
+				+ "   \"token_type\": \"bearer\",\n"
+				+ "   \"expires_in\": \"3600\",\n"
+				+ "   \"scope\": \"openid profile\"\n"
+				+ "}\n";
+		// @formatter:on
+		this.server.enqueue(jsonResponse(accessTokenSuccessResponse));
+		this.clientRegistration.scope("openid", "profile", "email", "address");
+		OAuth2AccessTokenResponse response = tokenResponseClientWithCustomWebClient
+				.getTokenResponse(authorizationCodeGrantRequest()).block();
+		verify(customClient, atLeastOnce()).post();
+	}
+
 }

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveClientCredentialsTokenResponseClientTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveClientCredentialsTokenResponseClientTests.java
@@ -470,4 +470,24 @@ public class WebClientReactiveClientCredentialsTokenResponseClientTests {
 				.isThrownBy(() -> this.client.getTokenResponse(clientCredentialsGrantRequest).block());
 	}
 
+	@Test
+	public void instantiateWithCustomWebClientThenCustomClientIsUsed() {
+		WebClient customClient = mock(WebClient.class);
+		WebClientReactiveClientCredentialsTokenResponseClient clientWithCustomWebClient = new WebClientReactiveClientCredentialsTokenResponseClient(
+				customClient);
+		given(customClient.post()).willReturn(WebClient.builder().build().post());
+		ClientRegistration registration = this.clientRegistration.build();
+		// @formatter:off
+		enqueueJson("{\n"
+				+ "  \"access_token\":\"MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI3\",\n"
+				+ "  \"token_type\":\"bearer\",\n"
+				+ "  \"expires_in\":3600,\n"
+				+ "  \"refresh_token\":\"IwOGYzYTlmM2YxOTQ5MGE3YmNmMDFkNTVk\"\n"
+				+ "}");
+		// @formatter:on
+		OAuth2ClientCredentialsGrantRequest request = new OAuth2ClientCredentialsGrantRequest(registration);
+		OAuth2AccessTokenResponse response = clientWithCustomWebClient.getTokenResponse(request).block();
+		verify(customClient, atLeastOnce()).post();
+	}
+
 }


### PR DESCRIPTION
This is to allow the passing in of a custom WebClient when instantiating any child of the class AbstractWebClientReactiveOAuth2AccessTokenResponseClient. This removes the overhead of having to first instantiate it with a default WebClient and then the setting of the required custom one.

It also lends itself well to spring boot to reduce the amount of equivalent vanilla instances of beans floating around when not needed.
