### PR TITLE
feat: encode with salt param to reproduce scrypt key

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/password/PasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password/PasswordEncoder.java
@@ -30,6 +30,7 @@ public interface PasswordEncoder {
 	 * greater hash combined with an 8-byte or greater randomly generated salt.
 	 */
 	String encode(CharSequence rawPassword);
+	String encode(CharSequence rawPassword, byte[] salt);
 
 	/**
 	 * Verify the encoded password obtained from storage matches the submitted raw

--- a/crypto/src/main/java/org/springframework/security/crypto/scrypt/SCryptPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/scrypt/SCryptPasswordEncoder.java
@@ -151,6 +151,11 @@ public class SCryptPasswordEncoder implements PasswordEncoder {
 	}
 
 	@Override
+	public String encode(CharSequence rawPassword, byte[] salt) {
+		return digest(rawPassword, salt);
+	}
+	
+	@Override
 	public boolean matches(CharSequence rawPassword, String encodedPassword) {
 		if (encodedPassword == null || encodedPassword.length() < this.keyLength) {
 			this.logger.warn("Empty encoded password");


### PR DESCRIPTION
`SCryptPasswordEncoder` provides `encode()` method but the salt is generated internally each time call the method.
To reproduce scrypt encoded password, it should also allow to pass salt in parameter.

just made overloading method to allow it.

[gh-13780](https://github.com/spring-projects/spring-security/issues/13780)