### PR TITLE
Add a factory method for RoleHierarchyImpl

### DIFF
--- a/core/src/main/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImpl.java
+++ b/core/src/main/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImpl.java
@@ -126,6 +126,17 @@ public class RoleHierarchyImpl implements RoleHierarchy {
 	}
 
 	/**
+	 * Create a role hierarchy instance with the given definition
+	 * @param roleHierarchyStringRepresentation String definition of the role hierarchy.
+	 * @return role hierarchy instance
+	 */
+	public static RoleHierarchyImpl of(String roleHierarchyStringRepresentation) {
+		RoleHierarchyImpl hierarchy = new RoleHierarchyImpl();
+		hierarchy.setHierarchy(roleHierarchyStringRepresentation);
+		return hierarchy;
+	}
+
+	/**
 	 * Set the role hierarchy and pre-calculate for every role the set of all reachable
 	 * roles, i.e. all roles lower in the hierarchy of every given role. Pre-calculation
 	 * is done for performance reasons (reachable roles can then be calculated in O(1)

--- a/core/src/test/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImplTests.java
+++ b/core/src/test/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImplTests.java
@@ -40,7 +40,8 @@ public class RoleHierarchyImplTests {
 	public void testRoleHierarchyWithNullOrEmptyAuthorities() {
 		List<GrantedAuthority> authorities0 = null;
 		List<GrantedAuthority> authorities1 = new ArrayList<>();
-		RoleHierarchyImpl roleHierarchyImpl = RoleHierarchyImpl.of("ROLE_A > ROLE_B");
+		RoleHierarchyImpl roleHierarchyImpl = new RoleHierarchyImpl();
+		roleHierarchyImpl.setHierarchy("ROLE_A > ROLE_B");
 		assertThat(roleHierarchyImpl.getReachableGrantedAuthorities(authorities0)).isNotNull();
 		assertThat(roleHierarchyImpl.getReachableGrantedAuthorities(authorities0)).isEmpty();
 		assertThat(roleHierarchyImpl.getReachableGrantedAuthorities(authorities1)).isNotNull();
@@ -52,7 +53,8 @@ public class RoleHierarchyImplTests {
 		List<GrantedAuthority> authorities0 = AuthorityUtils.createAuthorityList("ROLE_0");
 		List<GrantedAuthority> authorities1 = AuthorityUtils.createAuthorityList("ROLE_A");
 		List<GrantedAuthority> authorities2 = AuthorityUtils.createAuthorityList("ROLE_A", "ROLE_B");
-		RoleHierarchyImpl roleHierarchyImpl = RoleHierarchyImpl.of("ROLE_A > ROLE_B");
+		RoleHierarchyImpl roleHierarchyImpl = new RoleHierarchyImpl();
+		roleHierarchyImpl.setHierarchy("ROLE_A > ROLE_B");
 		assertThat(HierarchicalRolesTestHelper.containTheSameGrantedAuthorities(
 				roleHierarchyImpl.getReachableGrantedAuthorities(authorities0), authorities0))
 			.isTrue();
@@ -70,10 +72,8 @@ public class RoleHierarchyImplTests {
 		List<GrantedAuthority> authorities2 = AuthorityUtils.createAuthorityList("ROLE_A", "ROLE_B", "ROLE_C");
 		List<GrantedAuthority> authorities3 = AuthorityUtils.createAuthorityList("ROLE_A", "ROLE_B", "ROLE_C",
 				"ROLE_D");
-		RoleHierarchyImpl roleHierarchyImpl = RoleHierarchyImpl.of("""
-				ROLE_A > ROLE_B
-				ROLE_B > ROLE_C
-				""");
+		RoleHierarchyImpl roleHierarchyImpl = new RoleHierarchyImpl();
+		roleHierarchyImpl.setHierarchy("ROLE_A > ROLE_B\nROLE_B > ROLE_C");
 		assertThat(HierarchicalRolesTestHelper.containTheSameGrantedAuthorities(
 				roleHierarchyImpl.getReachableGrantedAuthorities(authorities1), authorities2))
 			.isTrue();
@@ -94,13 +94,8 @@ public class RoleHierarchyImplTests {
 		List<GrantedAuthority> authoritiesOutput3 = AuthorityUtils.createAuthorityList("ROLE_C", "ROLE_D");
 		List<GrantedAuthority> authoritiesInput4 = AuthorityUtils.createAuthorityList("ROLE_D");
 		List<GrantedAuthority> authoritiesOutput4 = AuthorityUtils.createAuthorityList("ROLE_D");
-		RoleHierarchyImpl roleHierarchyImpl = RoleHierarchyImpl
-				.of("""
-						ROLE_A > ROLE_B
-						ROLE_A > ROLE_C
-						ROLE_C > ROLE_D
-						ROLE_B > ROLE_D
-						""");
+		RoleHierarchyImpl roleHierarchyImpl = new RoleHierarchyImpl();
+		roleHierarchyImpl.setHierarchy("ROLE_A > ROLE_B\nROLE_A > ROLE_C\nROLE_C > ROLE_D\nROLE_B > ROLE_D");
 		assertThat(HierarchicalRolesTestHelper.containTheSameGrantedAuthorities(
 				roleHierarchyImpl.getReachableGrantedAuthorities(authoritiesInput1), authoritiesOutput1))
 			.isTrue();
@@ -143,7 +138,8 @@ public class RoleHierarchyImplTests {
 		List<GrantedAuthority> authorities0 = HierarchicalRolesTestHelper.createAuthorityList("ROLE_0");
 		List<GrantedAuthority> authorities1 = HierarchicalRolesTestHelper.createAuthorityList("ROLE_A");
 		List<GrantedAuthority> authorities2 = HierarchicalRolesTestHelper.createAuthorityList("ROLE_A", "ROLE_B");
-		RoleHierarchyImpl roleHierarchyImpl = RoleHierarchyImpl.of("ROLE_A > ROLE_B");
+		RoleHierarchyImpl roleHierarchyImpl = new RoleHierarchyImpl();
+		roleHierarchyImpl.setHierarchy("ROLE_A > ROLE_B");
 		assertThat(HierarchicalRolesTestHelper.containTheSameGrantedAuthoritiesCompareByAuthorityString(
 				roleHierarchyImpl.getReachableGrantedAuthorities(authorities0), authorities0))
 			.isTrue();
@@ -161,22 +157,12 @@ public class RoleHierarchyImplTests {
 		List<GrantedAuthority> authorities2 = AuthorityUtils.createAuthorityList("ROLE A", "ROLE B", "ROLE>C");
 		List<GrantedAuthority> authorities3 = AuthorityUtils.createAuthorityList("ROLE A", "ROLE B", "ROLE>C",
 				"ROLE D");
-		RoleHierarchyImpl roleHierarchyImpl = RoleHierarchyImpl.of("""
-				ROLE A > ROLE B
-				ROLE B > ROLE>C
-				""");
+		RoleHierarchyImpl roleHierarchyImpl = new RoleHierarchyImpl();
+		roleHierarchyImpl.setHierarchy("ROLE A > ROLE B\nROLE B > ROLE>C");
 		assertThat(HierarchicalRolesTestHelper.containTheSameGrantedAuthorities(
 				roleHierarchyImpl.getReachableGrantedAuthorities(authorities1), authorities2))
 			.isTrue();
 		roleHierarchyImpl.setHierarchy("ROLE A > ROLE B\nROLE B > ROLE>C\nROLE>C > ROLE D");
-		assertThat(HierarchicalRolesTestHelper.containTheSameGrantedAuthorities(
-				roleHierarchyImpl.getReachableGrantedAuthorities(authorities1), authorities2))
-			.isTrue();
-		roleHierarchyImpl.setHierarchy("""
-				ROLE A > ROLE B
-				ROLE B > ROLE>C
-				ROLE>C > ROLE D
-				""");
 		assertThat(HierarchicalRolesTestHelper.containTheSameGrantedAuthorities(
 				roleHierarchyImpl.getReachableGrantedAuthorities(authorities1), authorities3))
 			.isTrue();
@@ -214,10 +200,46 @@ public class RoleHierarchyImplTests {
 		List<GrantedAuthority> flatAuthorities = AuthorityUtils.createAuthorityList("ROLE_HIGHEST");
 		List<GrantedAuthority> allAuthorities = AuthorityUtils.createAuthorityList("ROLE_HIGHEST", "ROLE_HIGHER",
 				"ROLE_LOW", "ROLE_LOWER");
-		RoleHierarchyImpl roleHierarchyImpl = RoleHierarchyImpl
-				.of("ROLE_HIGHEST > ROLE_HIGHER > ROLE_LOW > ROLE_LOWER");
+		RoleHierarchyImpl roleHierarchyImpl = new RoleHierarchyImpl();
+		roleHierarchyImpl.setHierarchy("ROLE_HIGHEST > ROLE_HIGHER > ROLE_LOW > ROLE_LOWER");
 		assertThat(roleHierarchyImpl.getReachableGrantedAuthorities(flatAuthorities))
 			.containsExactlyInAnyOrderElementsOf(allAuthorities);
+	}
+
+	@Test
+	public void testFromHierarchyWithTextBlock() {
+		RoleHierarchyImpl roleHierarchyImpl = RoleHierarchyImpl.fromHierarchy("""
+				ROLE_A > ROLE_B
+				ROLE_B > ROLE_C
+				ROLE_B > ROLE_D
+				""");
+		List<GrantedAuthority> flatAuthorities = AuthorityUtils.createAuthorityList("ROLE_A");
+		List<GrantedAuthority> allAuthorities = AuthorityUtils.createAuthorityList("ROLE_A", "ROLE_B", "ROLE_C",
+				"ROLE_D");
+
+		assertThat(roleHierarchyImpl).isNotNull();
+		assertThat(roleHierarchyImpl.getReachableGrantedAuthorities(flatAuthorities))
+			.containsExactlyInAnyOrderElementsOf(allAuthorities);
+	}
+
+	@Test
+	public void testFromHierarchyNoCycles() {
+		assertThatNoException().isThrownBy(() -> RoleHierarchyImpl
+			.fromHierarchy("ROLE_A > ROLE_B\nROLE_A > ROLE_C\nROLE_C > ROLE_D\nROLE_B > ROLE_D"));
+	}
+
+	@Test
+	public void testFromHierarchyCycles() {
+		assertThatExceptionOfType(CycleInRoleHierarchyException.class)
+			.isThrownBy(() -> RoleHierarchyImpl.fromHierarchy("ROLE_A > ROLE_A"));
+		assertThatExceptionOfType(CycleInRoleHierarchyException.class)
+			.isThrownBy(() -> RoleHierarchyImpl.fromHierarchy("ROLE_A > ROLE_B\nROLE_B > ROLE_A"));
+		assertThatExceptionOfType(CycleInRoleHierarchyException.class)
+			.isThrownBy(() -> RoleHierarchyImpl.fromHierarchy("ROLE_A > ROLE_B\nROLE_B > ROLE_C\nROLE_C > ROLE_A"));
+		assertThatExceptionOfType(CycleInRoleHierarchyException.class).isThrownBy(() -> RoleHierarchyImpl
+			.fromHierarchy("ROLE_A > ROLE_B\nROLE_B > ROLE_C\nROLE_C > ROLE_E\nROLE_E > ROLE_D\nROLE_D > ROLE_B"));
+		assertThatExceptionOfType(CycleInRoleHierarchyException.class)
+			.isThrownBy(() -> RoleHierarchyImpl.fromHierarchy("ROLE_C > ROLE_B\nROLE_B > ROLE_A\nROLE_A > ROLE_B"));
 	}
 
 	@Test

--- a/core/src/test/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImplTests.java
+++ b/core/src/test/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImplTests.java
@@ -40,8 +40,7 @@ public class RoleHierarchyImplTests {
 	public void testRoleHierarchyWithNullOrEmptyAuthorities() {
 		List<GrantedAuthority> authorities0 = null;
 		List<GrantedAuthority> authorities1 = new ArrayList<>();
-		RoleHierarchyImpl roleHierarchyImpl = new RoleHierarchyImpl();
-		roleHierarchyImpl.setHierarchy("ROLE_A > ROLE_B");
+		RoleHierarchyImpl roleHierarchyImpl = RoleHierarchyImpl.of("ROLE_A > ROLE_B");
 		assertThat(roleHierarchyImpl.getReachableGrantedAuthorities(authorities0)).isNotNull();
 		assertThat(roleHierarchyImpl.getReachableGrantedAuthorities(authorities0)).isEmpty();
 		assertThat(roleHierarchyImpl.getReachableGrantedAuthorities(authorities1)).isNotNull();
@@ -53,8 +52,7 @@ public class RoleHierarchyImplTests {
 		List<GrantedAuthority> authorities0 = AuthorityUtils.createAuthorityList("ROLE_0");
 		List<GrantedAuthority> authorities1 = AuthorityUtils.createAuthorityList("ROLE_A");
 		List<GrantedAuthority> authorities2 = AuthorityUtils.createAuthorityList("ROLE_A", "ROLE_B");
-		RoleHierarchyImpl roleHierarchyImpl = new RoleHierarchyImpl();
-		roleHierarchyImpl.setHierarchy("ROLE_A > ROLE_B");
+		RoleHierarchyImpl roleHierarchyImpl = RoleHierarchyImpl.of("ROLE_A > ROLE_B");
 		assertThat(HierarchicalRolesTestHelper.containTheSameGrantedAuthorities(
 				roleHierarchyImpl.getReachableGrantedAuthorities(authorities0), authorities0))
 			.isTrue();
@@ -72,8 +70,10 @@ public class RoleHierarchyImplTests {
 		List<GrantedAuthority> authorities2 = AuthorityUtils.createAuthorityList("ROLE_A", "ROLE_B", "ROLE_C");
 		List<GrantedAuthority> authorities3 = AuthorityUtils.createAuthorityList("ROLE_A", "ROLE_B", "ROLE_C",
 				"ROLE_D");
-		RoleHierarchyImpl roleHierarchyImpl = new RoleHierarchyImpl();
-		roleHierarchyImpl.setHierarchy("ROLE_A > ROLE_B\nROLE_B > ROLE_C");
+		RoleHierarchyImpl roleHierarchyImpl = RoleHierarchyImpl.of("""
+				ROLE_A > ROLE_B
+				ROLE_B > ROLE_C
+				""");
 		assertThat(HierarchicalRolesTestHelper.containTheSameGrantedAuthorities(
 				roleHierarchyImpl.getReachableGrantedAuthorities(authorities1), authorities2))
 			.isTrue();
@@ -94,8 +94,13 @@ public class RoleHierarchyImplTests {
 		List<GrantedAuthority> authoritiesOutput3 = AuthorityUtils.createAuthorityList("ROLE_C", "ROLE_D");
 		List<GrantedAuthority> authoritiesInput4 = AuthorityUtils.createAuthorityList("ROLE_D");
 		List<GrantedAuthority> authoritiesOutput4 = AuthorityUtils.createAuthorityList("ROLE_D");
-		RoleHierarchyImpl roleHierarchyImpl = new RoleHierarchyImpl();
-		roleHierarchyImpl.setHierarchy("ROLE_A > ROLE_B\nROLE_A > ROLE_C\nROLE_C > ROLE_D\nROLE_B > ROLE_D");
+		RoleHierarchyImpl roleHierarchyImpl = RoleHierarchyImpl
+				.of("""
+						ROLE_A > ROLE_B
+						ROLE_A > ROLE_C
+						ROLE_C > ROLE_D
+						ROLE_B > ROLE_D
+						""");
 		assertThat(HierarchicalRolesTestHelper.containTheSameGrantedAuthorities(
 				roleHierarchyImpl.getReachableGrantedAuthorities(authoritiesInput1), authoritiesOutput1))
 			.isTrue();
@@ -138,8 +143,7 @@ public class RoleHierarchyImplTests {
 		List<GrantedAuthority> authorities0 = HierarchicalRolesTestHelper.createAuthorityList("ROLE_0");
 		List<GrantedAuthority> authorities1 = HierarchicalRolesTestHelper.createAuthorityList("ROLE_A");
 		List<GrantedAuthority> authorities2 = HierarchicalRolesTestHelper.createAuthorityList("ROLE_A", "ROLE_B");
-		RoleHierarchyImpl roleHierarchyImpl = new RoleHierarchyImpl();
-		roleHierarchyImpl.setHierarchy("ROLE_A > ROLE_B");
+		RoleHierarchyImpl roleHierarchyImpl = RoleHierarchyImpl.of("ROLE_A > ROLE_B");
 		assertThat(HierarchicalRolesTestHelper.containTheSameGrantedAuthoritiesCompareByAuthorityString(
 				roleHierarchyImpl.getReachableGrantedAuthorities(authorities0), authorities0))
 			.isTrue();
@@ -157,12 +161,22 @@ public class RoleHierarchyImplTests {
 		List<GrantedAuthority> authorities2 = AuthorityUtils.createAuthorityList("ROLE A", "ROLE B", "ROLE>C");
 		List<GrantedAuthority> authorities3 = AuthorityUtils.createAuthorityList("ROLE A", "ROLE B", "ROLE>C",
 				"ROLE D");
-		RoleHierarchyImpl roleHierarchyImpl = new RoleHierarchyImpl();
-		roleHierarchyImpl.setHierarchy("ROLE A > ROLE B\nROLE B > ROLE>C");
+		RoleHierarchyImpl roleHierarchyImpl = RoleHierarchyImpl.of("""
+				ROLE A > ROLE B
+				ROLE B > ROLE>C
+				""");
 		assertThat(HierarchicalRolesTestHelper.containTheSameGrantedAuthorities(
 				roleHierarchyImpl.getReachableGrantedAuthorities(authorities1), authorities2))
 			.isTrue();
 		roleHierarchyImpl.setHierarchy("ROLE A > ROLE B\nROLE B > ROLE>C\nROLE>C > ROLE D");
+		assertThat(HierarchicalRolesTestHelper.containTheSameGrantedAuthorities(
+				roleHierarchyImpl.getReachableGrantedAuthorities(authorities1), authorities2))
+			.isTrue();
+		roleHierarchyImpl.setHierarchy("""
+				ROLE A > ROLE B
+				ROLE B > ROLE>C
+				ROLE>C > ROLE D
+				""");
 		assertThat(HierarchicalRolesTestHelper.containTheSameGrantedAuthorities(
 				roleHierarchyImpl.getReachableGrantedAuthorities(authorities1), authorities3))
 			.isTrue();
@@ -200,8 +214,8 @@ public class RoleHierarchyImplTests {
 		List<GrantedAuthority> flatAuthorities = AuthorityUtils.createAuthorityList("ROLE_HIGHEST");
 		List<GrantedAuthority> allAuthorities = AuthorityUtils.createAuthorityList("ROLE_HIGHEST", "ROLE_HIGHER",
 				"ROLE_LOW", "ROLE_LOWER");
-		RoleHierarchyImpl roleHierarchyImpl = new RoleHierarchyImpl();
-		roleHierarchyImpl.setHierarchy("ROLE_HIGHEST > ROLE_HIGHER > ROLE_LOW > ROLE_LOWER");
+		RoleHierarchyImpl roleHierarchyImpl = RoleHierarchyImpl
+				.of("ROLE_HIGHEST > ROLE_HIGHER > ROLE_LOW > ROLE_LOWER");
 		assertThat(roleHierarchyImpl.getReachableGrantedAuthorities(flatAuthorities))
 			.containsExactlyInAnyOrderElementsOf(allAuthorities);
 	}

--- a/docs/modules/ROOT/pages/servlet/authorization/architecture.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/architecture.adoc
@@ -273,14 +273,14 @@ Xml::
 [source,java,role="secondary"]
 ----
 <bean id="roleHierarchy"
-		class="org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl">
-	<property name="hierarchy">
+		class="org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl" factory-method="fromHierarchy">
+	<constructor-arg>
 		<value>
 			ROLE_ADMIN > ROLE_STAFF
 			ROLE_STAFF > ROLE_USER
 			ROLE_USER > ROLE_GUEST
 		</value>
-	</property>
+	</constructor-arg>
 </bean>
 
 <!-- and, if using method security also add -->

--- a/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
@@ -233,7 +233,7 @@ Java::
 ----
 @Bean
 static RoleHierarchy roleHierarchy() {
-    return new RoleHierarchyImpl("ROLE_ADMIN > permission:read");
+    return RoleHierarchyImpl.fromHierarchy("ROLE_ADMIN > permission:read");
 }
 ----
 
@@ -244,7 +244,7 @@ Kotlin::
 companion object {
     @Bean
     fun roleHierarchy(): RoleHierarchy {
-        return RoleHierarchyImpl("ROLE_ADMIN > permission:read")
+        return RoleHierarchyImpl.fromHierarchy("ROLE_ADMIN > permission:read")
     }
 }
 ----
@@ -253,7 +253,8 @@ Xml::
 +
 [source,xml,role="secondary"]
 ----
-<bean id="roleHierarchy" class="org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl">
+<bean id="roleHierarchy"
+        class="org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl" factory-method="fromHierarchy">
     <constructor-arg value="ROLE_ADMIN > permission:read"/>
 </bean>
 ----


### PR DESCRIPTION
Currenctly Hierarchical Roles requires the setter method to define the hierarchy.

```java
RoleHierarchyImpl hierarchy = new RoleHierarchyImpl();
hierarchy.setHierarchy("...");
```

This PR adds a factory method for this use case to make it easier

```java
RoleHierarchyImpl hierarchy = RoleHierarchyImpl.of("...");
```

