### PR TITLE
Resolve The matchingRequestParameterName From The Query String

### DIFF
--- a/web/src/main/java/org/springframework/security/web/savedrequest/HttpSessionRequestCache.java
+++ b/web/src/main/java/org/springframework/security/web/savedrequest/HttpSessionRequestCache.java
@@ -28,6 +28,8 @@ import org.springframework.security.web.PortResolverImpl;
 import org.springframework.security.web.util.UrlUtils;
 import org.springframework.security.web.util.matcher.AnyRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * {@code RequestCache} which stores the {@code SavedRequest} in the HttpSession.
@@ -100,11 +102,14 @@ public class HttpSessionRequestCache implements RequestCache {
 
 	@Override
 	public HttpServletRequest getMatchingRequest(HttpServletRequest request, HttpServletResponse response) {
-		if (this.matchingRequestParameterName != null
-				&& request.getParameter(this.matchingRequestParameterName) == null) {
-			this.logger.trace(
-					"matchingRequestParameterName is required for getMatchingRequest to lookup a value, but not provided");
-			return null;
+		if (this.matchingRequestParameterName != null) {
+			if (!StringUtils.hasText(request.getQueryString())
+					|| !UriComponentsBuilder.fromUriString(UrlUtils.buildRequestUrl(request)).build().getQueryParams()
+							.containsKey(this.matchingRequestParameterName)) {
+				this.logger.trace(
+						"matchingRequestParameterName is required for getMatchingRequest to lookup a value, but not provided");
+				return null;
+			}
 		}
 		SavedRequest saved = getRequest(request, response);
 		if (saved == null) {


### PR DESCRIPTION
Prior to this commit, the `ServletRequest#getParameter` method was used in order to verify if the `matchingRequestParameterName` was present in the request. That method has some side effects like interfering in the execution of the `ServletRequest#getInputStream` and `ServletRequest#getReader` method when the request is an HTTP POST (if those methods are invoked after getParameter, or vice-versa, the content won't be available). This commit makes that we only use the query string to check for the parameter, avoiding draining the request's input stream.

Closes gh-13731

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
