### PR TITLE
Duplicate xsd entries are not created in assembled artifacts

### DIFF
--- a/config/spring-security-config.gradle
+++ b/config/spring-security-config.gradle
@@ -117,11 +117,6 @@ dependencies {
 	testRuntimeOnly 'org.hsqldb:hsqldb'
 }
 
-def versionlessXsd = project.tasks.create("versionlessXsd", CreateVersionlessXsdTask) {
-	inputFiles.from(project.sourceSets.main.resources)
-	versionlessXsdFile = project.layout.buildDirectory.file("versionlessXsd/spring-security.xsd")
-}
-
 def rncToXsd = tasks.named('rncToXsd', RncToXsd)
 rncToXsd.configure {
 	rncDir = file('src/main/resources/org/springframework/security/config/')
@@ -129,14 +124,19 @@ rncToXsd.configure {
 	xslFile = new File(rncDir, 'spring-security.xsl')
 }
 
+def versionlessXsd = tasks.register("versionlessXsd", CreateVersionlessXsdTask) {
+	inputFiles.from(rncToXsd.map { task -> project.fileTree(task.xsdDir) })
+	versionlessXsdFile = project.layout.buildDirectory.file("versionlessXsd/spring-security.xsd")
+}
+
 tasks.named('processResources', ProcessResources).configure {
-    from(versionlessXsd) {
-        into 'org/springframework/security/config/'
-    }
-    from(rncToXsd) {
-        duplicatesStrategy DuplicatesStrategy.EXCLUDE
-        into 'org/springframework/security/config/'
-    }
+	from(versionlessXsd) {
+		into 'org/springframework/security/config/'
+	}
+	from(rncToXsd) {
+		duplicatesStrategy DuplicatesStrategy.EXCLUDE
+		into 'org/springframework/security/config/'
+	}
 }
 
 tasks.withType(KotlinCompile).configureEach {

--- a/config/spring-security-config.gradle
+++ b/config/spring-security-config.gradle
@@ -122,24 +122,21 @@ def versionlessXsd = project.tasks.create("versionlessXsd", CreateVersionlessXsd
 	versionlessXsdFile = project.layout.buildDirectory.file("versionlessXsd/spring-security.xsd")
 }
 
-processResources {
-	from(versionlessXsd) {
-		into 'org/springframework/security/config/'
-	}
-}
-
-tasks.named('rncToXsd', RncToXsd).configure {
+def rncToXsd = tasks.named('rncToXsd', RncToXsd)
+rncToXsd.configure {
 	rncDir = file('src/main/resources/org/springframework/security/config/')
 	xsdDir = rncDir
 	xslFile = new File(rncDir, 'spring-security.xsl')
 }
 
-sourceSets {
-	main {
-		resources {
-			srcDir(tasks.named('rncToXsd'))
-		}
-	}
+tasks.named('processResources', ProcessResources).configure {
+    from(versionlessXsd) {
+        into 'org/springframework/security/config/'
+    }
+    from(rncToXsd) {
+        duplicatesStrategy DuplicatesStrategy.EXCLUDE
+        into 'org/springframework/security/config/'
+    }
 }
 
 tasks.withType(KotlinCompile).configureEach {

--- a/config/spring-security-config.gradle
+++ b/config/spring-security-config.gradle
@@ -139,6 +139,13 @@ tasks.named('processResources', ProcessResources).configure {
 	}
 }
 
+tasks.named('sourcesJar', Jar).configure {
+	from(rncToXsd) {
+		duplicatesStrategy DuplicatesStrategy.EXCLUDE
+		into 'org/springframework/security/config/'
+	}
+}
+
 tasks.withType(KotlinCompile).configureEach {
 	kotlinOptions {
 		languageVersion = "1.7"


### PR DESCRIPTION
This change prevents the `.xsd` entries that would appear in the top level of the assembled artifacts. This occurred because the output of the `rncToXsd` task does not consider the path beneath the resources directory (i.e. `org/springframework/security/config/`).

To fix this, I configured the `processResources` task directly configured with a copy spec so the required path can be set, rather than via the source sets container. This follows a similar pattern to the recent changes in #13819 to create the versionless `.xsd`.

Once I configured the resources in this way, some deprecations resurfaced that were attempted to be addressed by the original #13668 issue. This explains the last 2 commits.

Here we can see the duplicate files are no longer created:

```shell
$ ./gradlew :spring-security-config:versionlessXsd
$ find config/build -name "spring-security-config-*-SNAPSHOT.jar" | xargs unzip -l | grep xsd
   182205  09-18-2023 12:17   org/springframework/security/config/spring-security-5.8.xsd
    60116  09-18-2023 12:17   org/springframework/security/config/spring-security-2.0.1.xsd
    64570  09-18-2023 12:17   org/springframework/security/config/spring-security-2.0.2.xsd
    76866  09-18-2023 12:17   org/springframework/security/config/spring-security-3.0.3.xsd
    66970  09-18-2023 12:17   org/springframework/security/config/spring-security-2.0.4.xsd
   177520  09-18-2023 12:17   org/springframework/security/config/spring-security.xsd
   177520  09-18-2023 12:17   org/springframework/security/config/spring-security-6.0.xsd
   134962  09-18-2023 12:17   org/springframework/security/config/spring-security-4.2.xsd
   177520  09-18-2023 12:17   org/springframework/security/config/spring-security-6.1.xsd
   133053  09-18-2023 12:17   org/springframework/security/config/spring-security-4.1.xsd
   126183  09-18-2023 12:17   org/springframework/security/config/spring-security-4.0.xsd
   177520  09-18-2023 12:17   org/springframework/security/config/spring-security-6.2.xsd
    56498  09-18-2023 12:17   org/springframework/security/config/spring-security-2.0.xsd
   129773  09-18-2023 12:17   org/springframework/security/config/spring-security-5.1.xsd
   128952  09-18-2023 12:17   org/springframework/security/config/spring-security-5.0.xsd
   129937  09-18-2023 12:17   org/springframework/security/config/spring-security-5.2.xsd
   148533  09-18-2023 12:17   org/springframework/security/config/spring-security-5.3.xsd
   175341  09-18-2023 12:17   org/springframework/security/config/spring-security-5.7.xsd
   111756  09-18-2023 12:17   org/springframework/security/config/spring-security-3.1.xsd
    75687  09-18-2023 12:17   org/springframework/security/config/spring-security-3.0.xsd
   154273  09-18-2023 12:17   org/springframework/security/config/spring-security-5.6.xsd
   149651  09-18-2023 12:17   org/springframework/security/config/spring-security-5.4.xsd
   120998  09-18-2023 12:17   org/springframework/security/config/spring-security-3.2.xsd
   150842  09-18-2023 12:17   org/springframework/security/config/spring-security-5.5.xsd
```