### PR TITLE
Update doc references for forwarded headers support

### DIFF
--- a/docs/modules/ROOT/pages/features/exploits/http.adoc
+++ b/docs/modules/ROOT/pages/features/exploits/http.adoc
@@ -26,7 +26,7 @@ Without proper configuration, the application server can not know that the load 
 To fix this, you can use https://tools.ietf.org/html/rfc7239[RFC 7239] to specify that a load balancer is being used.
 To make the application aware of this, you need to configure your application server to be aware of the X-Forwarded headers.
 For example, Tomcat uses https://tomcat.apache.org/tomcat-10.1-doc/api/org/apache/catalina/valves/RemoteIpValve.html[`RemoteIpValve`] and Jetty uses https://eclipse.dev/jetty/javadoc/jetty-11/org/eclipse/jetty/server/ForwardedRequestCustomizer.html[`ForwardedRequestCustomizer`].
-Alternatively, Spring users can use https://github.com/spring-projects/spring-framework/blob/v4.3.3.RELEASE/spring-web/src/main/java/org/springframework/web/filter/ForwardedHeaderFilter.java[`ForwardedHeaderFilter`].
+Alternatively, Spring users can use https://docs.spring.io/spring-framework/reference/web/webmvc/filters.html#filters-forwarded-headers[`ForwardedHeaderFilter`] with the Servlet stack or https://docs.spring.io/spring-framework/reference/web/webflux/reactive-spring.html#webflux-forwarded-headers[`ForwardedHeaderTransformer`] with the Reactive stack.
 
-Spring Boot users can use the `server.use-forward-headers` property to configure the application.
-See the https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-use-tomcat-behind-a-proxy-server[Spring Boot documentation] for further details.
+Spring Boot users can use the `server.forward-headers-strategy` property to configure the application.
+See the https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto.webserver.use-behind-a-proxy-server[Spring Boot documentation] for further details.


### PR DESCRIPTION
This updates references to the deprecated `server.use-forward-headers` property to the recommended `server.forward-headers-strategy` property. This also mentions the Reactive `ForwardedHeaderTransformer` alongside the `ForwardedHeaderFilter` and updates their links to point to the respective reference docs.