### PR TITLE
Expaned visibility in DefaultServerOAuth2AuthorizationRequestResolver…

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
@@ -220,7 +220,7 @@ public final class ClientRegistration implements Serializable {
 
 		private Map<String, Object> configurationMetadata = Collections.emptyMap();
 
-		ProviderDetails() {
+		public ProviderDetails() {
 		}
 
 		/**

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/server/DefaultServerOAuth2AuthorizationRequestResolver.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/server/DefaultServerOAuth2AuthorizationRequestResolver.java
@@ -223,7 +223,7 @@ public class DefaultServerOAuth2AuthorizationRequestResolver implements ServerOA
 	 * {@code org.springframework.security.config.oauth2.client.CommonOAuth2Provider#DEFAULT_REDIRECT_URL}
 	 * @return expanded URI
 	 */
-	private static String expandRedirectUri(ServerHttpRequest request, ClientRegistration clientRegistration) {
+	protected String expandRedirectUri(ServerHttpRequest request, ClientRegistration clientRegistration) {
 		Map<String, String> uriVariables = new HashMap<>();
 		uriVariables.put("registrationId", clientRegistration.getRegistrationId());
 		// @formatter:off


### PR DESCRIPTION
Why should you do this:

I have the case where the consumer (i.e. the frontend asking for a OAuth2 redirect) needs to change the redirect uri on the fly. For that purpose we added a whitelist of permutations which the frontend can send in the request header to manually specify which "sub-site" it wants to redirect to. To avoid code duplication it would be better if one could just extend the "expandRedirectUri" Method and provide their custom implementation

@rwinch I think a lot of your classes are very useful and our project does a lot of customization on top of the standard OAuth2 mechanism. I would be willing do flesh out the OAuth2/OIDC Spring Documentation in exchange for visibility/scope changes