### PR TITLE
Use same case for all fields in toString

### DIFF
--- a/core/src/main/java/org/springframework/security/core/userdetails/User.java
+++ b/core/src/main/java/org/springframework/security/core/userdetails/User.java
@@ -201,7 +201,7 @@ public class User implements UserDetails, CredentialsContainer {
 		sb.append("Password=[PROTECTED], ");
 		sb.append("Enabled=").append(this.enabled).append(", ");
 		sb.append("AccountNonExpired=").append(this.accountNonExpired).append(", ");
-		sb.append("credentialsNonExpired=").append(this.credentialsNonExpired).append(", ");
+		sb.append("CredentialsNonExpired=").append(this.credentialsNonExpired).append(", ");
 		sb.append("AccountNonLocked=").append(this.accountNonLocked).append(", ");
 		sb.append("Granted Authorities=").append(this.authorities).append("]");
 		return sb.toString();


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
One field in `toString` implementation has a lower case but all others have an upper case - fix this misbehavior.