### PR TITLE
Update http.adoc: IP number does not follow IP number format

### DIFF
--- a/docs/modules/ROOT/pages/features/exploits/http.adoc
+++ b/docs/modules/ROOT/pages/features/exploits/http.adoc
@@ -20,8 +20,8 @@ Spring Security provides support for xref:features/exploits/headers.adoc#headers
 == Proxy Server Configuration
 
 When using a proxy server, it is important to ensure that you have configured your application properly.
-For example, many applications have a load balancer that responds to request for https://example.com/ by forwarding the request to an application server at https://192.168.1:8080
-Without proper configuration, the application server can not know that the load balancer exists and treats the request as though https://192.168.1:8080 was requested by the client.
+For example, many applications have a load balancer that responds to request for https://example.com/ by forwarding the request to an application server at https://192.168.0.107
+Without proper configuration, the application server can not know that the load balancer exists and treats the request as though https://192.168.0.107:8080 was requested by the client.
 
 To fix this, you can use https://tools.ietf.org/html/rfc7239[RFC 7239] to specify that a load balancer is being used.
 To make the application aware of this, you need to configure your application server to be aware of the X-Forwarded headers.


### PR DESCRIPTION
ip number does follow the ip number format, let it be 192.168.0.107

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
