### PR TITLE
Update to io.freefair.aspectj 8.4

### DIFF
--- a/aspects/spring-security-aspects.gradle
+++ b/aspects/spring-security-aspects.gradle
@@ -29,10 +29,4 @@ dependencies {
 	testAspect sourceSets.main.output
 }
 
-sourceSets.main.aspectj.srcDir "src/main/java"
-sourceSets.main.java.srcDirs = files()
-
-sourceSets.test.aspectj.srcDir "src/test/java"
-sourceSets.test.java.srcDirs = files()
-
 compileAspectj.ajcOptions.outxmlfile = "META-INF/aop.xml"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,7 @@ org-apache-maven-resolver-maven-resolver-connector-basic = { module = "org.apach
 org-apache-maven-resolver-maven-resolver-impl = { module = "org.apache.maven.resolver:maven-resolver-impl", version.ref = "org-apache-maven-resolver" }
 org-apache-maven-resolver-maven-resolver-transport-http = { module = "org.apache.maven.resolver:maven-resolver-transport-http", version.ref = "org-apache-maven-resolver" }
 org-apereo-cas-client-cas-client-core = "org.apereo.cas.client:cas-client-core:4.0.3"
-io-freefair-gradle-aspectj-plugin = "io.freefair.gradle:aspectj-plugin:6.6.3"
+io-freefair-gradle-aspectj-plugin = "io.freefair.gradle:aspectj-plugin:8.4"
 org-aspectj-aspectjrt = { module = "org.aspectj:aspectjrt", version.ref = "org-aspectj" }
 org-aspectj-aspectjweaver = { module = "org.aspectj:aspectjweaver", version.ref = "org-aspectj" }
 org-assertj-assertj-core = "org.assertj:assertj-core:3.24.2"


### PR DESCRIPTION
Starting with version 8.4 the custom configuration to change the source directory from `src/*/aspectj` to `src/*/java` is not necessary anymore.

see https://github.com/freefair/gradle-plugins/issues/881