### PR TITLE
Removed dash from observation name for since it's used as Micrometer metric

### DIFF
--- a/web/src/main/java/org/springframework/security/web/ObservationFilterChainDecorator.java
+++ b/web/src/main/java/org/springframework/security/web/ObservationFilterChainDecorator.java
@@ -141,7 +141,7 @@ public final class ObservationFilterChainDecorator implements FilterChainProxy.F
 
 	static final class ObservationFilter implements Filter {
 
-		private static final Map<String, String> OBSERVATION_NAMES = new HashMap<>();
+		static final Map<String, String> OBSERVATION_NAMES = new HashMap<>();
 
 		static {
 			OBSERVATION_NAMES.put("DisableEncodeUrlFilter", "session.urlencoding");

--- a/web/src/main/java/org/springframework/security/web/ObservationFilterChainDecorator.java
+++ b/web/src/main/java/org/springframework/security/web/ObservationFilterChainDecorator.java
@@ -144,8 +144,8 @@ public final class ObservationFilterChainDecorator implements FilterChainProxy.F
 		private static final Map<String, String> OBSERVATION_NAMES = new HashMap<>();
 
 		static {
-			OBSERVATION_NAMES.put("DisableEncodeUrlFilter", "session.url-encoding");
-			OBSERVATION_NAMES.put("ForceEagerSessionCreationFilter", "session.eager-create");
+			OBSERVATION_NAMES.put("DisableEncodeUrlFilter", "session.urlencoding");
+			OBSERVATION_NAMES.put("ForceEagerSessionCreationFilter", "session.eagercreate");
 			OBSERVATION_NAMES.put("ChannelProcessingFilter", "access.channel");
 			OBSERVATION_NAMES.put("WebAsyncManagerIntegrationFilter", "context.async");
 			OBSERVATION_NAMES.put("SecurityContextHolderFilter", "context.holder");

--- a/web/src/test/java/org/springframework/security/web/ObservationFilterChainDecoratorTests.java
+++ b/web/src/test/java/org/springframework/security/web/ObservationFilterChainDecoratorTests.java
@@ -150,6 +150,13 @@ public class ObservationFilterChainDecoratorTests {
 			.isEqualTo(expectedFilterNameTag);
 	}
 
+	// gh-13660
+	@Test
+	void observationNamesDoNotContainDashes() {
+		ObservationFilterChainDecorator.ObservationFilter.OBSERVATION_NAMES.values()
+			.forEach((name) -> assertThat(name).doesNotContain("-"));
+	}
+
 	static Stream<Arguments> decorateFiltersWhenCompletesThenHasSpringSecurityReachedFilterNameTag() {
 		Filter filterWithName = new BasicAuthenticationFilter();
 


### PR DESCRIPTION
This PR closes issue gh-13660

Issue with Micrometer having dash in it's label name, as for example prometheus does not allow dashes in metrics names.