### PR TITLE
Fix obsolete comment and typos

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/jaas/AbstractJaasAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/jaas/AbstractJaasAuthenticationProvider.java
@@ -165,7 +165,7 @@ public abstract class AbstractJaasAuthenticationProvider implements Authenticati
 		}
 		Set<GrantedAuthority> authorities;
 		try {
-			// Create the LoginContext object, and pass our InternallCallbackHandler
+			// Create the LoginContext object, and pass our InternalCallbackHandler
 			LoginContext loginContext = createLoginContext(new InternalCallbackHandler(auth));
 			// Attempt to login the user, the LoginContext will call our
 			// InternalCallbackHandler at this point.
@@ -284,7 +284,7 @@ public abstract class AbstractJaasAuthenticationProvider implements Authenticati
 	}
 
 	/**
-	 * Returns the AuthorityGrannter array that was passed to the
+	 * Returns the AuthorityGranter array that was passed to the
 	 * {@link #setAuthorityGranters(AuthorityGranter[])} method, or null if it none were
 	 * ever set.
 	 * @return The AuthorityGranter array, or null
@@ -318,7 +318,7 @@ public abstract class AbstractJaasAuthenticationProvider implements Authenticati
 	}
 
 	/**
-	 * Set the JAASAuthentcationCallbackHandler array to handle callback objects generated
+	 * Set the JAASAuthenticationCallbackHandler array to handle callback objects generated
 	 * by the LoginContext.login method.
 	 * @param callbackHandlers Array of JAASAuthenticationCallbackHandlers
 	 */

--- a/core/src/main/java/org/springframework/security/authentication/jaas/AuthorityGranter.java
+++ b/core/src/main/java/org/springframework/security/authentication/jaas/AuthorityGranter.java
@@ -22,7 +22,7 @@ import java.util.Set;
 /**
  * The AuthorityGranter interface is used to map a given principal to role names.
  * <p>
- * If a Windows NT login module were to be used from JAAS, an AuthrityGranter
+ * If a Windows NT login module were to be used from JAAS, an AuthorityGranter
  * implementation could be created to map a NT Group Principal to a ROLE_USER role for
  * instance.
  *
@@ -34,12 +34,12 @@ public interface AuthorityGranter {
 	 * The grant method is called for each principal returned from the LoginContext
 	 * subject. If the AuthorityGranter wishes to grant any authorities, it should return
 	 * a java.util.Set containing the role names it wishes to grant, such as ROLE_USER. If
-	 * the AuthrityGranter does not wish to grant any authorities it should return null.
+	 * the AuthorityGranter does not wish to grant any authorities it should return null.
 	 * <p>
 	 * The set may contain any object as all objects in the returned set will be passed to
 	 * the JaasGrantedAuthority constructor using toString().
 	 * @param principal One of the principals from the
-	 * LoginContext.getSubect().getPrincipals() method.
+	 * LoginContext.getSubject().getPrincipals() method.
 	 * @return the role names to grant, or null, meaning no roles should be granted to the
 	 * principal.
 	 */

--- a/core/src/main/java/org/springframework/security/authentication/jaas/JaasAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/jaas/JaasAuthenticationProvider.java
@@ -67,7 +67,7 @@ import org.springframework.util.Assert;
  * </pre>
  *
  * <p>
- * The loginContextName should coincide with a given index in the loginConfig specifed.
+ * The loginContextName should coincide with a given index in the loginConfig specified.
  * The loginConfig file used in the JUnit tests appears as the following...
  *
  * <pre>

--- a/core/src/main/java/org/springframework/security/authorization/event/AuthorizationEvent.java
+++ b/core/src/main/java/org/springframework/security/authorization/event/AuthorizationEvent.java
@@ -66,7 +66,7 @@ public class AuthorizationEvent extends ApplicationEvent {
 	}
 
 	/**
-	 * Get the response to the princpal's request
+	 * Get the response to the principal's request
 	 * @return
 	 */
 	public AuthorizationDecision getAuthorizationDecision() {

--- a/core/src/main/java/org/springframework/security/core/token/KeyBasedPersistenceTokenService.java
+++ b/core/src/main/java/org/springframework/security/core/token/KeyBasedPersistenceTokenService.java
@@ -133,7 +133,7 @@ public class KeyBasedPersistenceTokenService implements TokenService, Initializi
 	}
 
 	/**
-	 * @return a pseduo random number (hex encoded)
+	 * @return a pseudo random number (hex encoded)
 	 */
 	private String generatePseudoRandomNumber() {
 		byte[] randomBytes = new byte[this.pseudoRandomNumberBytes];

--- a/core/src/main/java/org/springframework/security/core/userdetails/ReactiveUserDetailsPasswordService.java
+++ b/core/src/main/java/org/springframework/security/core/userdetails/ReactiveUserDetailsPasswordService.java
@@ -28,7 +28,7 @@ public interface ReactiveUserDetailsPasswordService {
 
 	/**
 	 * Modify the specified user's password. This should change the user's password in the
-	 * persistent user repository (datbase, LDAP etc).
+	 * persistent user repository (database, LDAP etc).
 	 * @param user the user to modify the password for
 	 * @param newPassword the password to change to
 	 * @return the updated UserDetails with the new password

--- a/core/src/test/java/org/springframework/security/authentication/UsernamePasswordAuthenticationTokenTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/UsernamePasswordAuthenticationTokenTests.java
@@ -35,7 +35,7 @@ public class UsernamePasswordAuthenticationTokenTests {
 	public void authenticatedPropertyContractIsSatisfied() {
 		UsernamePasswordAuthenticationToken grantedToken = UsernamePasswordAuthenticationToken.authenticated("Test",
 				"Password", AuthorityUtils.NO_AUTHORITIES);
-		// check default given we passed some GrantedAuthorty[]s (well, we passed empty
+		// check default given we passed some GrantedAuthority[]s (well, we passed empty
 		// list)
 		assertThat(grantedToken.isAuthenticated()).isTrue();
 		// check explicit set to untrusted (we can safely go from trusted to untrusted,
@@ -43,7 +43,7 @@ public class UsernamePasswordAuthenticationTokenTests {
 		grantedToken.setAuthenticated(false);
 		assertThat(!grantedToken.isAuthenticated()).isTrue();
 		// Now let's create a UsernamePasswordAuthenticationToken without any
-		// GrantedAuthorty[]s (different constructor)
+		// GrantedAuthority[]s (different constructor)
 		UsernamePasswordAuthenticationToken noneGrantedToken = UsernamePasswordAuthenticationToken
 			.unauthenticated("Test", "Password");
 		assertThat(!noneGrantedToken.isAuthenticated()).isTrue();

--- a/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilter.java
@@ -221,7 +221,7 @@ public class BasicAuthenticationFilter extends OncePerRequestFilter {
 			return true;
 		}
 		// Handle unusual condition where an AnonymousAuthenticationToken is already
-		// present. This shouldn't happen very often, as BasicProcessingFitler is meant to
+		// present. This shouldn't happen very often, as BasicAuthenticationFilter is meant to
 		// be earlier in the filter chain than AnonymousAuthenticationFilter.
 		// Nevertheless, presence of both an AnonymousAuthenticationToken together with a
 		// BASIC authentication request header should indicate reauthentication using the


### PR DESCRIPTION
Found a weird reference to `BasicProcessingFilter` in the `BasicAuthenticationFilter` class. Seems to be a left-over after a renaming of the filter classes was done (commit 1286741c7c50fa7730e31852ea6fa4e03bc387ce).

While I was at it, fixed some more typos in comments in the core module.
