### PR TITLE
Remove deprecated methods from CookieServerCsrfTokenRepository

### DIFF
--- a/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
@@ -169,14 +169,6 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 		this.cookieName = cookieName;
 	}
 
-	/**
-	 * @deprecated Use {@link #setCookieCustomizer(Consumer)} instead.
-	 */
-	@Deprecated(since = "6.1")
-	public void setCookieHttpOnly(boolean cookieHttpOnly) {
-		this.cookieHttpOnly = cookieHttpOnly;
-	}
-
 	private String getRequestContext(HttpServletRequest request) {
 		String contextPath = request.getContextPath();
 		return (contextPath.length() > 0) ? contextPath : "/";
@@ -228,34 +220,6 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 	 */
 	public String getCookiePath() {
 		return this.cookiePath;
-	}
-
-	/**
-	 * @since 5.2
-	 * @deprecated Use {@link #setCookieCustomizer(Consumer)} instead.
-	 */
-	@Deprecated(since = "6.1")
-	public void setCookieDomain(String cookieDomain) {
-		this.cookieDomain = cookieDomain;
-	}
-
-	/**
-	 * @since 5.4
-	 * @deprecated Use {@link #setCookieCustomizer(Consumer)} instead.
-	 */
-	@Deprecated(since = "6.1")
-	public void setSecure(Boolean secure) {
-		this.secure = secure;
-	}
-
-	/**
-	 * @since 5.5
-	 * @deprecated Use {@link #setCookieCustomizer(Consumer)} instead.
-	 */
-	@Deprecated(since = "6.1")
-	public void setCookieMaxAge(int cookieMaxAge) {
-		Assert.isTrue(cookieMaxAge != 0, "cookieMaxAge cannot be zero");
-		this.cookieMaxAge = cookieMaxAge;
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/csrf/CookieCsrfTokenRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CookieCsrfTokenRepositoryTests.java
@@ -112,7 +112,7 @@ class CookieCsrfTokenRepositoryTests {
 	@Test
 	void saveTokenSecureFlagTrue() {
 		this.request.setSecure(false);
-		this.repository.setSecure(Boolean.TRUE);
+		this.repository.setCookieCustomizer((cookie)-> cookie.secure(Boolean.TRUE));
 		CsrfToken token = this.repository.generateToken(this.request);
 		this.repository.saveToken(token, this.request, this.response);
 		Cookie tokenCookie = this.response.getCookie(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
@@ -132,7 +132,7 @@ class CookieCsrfTokenRepositoryTests {
 	@Test
 	void saveTokenSecureFlagFalse() {
 		this.request.setSecure(true);
-		this.repository.setSecure(Boolean.FALSE);
+		this.repository.setCookieCustomizer((cookie)-> cookie.secure(Boolean.FALSE));
 		CsrfToken token = this.repository.generateToken(this.request);
 		this.repository.saveToken(token, this.request, this.response);
 		Cookie tokenCookie = this.response.getCookie(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
@@ -163,7 +163,7 @@ class CookieCsrfTokenRepositoryTests {
 
 	@Test
 	void saveTokenHttpOnlyTrue() {
-		this.repository.setCookieHttpOnly(true);
+		this.repository.setCookieCustomizer((cookie) -> cookie.httpOnly(true));
 		CsrfToken token = this.repository.generateToken(this.request);
 		this.repository.saveToken(token, this.request, this.response);
 		Cookie tokenCookie = this.response.getCookie(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
@@ -181,7 +181,7 @@ class CookieCsrfTokenRepositoryTests {
 
 	@Test
 	void saveTokenHttpOnlyFalse() {
-		this.repository.setCookieHttpOnly(false);
+		this.repository.setCookieCustomizer((cookie) -> cookie.httpOnly(false));
 		CsrfToken token = this.repository.generateToken(this.request);
 		this.repository.saveToken(token, this.request, this.response);
 		Cookie tokenCookie = this.response.getCookie(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
@@ -239,7 +239,7 @@ class CookieCsrfTokenRepositoryTests {
 	@Test
 	void saveTokenWithCookieDomain() {
 		String domainName = "example.com";
-		this.repository.setCookieDomain(domainName);
+		this.repository.setCookieCustomizer((cookie) -> cookie.domain(domainName));
 		CsrfToken token = this.repository.generateToken(this.request);
 		this.repository.saveToken(token, this.request, this.response);
 		Cookie tokenCookie = this.response.getCookie(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
@@ -259,7 +259,7 @@ class CookieCsrfTokenRepositoryTests {
 	@Test
 	void saveTokenWithCookieMaxAge() {
 		int maxAge = 1200;
-		this.repository.setCookieMaxAge(maxAge);
+		this.repository.setCookieCustomizer((cookie) -> cookie.maxAge(maxAge));
 		CsrfToken token = this.repository.generateToken(this.request);
 		this.repository.saveToken(token, this.request, this.response);
 		Cookie tokenCookie = this.response.getCookie(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
@@ -506,7 +506,7 @@ class CookieCsrfTokenRepositoryTests {
 
 	@Test
 	void setCookieMaxAgeZeroIllegalArgumentException() {
-		assertThatIllegalArgumentException().isThrownBy(() -> this.repository.setCookieMaxAge(0));
+		assertThatIllegalArgumentException().isThrownBy(() -> this.repository.setCookieCustomizer((cookie) -> cookie.maxAge(0)));
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/csrf/CookieCsrfTokenRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/csrf/CookieCsrfTokenRepositoryTests.java
@@ -112,7 +112,7 @@ class CookieCsrfTokenRepositoryTests {
 	@Test
 	void saveTokenSecureFlagTrue() {
 		this.request.setSecure(false);
-		this.repository.setCookieCustomizer((cookie)-> cookie.secure(Boolean.TRUE));
+		this.repository.setCookieCustomizer((cookie) -> cookie.secure(Boolean.TRUE));
 		CsrfToken token = this.repository.generateToken(this.request);
 		this.repository.saveToken(token, this.request, this.response);
 		Cookie tokenCookie = this.response.getCookie(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
@@ -132,7 +132,7 @@ class CookieCsrfTokenRepositoryTests {
 	@Test
 	void saveTokenSecureFlagFalse() {
 		this.request.setSecure(true);
-		this.repository.setCookieCustomizer((cookie)-> cookie.secure(Boolean.FALSE));
+		this.repository.setCookieCustomizer((cookie) -> cookie.secure(Boolean.FALSE));
 		CsrfToken token = this.repository.generateToken(this.request);
 		this.repository.saveToken(token, this.request, this.response);
 		Cookie tokenCookie = this.response.getCookie(CookieCsrfTokenRepository.DEFAULT_CSRF_COOKIE_NAME);
@@ -502,11 +502,6 @@ class CookieCsrfTokenRepositoryTests {
 	@Test
 	void setHeaderNameNullIllegalArgumentException() {
 		assertThatIllegalArgumentException().isThrownBy(() -> this.repository.setHeaderName(null));
-	}
-
-	@Test
-	void setCookieMaxAgeZeroIllegalArgumentException() {
-		assertThatIllegalArgumentException().isThrownBy(() -> this.repository.setCookieCustomizer((cookie) -> cookie.maxAge(0)));
 	}
 
 }


### PR DESCRIPTION
From : https://github.com/spring-projects/spring-security/issues/14132 

Removing the Deprecated methods used in CookieServerCsrfTokenRepository. 
