### PR TITLE
Update Javadoc Comments in AuthorizationEvent Class

### DIFF
--- a/core/src/main/java/org/springframework/security/authorization/event/AuthorizationEvent.java
+++ b/core/src/main/java/org/springframework/security/authorization/event/AuthorizationEvent.java
@@ -67,7 +67,7 @@ public class AuthorizationEvent extends ApplicationEvent {
 
 	/**
 	 * Get the response to the principal's request
-	 * @return
+	 * @return the response to the principal's request
 	 */
 	public AuthorizationDecision getAuthorizationDecision() {
 		return this.decision;


### PR DESCRIPTION
### Changes
Updated the Javadoc comment for the `getAuthorizationDecision` method in the `AuthorizationEvent` class.

### Reason
The `@return` tag in the Javadoc comment for the `getAuthorizationDecision` method was missing a description.