### PR TITLE
Fix: path in explanation to match path in example

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authorization/authorize-http-requests.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/authorize-http-requests.adoc
@@ -749,7 +749,7 @@ SecurityFilterChain web(HttpSecurity http) throws Exception {
 Each rule is considered in the order they were declared.
 <2> Dispatches `FORWARD` and `ERROR` are permitted to allow {spring-framework-reference-url}web.html#spring-web[Spring MVC] to render views and Spring Boot to render errors
 <3> We specified multiple URL patterns that any user can access.
-Specifically, any user can access a request if the URL starts with "/resources/", equals "/signup", or equals "/about".
+Specifically, any user can access a request if the URL starts with "/static/", equals "/signup", or equals "/about".
 <4> Any URL that starts with "/admin/" will be restricted to users who have the role "ROLE_ADMIN".
 You will notice that since we are invoking the `hasRole` method we do not need to specify the "ROLE_" prefix.
 <5> Any URL that starts with "/db/" requires the user to have both been granted the "db" permission as well as be a "ROLE_ADMIN".


### PR DESCRIPTION
Updated explanation of "Authorizing Requests" example to match the path of the example for point 3 listing the URLs

Description
```
any user can access a request if the URL starts with "/static/", equals "/signup", or equals "/about".
```
now matches example
```
.requestMatchers("/static/**", "/signup", "/about").permitAll()
```

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
