### PR TITLE
Fix typo in getClaimAsMap docstring

### DIFF
--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClaimAccessor.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ClaimAccessor.java
@@ -134,7 +134,7 @@ public interface ClaimAccessor {
 	 * @param claim the name of the claim
 	 * @return the claim value or {@code null} if the claim does not exist
 	 * @throws IllegalArgumentException if the claim value cannot be converted to a
-	 * {@code List}
+	 * {@code Map}
 	 * @throws NullPointerException if the claim value is {@code null}
 	 */
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
This fixes a typo in the docstring for `ClaimAccessor#getClaimAsMap` that mistakenly refers to the expected type as a List instead of a Map.