### PR TITLE
docs: make XML and Java/Kotlin consistent with AspectJExpressionPointcut

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
@@ -1265,8 +1265,8 @@ import static org.springframework.security.authorization.AuthorityAuthorizationM
 @Bean
 @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 static Advisor protectServicePointcut() {
-    JdkRegexpMethodPointcut pattern = new JdkRegexpMethodPointcut();
-    pattern.setPattern("execution(* com.mycompany.*Service.*(..))");
+    AspectJExpressionPointcut pattern = new AspectJExpressionPointcut();
+    pattern.setExpression("execution(* com.mycompany.*Service.*(..))");
     return new AuthorizationManagerBeforeMethodInterceptor(pattern, hasRole("USER"));
 }
 ----
@@ -1281,8 +1281,8 @@ companion object {
     @Bean
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     fun protectServicePointcut(): Advisor {
-        var pattern = JdkRegexpMethodPointcut();
-        pattern.setPattern("execution(* com.mycompany.*Service.*(..))");
+        var pattern = AspectJExpressionPointcut();
+        pattern.setExpression("execution(* com.mycompany.*Service.*(..))");
         return new AuthorizationManagerBeforeMethodInterceptor(pattern, hasRole("USER"));
     }
 }


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
Related to [14036](https://github.com/spring-projects/spring-security/issues/14036)

Make the XML and Java/Kotlin consistent with `AspectJExpressionPointcut`
