### PR TITLE
Updated broken documentation link in javadocs

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/builders/AuthenticationManagerBuilder.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/builders/AuthenticationManagerBuilder.java
@@ -149,7 +149,7 @@ public class AuthenticationManagerBuilder
 	 * {@link #getDefaultUserDetailsService()} method. Note that additional
 	 * {@link UserDetailsService}'s may override this {@link UserDetailsService} as the
 	 * default. See the <a href=
-	 * "https://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#user-schema"
+	 * "https://docs.spring.io/spring-security/reference/servlet/appendix/database-schema.html"
 	 * >User Schema</a> section of the reference for the default schema.
 	 * </p>
 	 * @return a {@link JdbcUserDetailsManagerConfigurer} to allow customization of the


### PR DESCRIPTION
Minor update of a link to documentation that has moved.
