### PR TITLE
Fix typo in Authorization Events' Doc Page

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authorization/events.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/events.adoc
@@ -2,7 +2,7 @@
 = Authorization Events
 
 For each authorization that is denied, an `AuthorizationDeniedEvent` is fired.
-Also, it's possible to fire and `AuthorizationGrantedEvent` for authorizations that are granted.
+Also, it's possible to fire an `AuthorizationGrantedEvent` for authorizations that are granted.
 
 To listen for these events, you must first publish an `AuthorizationEventPublisher`.
 


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
Minor correction in Authorization Events documentation page text.