### PR TITLE
Fix typo in Authorize HTTP Requests' Doc Page

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authorization/authorize-http-requests.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/authorize-http-requests.adoc
@@ -737,7 +737,7 @@ SecurityFilterChain web(HttpSecurity http) throws Exception {
             .dispatcherTypeMatchers(FORWARD, ERROR).permitAll() // <2>
 			.requestMatchers("/static/**", "/signup", "/about").permitAll()         // <3>
 			.requestMatchers("/admin/**").hasRole("ADMIN")                             // <4>
-			.requestMatchers("/db/**").access(allOf(hasAuthority('db'), hasRole('ADMIN')))   // <5>
+			.requestMatchers("/db/**").access(allOf(hasAuthority("db"), hasRole("ADMIN")))   // <5>
 			.anyRequest().denyAll()                                                // <6>
 		);
 


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

Minor typo in authorize HTTP requests Docs page. I changed double quotation for String value, It was single quotation. Copy and paste makes compile error. 

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
