### PR TITLE
Support overriding WebClient/RestOperations in (Reactive)OidcIdTokenDecoderFactory

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/authentication/ReactiveOidcIdTokenDecoderFactory.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/authentication/ReactiveOidcIdTokenDecoderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoderFactory;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
 
 /**
  * A {@link ReactiveJwtDecoderFactory factory} that provides a {@link ReactiveJwtDecoder}
@@ -88,6 +89,8 @@ public final class ReactiveOidcIdTokenDecoderFactory implements ReactiveJwtDecod
 
 	private Function<ClientRegistration, Converter<Map<String, Object>, Map<String, Object>>> claimTypeConverterFactory = (
 			clientRegistration) -> DEFAULT_CLAIM_TYPE_CONVERTER;
+
+	private Function<ClientRegistration, WebClient> webClientFactory = (clientRegistration) -> WebClient.create();
 
 	/**
 	 * Returns the default {@link Converter}'s used for type conversion of claim values
@@ -165,6 +168,7 @@ public final class ReactiveOidcIdTokenDecoderFactory implements ReactiveJwtDecod
 			}
 			return NimbusReactiveJwtDecoder.withJwkSetUri(jwkSetUri)
 				.jwsAlgorithm((SignatureAlgorithm) jwsAlgorithm)
+				.webClient(webClientFactory.apply(clientRegistration))
 				.build();
 		}
 		if (jwsAlgorithm != null && MacAlgorithm.class.isAssignableFrom(jwsAlgorithm.getClass())) {
@@ -239,6 +243,21 @@ public final class ReactiveOidcIdTokenDecoderFactory implements ReactiveJwtDecod
 			Function<ClientRegistration, Converter<Map<String, Object>, Map<String, Object>>> claimTypeConverterFactory) {
 		Assert.notNull(claimTypeConverterFactory, "claimTypeConverterFactory cannot be null");
 		this.claimTypeConverterFactory = claimTypeConverterFactory;
+	}
+
+	/**
+	 * Sets the factory that provides a {@link WebClient} used by
+	 * {@link NimbusReactiveJwtDecoder} to coordinate with the authorization servers
+	 * indicated in the <a href="https://tools.ietf.org/html/rfc7517#section-5">JWK
+	 * Set</a> uri.
+	 * @param webClientFactory the factory that provides a {@link WebClient} used by
+	 * {@link NimbusReactiveJwtDecoder}
+	 *
+	 * @since 6.3
+	 */
+	public void setWebClientFactory(Function<ClientRegistration, WebClient> webClientFactory) {
+		Assert.notNull(webClientFactory, "webClientFactory cannot be null");
+		this.webClientFactory = webClientFactory;
 	}
 
 }

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/authentication/OidcIdTokenDecoderFactoryTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/authentication/OidcIdTokenDecoderFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,8 @@ import org.springframework.security.oauth2.jose.jws.JwsAlgorithm;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -93,6 +95,12 @@ public class OidcIdTokenDecoderFactoryTests {
 	public void setClaimTypeConverterFactoryWhenNullThenThrowIllegalArgumentException() {
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> this.idTokenDecoderFactory.setClaimTypeConverterFactory(null));
+	}
+
+	@Test
+	public void setRestOperationsFactoryWhenNullThenThrowIllegalArgumentException() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> this.idTokenDecoderFactory.setRestOperationsFactory(null));
 	}
 
 	@Test
@@ -177,4 +185,15 @@ public class OidcIdTokenDecoderFactoryTests {
 		verify(customClaimTypeConverterFactory).apply(same(clientRegistration));
 	}
 
+	@Test
+	public void createDecoderWhenCustomRestOperationsFactorySetThenApplied() {
+		Function<ClientRegistration, RestOperations> customRestOperationsFactory = mock(
+				Function.class);
+		this.idTokenDecoderFactory.setRestOperationsFactory(customRestOperationsFactory);
+		ClientRegistration clientRegistration = this.registration.build();
+		given(customRestOperationsFactory.apply(same(clientRegistration)))
+				.willReturn(new RestTemplate());
+		this.idTokenDecoderFactory.createDecoder(clientRegistration);
+		verify(customRestOperationsFactory).apply(same(clientRegistration));
+	}
 }

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/authentication/ReactiveOidcIdTokenDecoderFactoryTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/authentication/ReactiveOidcIdTokenDecoderFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.security.oauth2.jose.jws.JwsAlgorithm;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -92,6 +93,12 @@ public class ReactiveOidcIdTokenDecoderFactoryTests {
 	public void setClaimTypeConverterFactoryWhenNullThenThrowIllegalArgumentException() {
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> this.idTokenDecoderFactory.setClaimTypeConverterFactory(null));
+	}
+
+	@Test
+	public void setWebClientFactoryWhenNullThenThrowIllegalArgumentException() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> this.idTokenDecoderFactory.setWebClientFactory(null));
 	}
 
 	@Test
@@ -176,4 +183,15 @@ public class ReactiveOidcIdTokenDecoderFactoryTests {
 		verify(customClaimTypeConverterFactory).apply(same(clientRegistration));
 	}
 
+	@Test
+	public void createDecoderWhenCustomWebClientFactorySetThenApplied() {
+		Function<ClientRegistration, WebClient> customWebClientFactory = mock(
+				Function.class);
+		this.idTokenDecoderFactory.setWebClientFactory(customWebClientFactory);
+		ClientRegistration clientRegistration = this.registration.build();
+		given(customWebClientFactory.apply(same(clientRegistration)))
+				.willReturn(WebClient.create());
+		this.idTokenDecoderFactory.createDecoder(clientRegistration);
+		verify(customWebClientFactory).apply(same(clientRegistration));
+	}
 }


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->

Discussed in the mentioned issue and implemented as suggested by @jzheaux.

- Adds support for overriding WebClient passed to NimbusReactiveJwtDecoder in ReactiveOidcIdTokenDecoderFactory
- Adds support for overriding RestOperations passed to NimbusJwtDecoder in OidcIdTokenDecoderFactory

Closes: gh-14178