### PR TITLE
Closes gh-14352

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/UsernamePasswordTypedAuthenticationToken.java
+++ b/core/src/main/java/org/springframework/security/authentication/UsernamePasswordTypedAuthenticationToken.java
@@ -1,0 +1,85 @@
+package org.springframework.security.authentication;
+
+import org.springframework.security.core.SpringSecurityCoreVersion;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link AbstractUserDetailsAuthentication} implementation that is designed for simple
+ * presentation of a username and password.
+ * <p>
+ *
+ * @param <D> The Details Object the Token can map to.
+ * @author Peter Eastham
+ */
+public class UsernamePasswordTypedAuthenticationToken<D> extends AbstractUserDetailsAuthentication<String, D> {
+
+	private static final long serialVersionUID = SpringSecurityCoreVersion.SERIAL_VERSION_UID;
+
+	private String credentials;
+
+	/**
+	 * Creates a token based on a supplied <tt>UserDetails</tt> instance and
+	 * <tt>String</tt> Object.
+	 *
+	 * @param principal a nonnull <tt>UserDetails</tt> for the principal.
+	 * @throws IllegalArgumentException if {@code principal.getAuthorities()} is null, or
+	 *                                  any Authorities in it are null.
+	 */
+	private UsernamePasswordTypedAuthenticationToken(UserDetails principal, String credentials, boolean authenticated) {
+		super(principal);
+		this.credentials = credentials;
+		super.setAuthenticated(authenticated);
+	}
+
+	/**
+	 * Factory method that support creation of an unauthenticated
+	 * <code>UsernamePasswordTypedAuthenticationToken</code>
+	 *
+	 * @param principal   Nonnull UserDetails object to set to the Principal
+	 * @param credentials Nullable String which represents the User's Password
+	 * @param <D>         The Type assigned to the <code>TypedAuthentication::getDetails</code>
+	 *                    method.
+	 * @return <code>UsernamePasswordTypedAuthenticationToken</code> with false
+	 * isAuthenticated() result.
+	 */
+	public static <D> UsernamePasswordTypedAuthenticationToken<D> unauthenticated(UserDetails principal,
+			String credentials) {
+		return new UsernamePasswordTypedAuthenticationToken<>(principal, credentials, false);
+	}
+
+	/**
+	 * Factory method that support creation of an unauthenticated
+	 * <code>UsernamePasswordTypedAuthenticationToken</code>
+	 *
+	 * @param principal   Nonnull UserDetails object to set to the Principal
+	 * @param credentials Nullable String which represents the User's Password
+	 * @param <D>         The Type assigned to the <code>TypedAuthentication::getDetails</code>
+	 *                    method.
+	 * @return <code>UsernamePasswordTypedAuthenticationToken</code> with true
+	 * isAuthenticated() result.
+	 */
+	public static <D> UsernamePasswordTypedAuthenticationToken<D> authenticated(UserDetails principal,
+			String credentials) {
+		return new UsernamePasswordTypedAuthenticationToken<>(principal, credentials, true);
+	}
+
+	@Override
+	public String getCredentials() {
+		return this.credentials;
+	}
+
+	@Override
+	public void eraseCredentials() {
+		super.eraseCredentials();
+		this.credentials = null;
+	}
+
+	@Override
+	public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+		Assert.isTrue(!isAuthenticated,
+				"Cannot set this token to trusted - use constructor which takes a GrantedAuthority list instead");
+		super.setAuthenticated(false);
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/core/TypedAuthentication.java
+++ b/core/src/main/java/org/springframework/security/core/TypedAuthentication.java
@@ -1,0 +1,20 @@
+package org.springframework.security.core;
+
+/**
+ * Provided as a wrapper for {@link Authentication}
+ *
+ * @author Peter Eastham
+ * @see Authentication
+ */
+public interface TypedAuthentication<C, D, P> extends Authentication {
+
+	@Override
+	C getCredentials();
+
+	@Override
+	D getDetails();
+
+	@Override
+	P getPrincipal();
+
+}

--- a/core/src/test/java/org/springframework/security/authentication/UsernamePasswordTypedAuthenticationTokenTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/UsernamePasswordTypedAuthenticationTokenTests.java
@@ -1,0 +1,75 @@
+package org.springframework.security.authentication;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.User;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Tests {@link UsernamePasswordTypedAuthenticationToken}.
+ * Replicates {@link UsernamePasswordAuthenticationTokenTests}
+ * @author Peter Eastham
+ */
+public class UsernamePasswordTypedAuthenticationTokenTests {
+
+	@Test
+	public void authenticatedPropertyContractIsSatisfied() {
+		User simpleUser = new User("Test", "Password", AuthorityUtils.NO_AUTHORITIES);
+		UsernamePasswordTypedAuthenticationToken<Object> grantedToken = UsernamePasswordTypedAuthenticationToken
+			.authenticated(simpleUser, simpleUser.getPassword());
+		// check default given we passed some GrantedAuthority[]s (well, we passed empty
+		// list)
+		assertThat(grantedToken.isAuthenticated()).isTrue();
+		// check explicit set to untrusted (we can safely go from trusted to untrusted,
+		// but not the reverse)
+		grantedToken.setAuthenticated(false);
+		assertThat(!grantedToken.isAuthenticated()).isTrue();
+		// Now let's create a UsernamePasswordAuthenticationToken without any
+		// GrantedAuthority[]s (different constructor)
+		UsernamePasswordTypedAuthenticationToken<Object> noneGrantedToken = UsernamePasswordTypedAuthenticationToken
+			.unauthenticated(simpleUser, simpleUser.getPassword());
+		assertThat(!noneGrantedToken.isAuthenticated()).isTrue();
+		// check we're allowed to still set it to untrusted
+		noneGrantedToken.setAuthenticated(false);
+		assertThat(!noneGrantedToken.isAuthenticated()).isTrue();
+		// check denied changing it to trusted
+		assertThatIllegalArgumentException().isThrownBy(() -> noneGrantedToken.setAuthenticated(true));
+	}
+
+	@Test
+	public void gettersReturnCorrectData() {
+		User simpleUser = new User("Test", "Password", AuthorityUtils.createAuthorityList("ROLE_ONE", "ROLE_TWO"));
+		UsernamePasswordTypedAuthenticationToken<Object> token = UsernamePasswordTypedAuthenticationToken
+			.authenticated(simpleUser, simpleUser.getPassword());
+		assertThat(token.getName()).isEqualTo("Test");
+		assertThat(token.getPrincipal().getUsername()).isEqualTo("Test");
+		assertThat(token.getCredentials()).isEqualTo("Password");
+		assertThat(AuthorityUtils.authorityListToSet(token.getAuthorities())).contains("ROLE_ONE");
+		assertThat(AuthorityUtils.authorityListToSet(token.getAuthorities())).contains("ROLE_TWO");
+	}
+
+	@Test
+	public void testNoArgConstructorDoesntExist() throws Exception {
+		Class<?> clazz = UsernamePasswordTypedAuthenticationToken.class;
+		assertThatExceptionOfType(NoSuchMethodException.class)
+			.isThrownBy(() -> clazz.getDeclaredConstructor((Class[]) null));
+	}
+
+	@Test
+	public void unauthenticatedFactoryMethodResultsUnauthenticatedToken() {
+		User simpleUser = new User("Test", "Password", AuthorityUtils.NO_AUTHORITIES);
+		UsernamePasswordTypedAuthenticationToken<Object> grantedToken = UsernamePasswordTypedAuthenticationToken
+			.unauthenticated(simpleUser, simpleUser.getPassword());
+		assertThat(grantedToken.isAuthenticated()).isFalse();
+	}
+
+	@Test
+	public void authenticatedFactoryMethodResultsAuthenticatedToken() {
+		User simpleUser = new User("Test", "Password", AuthorityUtils.NO_AUTHORITIES);
+		UsernamePasswordTypedAuthenticationToken<Object> grantedToken = UsernamePasswordTypedAuthenticationToken
+			.authenticated(simpleUser, simpleUser.getPassword());
+		assertThat(grantedToken.isAuthenticated()).isTrue();
+	}
+
+}


### PR DESCRIPTION
The goal of #14352 is to begin introducing a more strongly typed `Authentication` object into the Spring Security Ecosystem. This should hopefully (My fingers are crossed) help slowly reduce some overhead for developers across the board as the general flow of User -> Authentication Object can be made more clear with people being able to see they should put a `UserDetails` Object in the Principal to align with Spring Security's Testing Support, along with being able to see the flow of Types through Spring Security, where now you just see `Object` passed everywhere.

For this PR I left it at adding in the interface and replicating the simple `UsernamePasswordAuthenticationToken` with the new interface, along with creating a new `AbstractUserDetailsAuthentication<?, ?>` which mirrors the `AbstractAuthenticationToken`, but requires the Principal object to be a `UserDetails` implementation. I believe swapping the `UsernamePasswordAuthenticationToken` for the `UsernamePasswordTypedAuthenticationToken<?>` to be a breaking change, and will leave that level of integration to the hands of the larger Spring Team.

Additionally I swapped the `AbstractAuthenticationToken.eraseSecret(String)`'s instance check to be a more modern capture group, as I was already reviewing that entire class.

Last thing to note is at the time of this PR #14352 is still in "waiting-for-triage", but I had a free afternoon and felt like trying this out, figured that might also help triage effort as at least for me, seeing code makes life a lot easier.