### PR TITLE
Typo fix in configuration.adoc

### DIFF
--- a/docs/modules/ROOT/pages/migration-7/configuration.adoc
+++ b/docs/modules/ROOT/pages/migration-7/configuration.adoc
@@ -114,7 +114,7 @@ public class SecurityConfig {
 The Lambda DSL was created to accomplish to following goals:
 
 - Automatic indentation makes the configuration more readable.
-- The is no need to chain configuration options using `.and()`
+- There is no need to chain configuration options using `.and()`
 - The Spring Security DSL has a similar configuration style to other Spring DSLs such as Spring Integration and Spring Cloud Gateway.
 
 == Use `.with()` instead of `.apply()` for Custom DSLs


### PR DESCRIPTION
Typo fix in documentation

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
