### PR TITLE
Fix Spring initializr link in 'Getting Spring Security'

### DIFF
--- a/docs/modules/ROOT/pages/getting-spring-security.adoc
+++ b/docs/modules/ROOT/pages/getting-spring-security.adoc
@@ -24,7 +24,7 @@ The topics in this section describe how to consume Spring Security when using Ma
 === Spring Boot with Maven
 
 Spring Boot provides a `spring-boot-starter-security` starter that aggregates Spring Security-related dependencies.
-The simplest and preferred way to use the starter is to use https://docs.spring.io/initializr/docs/current/reference/htmlsingle/[Spring Initializr] by using an IDE integration in (https://joshlong.com/jl/blogPost/tech_tip_geting_started_with_spring_boot.html[Eclipse] or https://www.jetbrains.com/help/idea/spring-boot.html#d1489567e2[IntelliJ], https://github.com/AlexFalappa/nb-springboot/wiki/Quick-Tour[NetBeans]) or through https://start.spring.io.
+The simplest and preferred way to use the starter is to use https://docs.spring.io/initializr/docs/current/reference/html/[Spring Initializr] by using an IDE integration in (https://joshlong.com/jl/blogPost/tech_tip_geting_started_with_spring_boot.html[Eclipse] or https://www.jetbrains.com/help/idea/spring-boot.html#d1489567e2[IntelliJ], https://github.com/AlexFalappa/nb-springboot/wiki/Quick-Tour[NetBeans]) or through https://start.spring.io.
 Alternatively, you can manually add the starter, as the following example shows:
 
 
@@ -182,7 +182,7 @@ The following topics describe how to consume Spring Security when using Gradle.
 === Spring Boot with Gradle
 
 Spring Boot provides a `spring-boot-starter-security` starter that aggregates Spring Security related dependencies.
-The simplest and preferred method to use the starter is to use https://docs.spring.io/initializr/docs/current/reference/htmlsingle/[Spring Initializr] by using an IDE integration in (https://joshlong.com/jl/blogPost/tech_tip_geting_started_with_spring_boot.html[Eclipse] or https://www.jetbrains.com/help/idea/spring-boot.html#d1489567e2[IntelliJ], https://github.com/AlexFalappa/nb-springboot/wiki/Quick-Tour[NetBeans]) or through https://start.spring.io.
+The simplest and preferred method to use the starter is to use https://docs.spring.io/initializr/docs/current/reference/html/[Spring Initializr] by using an IDE integration in (https://joshlong.com/jl/blogPost/tech_tip_geting_started_with_spring_boot.html[Eclipse] or https://www.jetbrains.com/help/idea/spring-boot.html#d1489567e2[IntelliJ], https://github.com/AlexFalappa/nb-springboot/wiki/Quick-Tour[NetBeans]) or through https://start.spring.io.
 
 Alternatively, you can manually add the starter:
 


### PR DESCRIPTION
Fix link of Spring initializr. It goes to [broken link](https://docs.spring.io/initializr/docs/current/reference/htmlsingle/). I think it should be [this one](https://docs.spring.io/initializr/docs/current/reference/html/) 