### PR TITLE
Update CI workflow badge

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 image::https://badges.gitter.im/Join%20Chat.svg[Gitter,link=https://gitter.im/spring-projects/spring-security?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge]
 
-image:https://github.com/spring-projects/spring-security/workflows/CI/badge.svg?branch=main["Build Status", link="https://github.com/spring-projects/spring-security/actions?query=workflow%3ACI"]
+image:https://github.com/spring-projects/spring-security/actions/workflows/continuous-integration-workflow.yml/badge.svg?branch=main["Build Status", link="https://github.com/spring-projects/spring-security/actions/workflows/continuous-integration-workflow.yml"]
 
 image:https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A["Revved up by Gradle Enterprise", link="https://ge.spring.io/scans?search.rootProjectNames=spring-security"]
 


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->

CI badge link in README is outdated and always "failed" no matter CI status, so it l updated with current CI workflow badge

![prev CI](https://github.com/spring-projects/spring-security/workflows/CI/badge.svg?branch=main) (as-is)
```
https://github.com/spring-projects/spring-security/workflows/CI/badge.svg?branch=main
```

[![CI](https://github.com/spring-projects/spring-security/actions/workflows/continuous-integration-workflow.yml/badge.svg)](https://github.com/spring-projects/spring-security/actions/workflows/continuous-integration-workflow.yml) (to-be)
```
https://github.com/spring-projects/spring-security/actions/workflows/continuous-integration-workflow.yml/badge.svg
```