### PR TITLE
Updated the Configuration examples in docs

### DIFF
--- a/docs/modules/ROOT/pages/servlet/configuration/java.adoc
+++ b/docs/modules/ROOT/pages/servlet/configuration/java.adoc
@@ -173,7 +173,7 @@ It is configured with the following default implementation:
 @Bean
 public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 	http
-		.authorizeRequests(authorize -> authorize
+		.authorizeHttpRequests(authorize -> authorize
 			.anyRequest().authenticated()
 		)
 		.formLogin(withDefaults())
@@ -326,7 +326,7 @@ class MyCustomDsl : AbstractHttpConfigurer<MyCustomDsl, HttpSecurity>() {
 
 [NOTE]
 ====
-This is actually how methods like `HttpSecurity.authorizeRequests()` are implemented.
+This is actually how methods like `HttpSecurity.authorizeHttpRequests()` are implemented.
 ====
 
 You can then use the custom DSL:
@@ -451,7 +451,7 @@ For example, to configure the `filterSecurityPublishAuthorizationSuccess` proper
 @Bean
 public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 	http
-		.authorizeRequests(authorize -> authorize
+		.authorizeHttpRequests(authorize -> authorize
 			.anyRequest().authenticated()
 			.withObjectPostProcessor(new ObjectPostProcessor<FilterSecurityInterceptor>() {
 				public <O extends FilterSecurityInterceptor> O postProcess(

--- a/docs/modules/ROOT/pages/servlet/configuration/kotlin.adoc
+++ b/docs/modules/ROOT/pages/servlet/configuration/kotlin.adoc
@@ -24,7 +24,7 @@ import org.springframework.security.config.annotation.web.invoke
 @Bean
 open fun filterChain(http: HttpSecurity): SecurityFilterChain {
    http {
-        authorizeRequests {
+        authorizeHttpRequests {
             authorize(anyRequest, authenticated)
         }
        formLogin { }
@@ -81,7 +81,7 @@ class MultiHttpSecurityConfig {
     open fun apiFilterChain(http: HttpSecurity): SecurityFilterChain {
         http {
             securityMatcher("/api/**")                               <3>
-            authorizeRequests {
+            authorizeHttpRequests {
                 authorize(anyRequest, hasRole("ADMIN"))
             }
             httpBasic { }
@@ -92,7 +92,7 @@ class MultiHttpSecurityConfig {
     @Bean                                                            <4>
     open fun formLoginFilterChain(http: HttpSecurity): SecurityFilterChain {
         http {
-            authorizeRequests {
+            authorizeHttpRequests {
                 authorize(anyRequest, authenticated)
             }
             formLogin { }


### PR DESCRIPTION
• Updated the Java Configuration example in the docs to use `authorizeHttpRequests` instead of `authorizeRequests`
• Updated the Kotlin Configuration example in the docs to use `authorizeHttpRequests` instead of `authorizeRequests`
• Issue Number : #14384 