### PR TITLE
fix: typo in Authentication Architecture ProviderManager

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/architecture.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/architecture.adoc
@@ -200,7 +200,7 @@ If the `Authentication` contains a reference to an object in the cache (such as 
 You need to take this into account if you use a cache.
 An obvious solution is to first make a copy of the object, either in the cache implementation or in the `AuthenticationProvider` that creates the returned `Authentication` object.
 Alternatively, you can disable the `eraseCredentialsAfterAuthentication` property on `ProviderManager`.
-See the Javadoc for the {security-api-url}org/springframework/security/authentication/ProviderManager.html[Javadoc] class.
+See the Javadoc for the {security-api-url}org/springframework/security/authentication/ProviderManager.html[ProviderManager] class.
 
 [[servlet-authentication-authenticationprovider]]
 == AuthenticationProvider


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
"See the Javadoc for the [Javadoc](https://docs.spring.io/spring-security/site/docs/6.2.1/api/org/springframework/security/authentication/ProviderManager.html) class." under ProviderManager should be changed to the following:

"See the Javadoc for the [ProviderManager](https://docs.spring.io/spring-security/site/docs/6.2.1/api/org/springframework/security/authentication/ProviderManager.html) class."