### PR TITLE
Enhance JWT decoding error handling

### DIFF
--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -145,20 +145,17 @@ public final class NimbusReactiveJwtDecoder implements ReactiveJwtDecoder {
 	}
 
 	@Override
-	public Mono<Jwt> decode(String token) throws JwtException {
-		JWT jwt = parse(token);
-		if (jwt instanceof PlainJWT) {
-			throw new BadJwtException("Unsupported algorithm of " + jwt.getHeader().getAlgorithm());
-		}
-		return this.decode(jwt);
-	}
-
-	private JWT parse(String token) {
+	public Mono<Jwt> decode(String token) {
 		try {
-			return JWTParser.parse(token);
+			JWT jwt = JWTParser.parse(token);
+			if (jwt instanceof PlainJWT) {
+				return Mono.error(new BadJwtException("Unsupported algorithm of " + jwt.getHeader().getAlgorithm()));
+			}
+			return this.decode(jwt);
 		}
 		catch (Exception ex) {
-			throw new BadJwtException("An error occurred while attempting to decode the Jwt: " + ex.getMessage(), ex);
+			return Mono.error(new BadJwtException(
+					"An error occurred while attempting to decode the Jwt: " + ex.getMessage(), ex));
 		}
 	}
 


### PR DESCRIPTION
Previously, the `decode` method threw a `JwtException` directly when encountering an unsupported algorithm or any exception during parsing. This commit introduces a more robust error handling mechanism. 

Now, instead of throwing exceptions directly, it returns a `Mono.error()` with a `BadJwtException` containing detailed error information. This approach provides more flexibility and allows the caller to handle errors in a more granular way, by being able to use project reactors onError functionality.

Closes gh-14467
