### PR TITLE
Update Revved up by Develocity badge

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@ image::https://badges.gitter.im/Join%20Chat.svg[Gitter,link=https://gitter.im/sp
 
 image:https://github.com/spring-projects/spring-security/actions/workflows/continuous-integration-workflow.yml/badge.svg?branch=main["Build Status", link="https://github.com/spring-projects/spring-security/actions/workflows/continuous-integration-workflow.yml"]
 
-image:https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A["Revved up by Gradle Enterprise", link="https://ge.spring.io/scans?search.rootProjectNames=spring-security"]
+image:https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A["Revved up by Develocity", link="https://ge.spring.io/scans?search.rootProjectNames=spring-security"]
 
 = Spring Security
 


### PR DESCRIPTION
Gradle Enterprise is now called Develocity. This PR updates the badge in the README to reflect this change.

https://gradle.com/press-media/gradle-enterprise-is-now-develocity
