### PR TITLE
Add `usernameParameter` and `passwordParameter` to FormLoginDsl

### DIFF
--- a/config/src/main/kotlin/org/springframework/security/config/annotation/web/FormLoginDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/annotation/web/FormLoginDsl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,8 @@ import jakarta.servlet.http.HttpServletRequest
  * @property loginProcessingUrl the URL to validate the credentials
  * @property permitAll whether to grant access to the urls for [failureUrl] as well as
  * for the [HttpSecurityBuilder], the [loginPage] and [loginProcessingUrl] for every user
+ * @property usernameParameter the HTTP parameter to look for the username when performing authentication
+ * @property passwordParameter the HTTP parameter to look for the password when performing authentication
  */
 @SecurityMarker
 class FormLoginDsl {
@@ -48,6 +50,8 @@ class FormLoginDsl {
     var loginProcessingUrl: String? = null
     var permitAll: Boolean? = null
     var authenticationDetailsSource: AuthenticationDetailsSource<HttpServletRequest, *>? = null
+    var usernameParameter: String? = null
+    var passwordParameter: String? = null
 
     private var defaultSuccessUrlOption: Pair<String, Boolean>? = null
 
@@ -95,6 +99,8 @@ class FormLoginDsl {
             authenticationSuccessHandler?.also { login.successHandler(authenticationSuccessHandler) }
             authenticationFailureHandler?.also { login.failureHandler(authenticationFailureHandler) }
             authenticationDetailsSource?.also { login.authenticationDetailsSource(authenticationDetailsSource) }
+            usernameParameter?.also { login.usernameParameter(usernameParameter) }
+            passwordParameter?.also { login.passwordParameter(passwordParameter) }
             if (disabled) {
                 login.disable()
             }

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/FormLoginDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/FormLoginDslTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.security.config.test.SpringTestContextExtension
 import org.springframework.security.core.userdetails.User
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.formLogin
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler
@@ -365,6 +366,50 @@ class FormLoginDslTests {
             }
 
         verify(exactly = 1) { CustomAuthenticationDetailsSourceConfig.AUTHENTICATION_DETAILS_SOURCE.buildDetails(any()) }
+    }
+
+    @Configuration
+    @EnableWebSecurity
+    open class CustomUsernameParameterConfig {
+        @Bean
+        open fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+            http {
+                formLogin {
+                    usernameParameter = "custom-username"
+                }
+            }
+            return http.build()
+        }
+    }
+
+    @Test
+    fun `form login when custom username parameter then used`() {
+        this.spring.register(CustomUsernameParameterConfig::class.java, UserConfig::class.java).autowire()
+
+        this.mockMvc.perform(formLogin().userParameter("custom-username"))
+                .andExpect(authenticated())
+    }
+
+    @Configuration
+    @EnableWebSecurity
+    open class CustomPasswordParameterConfig {
+        @Bean
+        open fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+            http {
+                formLogin {
+                    passwordParameter = "custom-password"
+                }
+            }
+            return http.build()
+        }
+    }
+
+    @Test
+    fun `form login when custom password parameter then used`() {
+        this.spring.register(CustomPasswordParameterConfig::class.java, UserConfig::class.java).autowire()
+
+        this.mockMvc.perform(formLogin().passwordParam("custom-password"))
+                .andExpect(authenticated())
     }
 
     @Configuration


### PR DESCRIPTION
Closes gh-14474

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
