### PR TITLE
Typo: Update ldap.adoc

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/passwords/ldap.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/passwords/ldap.adoc
@@ -614,7 +614,7 @@ You need only supply the domain name and an LDAP URL that supplies the address o
 
 [NOTE]
 ====
-It is also possible to obtain the server's IP address byusing a DNS lookup.
+It is also possible to obtain the server's IP address by using a DNS lookup.
 This is not currently supported, but hopefully will be in a future version.
 ====
 


### PR DESCRIPTION
there is no word like 'byusing'. I fixed 'byusing' to 'by using'.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
