### PR TITLE
Typo: Update session-management.adoc

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/session-management.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/session-management.adoc
@@ -788,7 +788,7 @@ Java::
 @Bean
 public SecurityFilterChain filterChain(HttpSecurity http) {
     http
-        .sessionManagement((session) - session
+        .sessionManagement((session) -> session
             .sessionFixation((sessionFixation) -> sessionFixation
                 .newSession()
             )


### PR DESCRIPTION
lambda expression typo. I changed '(session) - session' to '(session) -> session'

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
