### PR TITLE
Fixes logout link in advanced oauth2 servlet configuration (was point…

### DIFF
--- a/docs/modules/ROOT/pages/servlet/oauth2/login/advanced.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/login/advanced.adoc
@@ -930,4 +930,4 @@ If more than one `ClientRegistration` is configured for OpenID Connect 1.0 Authe
 ====
 
 [[oauth2login-advanced-oidc-logout]]
-Then, you can proceed to configure xref:reactive/oauth2/login/logout.adoc[logout]
+Then, you can proceed to configure xref:servlet/oauth2/login/logout.adoc[logout]


### PR DESCRIPTION
This simple commit fixes the logout link for the oauth2 advanced configuration of the servlet documentation pages (https://docs.spring.io/spring-security/reference/servlet/oauth2/login/advanced.html#oauth2login-advanced-oidc-logout)
It was pointing to the the reactive documentation page.