### PR TITLE
gh-14525 Extend `org.springframework.security.web.authentication.logo…

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurer.java
@@ -270,12 +270,14 @@ public final class Saml2LogoutConfigurer<H extends HttpSecurityBuilder<H>>
 		return postProcess(logoutResponseFilter);
 	}
 
-	private LogoutFilter createRelyingPartyLogoutFilter(RelyingPartyRegistrationRepository registrations) {
+	private Saml2RelyingPartyInitiatedLogoutFilter createRelyingPartyLogoutFilter(
+			RelyingPartyRegistrationRepository registrations) {
 		LogoutHandler[] logoutHandlers = this.logoutHandlers.toArray(new LogoutHandler[0]);
 		Saml2RelyingPartyInitiatedLogoutSuccessHandler logoutRequestSuccessHandler = createSaml2LogoutRequestSuccessHandler(
 				registrations);
 		logoutRequestSuccessHandler.setLogoutRequestRepository(this.logoutRequestConfigurer.logoutRequestRepository);
-		LogoutFilter logoutFilter = new LogoutFilter(logoutRequestSuccessHandler, logoutHandlers);
+		Saml2RelyingPartyInitiatedLogoutFilter logoutFilter = new Saml2RelyingPartyInitiatedLogoutFilter(
+				logoutRequestSuccessHandler, logoutHandlers);
 		logoutFilter.setLogoutRequestMatcher(createLogoutMatcher());
 		return postProcess(logoutFilter);
 	}
@@ -519,6 +521,15 @@ public final class Saml2LogoutConfigurer<H extends HttpSecurityBuilder<H>>
 		@Override
 		public boolean matches(HttpServletRequest request) {
 			return this.test.test(request.getParameter(this.name));
+		}
+
+	}
+
+	private static class Saml2RelyingPartyInitiatedLogoutFilter extends LogoutFilter {
+
+		public Saml2RelyingPartyInitiatedLogoutFilter(LogoutSuccessHandler logoutSuccessHandler,
+				LogoutHandler... handlers) {
+			super(logoutSuccessHandler, handlers);
 		}
 
 	}


### PR DESCRIPTION
…ut.LogoutFilter` so that the relying party initiated logout filter is ordered before the existing `org.springframework.security.web.authentication.logout.LogoutFilter`
