### PR TITLE
Implement providing a custom AuthoritiesPopulator in ADLdapAuthProvider

### DIFF
--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/ad/ActiveDirectoryLdapAuthenticationProvider.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/ad/ActiveDirectoryLdapAuthenticationProvider.java
@@ -143,7 +143,6 @@ public final class ActiveDirectoryLdapAuthenticationProvider extends AbstractLda
 		this.domain = StringUtils.hasText(domain) ? domain.toLowerCase() : null;
 		this.url = url;
 		this.rootDn = StringUtils.hasText(rootDn) ? rootDn.toLowerCase() : null;
-		this.setAuthoritiesPopulator(this.authoritiesPopulator);
 	}
 
 	/**
@@ -155,7 +154,6 @@ public final class ActiveDirectoryLdapAuthenticationProvider extends AbstractLda
 		this.domain = StringUtils.hasText(domain) ? domain.toLowerCase() : null;
 		this.url = url;
 		this.rootDn = (this.domain != null) ? rootDnFromDomain(this.domain) : null;
-		this.setAuthoritiesPopulator(this.authoritiesPopulator);
 	}
 
 	@Override
@@ -179,6 +177,10 @@ public final class ActiveDirectoryLdapAuthenticationProvider extends AbstractLda
 		}
 	}
 
+	/**
+	 * Creates the user authority list from the values of the {@code memberOf} attribute
+	 * obtained from the user's Active Directory entry.
+	 */
 	@Override
 	protected Collection<? extends GrantedAuthority> loadUserAuthorities(DirContextOperations userData, String username,
 			String password) {
@@ -389,7 +391,7 @@ public final class ActiveDirectoryLdapAuthenticationProvider extends AbstractLda
 	 * @since 6.3
 	 */
 	public void setAuthoritiesPopulator(LdapAuthoritiesPopulator authoritiesPopulator) {
-		Assert.notNull(authoritiesPopulator, "An LdapAuthoritiesPopulator must be supplied");
+		Assert.notNull(authoritiesPopulator, "authoritiesPopulator must not be null");
 		this.authoritiesPopulator = authoritiesPopulator;
 	}
 

--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/ad/DefaultActiveDirectoryAuthoritiesPopulator.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/ad/DefaultActiveDirectoryAuthoritiesPopulator.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.ldap.authentication.ad;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.ldap.core.DistinguishedName;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator;
+
+/**
+ * The default strategy for obtaining user role information from the active directory.
+ * Creates the user authority list from the values of the {@code memberOf} attribute
+ * obtained from the user's Active Directory entry.
+ *
+ * @author Luke Taylor
+ * @author Roman Zabaluev
+ */
+public final class DefaultActiveDirectoryAuthoritiesPopulator implements LdapAuthoritiesPopulator {
+
+	private final Log logger = LogFactory.getLog(getClass());
+
+	@Override
+	public Collection<? extends GrantedAuthority> getGrantedAuthorities(DirContextOperations userData,
+			String username) {
+		String[] groups = userData.getStringAttributes("memberOf");
+		if (groups == null) {
+			this.logger.debug("No values for 'memberOf' attribute.");
+			return AuthorityUtils.NO_AUTHORITIES;
+		}
+		if (this.logger.isDebugEnabled()) {
+			this.logger.debug("'memberOf' attribute values: " + Arrays.asList(groups));
+		}
+
+		List<GrantedAuthority> authorities = new ArrayList<>(groups.length);
+
+		for (String group : groups) {
+			authorities.add(new SimpleGrantedAuthority(new DistinguishedName(group).removeLast().getValue()));
+		}
+
+		return authorities;
+	}
+
+}

--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/ad/DefaultActiveDirectoryAuthoritiesPopulator.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/ad/DefaultActiveDirectoryAuthoritiesPopulator.java
@@ -38,6 +38,7 @@ import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator;
  *
  * @author Luke Taylor
  * @author Roman Zabaluev
+ * @since 6.3
  */
 public final class DefaultActiveDirectoryAuthoritiesPopulator implements LdapAuthoritiesPopulator {
 


### PR DESCRIPTION
Implemented a possibility to provide a custom `AuthoritiesPopulator` in `ActiveDirectoryLdapAuthenticationProvider`

Discussed in #4490

- I have extracted the existing implementation within `loadUserAuthorities` into a separate default AD populator, the same way it's done for non-AD LDAP AuthenticationProvider. Replaced a for with streams when collecting authorities;
- Mirrored existing constructors with a new parameter, keeping the old ones for back compatibility;
- Applied a few straightforward IDE-suggested fixes, let me know if you'd like me to revert them.


Resolves #4490