### PR TITLE
Add ContinueOnError Support for Failed Authentications

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/DelegatingReactiveAuthenticationManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/DelegatingReactiveAuthenticationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,10 @@ package org.springframework.security.authentication;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -28,7 +31,7 @@ import org.springframework.util.Assert;
 /**
  * A {@link ReactiveAuthenticationManager} that delegates to other
  * {@link ReactiveAuthenticationManager} instances using the result from the first non
- * empty result.
+ * empty result. Errors from delegates will be ignored if continueOnError is true.
  *
  * @author Rob Winch
  * @since 5.1
@@ -36,6 +39,10 @@ import org.springframework.util.Assert;
 public class DelegatingReactiveAuthenticationManager implements ReactiveAuthenticationManager {
 
 	private final List<ReactiveAuthenticationManager> delegates;
+
+	private boolean continueOnError = false;
+
+	private final Log logger = LogFactory.getLog(getClass());
 
 	public DelegatingReactiveAuthenticationManager(ReactiveAuthenticationManager... entryPoints) {
 		this(Arrays.asList(entryPoints));
@@ -48,11 +55,15 @@ public class DelegatingReactiveAuthenticationManager implements ReactiveAuthenti
 
 	@Override
 	public Mono<Authentication> authenticate(Authentication authentication) {
-		// @formatter:off
-		return Flux.fromIterable(this.delegates)
-				.concatMap((m) -> m.authenticate(authentication))
-				.next();
-		// @formatter:on
+		Flux<ReactiveAuthenticationManager> result = Flux.fromIterable(this.delegates);
+		Function<ReactiveAuthenticationManager, Mono<Authentication>> logging = (m) -> m.authenticate(authentication)
+			.doOnError(this.logger::debug);
+
+		return ((this.continueOnError) ? result.concatMapDelayError(logging) : result.concatMap(logging)).next();
+	}
+
+	public void setContinueOnError(boolean continueOnError) {
+		this.continueOnError = continueOnError;
 	}
 
 }

--- a/core/src/main/java/org/springframework/security/authentication/DelegatingReactiveAuthenticationManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/DelegatingReactiveAuthenticationManager.java
@@ -30,8 +30,9 @@ import org.springframework.util.Assert;
 
 /**
  * A {@link ReactiveAuthenticationManager} that delegates to other
- * {@link ReactiveAuthenticationManager} instances using the result from the first non
- * empty result. Errors from delegates will be ignored if continueOnError is true.
+ * {@link ReactiveAuthenticationManager} instances. When {@code continueOnError} is
+ * {@code true}, will continue until the first non-empty, non-error result; otherwise,
+ * will continue only until the first non-empty result.
  *
  * @author Rob Winch
  * @since 5.1
@@ -62,6 +63,11 @@ public class DelegatingReactiveAuthenticationManager implements ReactiveAuthenti
 		return ((this.continueOnError) ? result.concatMapDelayError(logging) : result.concatMap(logging)).next();
 	}
 
+	/**
+	 * Continue iterating when a delegate errors, defaults to {@code false}
+	 * @param continueOnError whether to continue when a delegate errors
+	 * @since 6.3
+	 */
 	public void setContinueOnError(boolean continueOnError) {
 		this.continueOnError = continueOnError;
 	}

--- a/core/src/test/java/org/springframework/security/authentication/DelegatingReactiveAuthenticationManagerTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/DelegatingReactiveAuthenticationManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +75,45 @@ public class DelegatingReactiveAuthenticationManagerTests {
 		StepVerifier.create(manager.authenticate(this.authentication))
 			.expectError(BadCredentialsException.class)
 			.verify();
+	}
+
+	@Test
+	public void authenticateWhenContinueOnErrorAndFirstBadCredentialsThenTriesSecond() {
+		given(this.delegate1.authenticate(any())).willReturn(Mono.error(new BadCredentialsException("Test")));
+		given(this.delegate2.authenticate(any())).willReturn(Mono.just(this.authentication));
+
+		DelegatingReactiveAuthenticationManager manager = managerWithContinueOnError();
+
+		assertThat(manager.authenticate(this.authentication).block()).isEqualTo(this.authentication);
+	}
+
+	@Test
+	public void authenticateWhenContinueOnErrorAndBothDelegatesBadCredentialsThenError() {
+		given(this.delegate1.authenticate(any())).willReturn(Mono.error(new BadCredentialsException("Test")));
+		given(this.delegate2.authenticate(any())).willReturn(Mono.error(new BadCredentialsException("Test")));
+
+		DelegatingReactiveAuthenticationManager manager = managerWithContinueOnError();
+
+		StepVerifier.create(manager.authenticate(this.authentication))
+			.expectError(BadCredentialsException.class)
+			.verify();
+	}
+
+	@Test
+	public void authenticateWhenContinueOnErrorAndDelegate1NotEmptyThenReturnsNotEmpty() {
+		given(this.delegate1.authenticate(any())).willReturn(Mono.just(this.authentication));
+
+		DelegatingReactiveAuthenticationManager manager = managerWithContinueOnError();
+
+		assertThat(manager.authenticate(this.authentication).block()).isEqualTo(this.authentication);
+	}
+
+	private DelegatingReactiveAuthenticationManager managerWithContinueOnError() {
+		DelegatingReactiveAuthenticationManager manager = new DelegatingReactiveAuthenticationManager(this.delegate1,
+				this.delegate2);
+		manager.setContinueOnError(true);
+
+		return manager;
 	}
 
 }


### PR DESCRIPTION
continueOnError flag has been added to DelegatingReactiveAuthenticationManager

Closes gh-14521

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
