### PR TITLE
Improve JdbcUserDetailsManager.userExists method

### DIFF
--- a/core/src/main/java/org/springframework/security/provisioning/JdbcUserDetailsManager.java
+++ b/core/src/main/java/org/springframework/security/provisioning/JdbcUserDetailsManager.java
@@ -77,7 +77,7 @@ public class JdbcUserDetailsManager extends JdbcDaoImpl implements UserDetailsMa
 
 	public static final String DEF_DELETE_USER_AUTHORITIES_SQL = "delete from authorities where username = ?";
 
-	public static final String DEF_USER_EXISTS_SQL = "select username from users where username = ?";
+	public static final String DEF_USER_EXISTS_SQL = "select count(*) from users where username = ?";
 
 	public static final String DEF_CHANGE_PASSWORD_SQL = "update users set password = ? where username = ?";
 
@@ -337,12 +337,13 @@ public class JdbcUserDetailsManager extends JdbcDaoImpl implements UserDetailsMa
 
 	@Override
 	public boolean userExists(String username) {
-		List<String> users = requireJdbcTemplate().queryForList(this.userExistsSql, String.class, username);
-		if (users.size() > 1) {
-			throw new IncorrectResultSizeDataAccessException("More than one user found with name '" + username + "'",
-					1);
+		@SuppressWarnings("ConstantConditions")
+		int usersCount = getJdbcTemplate().queryForObject(this.userExistsSql, Integer.class, username);
+		if (usersCount > 1) {
+			throw new IncorrectResultSizeDataAccessException(
+					"[" + usersCount + "] users found with name '" + username + "', expected 1", 1);
 		}
-		return users.size() == 1;
+		return usersCount == 1;
 	}
 
 	@Override

--- a/core/src/test/java/org/springframework/security/provisioning/JdbcUserDetailsManagerTests.java
+++ b/core/src/test/java/org/springframework/security/provisioning/JdbcUserDetailsManagerTests.java
@@ -190,6 +190,11 @@ public class JdbcUserDetailsManagerTests {
 	}
 
 	@Test
+	public void userExistsReturnsFalseForNullUsername() {
+		assertThat(this.manager.userExists(null)).isFalse();
+	}
+
+	@Test
 	public void userExistsReturnsTrueForExistingUsername() {
 		insertJoe();
 		assertThat(this.manager.userExists("joe")).isTrue();


### PR DESCRIPTION
Hello everyone,

This proposal is about tiny enhancements applied to JdbcUserDetailsManager.userExists() method.
As we do not really use an information returned by select query
`select username from users where username = ?`,
and only resultset size is important, my idea is to replace it with an ordinary `count` query.
Some pros of this approach:
* It works faster on DB side and IMO the code is more straightforward in this case, you see what's the purpose just looking on sql
* No need to create unnecessary wrappers on Java side. Currently JdbcTemplate creates a list with a one single purpose - to let the code check its size - and then it goes directly to GC. Not used for iterating over it or any modification/read operations.
* Overloaded version of queryForList() method used there is already marked as  `@Deprecated` as of Spring 5.3 release in favor of queryForList(String, Class, Object...). However that's a separate topic, some other JdbcUserDetailsManager methods also use it, e.g. findUsersInGroup(), that could be resolved in a separate PR to not mix the things up. 

Also, a unit test was added in case if userExists() was invoked with a 'null' parameter. That use-case is not something that really-really should be used as most databases expect `is [not] null` query pattern instead (well, with rare exclusions for null-aware mode support), However as long as this method is designed in this fail-safe manner, let's create a test to be informed about any breaking changes.