### PR TITLE
Update the documentation of AuthenticationProvider.java

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/AuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/AuthenticationProvider.java
@@ -47,10 +47,10 @@ public interface AuthenticationProvider {
 	 * <p>
 	 * Returning <code>true</code> does not guarantee an
 	 * <code>AuthenticationProvider</code> will be able to authenticate the presented
-	 * instance of the <code>Authentication</code> class. It simply indicates it can
-	 * support closer evaluation of it. An <code>AuthenticationProvider</code> can still
-	 * return <code>null</code> from the {@link #authenticate(Authentication)} method to
-	 * indicate another <code>AuthenticationProvider</code> should be tried.
+	 * <code>Authentication</code> object. It simply indicates it can support closer
+	 * evaluation of it. An <code>AuthenticationProvider</code> can still return
+	 * <code>null</code> from the {@link #authenticate(Authentication)} method to indicate
+	 * another <code>AuthenticationProvider</code> should be tried.
 	 * </p>
 	 * <p>
 	 * Selection of an <code>AuthenticationProvider</code> capable of performing


### PR DESCRIPTION
"Authentication" is an interface, not a class. So, It's not correct to say 'instance of the Authentication class.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
