### PR TITLE
Improve logging for Global Authentication

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeUserDetailsBeanManagerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeUserDetailsBeanManagerConfigurer.java
@@ -16,9 +16,16 @@
 
 package org.springframework.security.config.annotation.authentication.configuration;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.core.log.LogMessage;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.userdetails.UserDetailsPasswordService;
@@ -54,15 +61,35 @@ class InitializeUserDetailsBeanManagerConfigurer extends GlobalAuthenticationCon
 
 	class InitializeUserDetailsManagerConfigurer extends GlobalAuthenticationConfigurerAdapter {
 
+		private final Log logger = LogFactory.getLog(getClass());
+
 		@Override
 		public void configure(AuthenticationManagerBuilder auth) throws Exception {
+			List<BeanWithName<UserDetailsService>> userDetailsServices = getBeansWithName(UserDetailsService.class);
 			if (auth.isConfigured()) {
+				if (!userDetailsServices.isEmpty()) {
+					this.logger.warn("Global AuthenticationManager configured with an AuthenticationProvider bean. "
+							+ "UserDetailsService beans will not be used for username/password login. "
+							+ "Consider removing the AuthenticationProvider bean. "
+							+ "Alternatively, consider using the UserDetailsService in a manually instantiated "
+							+ "DaoAuthenticationProvider.");
+				}
 				return;
 			}
-			UserDetailsService userDetailsService = getBeanOrNull(UserDetailsService.class);
-			if (userDetailsService == null) {
+
+			if (userDetailsServices.isEmpty()) {
 				return;
 			}
+			else if (userDetailsServices.size() > 1) {
+				List<String> beanNames = userDetailsServices.stream().map(BeanWithName::getName).toList();
+				this.logger.warn(LogMessage.format("Found %s UserDetailsService beans, with names %s. "
+						+ "Global Authentication Manager will not use a UserDetailsService for username/password login. "
+						+ "Consider publishing a single UserDetailsService bean.", userDetailsServices.size(),
+						beanNames));
+				return;
+			}
+			var userDetailsService = userDetailsServices.get(0).getBean();
+			var userDetailsServiceBeanName = userDetailsServices.get(0).getName();
 			PasswordEncoder passwordEncoder = getBeanOrNull(PasswordEncoder.class);
 			UserDetailsPasswordService passwordManager = getBeanOrNull(UserDetailsPasswordService.class);
 			DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
@@ -75,6 +102,9 @@ class InitializeUserDetailsBeanManagerConfigurer extends GlobalAuthenticationCon
 			}
 			provider.afterPropertiesSet();
 			auth.authenticationProvider(provider);
+			this.logger.info(LogMessage.format(
+					"Global AuthenticationManager configured with UserDetailsService bean with name %s",
+					userDetailsServiceBeanName));
 		}
 
 		/**
@@ -87,6 +117,41 @@ class InitializeUserDetailsBeanManagerConfigurer extends GlobalAuthenticationCon
 				return null;
 			}
 			return InitializeUserDetailsBeanManagerConfigurer.this.context.getBean(beanNames[0], type);
+		}
+
+		/**
+		 * @return a list of beans of the requested class, along with their names. If
+		 * there are no registered beans of that type, the list is empty.
+		 */
+		private <T> List<BeanWithName<T>> getBeansWithName(Class<T> type) {
+			List<BeanWithName<T>> beanWithNames = new ArrayList<>();
+			String[] beanNames = InitializeUserDetailsBeanManagerConfigurer.this.context.getBeanNamesForType(type);
+			for (String beanName : beanNames) {
+				T bean = InitializeUserDetailsBeanManagerConfigurer.this.context.getBean(beanNames[0], type);
+				beanWithNames.add(new BeanWithName<T>(bean, beanName));
+			}
+			return beanWithNames;
+		}
+
+		static class BeanWithName<T> {
+
+			private final T bean;
+
+			private final String name;
+
+			BeanWithName(T bean, String name) {
+				this.bean = bean;
+				this.name = name;
+			}
+
+			T getBean() {
+				return this.bean;
+			}
+
+			String getName() {
+				return this.name;
+			}
+
 		}
 
 	}


### PR DESCRIPTION
Closes gh-14663

See the issue for use-case matrix.

## Open questions

I'd like to draw your attention to the following:

- [ ] Review log messages, are they appropriate?
- [ ] Review log levels, are they appropriate?
- [ ] The class names are too long and are truncated in the log lines. Is there something I should do?

## Example log lines:

1 UserDetailsService ; `INFO` level:

```
2024-03-08T14:23:23.058+01:00  INFO 49038 --- [           main] r$InitializeUserDetailsManagerConfigurer : Global AuthenticationManager configured with UserDetailsService bean with name myUserDetailsService
```

2 UserDetailsService ; `WARN` level:

```
2024-03-08T14:25:11.644+01:00  WARN 49146 --- [           main] r$InitializeUserDetailsManagerConfigurer : Found 2 UserDetailsService beans, with names [myUserDetailsService, secondUserDetailsService]. Global Authentication Manager will not use a UserDetailsService for username/password login.
```

1 AuthenticationProvider and at least 1 UserDetailsService bean, `WARN` level:

```
2024-03-08T14:22:27.832+01:00  WARN 48979 --- [           main] r$InitializeUserDetailsManagerConfigurer : Global AuthenticationManager configured with an AuthenticationProvider bean. UserDetailsService beans will not be used for username/password login.
```

1 AuthenticationProvider, `INFO` level:

```
2024-03-08T14:22:27.831+01:00  INFO 48979 --- [           main] eAuthenticationProviderManagerConfigurer : Global AuthenticationManager configured with AuthenticationProvider bean with name myAuthProvider
```

2 AuthenticationProviders, `WARN` level:

```
2024-03-08T14:23:23.048+01:00  WARN 49038 --- [           main] eAuthenticationProviderManagerConfigurer : Found 2 AuthenticationProvider beans, with names [myAuthProvider, secondAuthProvider]. Global Authentication Manager will not be configured with AuthenticationProviders.
```

## Interaction between the configurers

When the two configurers produce log lines, here are a few examples:

2 AuthenticationProvider, 1 UserDetailsService:

```
2024-03-08T14:22:27.831+01:00  INFO 48979 --- [           main] eAuthenticationProviderManagerConfigurer : Global AuthenticationManager configured with AuthenticationProvider bean with name myAuthProvider
2024-03-08T14:22:27.832+01:00  WARN 48979 --- [           main] r$InitializeUserDetailsManagerConfigurer : Global AuthenticationManager configured with an AuthenticationProvider bean. UserDetailsService beans will not be used for username/password login.
```

2 AuthenticationProviders, 1 UserDetailsService:

```
2024-03-08T14:23:23.048+01:00  WARN 49038 --- [           main] eAuthenticationProviderManagerConfigurer : Found 2 AuthenticationProvider beans, with names [myAuthProvider, secondAuthProvider]. Global Authentication Manager will not be configured with AuthenticationProviders.
2024-03-08T14:23:23.058+01:00  INFO 49038 --- [           main] r$InitializeUserDetailsManagerConfigurer : Global AuthenticationManager configured with UserDetailsService bean with name myUserDetailsService
```
