### PR TITLE
Add Authorization Denied Handlers for Method Security

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/MethodSecuritySelector.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/MethodSecuritySelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/PrePostMethodSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/PrePostMethodSecurityConfiguration.java
@@ -98,6 +98,7 @@ final class PrePostMethodSecurityConfiguration implements ImportAware, AopInfras
 			ObjectProvider<ObservationRegistry> registryProvider, ObjectProvider<RoleHierarchy> roleHierarchyProvider,
 			PrePostMethodSecurityConfiguration configuration, ApplicationContext context) {
 		PreAuthorizeAuthorizationManager manager = new PreAuthorizeAuthorizationManager();
+		manager.setApplicationContext(context);
 		AuthorizationManagerBeforeMethodInterceptor preAuthorize = AuthorizationManagerBeforeMethodInterceptor
 			.preAuthorize(manager(manager, registryProvider));
 		preAuthorize.setOrder(preAuthorize.getOrder() + configuration.interceptorOrderOffset);
@@ -121,6 +122,7 @@ final class PrePostMethodSecurityConfiguration implements ImportAware, AopInfras
 			ObjectProvider<ObservationRegistry> registryProvider, ObjectProvider<RoleHierarchy> roleHierarchyProvider,
 			PrePostMethodSecurityConfiguration configuration, ApplicationContext context) {
 		PostAuthorizeAuthorizationManager manager = new PostAuthorizeAuthorizationManager();
+		manager.setApplicationContext(context);
 		AuthorizationManagerAfterMethodInterceptor postAuthorize = AuthorizationManagerAfterMethodInterceptor
 			.postAuthorize(manager(manager, registryProvider));
 		postAuthorize.setOrder(postAuthorize.getOrder() + configuration.interceptorOrderOffset);

--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/ReactiveAuthorizationManagerMethodSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/ReactiveAuthorizationManagerMethodSecurityConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.aop.framework.AopInfrastructureBean;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Role;
@@ -74,9 +75,10 @@ final class ReactiveAuthorizationManagerMethodSecurityConfiguration implements A
 	static MethodInterceptor preAuthorizeAuthorizationMethodInterceptor(
 			MethodSecurityExpressionHandler expressionHandler,
 			ObjectProvider<PrePostTemplateDefaults> defaultsObjectProvider,
-			ObjectProvider<ObservationRegistry> registryProvider) {
+			ObjectProvider<ObservationRegistry> registryProvider, ApplicationContext context) {
 		PreAuthorizeReactiveAuthorizationManager manager = new PreAuthorizeReactiveAuthorizationManager(
 				expressionHandler);
+		manager.setApplicationContext(context);
 		ReactiveAuthorizationManager<MethodInvocation> authorizationManager = manager(manager, registryProvider);
 		AuthorizationAdvisor interceptor = AuthorizationManagerBeforeReactiveMethodInterceptor
 			.preAuthorize(authorizationManager);
@@ -99,9 +101,10 @@ final class ReactiveAuthorizationManagerMethodSecurityConfiguration implements A
 	static MethodInterceptor postAuthorizeAuthorizationMethodInterceptor(
 			MethodSecurityExpressionHandler expressionHandler,
 			ObjectProvider<PrePostTemplateDefaults> defaultsObjectProvider,
-			ObjectProvider<ObservationRegistry> registryProvider) {
+			ObjectProvider<ObservationRegistry> registryProvider, ApplicationContext context) {
 		PostAuthorizeReactiveAuthorizationManager manager = new PostAuthorizeReactiveAuthorizationManager(
 				expressionHandler);
+		manager.setApplicationContext(context);
 		ReactiveAuthorizationManager<MethodInvocationResult> authorizationManager = manager(manager, registryProvider);
 		AuthorizationAdvisor interceptor = AuthorizationManagerAfterReactiveMethodInterceptor
 			.postAuthorize(authorizationManager);

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/MethodSecurityServiceImpl.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/MethodSecurityServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.security.config.annotation.method.configuration;
 
 import java.util.List;
 
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -124,6 +125,76 @@ public class MethodSecurityServiceImpl implements MethodSecurityService {
 
 	@Override
 	public void repeatedAnnotations() {
+	}
+
+	@Override
+	public String postAuthorizeGetCardNumberIfAdmin(String cardNumber) {
+		return cardNumber;
+	}
+
+	@Override
+	public String preAuthorizeGetCardNumberIfAdmin(String cardNumber) {
+		return cardNumber;
+	}
+
+	@Override
+	public String preAuthorizeWithHandlerChildGetCardNumberIfAdmin(String cardNumber) {
+		return cardNumber;
+	}
+
+	@Override
+	public String preAuthorizeThrowAccessDeniedManually() {
+		throw new AccessDeniedException("Access Denied");
+	}
+
+	@Override
+	public String postAuthorizeThrowAccessDeniedManually() {
+		throw new AccessDeniedException("Access Denied");
+	}
+
+	@Override
+	public String preAuthorizeDeniedMethodWithMaskAnnotation() {
+		return "ok";
+	}
+
+	@Override
+	public String preAuthorizeDeniedMethodWithNoMaskAnnotation() {
+		return "ok";
+	}
+
+	@Override
+	public String postAuthorizeDeniedWithNullDenied() {
+		return "ok";
+	}
+
+	@Override
+	public String postAuthorizeDeniedMethodWithMaskAnnotation() {
+		return "ok";
+	}
+
+	@Override
+	public String postAuthorizeDeniedMethodWithNoMaskAnnotation() {
+		return "ok";
+	}
+
+	@Override
+	public String preAuthorizeWithMaskAnnotationUsingBean() {
+		return "ok";
+	}
+
+	@Override
+	public String postAuthorizeWithMaskAnnotationUsingBean() {
+		return "ok";
+	}
+
+	@Override
+	public UserRecordWithEmailProtected getUserRecordWithEmailProtected() {
+		return new UserRecordWithEmailProtected("username", "useremail@example.com");
+	}
+
+	@Override
+	public UserRecordWithEmailProtected getUserWithFallbackWhenUnauthorized() {
+		return new UserRecordWithEmailProtected("username", "useremail@example.com");
 	}
 
 }

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/MyMasker.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/MyMasker.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.config.annotation.method.configuration;
+
+public class MyMasker {
+
+	public String getMask(String value) {
+		return value + "-masked";
+	}
+
+	public String getMask() {
+		return "mask";
+	}
+
+}

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/PrePostReactiveMethodSecurityConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/PrePostReactiveMethodSecurityConfigurationTests.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.config.annotation.method.configuration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import reactor.test.StepVerifier;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.config.test.SpringTestContext;
+import org.springframework.security.config.test.SpringTestContextExtension;
+import org.springframework.security.test.context.annotation.SecurityTestExecutionListeners;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith({ SpringExtension.class, SpringTestContextExtension.class })
+@SecurityTestExecutionListeners
+public class PrePostReactiveMethodSecurityConfigurationTests {
+
+	public final SpringTestContext spring = new SpringTestContext(this);
+
+	@Test
+	@WithMockUser
+	void getCardNumberWhenPostAuthorizeAndNotAdminThenReturnMasked() {
+		this.spring
+			.register(MethodSecurityServiceEnabledConfig.class,
+					ReactiveMethodSecurityService.CardNumberMaskingPostProcessor.class)
+			.autowire();
+		ReactiveMethodSecurityService service = this.spring.getContext().getBean(ReactiveMethodSecurityService.class);
+		StepVerifier.create(service.postAuthorizeGetCardNumberIfAdmin("4444-3333-2222-1111"))
+			.expectNext("****-****-****-1111")
+			.verifyComplete();
+	}
+
+	@Test
+	@WithMockUser
+	void getCardNumberWhenPreAuthorizeAndNotAdminThenReturnMasked() {
+		this.spring
+			.register(MethodSecurityServiceEnabledConfig.class, ReactiveMethodSecurityService.StarMaskingHandler.class)
+			.autowire();
+		ReactiveMethodSecurityService service = this.spring.getContext().getBean(ReactiveMethodSecurityService.class);
+		StepVerifier.create(service.preAuthorizeGetCardNumberIfAdmin("4444-3333-2222-1111"))
+			.expectNext("***")
+			.verifyComplete();
+	}
+
+	@Test
+	@WithMockUser
+	void getCardNumberWhenPreAuthorizeAndNotAdminAndChildHandlerThenResolveCorrectHandlerAndReturnMasked() {
+		this.spring
+			.register(MethodSecurityServiceEnabledConfig.class, ReactiveMethodSecurityService.StarMaskingHandler.class,
+					ReactiveMethodSecurityService.StartMaskingHandlerChild.class)
+			.autowire();
+		ReactiveMethodSecurityService service = this.spring.getContext().getBean(ReactiveMethodSecurityService.class);
+		StepVerifier.create(service.preAuthorizeWithHandlerChildGetCardNumberIfAdmin("4444-3333-2222-1111"))
+			.expectNext("***-child")
+			.verifyComplete();
+	}
+
+	@Test
+	@WithMockUser(roles = "ADMIN")
+	void preAuthorizeWhenHandlerAndAccessDeniedNotThrownFromPreAuthorizeThenNotHandled() {
+		this.spring
+			.register(MethodSecurityServiceEnabledConfig.class, ReactiveMethodSecurityService.StarMaskingHandler.class)
+			.autowire();
+		ReactiveMethodSecurityService service = this.spring.getContext().getBean(ReactiveMethodSecurityService.class);
+		StepVerifier.create(service.preAuthorizeThrowAccessDeniedManually())
+			.expectError(AccessDeniedException.class)
+			.verify();
+	}
+
+	@Test
+	@WithMockUser
+	void preAuthorizeWhenDeniedAndHandlerWithCustomAnnotationThenHandlerCanUseMaskFromOtherAnnotation() {
+		this.spring
+			.register(MethodSecurityServiceEnabledConfig.class,
+					ReactiveMethodSecurityService.MaskAnnotationHandler.class)
+			.autowire();
+		ReactiveMethodSecurityService service = this.spring.getContext().getBean(ReactiveMethodSecurityService.class);
+		StepVerifier.create(service.preAuthorizeDeniedMethodWithMaskAnnotation())
+			.expectNext("methodmask")
+			.verifyComplete();
+	}
+
+	@Test
+	@WithMockUser
+	void preAuthorizeWhenDeniedAndHandlerWithCustomAnnotationInClassThenHandlerCanUseMaskFromOtherAnnotation() {
+		this.spring
+			.register(MethodSecurityServiceEnabledConfig.class,
+					ReactiveMethodSecurityService.MaskAnnotationHandler.class)
+			.autowire();
+		ReactiveMethodSecurityService service = this.spring.getContext().getBean(ReactiveMethodSecurityService.class);
+		StepVerifier.create(service.preAuthorizeDeniedMethodWithNoMaskAnnotation())
+			.expectNext("classmask")
+			.verifyComplete();
+	}
+
+	@Test
+	@WithMockUser(roles = "ADMIN")
+	void postAuthorizeWhenHandlerAndAccessDeniedNotThrownFromPostAuthorizeThenNotHandled() {
+		this.spring
+			.register(MethodSecurityServiceEnabledConfig.class,
+					ReactiveMethodSecurityService.PostMaskingPostProcessor.class)
+			.autowire();
+		ReactiveMethodSecurityService service = this.spring.getContext().getBean(ReactiveMethodSecurityService.class);
+		StepVerifier.create(service.postAuthorizeThrowAccessDeniedManually())
+			.expectError(AccessDeniedException.class)
+			.verify();
+	}
+
+	@Test
+	@WithMockUser
+	void postAuthorizeWhenNullDeniedMetaAnnotationThanWorks() {
+		this.spring
+			.register(MethodSecurityServiceEnabledConfig.class, ReactiveMethodSecurityService.NullPostProcessor.class)
+			.autowire();
+		ReactiveMethodSecurityService service = this.spring.getContext().getBean(ReactiveMethodSecurityService.class);
+		StepVerifier.create(service.postAuthorizeDeniedWithNullDenied()).verifyComplete();
+	}
+
+	@Test
+	@WithMockUser
+	void postAuthorizeWhenDeniedAndHandlerWithCustomAnnotationThenHandlerCanUseMaskFromOtherAnnotation() {
+		this.spring
+			.register(MethodSecurityServiceEnabledConfig.class,
+					ReactiveMethodSecurityService.MaskAnnotationPostProcessor.class)
+			.autowire();
+		ReactiveMethodSecurityService service = this.spring.getContext().getBean(ReactiveMethodSecurityService.class);
+		StepVerifier.create(service.postAuthorizeDeniedMethodWithMaskAnnotation())
+			.expectNext("methodmask")
+			.verifyComplete();
+	}
+
+	@Test
+	@WithMockUser
+	void postAuthorizeWhenDeniedAndHandlerWithCustomAnnotationInClassThenHandlerCanUseMaskFromOtherAnnotation() {
+		this.spring
+			.register(MethodSecurityServiceEnabledConfig.class,
+					ReactiveMethodSecurityService.MaskAnnotationPostProcessor.class)
+			.autowire();
+		ReactiveMethodSecurityService service = this.spring.getContext().getBean(ReactiveMethodSecurityService.class);
+		StepVerifier.create(service.postAuthorizeDeniedMethodWithNoMaskAnnotation())
+			.expectNext("classmask")
+			.verifyComplete();
+	}
+
+	@Test
+	@WithMockUser
+	void postAuthorizeWhenDeniedAndHandlerWithCustomAnnotationUsingBeanThenHandlerCanUseMaskFromOtherAnnotation() {
+		this.spring
+			.register(MethodSecurityServiceEnabledConfig.class,
+					ReactiveMethodSecurityService.MaskAnnotationPostProcessor.class, MyMasker.class)
+			.autowire();
+		ReactiveMethodSecurityService service = this.spring.getContext().getBean(ReactiveMethodSecurityService.class);
+		StepVerifier.create(service.postAuthorizeWithMaskAnnotationUsingBean())
+			.expectNext("ok-masked")
+			.verifyComplete();
+	}
+
+	@Test
+	@WithMockUser(roles = "ADMIN")
+	void postAuthorizeWhenAllowedAndHandlerWithCustomAnnotationUsingBeanThenInvokeMethodNormally() {
+		this.spring
+			.register(MethodSecurityServiceEnabledConfig.class,
+					ReactiveMethodSecurityService.MaskAnnotationPostProcessor.class, MyMasker.class)
+			.autowire();
+		ReactiveMethodSecurityService service = this.spring.getContext().getBean(ReactiveMethodSecurityService.class);
+		StepVerifier.create(service.postAuthorizeWithMaskAnnotationUsingBean()).expectNext("ok").verifyComplete();
+	}
+
+	@Test
+	@WithMockUser
+	void preAuthorizeWhenDeniedAndHandlerWithCustomAnnotationUsingBeanThenHandlerCanUseMaskFromOtherAnnotation() {
+		this.spring
+			.register(MethodSecurityServiceEnabledConfig.class,
+					ReactiveMethodSecurityService.MaskAnnotationHandler.class, MyMasker.class)
+			.autowire();
+		ReactiveMethodSecurityService service = this.spring.getContext().getBean(ReactiveMethodSecurityService.class);
+		StepVerifier.create(service.preAuthorizeWithMaskAnnotationUsingBean()).expectNext("mask").verifyComplete();
+	}
+
+	@Test
+	@WithMockUser(roles = "ADMIN")
+	void preAuthorizeWhenAllowedAndHandlerWithCustomAnnotationUsingBeanThenInvokeMethodNormally() {
+		this.spring
+			.register(MethodSecurityServiceEnabledConfig.class,
+					ReactiveMethodSecurityService.MaskAnnotationHandler.class, MyMasker.class)
+			.autowire();
+		ReactiveMethodSecurityService service = this.spring.getContext().getBean(ReactiveMethodSecurityService.class);
+		StepVerifier.create(service.preAuthorizeWithMaskAnnotationUsingBean()).expectNext("ok").verifyComplete();
+	}
+
+	@Configuration
+	@EnableReactiveMethodSecurity
+	static class MethodSecurityServiceEnabledConfig {
+
+		@Bean
+		ReactiveMethodSecurityService methodSecurityService() {
+			return new ReactiveMethodSecurityServiceImpl();
+		}
+
+	}
+
+}

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/ReactiveMethodSecurityService.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/ReactiveMethodSecurityService.java
@@ -21,157 +21,69 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.List;
 
-import jakarta.annotation.security.DenyAll;
-import jakarta.annotation.security.PermitAll;
-import jakarta.annotation.security.RolesAllowed;
 import org.aopalliance.intercept.MethodInvocation;
+import reactor.core.publisher.Mono;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
-import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
 import org.springframework.security.access.prepost.PostAuthorize;
-import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.access.prepost.PreFilter;
 import org.springframework.security.authorization.AuthorizationResult;
-import org.springframework.security.authorization.method.AuthorizeReturnObject;
 import org.springframework.security.authorization.method.MethodAuthorizationDeniedHandler;
 import org.springframework.security.authorization.method.MethodAuthorizationDeniedPostProcessor;
 import org.springframework.security.authorization.method.MethodInvocationResult;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.parameters.P;
 import org.springframework.util.StringUtils;
 
 /**
  * @author Rob Winch
  */
-@MethodSecurityService.Mask("classmask")
-public interface MethodSecurityService {
-
-	@PreAuthorize("denyAll")
-	String preAuthorize();
-
-	@Secured("ROLE_ADMIN")
-	String secured();
-
-	@Secured("ROLE_USER")
-	String securedUser();
-
-	@DenyAll
-	String jsr250();
-
-	@PermitAll
-	String jsr250PermitAll();
-
-	@RolesAllowed("ADMIN")
-	String jsr250RolesAllowed();
-
-	@RolesAllowed("USER")
-	String jsr250RolesAllowedUser();
-
-	@Secured({ "ROLE_USER", "RUN_AS_SUPER" })
-	Authentication runAs();
-
-	@PreAuthorize("permitAll")
-	String preAuthorizePermitAll();
-
-	@PreAuthorize("!anonymous")
-	void preAuthorizeNotAnonymous();
-
-	@PreAuthorize("@authz.check(#result)")
-	void preAuthorizeBean(@P("result") boolean result);
-
-	@PreAuthorize("hasRole('ADMIN')")
-	void preAuthorizeAdmin();
-
-	@PreAuthorize("hasRole('USER')")
-	void preAuthorizeUser();
-
-	@PreAuthorize("hasPermission(#object,'read')")
-	String hasPermission(String object);
-
-	@PostAuthorize("hasPermission(#object,'read')")
-	String postHasPermission(String object);
-
-	@PostAuthorize("#o?.contains('grant')")
-	String postAnnotation(@P("o") String object);
-
-	@PreFilter("filterObject == authentication.name")
-	List<String> preFilterByUsername(List<String> array);
-
-	@PostFilter("filterObject == authentication.name")
-	List<String> postFilterByUsername(List<String> array);
-
-	@PreFilter("filterObject.length > 3")
-	@PreAuthorize("hasRole('ADMIN')")
-	@Secured("ROLE_USER")
-	@PostFilter("filterObject.length > 5")
-	@PostAuthorize("returnObject.size == 2")
-	List<String> manyAnnotations(List<String> array);
-
-	@PreFilter("filterObject != 'DropOnPreFilter'")
-	@PreAuthorize("#list.remove('DropOnPreAuthorize')")
-	@Secured("ROLE_SECURED")
-	@RolesAllowed("JSR250")
-	@PostAuthorize("#list.remove('DropOnPostAuthorize')")
-	@PostFilter("filterObject != 'DropOnPostFilter'")
-	List<String> allAnnotations(List<String> list);
-
-	@RequireUserRole
-	@RequireAdminRole
-	void repeatedAnnotations();
+@ReactiveMethodSecurityService.Mask("classmask")
+public interface ReactiveMethodSecurityService {
 
 	@PreAuthorize(value = "hasRole('ADMIN')", handlerClass = StarMaskingHandler.class)
-	String preAuthorizeGetCardNumberIfAdmin(String cardNumber);
+	Mono<String> preAuthorizeGetCardNumberIfAdmin(String cardNumber);
 
 	@PreAuthorize(value = "hasRole('ADMIN')", handlerClass = StartMaskingHandlerChild.class)
-	String preAuthorizeWithHandlerChildGetCardNumberIfAdmin(String cardNumber);
+	Mono<String> preAuthorizeWithHandlerChildGetCardNumberIfAdmin(String cardNumber);
 
 	@PreAuthorize(value = "hasRole('ADMIN')", handlerClass = StarMaskingHandler.class)
-	String preAuthorizeThrowAccessDeniedManually();
+	Mono<String> preAuthorizeThrowAccessDeniedManually();
 
 	@PostAuthorize(value = "hasRole('ADMIN')", postProcessorClass = CardNumberMaskingPostProcessor.class)
-	String postAuthorizeGetCardNumberIfAdmin(String cardNumber);
+	Mono<String> postAuthorizeGetCardNumberIfAdmin(String cardNumber);
 
 	@PostAuthorize(value = "hasRole('ADMIN')", postProcessorClass = PostMaskingPostProcessor.class)
-	String postAuthorizeThrowAccessDeniedManually();
+	Mono<String> postAuthorizeThrowAccessDeniedManually();
 
 	@PreAuthorize(value = "denyAll()", handlerClass = MaskAnnotationHandler.class)
 	@Mask("methodmask")
-	String preAuthorizeDeniedMethodWithMaskAnnotation();
+	Mono<String> preAuthorizeDeniedMethodWithMaskAnnotation();
 
 	@PreAuthorize(value = "denyAll()", handlerClass = MaskAnnotationHandler.class)
-	String preAuthorizeDeniedMethodWithNoMaskAnnotation();
+	Mono<String> preAuthorizeDeniedMethodWithNoMaskAnnotation();
 
 	@NullDenied(role = "ADMIN")
-	String postAuthorizeDeniedWithNullDenied();
+	Mono<String> postAuthorizeDeniedWithNullDenied();
 
 	@PostAuthorize(value = "denyAll()", postProcessorClass = MaskAnnotationPostProcessor.class)
 	@Mask("methodmask")
-	String postAuthorizeDeniedMethodWithMaskAnnotation();
+	Mono<String> postAuthorizeDeniedMethodWithMaskAnnotation();
 
 	@PostAuthorize(value = "denyAll()", postProcessorClass = MaskAnnotationPostProcessor.class)
-	String postAuthorizeDeniedMethodWithNoMaskAnnotation();
+	Mono<String> postAuthorizeDeniedMethodWithNoMaskAnnotation();
 
 	@PreAuthorize(value = "hasRole('ADMIN')", handlerClass = MaskAnnotationHandler.class)
 	@Mask(expression = "@myMasker.getMask()")
-	String preAuthorizeWithMaskAnnotationUsingBean();
+	Mono<String> preAuthorizeWithMaskAnnotationUsingBean();
 
 	@PostAuthorize(value = "hasRole('ADMIN')", postProcessorClass = MaskAnnotationPostProcessor.class)
 	@Mask(expression = "@myMasker.getMask(returnObject)")
-	String postAuthorizeWithMaskAnnotationUsingBean();
-
-	@AuthorizeReturnObject
-	UserRecordWithEmailProtected getUserRecordWithEmailProtected();
-
-	@PreAuthorize(value = "hasRole('ADMIN')", handlerClass = UserFallbackDeniedHandler.class)
-	UserRecordWithEmailProtected getUserWithFallbackWhenUnauthorized();
+	Mono<String> postAuthorizeWithMaskAnnotationUsingBean();
 
 	class StarMaskingHandler implements MethodAuthorizationDeniedHandler {
 
@@ -240,9 +152,9 @@ public interface MethodSecurityService {
 			this.expressionHandler.setApplicationContext(context);
 		}
 
-		String resolveValue(Mask mask, MethodInvocation mi, Object returnObject) {
+		Mono<String> resolveValue(Mask mask, MethodInvocation mi, Object returnObject) {
 			if (StringUtils.hasText(mask.value())) {
-				return mask.value();
+				return Mono.just(mask.value());
 			}
 			Expression expression = this.expressionHandler.getExpressionParser().parseExpression(mask.expression());
 			EvaluationContext evaluationContext = this.expressionHandler
@@ -250,7 +162,7 @@ public interface MethodSecurityService {
 			if (returnObject != null) {
 				this.expressionHandler.setReturnObject(returnObject, evaluationContext);
 			}
-			return expression.getValue(evaluationContext, String.class);
+			return Mono.just(expression.getValue(evaluationContext, String.class));
 		}
 
 	}
@@ -304,18 +216,6 @@ public interface MethodSecurityService {
 	@interface NullDenied {
 
 		String role();
-
-	}
-
-	class UserFallbackDeniedHandler implements MethodAuthorizationDeniedHandler {
-
-		private static final UserRecordWithEmailProtected FALLBACK = new UserRecordWithEmailProtected("Protected",
-				"Protected");
-
-		@Override
-		public Object handle(MethodInvocation methodInvocation, AuthorizationResult authorizationResult) {
-			return FALLBACK;
-		}
 
 	}
 

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/ReactiveMethodSecurityServiceImpl.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/ReactiveMethodSecurityServiceImpl.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.config.annotation.method.configuration;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.security.access.AccessDeniedException;
+
+public class ReactiveMethodSecurityServiceImpl implements ReactiveMethodSecurityService {
+
+	@Override
+	public Mono<String> preAuthorizeGetCardNumberIfAdmin(String cardNumber) {
+		return Mono.just(cardNumber);
+	}
+
+	@Override
+	public Mono<String> preAuthorizeWithHandlerChildGetCardNumberIfAdmin(String cardNumber) {
+		return Mono.just(cardNumber);
+	}
+
+	@Override
+	public Mono<String> preAuthorizeThrowAccessDeniedManually() {
+		return Mono.error(new AccessDeniedException("Access Denied"));
+	}
+
+	@Override
+	public Mono<String> postAuthorizeGetCardNumberIfAdmin(String cardNumber) {
+		return Mono.just(cardNumber);
+	}
+
+	@Override
+	public Mono<String> postAuthorizeThrowAccessDeniedManually() {
+		return Mono.error(new AccessDeniedException("Access Denied"));
+	}
+
+	@Override
+	public Mono<String> preAuthorizeDeniedMethodWithMaskAnnotation() {
+		return Mono.just("ok");
+	}
+
+	@Override
+	public Mono<String> preAuthorizeDeniedMethodWithNoMaskAnnotation() {
+		return Mono.just("ok");
+	}
+
+	@Override
+	public Mono<String> postAuthorizeDeniedWithNullDenied() {
+		return Mono.just("ok");
+	}
+
+	@Override
+	public Mono<String> postAuthorizeDeniedMethodWithMaskAnnotation() {
+		return Mono.just("ok");
+	}
+
+	@Override
+	public Mono<String> postAuthorizeDeniedMethodWithNoMaskAnnotation() {
+		return Mono.just("ok");
+	}
+
+	@Override
+	public Mono<String> preAuthorizeWithMaskAnnotationUsingBean() {
+		return Mono.just("ok");
+	}
+
+	@Override
+	public Mono<String> postAuthorizeWithMaskAnnotationUsingBean() {
+		return Mono.just("ok");
+	}
+
+}

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/UserRecordWithEmailProtected.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/UserRecordWithEmailProtected.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.config.annotation.method.configuration;
+
+import org.springframework.security.access.prepost.PostAuthorize;
+import org.springframework.security.authorization.AuthorizationResult;
+import org.springframework.security.authorization.method.MethodAuthorizationDeniedPostProcessor;
+import org.springframework.security.authorization.method.MethodInvocationResult;
+
+public class UserRecordWithEmailProtected {
+
+	private final String name;
+
+	private final String email;
+
+	public UserRecordWithEmailProtected(String name, String email) {
+		this.name = name;
+		this.email = email;
+	}
+
+	public String name() {
+		return this.name;
+	}
+
+	@PostAuthorize(value = "hasRole('ADMIN')", postProcessorClass = EmailMaskingPostProcessor.class)
+	public String email() {
+		return this.email;
+	}
+
+	public static class EmailMaskingPostProcessor implements MethodAuthorizationDeniedPostProcessor {
+
+		@Override
+		public Object postProcessResult(MethodInvocationResult methodInvocationResult,
+				AuthorizationResult authorizationResult) {
+			String email = (String) methodInvocationResult.getResult();
+			return email.replaceAll("(^[^@]{3}|(?!^)\\G)[^@]", "$1*");
+		}
+
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/access/prepost/PostAuthorize.java
+++ b/core/src/main/java/org/springframework/security/access/prepost/PostAuthorize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.security.authorization.method.MethodAuthorizationDeniedPostProcessor;
+import org.springframework.security.authorization.method.ThrowingMethodAuthorizationDeniedPostProcessor;
+
 /**
  * Annotation for specifying a method access-control expression which will be evaluated
  * after a method has been invoked.
@@ -41,5 +44,11 @@ public @interface PostAuthorize {
 	 * method
 	 */
 	String value();
+
+	/**
+	 * @return the {@link MethodAuthorizationDeniedPostProcessor} class used to
+	 * post-process access denied
+	 */
+	Class<? extends MethodAuthorizationDeniedPostProcessor> postProcessorClass() default ThrowingMethodAuthorizationDeniedPostProcessor.class;
 
 }

--- a/core/src/main/java/org/springframework/security/access/prepost/PreAuthorize.java
+++ b/core/src/main/java/org/springframework/security/access/prepost/PreAuthorize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.security.authorization.method.MethodAuthorizationDeniedHandler;
+import org.springframework.security.authorization.method.ThrowingMethodAuthorizationDeniedHandler;
+
 /**
  * Annotation for specifying a method access-control expression which will be evaluated to
  * decide whether a method invocation is allowed or not.
@@ -41,5 +44,11 @@ public @interface PreAuthorize {
 	 * method
 	 */
 	String value();
+
+	/**
+	 * @return the {@link MethodAuthorizationDeniedHandler} class used to handle access
+	 * denied
+	 */
+	Class<? extends MethodAuthorizationDeniedHandler> handlerClass() default ThrowingMethodAuthorizationDeniedHandler.class;
 
 }

--- a/core/src/main/java/org/springframework/security/authorization/AuthorizationDeniedException.java
+++ b/core/src/main/java/org/springframework/security/authorization/AuthorizationDeniedException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authorization;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.util.Assert;
+
+/**
+ * An {@link AccessDeniedException} that contains the {@link AuthorizationResult}
+ *
+ * @author Marcus da Coregio
+ * @since 6.3
+ */
+public class AuthorizationDeniedException extends AccessDeniedException {
+
+	private final AuthorizationResult result;
+
+	public AuthorizationDeniedException(String msg, AuthorizationResult authorizationResult) {
+		super(msg);
+		Assert.notNull(authorizationResult, "authorizationResult cannot be null");
+		Assert.isTrue(!authorizationResult.isGranted(), "Granted authorization results are not supported");
+		this.result = authorizationResult;
+	}
+
+	public AuthorizationResult getAuthorizationResult() {
+		return this.result;
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/authorization/AuthorizationResult.java
+++ b/core/src/main/java/org/springframework/security/authorization/AuthorizationResult.java
@@ -17,25 +17,16 @@
 package org.springframework.security.authorization;
 
 /**
- * @author Rob Winch
- * @since 5.0
+ * Represents an authorization result
+ *
+ * @author Marcus da Coregio
+ * @since 6.3
  */
-public class AuthorizationDecision implements AuthorizationResult {
+public interface AuthorizationResult {
 
-	private final boolean granted;
-
-	public AuthorizationDecision(boolean granted) {
-		this.granted = granted;
-	}
-
-	@Override
-	public boolean isGranted() {
-		return this.granted;
-	}
-
-	@Override
-	public String toString() {
-		return getClass().getSimpleName() + " [granted=" + this.granted + "]";
-	}
+	/**
+	 * @return whether the access has been granted
+	 */
+	boolean isGranted();
 
 }

--- a/core/src/main/java/org/springframework/security/authorization/method/MethodAuthorizationDeniedHandler.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/MethodAuthorizationDeniedHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authorization.method;
+
+import org.aopalliance.intercept.MethodInvocation;
+
+import org.springframework.lang.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
+
+/**
+ * An interface used to define a strategy to handle denied method invocations
+ *
+ * @author Marcus da Coregio
+ * @since 6.3
+ * @see org.springframework.security.access.prepost.PreAuthorize
+ */
+public interface MethodAuthorizationDeniedHandler {
+
+	/**
+	 * Handle denied method invocations, implementations might either throw an
+	 * {@link org.springframework.security.access.AccessDeniedException} or a replacement
+	 * result instead of invoking the method, e.g. a masked value.
+	 * @param methodInvocation the {@link MethodInvocation} related to the authorization
+	 * denied
+	 * @param authorizationResult the authorization denied result
+	 * @return a replacement result for the denied method invocation, or null, or a
+	 * {@link reactor.core.publisher.Mono} for reactive applications
+	 */
+	@Nullable
+	Object handle(MethodInvocation methodInvocation, AuthorizationResult authorizationResult);
+
+}

--- a/core/src/main/java/org/springframework/security/authorization/method/MethodAuthorizationDeniedPostProcessor.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/MethodAuthorizationDeniedPostProcessor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authorization.method;
+
+import org.springframework.lang.Nullable;
+import org.springframework.security.authorization.AuthorizationResult;
+
+/**
+ * An interface to define a strategy to handle denied method invocation results
+ *
+ * @author Marcus da Coregio
+ * @since 6.3
+ * @see org.springframework.security.access.prepost.PostAuthorize
+ */
+public interface MethodAuthorizationDeniedPostProcessor {
+
+	/**
+	 * Post-process the denied result produced by a method invocation, implementations
+	 * might either throw an
+	 * {@link org.springframework.security.access.AccessDeniedException} or return a
+	 * replacement result instead of the denied result, e.g. a masked value.
+	 * @param methodInvocationResult the object containing the method invocation and the
+	 * result produced
+	 * @param authorizationResult the {@link AuthorizationResult} containing the
+	 * authorization denied details
+	 * @return a replacement result for the denied result, or null, or a
+	 * {@link reactor.core.publisher.Mono} for reactive applications
+	 */
+	@Nullable
+	Object postProcessResult(MethodInvocationResult methodInvocationResult, AuthorizationResult authorizationResult);
+
+}

--- a/core/src/main/java/org/springframework/security/authorization/method/PostAuthorizeAuthorizationDecision.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/PostAuthorizeAuthorizationDecision.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authorization.method;
+
+import org.springframework.expression.Expression;
+import org.springframework.security.authorization.AuthorizationResult;
+import org.springframework.security.authorization.ExpressionAuthorizationDecision;
+import org.springframework.util.Assert;
+
+class PostAuthorizeAuthorizationDecision extends ExpressionAuthorizationDecision
+		implements MethodAuthorizationDeniedPostProcessor {
+
+	private final MethodAuthorizationDeniedPostProcessor postProcessor;
+
+	PostAuthorizeAuthorizationDecision(boolean granted, Expression expression,
+			MethodAuthorizationDeniedPostProcessor postProcessor) {
+		super(granted, expression);
+		Assert.notNull(postProcessor, "postProcessor cannot be null");
+		this.postProcessor = postProcessor;
+	}
+
+	@Override
+	public Object postProcessResult(MethodInvocationResult methodInvocationResult, AuthorizationResult result) {
+		return this.postProcessor.postProcessResult(methodInvocationResult, result);
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/authorization/method/PostAuthorizeAuthorizationManager.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/PostAuthorizeAuthorizationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,13 +20,13 @@ import java.util.function.Supplier;
 
 import org.aopalliance.intercept.MethodInvocation;
 
+import org.springframework.context.ApplicationContext;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.security.access.expression.ExpressionUtils;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
 import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
-import org.springframework.security.authorization.ExpressionAuthorizationDecision;
 import org.springframework.security.core.Authentication;
 
 /**
@@ -62,6 +62,18 @@ public final class PostAuthorizeAuthorizationManager implements AuthorizationMan
 	}
 
 	/**
+	 * Invokes
+	 * {@link PostAuthorizeExpressionAttributeRegistry#setApplicationContext(ApplicationContext)}
+	 * with the provided {@link ApplicationContext}.
+	 * @param context the {@link ApplicationContext}
+	 * @since 6.3
+	 * @see PreAuthorizeExpressionAttributeRegistry#setApplicationContext(ApplicationContext)
+	 */
+	public void setApplicationContext(ApplicationContext context) {
+		this.registry.setApplicationContext(context);
+	}
+
+	/**
 	 * Determine if an {@link Authentication} has access to the returned object by
 	 * evaluating the {@link PostAuthorize} annotation that the {@link MethodInvocation}
 	 * specifies.
@@ -76,11 +88,13 @@ public final class PostAuthorizeAuthorizationManager implements AuthorizationMan
 		if (attribute == ExpressionAttribute.NULL_ATTRIBUTE) {
 			return null;
 		}
+		PostAuthorizeExpressionAttribute postAuthorizeAttribute = (PostAuthorizeExpressionAttribute) attribute;
 		MethodSecurityExpressionHandler expressionHandler = this.registry.getExpressionHandler();
 		EvaluationContext ctx = expressionHandler.createEvaluationContext(authentication, mi.getMethodInvocation());
 		expressionHandler.setReturnObject(mi.getResult(), ctx);
-		boolean granted = ExpressionUtils.evaluateAsBoolean(attribute.getExpression(), ctx);
-		return new ExpressionAuthorizationDecision(granted, attribute.getExpression());
+		boolean granted = ExpressionUtils.evaluateAsBoolean(postAuthorizeAttribute.getExpression(), ctx);
+		return new PostAuthorizeAuthorizationDecision(granted, postAuthorizeAttribute.getExpression(),
+				postAuthorizeAttribute.getPostProcessor());
 	}
 
 }

--- a/core/src/main/java/org/springframework/security/authorization/method/PostAuthorizeExpressionAttribute.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/PostAuthorizeExpressionAttribute.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authorization.method;
+
+import org.springframework.expression.Expression;
+import org.springframework.util.Assert;
+
+/**
+ * An {@link ExpressionAttribute} that carries additional properties for
+ * {@code @PostAuthorize}.
+ *
+ * @author Marcus da Coregio
+ */
+class PostAuthorizeExpressionAttribute extends ExpressionAttribute {
+
+	private final MethodAuthorizationDeniedPostProcessor postProcessor;
+
+	PostAuthorizeExpressionAttribute(Expression expression, MethodAuthorizationDeniedPostProcessor postProcessor) {
+		super(expression);
+		Assert.notNull(postProcessor, "postProcessor cannot be null");
+		this.postProcessor = postProcessor;
+	}
+
+	MethodAuthorizationDeniedPostProcessor getPostProcessor() {
+		return this.postProcessor;
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/authorization/method/PostAuthorizeReactiveAuthorizationManager.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/PostAuthorizeReactiveAuthorizationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.security.authorization.method;
 import org.aopalliance.intercept.MethodInvocation;
 import reactor.core.publisher.Mono;
 
+import org.springframework.context.ApplicationContext;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
 import org.springframework.security.access.prepost.PostAuthorize;
@@ -61,6 +62,10 @@ public final class PostAuthorizeReactiveAuthorizationManager
 		this.registry.setTemplateDefaults(defaults);
 	}
 
+	public void setApplicationContext(ApplicationContext context) {
+		this.registry.setApplicationContext(context);
+	}
+
 	/**
 	 * Determines if an {@link Authentication} has access to the returned object from the
 	 * {@link MethodInvocation} by evaluating an expression from the {@link PostAuthorize}
@@ -77,13 +82,14 @@ public final class PostAuthorizeReactiveAuthorizationManager
 		if (attribute == ExpressionAttribute.NULL_ATTRIBUTE) {
 			return Mono.empty();
 		}
+		PostAuthorizeExpressionAttribute postAuthorizeAttribute = (PostAuthorizeExpressionAttribute) attribute;
 		MethodSecurityExpressionHandler expressionHandler = this.registry.getExpressionHandler();
 		// @formatter:off
 		return authentication
 				.map((auth) -> expressionHandler.createEvaluationContext(auth, mi))
 				.doOnNext((ctx) -> expressionHandler.setReturnObject(result.getResult(), ctx))
 				.flatMap((ctx) -> ReactiveExpressionUtils.evaluateAsBoolean(attribute.getExpression(), ctx))
-				.map((granted) -> new ExpressionAttributeAuthorizationDecision(granted, attribute));
+				.map((granted) -> new PostAuthorizeAuthorizationDecision(granted, postAuthorizeAttribute.getExpression(), postAuthorizeAttribute.getPostProcessor()));
 		// @formatter:on
 	}
 

--- a/core/src/main/java/org/springframework/security/authorization/method/PreAuthorizeAuthorizationDecision.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/PreAuthorizeAuthorizationDecision.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authorization.method;
+
+import org.aopalliance.intercept.MethodInvocation;
+
+import org.springframework.expression.Expression;
+import org.springframework.security.authorization.AuthorizationResult;
+import org.springframework.security.authorization.ExpressionAuthorizationDecision;
+import org.springframework.util.Assert;
+
+class PreAuthorizeAuthorizationDecision extends ExpressionAuthorizationDecision
+		implements MethodAuthorizationDeniedHandler {
+
+	private final MethodAuthorizationDeniedHandler handler;
+
+	PreAuthorizeAuthorizationDecision(boolean granted, Expression expression,
+			MethodAuthorizationDeniedHandler handler) {
+		super(granted, expression);
+		Assert.notNull(handler, "handler cannot be null");
+		this.handler = handler;
+	}
+
+	@Override
+	public Object handle(MethodInvocation methodInvocation, AuthorizationResult result) {
+		return this.handler.handle(methodInvocation, result);
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/authorization/method/PreAuthorizeAuthorizationManager.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/PreAuthorizeAuthorizationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,13 +20,13 @@ import java.util.function.Supplier;
 
 import org.aopalliance.intercept.MethodInvocation;
 
+import org.springframework.context.ApplicationContext;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.security.access.expression.ExpressionUtils;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
-import org.springframework.security.authorization.ExpressionAuthorizationDecision;
 import org.springframework.security.core.Authentication;
 
 /**
@@ -61,6 +61,10 @@ public final class PreAuthorizeAuthorizationManager implements AuthorizationMana
 		this.registry.setTemplateDefaults(defaults);
 	}
 
+	public void setApplicationContext(ApplicationContext context) {
+		this.registry.setApplicationContext(context);
+	}
+
 	/**
 	 * Determine if an {@link Authentication} has access to a method by evaluating an
 	 * expression from the {@link PreAuthorize} annotation that the
@@ -76,9 +80,11 @@ public final class PreAuthorizeAuthorizationManager implements AuthorizationMana
 		if (attribute == ExpressionAttribute.NULL_ATTRIBUTE) {
 			return null;
 		}
+		PreAuthorizeExpressionAttribute preAuthorizeAttribute = (PreAuthorizeExpressionAttribute) attribute;
 		EvaluationContext ctx = this.registry.getExpressionHandler().createEvaluationContext(authentication, mi);
-		boolean granted = ExpressionUtils.evaluateAsBoolean(attribute.getExpression(), ctx);
-		return new ExpressionAuthorizationDecision(granted, attribute.getExpression());
+		boolean granted = ExpressionUtils.evaluateAsBoolean(preAuthorizeAttribute.getExpression(), ctx);
+		return new PreAuthorizeAuthorizationDecision(granted, preAuthorizeAttribute.getExpression(),
+				preAuthorizeAttribute.getHandler());
 	}
 
 }

--- a/core/src/main/java/org/springframework/security/authorization/method/PreAuthorizeExpressionAttribute.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/PreAuthorizeExpressionAttribute.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authorization.method;
+
+import org.springframework.expression.Expression;
+import org.springframework.util.Assert;
+
+/**
+ * An {@link ExpressionAttribute} that carries additional properties for
+ * {@code @PreAuthorize}.
+ *
+ * @author Marcus da Coregio
+ */
+class PreAuthorizeExpressionAttribute extends ExpressionAttribute {
+
+	private final MethodAuthorizationDeniedHandler handler;
+
+	PreAuthorizeExpressionAttribute(Expression expression, MethodAuthorizationDeniedHandler handler) {
+		super(expression);
+		Assert.notNull(handler, "handler cannot be null");
+		this.handler = handler;
+	}
+
+	MethodAuthorizationDeniedHandler getHandler() {
+		return this.handler;
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/authorization/method/ThrowingMethodAuthorizationDeniedHandler.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/ThrowingMethodAuthorizationDeniedHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authorization.method;
+
+import org.aopalliance.intercept.MethodInvocation;
+
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.security.authorization.AuthorizationResult;
+
+/**
+ * An implementation of {@link MethodAuthorizationDeniedHandler} that throws
+ * {@link AuthorizationDeniedException}
+ *
+ * @author Marcus da Coregio
+ * @since 6.3
+ */
+public final class ThrowingMethodAuthorizationDeniedHandler implements MethodAuthorizationDeniedHandler {
+
+	@Override
+	public Object handle(MethodInvocation methodInvocation, AuthorizationResult result) {
+		throw new AuthorizationDeniedException("Access Denied", result);
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/authorization/method/ThrowingMethodAuthorizationDeniedPostProcessor.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/ThrowingMethodAuthorizationDeniedPostProcessor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authorization.method;
+
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.security.authorization.AuthorizationResult;
+
+/**
+ * An implementation of {@link MethodAuthorizationDeniedPostProcessor} that throws
+ * {@link AuthorizationDeniedException}
+ *
+ * @author Marcus da Coregio
+ * @since 6.3
+ */
+public final class ThrowingMethodAuthorizationDeniedPostProcessor implements MethodAuthorizationDeniedPostProcessor {
+
+	@Override
+	public Object postProcessResult(MethodInvocationResult methodInvocationResult, AuthorizationResult result) {
+		throw new AuthorizationDeniedException("Access Denied", result);
+	}
+
+}

--- a/core/src/test/java/org/springframework/security/authorization/method/AuthorizationManagerBeforeReactiveMethodInterceptorTests.java
+++ b/core/src/test/java/org/springframework/security/authorization/method/AuthorizationManagerBeforeReactiveMethodInterceptorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,12 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.springframework.aop.Pointcut;
+import org.springframework.expression.common.LiteralExpression;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.intercept.method.MockMethodInvocation;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.security.authorization.AuthorizationResult;
 import org.springframework.security.authorization.ReactiveAuthorizationManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -67,14 +71,15 @@ public class AuthorizationManagerBeforeReactiveMethodInterceptorTests {
 		given(mockMethodInvocation.proceed()).willReturn(Mono.just("john"));
 		ReactiveAuthorizationManager<MethodInvocation> mockReactiveAuthorizationManager = mock(
 				ReactiveAuthorizationManager.class);
-		given(mockReactiveAuthorizationManager.verify(any(), eq(mockMethodInvocation))).willReturn(Mono.empty());
+		given(mockReactiveAuthorizationManager.check(any(), eq(mockMethodInvocation)))
+			.willReturn(Mono.just(new AuthorizationDecision(true)));
 		AuthorizationManagerBeforeReactiveMethodInterceptor interceptor = new AuthorizationManagerBeforeReactiveMethodInterceptor(
 				Pointcut.TRUE, mockReactiveAuthorizationManager);
 		Object result = interceptor.invoke(mockMethodInvocation);
 		assertThat(result).asInstanceOf(InstanceOfAssertFactories.type(Mono.class))
 			.extracting(Mono::block)
 			.isEqualTo("john");
-		verify(mockReactiveAuthorizationManager).verify(any(), eq(mockMethodInvocation));
+		verify(mockReactiveAuthorizationManager).check(any(), eq(mockMethodInvocation));
 	}
 
 	@Test
@@ -84,7 +89,8 @@ public class AuthorizationManagerBeforeReactiveMethodInterceptorTests {
 		given(mockMethodInvocation.proceed()).willReturn(Flux.just("john", "bob"));
 		ReactiveAuthorizationManager<MethodInvocation> mockReactiveAuthorizationManager = mock(
 				ReactiveAuthorizationManager.class);
-		given(mockReactiveAuthorizationManager.verify(any(), eq(mockMethodInvocation))).willReturn(Mono.empty());
+		given(mockReactiveAuthorizationManager.check(any(), eq(mockMethodInvocation)))
+			.willReturn(Mono.just(new AuthorizationDecision((true))));
 		AuthorizationManagerBeforeReactiveMethodInterceptor interceptor = new AuthorizationManagerBeforeReactiveMethodInterceptor(
 				Pointcut.TRUE, mockReactiveAuthorizationManager);
 		Object result = interceptor.invoke(mockMethodInvocation);
@@ -92,7 +98,7 @@ public class AuthorizationManagerBeforeReactiveMethodInterceptorTests {
 			.extracting(Flux::collectList)
 			.extracting(Mono::block, InstanceOfAssertFactories.list(String.class))
 			.containsExactly("john", "bob");
-		verify(mockReactiveAuthorizationManager).verify(any(), eq(mockMethodInvocation));
+		verify(mockReactiveAuthorizationManager).check(any(), eq(mockMethodInvocation));
 	}
 
 	@Test
@@ -102,8 +108,8 @@ public class AuthorizationManagerBeforeReactiveMethodInterceptorTests {
 		given(mockMethodInvocation.proceed()).willReturn(Mono.just("john"));
 		ReactiveAuthorizationManager<MethodInvocation> mockReactiveAuthorizationManager = mock(
 				ReactiveAuthorizationManager.class);
-		given(mockReactiveAuthorizationManager.verify(any(), eq(mockMethodInvocation)))
-			.willReturn(Mono.error(new AccessDeniedException("Access Denied")));
+		given(mockReactiveAuthorizationManager.check(any(), eq(mockMethodInvocation)))
+			.willReturn(Mono.just(new AuthorizationDecision(false)));
 		AuthorizationManagerBeforeReactiveMethodInterceptor interceptor = new AuthorizationManagerBeforeReactiveMethodInterceptor(
 				Pointcut.TRUE, mockReactiveAuthorizationManager);
 		Object result = interceptor.invoke(mockMethodInvocation);
@@ -111,7 +117,119 @@ public class AuthorizationManagerBeforeReactiveMethodInterceptorTests {
 			.isThrownBy(() -> assertThat(result).asInstanceOf(InstanceOfAssertFactories.type(Mono.class))
 				.extracting(Mono::block))
 			.withMessage("Access Denied");
-		verify(mockReactiveAuthorizationManager).verify(any(), eq(mockMethodInvocation));
+		verify(mockReactiveAuthorizationManager).check(any(), eq(mockMethodInvocation));
+	}
+
+	@Test
+	public void invokeMonoWhenDeniedAndPostProcessorThenInvokePostProcessor() throws Throwable {
+		MethodInvocation mockMethodInvocation = spy(
+				new MockMethodInvocation(new Sample(), Sample.class.getDeclaredMethod("mono")));
+		given(mockMethodInvocation.proceed()).willReturn(Mono.just("john"));
+		ReactiveAuthorizationManager<MethodInvocation> mockReactiveAuthorizationManager = mock(
+				ReactiveAuthorizationManager.class);
+		PreAuthorizeAuthorizationDecision decision = new PreAuthorizeAuthorizationDecision(false,
+				new LiteralExpression("1234"), new MaskingPostProcessor());
+		given(mockReactiveAuthorizationManager.check(any(), eq(mockMethodInvocation))).willReturn(Mono.just(decision));
+		AuthorizationManagerBeforeReactiveMethodInterceptor interceptor = new AuthorizationManagerBeforeReactiveMethodInterceptor(
+				Pointcut.TRUE, mockReactiveAuthorizationManager);
+		Object result = interceptor.invoke(mockMethodInvocation);
+		assertThat(result).asInstanceOf(InstanceOfAssertFactories.type(Mono.class))
+			.extracting(Mono::block)
+			.isEqualTo("***");
+		verify(mockReactiveAuthorizationManager).check(any(), eq(mockMethodInvocation));
+	}
+
+	@Test
+	public void invokeMonoWhenDeniedAndMonoPostProcessorThenInvokePostProcessor() throws Throwable {
+		MethodInvocation mockMethodInvocation = spy(
+				new MockMethodInvocation(new Sample(), Sample.class.getDeclaredMethod("mono")));
+		given(mockMethodInvocation.proceed()).willReturn(Mono.just("john"));
+		ReactiveAuthorizationManager<MethodInvocation> mockReactiveAuthorizationManager = mock(
+				ReactiveAuthorizationManager.class);
+		PreAuthorizeAuthorizationDecision decision = new PreAuthorizeAuthorizationDecision(false,
+				new LiteralExpression("1234"), new MonoMaskingPostProcessor());
+		given(mockReactiveAuthorizationManager.check(any(), eq(mockMethodInvocation))).willReturn(Mono.just(decision));
+		AuthorizationManagerBeforeReactiveMethodInterceptor interceptor = new AuthorizationManagerBeforeReactiveMethodInterceptor(
+				Pointcut.TRUE, mockReactiveAuthorizationManager);
+		Object result = interceptor.invoke(mockMethodInvocation);
+		assertThat(result).asInstanceOf(InstanceOfAssertFactories.type(Mono.class))
+			.extracting(Mono::block)
+			.isEqualTo("***");
+		verify(mockReactiveAuthorizationManager).check(any(), eq(mockMethodInvocation));
+	}
+
+	@Test
+	public void invokeFluxWhenDeniedAndPostProcessorThenInvokePostProcessor() throws Throwable {
+		MethodInvocation mockMethodInvocation = spy(
+				new MockMethodInvocation(new Sample(), Sample.class.getDeclaredMethod("flux")));
+		given(mockMethodInvocation.proceed()).willReturn(Flux.just("john", "bob"));
+		ReactiveAuthorizationManager<MethodInvocation> mockReactiveAuthorizationManager = mock(
+				ReactiveAuthorizationManager.class);
+		PreAuthorizeAuthorizationDecision decision = new PreAuthorizeAuthorizationDecision(false,
+				new LiteralExpression("1234"), new MonoMaskingPostProcessor());
+		given(mockReactiveAuthorizationManager.check(any(), eq(mockMethodInvocation))).willReturn(Mono.just(decision));
+		AuthorizationManagerBeforeReactiveMethodInterceptor interceptor = new AuthorizationManagerBeforeReactiveMethodInterceptor(
+				Pointcut.TRUE, mockReactiveAuthorizationManager);
+		Object result = interceptor.invoke(mockMethodInvocation);
+		assertThat(result).asInstanceOf(InstanceOfAssertFactories.type(Flux.class))
+			.extracting(Flux::collectList)
+			.extracting(Mono::block, InstanceOfAssertFactories.list(String.class))
+			.containsExactly("***");
+		verify(mockReactiveAuthorizationManager).check(any(), eq(mockMethodInvocation));
+	}
+
+	@Test
+	public void invokeMonoWhenEmptyDecisionThenInvokeDefaultPostProcessor() throws Throwable {
+		MethodInvocation mockMethodInvocation = spy(
+				new MockMethodInvocation(new Sample(), Sample.class.getDeclaredMethod("mono")));
+		given(mockMethodInvocation.proceed()).willReturn(Mono.just("john"));
+		ReactiveAuthorizationManager<MethodInvocation> mockReactiveAuthorizationManager = mock(
+				ReactiveAuthorizationManager.class);
+		given(mockReactiveAuthorizationManager.check(any(), eq(mockMethodInvocation))).willReturn(Mono.empty());
+		AuthorizationManagerBeforeReactiveMethodInterceptor interceptor = new AuthorizationManagerBeforeReactiveMethodInterceptor(
+				Pointcut.TRUE, mockReactiveAuthorizationManager);
+		Object result = interceptor.invoke(mockMethodInvocation);
+		assertThatExceptionOfType(AuthorizationDeniedException.class)
+			.isThrownBy(() -> assertThat(result).asInstanceOf(InstanceOfAssertFactories.type(Mono.class))
+				.extracting(Mono::block))
+			.withMessage("Access Denied");
+		verify(mockReactiveAuthorizationManager).check(any(), eq(mockMethodInvocation));
+	}
+
+	@Test
+	public void invokeFluxWhenEmptyDecisionThenInvokeDefaultPostProcessor() throws Throwable {
+		MethodInvocation mockMethodInvocation = spy(
+				new MockMethodInvocation(new Sample(), Sample.class.getDeclaredMethod("flux")));
+		given(mockMethodInvocation.proceed()).willReturn(Flux.just("john", "bob"));
+		ReactiveAuthorizationManager<MethodInvocation> mockReactiveAuthorizationManager = mock(
+				ReactiveAuthorizationManager.class);
+		given(mockReactiveAuthorizationManager.check(any(), eq(mockMethodInvocation))).willReturn(Mono.empty());
+		AuthorizationManagerBeforeReactiveMethodInterceptor interceptor = new AuthorizationManagerBeforeReactiveMethodInterceptor(
+				Pointcut.TRUE, mockReactiveAuthorizationManager);
+		Object result = interceptor.invoke(mockMethodInvocation);
+		assertThatExceptionOfType(AuthorizationDeniedException.class)
+			.isThrownBy(() -> assertThat(result).asInstanceOf(InstanceOfAssertFactories.type(Flux.class))
+				.extracting(Flux::blockFirst))
+			.withMessage("Access Denied");
+		verify(mockReactiveAuthorizationManager).check(any(), eq(mockMethodInvocation));
+	}
+
+	static class MaskingPostProcessor implements MethodAuthorizationDeniedHandler {
+
+		@Override
+		public Object handle(MethodInvocation methodInvocation, AuthorizationResult result) {
+			return "***";
+		}
+
+	}
+
+	static class MonoMaskingPostProcessor implements MethodAuthorizationDeniedHandler {
+
+		@Override
+		public Object handle(MethodInvocation methodInvocation, AuthorizationResult result) {
+			return Mono.just("***");
+		}
+
 	}
 
 	class Sample {

--- a/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
@@ -44,6 +44,7 @@ Consider learning about the following use cases:
 * Understanding <<method-security-architecture,how method security works>> and reasons to use it
 * Comparing <<request-vs-method,request-level and method-level authorization>>
 * Authorizing methods with <<use-preauthorize,`@PreAuthorize`>> and <<use-postauthorize,`@PostAuthorize`>>
+* Providing <<fallback-values-authorization-denied,fallback values when authorization is denied>>
 * Filtering methods with <<use-prefilter,`@PreFilter`>> and <<use-postfilter,`@PostFilter`>>
 * Authorizing methods with <<use-jsr250,JSR-250 annotations>>
 * Authorizing methods with <<use-aspectj,AspectJ expressions>>
@@ -2207,6 +2208,459 @@ And if they do have that authority, they'll see:
 ====
 You can also add the Spring Boot property `spring.jackson.default-property-inclusion=non_null` to exclude the null value, if you also don't want to reveal the JSON key to an unauthorized user.
 ====
+
+[[fallback-values-authorization-denied]]
+== Providing Fallback Values When Authorization is Denied
+
+There are some scenarios where you may not wish to throw an `AccessDeniedException` when a method is invoked without the required permissions.
+Instead, you might wish to return a post-processed result, like a masked result, or a default value in cases where access denied happened before invoking the method.
+
+Spring Security provides support for handling and post-processing method access denied with the <<authorizing-with-annotations,`@PreAuthorize` and `@PostAuthorize` annotations>> respectively.
+The `@PreAuthorize` annotation works with implementations of `MethodAuthorizationDeniedHandler` while the `@PostAuthorize` annotation works with implementations of `MethodAuthorizationDeniedPostProcessor`.
+
+=== Using with `@PreAuthorize`
+
+Let's consider the example from the <<authorize-object,previous section>>, but instead of creating the `AccessDeniedExceptionInterceptor` to transform an `AccessDeniedException` to a `null` return value, we will use the `handlerClass` attribute from `@PreAuthorize`:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+public class NullMethodAuthorizationDeniedHandler implements MethodAuthorizationDeniedHandler { <1>
+
+    @Override
+    public Object handle(MethodInvocation methodInvocation, AuthorizationResult authorizationResult) {
+        return null;
+    }
+
+}
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean <2>
+    public NullMethodAuthorizationDeniedHandler nullMethodAuthorizationDeniedHandler() {
+        return new NullMethodAuthorizationDeniedHandler();
+    }
+
+}
+
+public class User {
+    // ...
+
+    @PreAuthorize(value = "hasAuthority('user:read')", handlerClass = NullMethodAuthorizationDeniedHandler.class)
+    public String getEmail() {
+        return this.email;
+    }
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+class NullMethodAuthorizationDeniedHandler : MethodAuthorizationDeniedHandler { <1>
+
+    override fun handle(methodInvocation: MethodInvocation, authorizationResult: AuthorizationResult): Any {
+        return null
+    }
+
+}
+
+@Configuration
+@EnableMethodSecurity
+class SecurityConfig {
+
+    @Bean <2>
+    fun nullMethodAuthorizationDeniedHandler(): NullMethodAuthorizationDeniedHandler {
+        return MaskMethodAuthorizationDeniedHandler()
+    }
+
+}
+
+class User (val name:String, @get:PreAuthorize(value = "hasAuthority('user:read')", handlerClass = NullMethodAuthorizationDeniedHandler::class) val email:String) <3>
+----
+======
+
+<1> Create an implementation of `MethodAuthorizationDeniedHandler` that returns a `null` value
+<2> Register the `NullMethodAuthorizationDeniedHandler` as a bean
+<3> Pass the `NullMethodAuthorizationDeniedHandler` to the `handlerClass` attribute of `@PreAuthorize`
+
+And then you can verify that a `null` value is returned instead of the `AccessDeniedException`:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Autowired
+UserRepository users;
+
+@Test
+void getEmailWhenProxiedThenNullEmail() {
+    Optional<User> securedUser = users.findByName("name");
+    assertThat(securedUser.get().getEmail()).isNull();
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@Autowired
+var users:UserRepository? = null
+
+@Test
+fun getEmailWhenProxiedThenNullEmail() {
+    val securedUser: Optional<User> = users.findByName("name")
+    assertThat(securedUser.get().getEmail()).isNull()
+}
+----
+======
+
+=== Using with `@PostAuthorize`
+
+The same can be achieved with `@PostAuthorize`, however, since `@PostAuthorize` checks are performed after the method is invoked, we have access to the resulting value of the invocation, allowing you to provide fallback values based on the unauthorized results.
+Let's continue with the previous example, but instead of returning `null`, we will return a masked value of the email:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+public class EmailMaskingMethodAuthorizationDeniedPostProcessor implements MethodAuthorizationDeniedPostProcessor { <1>
+
+    @Override
+    public Object postProcessResult(MethodInvocationResult methodInvocationResult, AuthorizationResult authorizationResult) {
+        String email = (String) methodInvocationResult.getResult();
+        return email.replaceAll("(^[^@]{3}|(?!^)\\G)[^@]", "$1*");
+    }
+
+}
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean <2>
+    public EmailMaskingMethodAuthorizationDeniedPostProcessor emailMaskingMethodAuthorizationDeniedPostProcessor() {
+        return new EmailMaskingMethodAuthorizationDeniedPostProcessor();
+    }
+
+}
+
+public class User {
+    // ...
+
+    @PostAuthorize(value = "hasAuthority('user:read')", postProcessorClass = EmailMaskingMethodAuthorizationDeniedPostProcessor.class)
+    public String getEmail() {
+        return this.email;
+    }
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+class EmailMaskingMethodAuthorizationDeniedPostProcessor : MethodAuthorizationDeniedPostProcessor {
+
+    override fun postProcessResult(methodInvocationResult: MethodInvocationResult, authorizationResult: AuthorizationResult): Any {
+        val email = methodInvocationResult.result as String
+        return email.replace("(^[^@]{3}|(?!^)\\G)[^@]".toRegex(), "$1*")
+    }
+
+}
+
+@Configuration
+@EnableMethodSecurity
+class SecurityConfig {
+
+    @Bean
+    fun emailMaskingMethodAuthorizationDeniedPostProcessor(): EmailMaskingMethodAuthorizationDeniedPostProcessor {
+        return EmailMaskingMethodAuthorizationDeniedPostProcessor()
+    }
+
+}
+
+class User (val name:String, @PostAuthorize(value = "hasAuthority('user:read')", postProcessorClass = EmailMaskingMethodAuthorizationDeniedPostProcessor::class) val email:String) <3>
+----
+======
+
+<1> Create an implementation of `MethodAuthorizationDeniedPostProcessor` that returns a masked value of the unauthorized result value
+<2> Register the `EmailMaskingMethodAuthorizationDeniedPostProcessor` as a bean
+<3> Pass the `EmailMaskingMethodAuthorizationDeniedPostProcessor` to the `postProcessorClass` attribute of `@PostAuthorize`
+
+And then you can verify that a masked email is returned instead of an `AccessDeniedException`:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Autowired
+UserRepository users;
+
+@Test
+void getEmailWhenProxiedThenMaskedEmail() {
+    Optional<User> securedUser = users.findByName("name");
+    // email is useremail@example.com
+    assertThat(securedUser.get().getEmail()).isEqualTo("use******@example.com");
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@Autowired
+var users:UserRepository? = null
+
+@Test
+fun getEmailWhenProxiedThenMaskedEmail() {
+    val securedUser: Optional<User> = users.findByName("name")
+    // email is useremail@example.com
+    assertThat(securedUser.get().getEmail()).isEqualTo("use******@example.com")
+}
+----
+======
+
+When implementing the `MethodAuthorizationDeniedHandler` or the `MethodAuthorizationDeniedPostProcessor` you have a few options on what you can return:
+
+- A `null` value.
+- A non-null value, respecting the method's return type.
+- Throw an exception, usually an instance of `AccessDeniedException`. This is the default behavior.
+- A `Mono` type for reactive applications.
+
+Note that since the handler and the post-processor must be registered as beans, you can inject dependencies into them if you need a more complex logic.
+In addition to that, you have available the `MethodInvocation` or the `MethodInvocationResult`, as well as the `AuthorizationResult` for more details related to the authorization decision.
+
+=== Deciding What to Return Based on Available Parameters
+
+Consider a scenario where there might multiple mask values for different methods, it would be not so productive if we had to create a handler or post-processor for each of those methods, although it is perfectly fine to do that.
+In such cases, we can use the information passed via parameters to decide what to do.
+For example, we can create a custom `@Mask` annotation and a handler that detects that annotation to decide what mask value to return:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+import org.springframework.core.annotation.AnnotationUtils;
+
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Mask {
+
+    String value();
+
+}
+
+public class MaskAnnotationDeniedHandler implements MethodAuthorizationDeniedHandler {
+
+    @Override
+    public Object handle(MethodInvocation methodInvocation, AuthorizationResult authorizationResult) {
+        Mask mask = AnnotationUtils.getAnnotation(methodInvocation.getMethod(), Mask.class);
+        return mask.value();
+    }
+
+}
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    public MaskAnnotationDeniedHandler maskAnnotationDeniedHandler() {
+        return new MaskAnnotationDeniedHandler();
+    }
+
+}
+
+@Component
+public class MyService {
+
+    @PreAuthorize(value = "hasAuthority('user:read')", handlerClass = MaskAnnotationDeniedHandler.class)
+    @Mask("***")
+    public String foo() {
+        return "foo";
+    }
+
+    @PreAuthorize(value = "hasAuthority('user:read')", handlerClass = MaskAnnotationDeniedHandler.class)
+    @Mask("???")
+    public String bar() {
+        return "bar";
+    }
+
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+import org.springframework.core.annotation.AnnotationUtils
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Mask(val value: String)
+
+class MaskAnnotationDeniedHandler : MethodAuthorizationDeniedHandler {
+
+    override fun handle(methodInvocation: MethodInvocation, authorizationResult: AuthorizationResult): Any {
+        val mask = AnnotationUtils.getAnnotation(methodInvocation.method, Mask::class.java)
+        return mask.value
+    }
+
+}
+
+@Configuration
+@EnableMethodSecurity
+class SecurityConfig {
+
+    @Bean
+    fun maskAnnotationDeniedHandler(): MaskAnnotationDeniedHandler {
+        return MaskAnnotationDeniedHandler()
+    }
+
+}
+
+@Component
+class MyService {
+
+    @PreAuthorize(value = "hasAuthority('user:read')", handlerClass = MaskAnnotationDeniedHandler::class)
+    @Mask("***")
+    fun foo(): String {
+        return "foo"
+    }
+
+    @PreAuthorize(value = "hasAuthority('user:read')", handlerClass = MaskAnnotationDeniedHandler::class)
+    @Mask("???")
+    fun bar(): String {
+        return "bar"
+    }
+
+}
+----
+======
+
+Now the return values when access is denied will be decided based on the `@Mask` annotation:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Autowired
+MyService myService;
+
+@Test
+void fooWhenDeniedThenReturnStars() {
+    String value = this.myService.foo();
+    assertThat(value).isEqualTo("***");
+}
+
+@Test
+void barWhenDeniedThenReturnQuestionMarks() {
+    String value = this.myService.foo();
+    assertThat(value).isEqualTo("???");
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@Autowired
+var myService: MyService
+
+@Test
+fun fooWhenDeniedThenReturnStars() {
+    val value: String = myService.foo()
+    assertThat(value).isEqualTo("***")
+}
+
+@Test
+fun barWhenDeniedThenReturnQuestionMarks() {
+    val value: String = myService.foo()
+    assertThat(value).isEqualTo("???")
+}
+----
+======
+
+=== Combining with Meta Annotation Support
+
+Some authorization expressions may be long enough that it can become hard to read or to maintain.
+For example, consider the following `@PreAuthorize` expression:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@PreAuthorize(value = "@myAuthorizationBean.check()", handlerClass = NullAuthorizationDeniedHandler.class)
+public String myMethod() {
+    // ...
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@PreAuthorize(value = "@myAuthorizationBean.check()", handlerClass = NullAuthorizationDeniedHandler::class)
+fun myMethod(): String {
+    // ...
+}
+----
+======
+
+The way it is, it is somewhat hard to read it, but we can do better.
+By using the <<meta-annotations,meta annotation support>>, we can simplify it to:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize(value = "@myAuthorizationBean.check()", handlerClass = NullAuthorizationDeniedHandler.class)
+public @interface NullDenied {}
+
+@NullDenied
+public String myMethod() {
+    // ...
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@PreAuthorize(value = "@myAuthorizationBean.check()", handlerClass = NullAuthorizationDeniedHandler::class)
+annotation class NullDenied
+
+@NullDenied
+fun myMethod(): String {
+    // ...
+}
+----
+======
+
+Make sure to read the <<meta-annotations,Meta Annotations Support>> section for more details on the usage.
 
 [[migration-enableglobalmethodsecurity]]
 == Migrating from `@EnableGlobalMethodSecurity`

--- a/docs/modules/ROOT/pages/whats-new.adoc
+++ b/docs/modules/ROOT/pages/whats-new.adoc
@@ -12,6 +12,7 @@ Below are the highlights of the release.
 
 - https://github.com/spring-projects/spring-security/issues/14596[gh-14596] - xref:servlet/authorization/method-security.adoc[docs] - Add Programmatic Proxy Support for Method Security
 - https://github.com/spring-projects/spring-security/issues/14597[gh-14597] - xref:servlet/authorization/method-security.adoc[docs] - Add Securing of Return Values
+- https://github.com/spring-projects/spring-security/issues/14601[gh-14601] - xref:servlet/authorization/method-security.adoc#fallback-values-authorization-denied[docs] - Add Authorization Denied Handlers for Method Security
 
 == Configuration
 


### PR DESCRIPTION
For this feature, we have at least 2 options:

1. Create a `DeniedHandlerMethodInterceptor` that intercepts `AccessDeniedException` thrown from methods annotated with `@DeniedHandler`:
- The `AuthorizationManagerAfterMethodInterceptor` would have to throw a more contextual `AccessDeniedException`, something like `MethodInvocationResultAccessDeniedException` so we can have access to the result object that resulted in an exception to pass it to the `MethodAccessDeniedHandler`.
- When the `@Pre/PostFilter` filters non-collection types, it would have to throw an `AccessDeniedException` for not authorized objects instead of just returning `null` so `DeniedHandlerMethodInterceptor` can catch it.

2. Add the logic inside `AuthorizationManagerAfterMethodInterceptor`, `AuthorizationManagerBeforeMethodInterceptor` and `DefaultMethodSecurityExpressionHandler`:
- The `MethodSecurityEvaluationContext` would have to expose the `Method` in order to access it from `DefaultMethodSecurityExpressionHandler`
- Don't need to throw an exception if the `@DeniedHandler` is present
- Don't need to create contextual `AccessDeniedException`, those classes have access to both `MethodInvocation` and the `result`.

