### PR TITLE
[ISSUE-11725] Add secondary statusCode messages on error

### DIFF
--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/OpenSaml4AuthenticationProvider.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/OpenSaml4AuthenticationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/OpenSaml4AuthenticationProvider.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/OpenSaml4AuthenticationProvider.java
@@ -26,6 +26,9 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Arrays;
 import java.util.function.Consumer;
 
 import javax.annotation.Nonnull;
@@ -93,6 +96,8 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
+
+import static org.opensaml.saml.saml2.core.StatusCode.*;
 
 /**
  * Implementation of {@link AuthenticationProvider} for SAML authentications when
@@ -621,7 +626,17 @@ public final class OpenSaml4AuthenticationProvider implements AuthenticationProv
 		if (response.getStatus().getStatusCode() == null) {
 			return StatusCode.SUCCESS;
 		}
-		return response.getStatus().getStatusCode().getValue();
+
+		Set<String> statusCodes = new HashSet<>(Arrays.asList(REQUESTER, RESPONDER, VERSION_MISMATCH));
+		StatusCode parentStatusCode = response.getStatus().getStatusCode();
+		String parentStatusCodeValue = parentStatusCode.getValue();
+		if (statusCodes.contains(parentStatusCodeValue)) {
+			StatusCode childStatusCode = parentStatusCode.getStatusCode();
+			String childStatusCodeValue = childStatusCode.getValue();
+			return parentStatusCodeValue + childStatusCodeValue;
+		}
+
+		return parentStatusCodeValue;
 	}
 
 	private Converter<AssertionToken, Saml2ResponseValidatorResult> createDefaultAssertionSignatureValidator() {


### PR DESCRIPTION
This fixes https://github.com/spring-projects/spring-security/issues/11725 and reflects the feedback from https://github.com/spring-projects/spring-security/pull/12818 