### PR TITLE
Provide Runtime Hints for Beans used in Pre/PostAuthorize Expressions

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/PrePostAuthorizeBeanFactoryInitializationAotProcessor.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/PrePostAuthorizeBeanFactoryInitializationAotProcessor.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.config.annotation.method.configuration;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.aot.generate.GenerationContext;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationCode;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.RegisteredBean;
+import org.springframework.core.annotation.AnnotationConfigurationException;
+import org.springframework.core.annotation.MergedAnnotation;
+import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.core.annotation.RepeatableContainers;
+import org.springframework.core.log.LogMessage;
+import org.springframework.expression.spel.SpelNode;
+import org.springframework.expression.spel.ast.BeanReference;
+import org.springframework.expression.spel.standard.SpelExpression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.security.access.prepost.PostAuthorize;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * AOT BeanFactoryInitializationAotProcessor that detects the presence of
+ * {@link PreAuthorize} and {@link PostAuthorize} on annotated elements of all registered
+ * beans and register runtime hints for the beans used within the security expressions.
+ *
+ * @author Marcus da Coregio
+ * @since 6.3
+ */
+class PrePostAuthorizeBeanFactoryInitializationAotProcessor implements BeanFactoryInitializationAotProcessor {
+
+	@Override
+	public BeanFactoryInitializationAotContribution processAheadOfTime(ConfigurableListableBeanFactory beanFactory) {
+		Class<?>[] beanTypes = Arrays.stream(beanFactory.getBeanDefinitionNames())
+			.map((beanName) -> RegisteredBean.of(beanFactory, beanName).getBeanClass())
+			.toArray(Class<?>[]::new);
+		return new PrePostAuthorizeContribution(beanTypes, beanFactory);
+	}
+
+	private static class PrePostAuthorizeContribution implements BeanFactoryInitializationAotContribution {
+
+		private final Log logger = LogFactory.getLog(getClass());
+
+		private final Class<?>[] types;
+
+		private final ConfigurableListableBeanFactory beanFactory;
+
+		private final SpelExpressionParser expressionParser = new SpelExpressionParser();
+
+		PrePostAuthorizeContribution(Class<?>[] types, ConfigurableListableBeanFactory beanFactory) {
+			this.types = types;
+			this.beanFactory = beanFactory;
+		}
+
+		@Override
+		public void applyTo(GenerationContext generationContext,
+				BeanFactoryInitializationCode beanFactoryInitializationCode) {
+			List<PreAuthorize> preAuthorizes = new ArrayList<>();
+			List<PostAuthorize> postAuthorizes = new ArrayList<>();
+			for (Class<?> type : this.types) {
+				preAuthorizes.addAll(collectAnnotations(type, PreAuthorize.class));
+				postAuthorizes.addAll(collectAnnotations(type, PostAuthorize.class));
+			}
+			Set<String> expressions = Stream
+				.concat(preAuthorizes.stream().map(PreAuthorize::value),
+						postAuthorizes.stream().map(PostAuthorize::value))
+				.collect(Collectors.toSet());
+			Set<String> beanNames = new HashSet<>();
+			for (String expr : expressions) {
+				beanNames.addAll(extractBeanNames(expr));
+			}
+			registerHints(beanNames, generationContext.getRuntimeHints());
+		}
+
+		private void registerHints(Set<String> beanNames, RuntimeHints runtimeHints) {
+			for (String beanName : beanNames) {
+				try {
+					BeanDefinition definition = this.beanFactory.getBeanDefinition(beanName);
+					runtimeHints.reflection()
+						.registerType(TypeReference.of(definition.getBeanClassName()),
+								MemberCategory.INVOKE_DECLARED_METHODS);
+				}
+				catch (NoSuchBeanDefinitionException ex) {
+					this.logger.debug(LogMessage.format(
+							"""
+									Could not register runtime hints for bean with name [%s] because it is not available, please provide
+									the needed hints manually""",
+							beanName));
+				}
+			}
+		}
+
+		private <A extends Annotation> List<A> collectAnnotations(Class<?> type, Class<A> annotationType) {
+			List<A> annotations = new ArrayList<>();
+			A classAnnotation = findDistinctAnnotation(type, annotationType, MergedAnnotation::synthesize);
+			if (classAnnotation != null) {
+				annotations.add(classAnnotation);
+			}
+			for (Method method : type.getDeclaredMethods()) {
+				A methodAnnotation = findDistinctAnnotation(method, annotationType, MergedAnnotation::synthesize);
+				if (methodAnnotation != null) {
+					annotations.add(methodAnnotation);
+				}
+			}
+			return annotations;
+		}
+
+		private Set<String> extractBeanNames(String rawExpression) {
+			SpelExpression expression = this.expressionParser.parseRaw(rawExpression);
+			SpelNode node = expression.getAST();
+			Set<String> beanNames = new HashSet<>();
+			resolveBeanNames(beanNames, node);
+			return beanNames;
+		}
+
+		private void resolveBeanNames(Set<String> beanNames, SpelNode node) {
+			if (node instanceof BeanReference br) {
+				beanNames.add(resolveBeanName(br));
+			}
+			int childCount = node.getChildCount();
+			if (childCount == 0) {
+				return;
+			}
+			for (int i = 0; i < childCount; i++) {
+				resolveBeanNames(beanNames, node.getChild(i));
+			}
+		}
+
+		private String resolveBeanName(BeanReference br) {
+			try {
+				Field field = ReflectionUtils.findField(BeanReference.class, "beanName");
+				field.setAccessible(true);
+				return (String) field.get(br);
+			}
+			catch (IllegalAccessException ex) {
+				throw new IllegalStateException("Could not resolve beanName for BeanReference [%s]".formatted(br), ex);
+			}
+		}
+
+		private static <A extends Annotation> A findDistinctAnnotation(AnnotatedElement annotatedElement,
+				Class<A> annotationType, Function<MergedAnnotation<A>, A> map) {
+			MergedAnnotations mergedAnnotations = MergedAnnotations.from(annotatedElement,
+					MergedAnnotations.SearchStrategy.TYPE_HIERARCHY, RepeatableContainers.none());
+			List<A> annotations = mergedAnnotations.stream(annotationType)
+				.map(MergedAnnotation::withNonMergedAttributes)
+				.map(map)
+				.distinct()
+				.toList();
+
+			return switch (annotations.size()) {
+				case 0 -> null;
+				case 1 -> annotations.get(0);
+				default -> throw new AnnotationConfigurationException("""
+						Please ensure there is one unique annotation of type @%s attributed to %s. \
+						Found %d competing annotations: %s""".formatted(annotationType.getName(), annotatedElement,
+						annotations.size(), annotations));
+			};
+		}
+
+	}
+
+}

--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/PrePostMethodSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/PrePostMethodSecurityConfiguration.java
@@ -152,6 +152,12 @@ final class PrePostMethodSecurityConfiguration implements ImportAware, AopInfras
 		});
 	}
 
+	@Bean
+	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+	static PrePostAuthorizeBeanFactoryInitializationAotProcessor prePostAuthorizeBeanFactoryInitializationAotProcessor() {
+		return new PrePostAuthorizeBeanFactoryInitializationAotProcessor();
+	}
+
 	private static MethodSecurityExpressionHandler defaultExpressionHandler(
 			ObjectProvider<GrantedAuthorityDefaults> defaultsProvider,
 			ObjectProvider<RoleHierarchy> roleHierarchyProvider, ApplicationContext context) {

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/PrePostAuthorizeBeanFactoryInitializationAotProcessorTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/PrePostAuthorizeBeanFactoryInitializationAotProcessorTests.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.config.annotation.method.configuration;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aot.generate.GenerationContext;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+import org.springframework.aot.test.generate.TestGenerationContext;
+import org.springframework.beans.factory.aot.BeanFactoryInitializationAotContribution;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.security.access.prepost.PostAuthorize;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link PrePostAuthorizeBeanFactoryInitializationAotProcessor}
+ *
+ * @author Marcus da Coregio
+ */
+class PrePostAuthorizeBeanFactoryInitializationAotProcessorTests {
+
+	private final PrePostAuthorizeBeanFactoryInitializationAotProcessor processor = new PrePostAuthorizeBeanFactoryInitializationAotProcessor();
+
+	private final GenerationContext generationContext = new TestGenerationContext();
+
+	@Test
+	void processWhenPreAuthorizeOnTypeThenProcessed() {
+		process(Authz.class, PreAuthorizeOnClass.class);
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(Authz.class)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_METHODS))
+			.accepts(this.generationContext.getRuntimeHints());
+	}
+
+	@Test
+	void processWhenPostAuthorizeOnTypeThenProcessed() {
+		process(Authz.class, PostAuthorizeOnClass.class);
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(Authz.class)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_METHODS))
+			.accepts(this.generationContext.getRuntimeHints());
+	}
+
+	@Test
+	void processWhenPreAuthorizeOnMethodsThenProcessed() {
+		process(Authz.class, Foo.class, PreAuthorizeOnMethods.class);
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(Authz.class)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_METHODS))
+			.accepts(this.generationContext.getRuntimeHints());
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(Foo.class)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_METHODS))
+			.accepts(this.generationContext.getRuntimeHints());
+	}
+
+	@Test
+	void processWhenPostAuthorizeOnMethodsThenProcessed() {
+		process(Authz.class, Foo.class, PostAuthorizeOnMethods.class);
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(Authz.class)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_METHODS))
+			.accepts(this.generationContext.getRuntimeHints());
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(Foo.class)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_METHODS))
+			.accepts(this.generationContext.getRuntimeHints());
+	}
+
+	@Test
+	void processWhenPreAuthorizeExpressionWithMultipleBeansThenRegisterHintsForAllBeans() {
+		process(Authz.class, Foo.class, PreAuthorizeMultipleBeans.class);
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(Authz.class)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_METHODS))
+			.accepts(this.generationContext.getRuntimeHints());
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(Foo.class)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_METHODS))
+			.accepts(this.generationContext.getRuntimeHints());
+	}
+
+	@Test
+	void processWhenPostAuthorizeExpressionWithMultipleBeansThenRegisterHintsForAllBeans() {
+		process(Authz.class, Foo.class, PostAuthorizeMultipleBeans.class);
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(Authz.class)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_METHODS))
+			.accepts(this.generationContext.getRuntimeHints());
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(Foo.class)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_METHODS))
+			.accepts(this.generationContext.getRuntimeHints());
+	}
+
+	@Test
+	void processWhenPreAuthorizeOnTypeAndMethodThenRegisterHintsForBoth() {
+		process(Authz.class, Foo.class, PreAuthorizeOnTypeAndMethod.class);
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(Authz.class)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_METHODS))
+			.accepts(this.generationContext.getRuntimeHints());
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(Foo.class)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_METHODS))
+			.accepts(this.generationContext.getRuntimeHints());
+	}
+
+	@Test
+	void processWhenPostAuthorizeOnTypeAndMethodThenRegisterHintsForBoth() {
+		process(Authz.class, Foo.class, PostAuthorizeOnTypeAndMethod.class);
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(Authz.class)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_METHODS))
+			.accepts(this.generationContext.getRuntimeHints());
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(Foo.class)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_METHODS))
+			.accepts(this.generationContext.getRuntimeHints());
+	}
+
+	private void process(Class<?>... beanClasses) {
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		for (Class<?> beanClass : beanClasses) {
+			beanFactory.registerBeanDefinition(beanClass.getSimpleName().toLowerCase(),
+					new RootBeanDefinition(beanClass));
+		}
+		BeanFactoryInitializationAotContribution contribution = this.processor.processAheadOfTime(beanFactory);
+		assertThat(contribution).isNotNull();
+		contribution.applyTo(this.generationContext, mock());
+	}
+
+	@PreAuthorize("@authz.check()")
+	static class PreAuthorizeOnClass {
+
+	}
+
+	@PostAuthorize("@authz.check()")
+	static class PostAuthorizeOnClass {
+
+	}
+
+	static class PreAuthorizeOnMethods {
+
+		@PreAuthorize("@authz.check()")
+		void method1() {
+		}
+
+		@PreAuthorize("@foo.bar()")
+		void method2() {
+		}
+
+	}
+
+	static class PostAuthorizeOnMethods {
+
+		@PostAuthorize("@authz.check()")
+		void method1() {
+		}
+
+		@PostAuthorize("@foo.bar()")
+		void method2() {
+		}
+
+	}
+
+	static class PreAuthorizeMultipleBeans {
+
+		@PreAuthorize("@authz.check() ? true : @foo.bar()")
+		void method1() {
+		}
+
+	}
+
+	static class PostAuthorizeMultipleBeans {
+
+		@PostAuthorize("@authz.check() ? true : @foo.bar()")
+		void method1() {
+		}
+
+	}
+
+	@PreAuthorize("@authz.check()")
+	static class PreAuthorizeOnTypeAndMethod {
+
+		@PreAuthorize("@foo.bar()")
+		void method1() {
+		}
+
+	}
+
+	@PostAuthorize("@authz.check()")
+	static class PostAuthorizeOnTypeAndMethod {
+
+		@PostAuthorize("@foo.bar()")
+		void method1() {
+		}
+
+	}
+
+	static class Authz {
+
+		boolean check() {
+			return true;
+		}
+
+	}
+
+	static class Foo {
+
+		boolean bar() {
+			return true;
+		}
+
+	}
+
+}

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/PrePostMethodSecurityConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/PrePostMethodSecurityConfigurationTests.java
@@ -740,6 +740,14 @@ public class PrePostMethodSecurityConfigurationTests {
 		});
 	}
 
+	@Test
+	void configureWhenPrePostEnabledThenRegisterPrePostAuthorizeBeanFactoryInitializationAotProcessor() {
+		this.spring.register(MethodSecurityServiceConfig.class).autowire();
+		PrePostAuthorizeBeanFactoryInitializationAotProcessor processor = this.spring.getContext()
+			.getBean(PrePostAuthorizeBeanFactoryInitializationAotProcessor.class);
+		assertThat(processor).isNotNull();
+	}
+
 	private static Consumer<ConfigurableWebApplicationContext> disallowBeanOverriding() {
 		return (context) -> ((AnnotationConfigWebApplicationContext) context).setAllowBeanDefinitionOverriding(false);
 	}

--- a/docs/modules/ROOT/pages/whats-new.adoc
+++ b/docs/modules/ROOT/pages/whats-new.adoc
@@ -12,6 +12,7 @@ Below are the highlights of the release.
 
 - https://github.com/spring-projects/spring-security/issues/14596[gh-14596] - xref:servlet/authorization/method-security.adoc[docs] - Add Programmatic Proxy Support for Method Security
 - https://github.com/spring-projects/spring-security/issues/14597[gh-14597] - xref:servlet/authorization/method-security.adoc[docs] - Add Securing of Return Values
+- https://github.com/spring-projects/spring-security/issues/14652[gh-14652] - Provide Runtime Hints for Beans used in Pre/PostAuthorize Expressions
 
 == Configuration
 


### PR DESCRIPTION
Closes gh-14652

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
