### PR TITLE
Fix HeadersConfigurer#permissionsPolicy method with customizer

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HeadersConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HeadersConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -607,15 +607,15 @@ public class HeadersConfigurer<H extends HttpSecurityBuilder<H>>
 	 * <p>
 	 * Configuration is provided to the {@link PermissionsPolicyHeaderWriter} which is
 	 * responsible for writing the header.
-	 * @return the {@link PermissionsPolicyConfig} for additional configuration
-	 * @throws IllegalArgumentException if policyDirectives is {@code null} or empty
+	 * </p>
+	 * @return the {@link HeadersConfigurer} for additional customizations
 	 * @since 5.5
 	 * @see PermissionsPolicyHeaderWriter
 	 */
-	public PermissionsPolicyConfig permissionsPolicy(Customizer<PermissionsPolicyConfig> permissionsPolicyCustomizer) {
+	public HeadersConfigurer<H> permissionsPolicy(Customizer<PermissionsPolicyConfig> permissionsPolicyCustomizer) {
 		this.permissionsPolicy.writer = new PermissionsPolicyHeaderWriter();
 		permissionsPolicyCustomizer.customize(this.permissionsPolicy);
-		return this.permissionsPolicy;
+		return HeadersConfigurer.this;
 	}
 
 	/**


### PR DESCRIPTION
Preserve HeadersConfigurer's chaining like other methods with customizer (New SpringSecurity DSL)

Closes gh-14803

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
