### PR TITLE
Fix Variable Naming Convention

### DIFF
--- a/core/src/main/java/org/springframework/security/core/ComparableVersion.java
+++ b/core/src/main/java/org/springframework/security/core/ComparableVersion.java
@@ -66,9 +66,9 @@ import java.util.Properties;
  */
 class ComparableVersion implements Comparable<ComparableVersion> {
 
-	private static final int MAX_INTITEM_LENGTH = 9;
+	private static final int MAX_INT_ITEM_LENGTH = 9;
 
-	private static final int MAX_LONGITEM_LENGTH = 18;
+	private static final int MAX_LONG_ITEM_LENGTH = 18;
 
 	private String value;
 
@@ -559,11 +559,11 @@ class ComparableVersion implements Comparable<ComparableVersion> {
 	private static Item parseItem(boolean isDigit, String buf) {
 		if (isDigit) {
 			buf = stripLeadingZeroes(buf);
-			if (buf.length() <= MAX_INTITEM_LENGTH) {
+			if (buf.length() <= MAX_INT_ITEM_LENGTH) {
 				// lower than 2^31
 				return new IntItem(buf);
 			}
-			else if (buf.length() <= MAX_LONGITEM_LENGTH) {
+			else if (buf.length() <= MAX_LONG_ITEM_LENGTH) {
 				// lower than 2^63
 				return new LongItem(buf);
 			}


### PR DESCRIPTION
Changed the variable name from MAX_INTITEM_LENGTH to MAX_INT_ITEM_LENGTH to adhere to naming conventions

1. According to Java's naming convention, constant names are typically all capitalized, separated by an underscore (_) between words.
2. It increases readability.
3. MAX_INTITEM_LENGTH can be difficult to understand the meaning of a variable because the term "INTITEM" is not commonly used.
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
