### PR TITLE
Revert "Bump com.gradle.enterprise from 3.16.2 to 3.17"

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ pluginManagement {
 }
 
 plugins {
-	id "com.gradle.enterprise" version "3.17"
+	id "com.gradle.enterprise" version "3.16.2"
 	id "io.spring.ge.conventions" version "0.0.16"
 }
 


### PR DESCRIPTION
Reverts spring-projects/spring-security#14833

Gradle Enterprise plugin version 3.17 is newer than the newest version supported by Gradle Enterprise 2023.4.6 which is 3.16. Please update to a newer version of Gradle Enterprise.
