### PR TITLE
Remove useBase64 parameter

### DIFF
--- a/config/src/main/java/org/springframework/security/config/authentication/PasswordEncoderParser.java
+++ b/config/src/main/java/org/springframework/security/config/authentication/PasswordEncoderParser.java
@@ -41,8 +41,6 @@ public class PasswordEncoderParser {
 
 	public static final String ATT_HASH = "hash";
 
-	static final String ATT_BASE_64 = "base64";
-
 	static final String OPT_HASH_BCRYPT = "bcrypt";
 
 	private static final Map<String, Class<?>> ENCODER_CLASSES = Collections.singletonMap(OPT_HASH_BCRYPT,
@@ -62,19 +60,17 @@ public class PasswordEncoderParser {
 			return;
 		}
 		String hash = element.getAttribute(ATT_HASH);
-		boolean useBase64 = StringUtils.hasText(element.getAttribute(ATT_BASE_64))
-				&& Boolean.parseBoolean(element.getAttribute(ATT_BASE_64));
 		String ref = element.getAttribute(ATT_REF);
 		if (StringUtils.hasText(ref)) {
 			this.passwordEncoder = new RuntimeBeanReference(ref);
 		}
 		else {
-			this.passwordEncoder = createPasswordEncoderBeanDefinition(hash, useBase64);
+			this.passwordEncoder = createPasswordEncoderBeanDefinition(hash);
 			((RootBeanDefinition) this.passwordEncoder).setSource(parserContext.extractSource(element));
 		}
 	}
 
-	public static BeanDefinition createPasswordEncoderBeanDefinition(String hash, boolean useBase64) {
+	public static BeanDefinition createPasswordEncoderBeanDefinition(String hash) {
 		Class<?> beanClass = ENCODER_CLASSES.get(hash);
 		BeanDefinitionBuilder beanBldr = BeanDefinitionBuilder.rootBeanDefinition(beanClass);
 		return beanBldr.getBeanDefinition();

--- a/config/src/main/java/org/springframework/security/config/ldap/LdapProviderBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/ldap/LdapProviderBeanDefinitionParser.java
@@ -98,7 +98,7 @@ public class LdapProviderBeanDefinitionParser implements BeanDefinitionParser {
 			}
 			else if (StringUtils.hasText(hash)) {
 				authenticatorBuilder.addPropertyValue("passwordEncoder",
-						PasswordEncoderParser.createPasswordEncoderBeanDefinition(hash, false));
+						PasswordEncoderParser.createPasswordEncoderBeanDefinition(hash));
 			}
 		}
 		authenticatorBuilder.addConstructorArgValue(contextSource);

--- a/config/src/test/java/org/springframework/security/config/authentication/PasswordEncoderParserTests.java
+++ b/config/src/test/java/org/springframework/security/config/authentication/PasswordEncoderParserTests.java
@@ -20,10 +20,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.security.config.test.SpringTestContext;
 import org.springframework.security.config.test.SpringTestContextExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -63,6 +66,17 @@ public class PasswordEncoderParserTests {
 		this.mockMvc.perform(get("/").with(httpBasic("user", "password")))
 				.andExpect(status().isOk());
 		// @formatter:on
+	}
+
+	@Test
+	void testCreatePasswordEncoderBeanDefinition() throws Exception {
+		String hash = "bcrypt";
+		Class<?> expectedBeanClass = BCryptPasswordEncoder.class;
+
+		BeanDefinition beanDefinition = PasswordEncoderParser.createPasswordEncoderBeanDefinition(hash);
+
+		Class<?> actualBeanClass = Class.forName(beanDefinition.getBeanClassName());
+		assertThat(actualBeanClass).isEqualTo(expectedBeanClass);
 	}
 
 }


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->


This PR removes the 'useBase64' parameter from createPasswordEncoderBeanDefinition. It's no longer needed, simplifying the function's interface and ensuring consistency. The PR  also removed `false` from  `createPasswordEncoderBeanDefinition` method call.