### PR TITLE
Add timeout defaults to JwtDecoders

### DIFF
--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoderProviderConfigurationUtils.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoderProviderConfigurationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
 import org.springframework.util.Assert;
 import org.springframework.web.client.HttpClientErrorException;
@@ -64,6 +65,15 @@ final class JwtDecoderProviderConfigurationUtils {
 	private static final String OAUTH_METADATA_PATH = "/.well-known/oauth-authorization-server";
 
 	private static final RestTemplate rest = new RestTemplate();
+
+	static {
+		int connectTimeout = Integer.parseInt(System.getProperty("sun.net.client.defaultConnectTimeout", "30000"));
+		int readTimeout = Integer.parseInt(System.getProperty("sun.net.client.defaultReadTimeout", "30000"));
+		SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+		requestFactory.setConnectTimeout(connectTimeout);
+		requestFactory.setReadTimeout(readTimeout);
+		rest.setRequestFactory(requestFactory);
+	}
 
 	private static final ParameterizedTypeReference<Map<String, Object>> STRING_OBJECT_MAP = new ParameterizedTypeReference<Map<String, Object>>() {
 	};


### PR DESCRIPTION
This PR adds reasonable timeouts to JwtDecoderProviderConfigurationUtils and NimbusJwtDecoder.
It's fixing [Issue GH-14269](https://github.com/spring-projects/spring-security/issues/14269)

Since the `RestOperations` instance in `JwkSetUriJwtDecoderBuilder` is not static, I couldn't have used a static initializer block and had to use the following solution. I am open to suggestions if you think there is a better solution for this.