### PR TITLE
Replace "Spring Boot 2.x" with "Spring Boot"

### DIFF
--- a/docs/modules/ROOT/pages/reactive/oauth2/client/client-authentication.adoc
+++ b/docs/modules/ROOT/pages/reactive/oauth2/client/client-authentication.adoc
@@ -18,7 +18,7 @@ is supplied by the `com.nimbusds.jose.jwk.JWK` resolver associated with `NimbusJ
 
 === Authenticate using `private_key_jwt`
 
-Given the following Spring Boot 2.x properties for an OAuth 2.0 Client registration:
+Given the following Spring Boot properties for an OAuth 2.0 Client registration:
 
 [source,yaml]
 ----
@@ -89,7 +89,7 @@ tokenResponseClient.addParametersConverter(
 
 === Authenticate using `client_secret_jwt`
 
-Given the following Spring Boot 2.x properties for an OAuth 2.0 Client registration:
+Given the following Spring Boot properties for an OAuth 2.0 Client registration:
 
 [source,yaml]
 ----

--- a/docs/modules/ROOT/pages/reactive/oauth2/client/core.adoc
+++ b/docs/modules/ROOT/pages/reactive/oauth2/client/core.adoc
@@ -59,7 +59,7 @@ The name may be used in certain scenarios, such as when displaying the name of t
  which contains the cryptographic key(s) used to verify the https://tools.ietf.org/html/rfc7515[JSON Web Signature (JWS)] of the ID Token and optionally the UserInfo Response.
 <12> `issuerUri`: Returns the issuer identifier uri for the OpenID Connect 1.0 provider or the OAuth 2.0 Authorization Server.
 <13> `configurationMetadata`: The https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig[OpenID Provider Configuration Information].
- This information will only be available if the Spring Boot 2.x property `spring.security.oauth2.client.provider.[providerId].issuerUri` is configured.
+ This information will only be available if the Spring Boot property `spring.security.oauth2.client.provider.[providerId].issuerUri` is configured.
 <14> `(userInfoEndpoint)uri`: The UserInfo Endpoint URI used to access the claims/attributes of the authenticated end-user.
 <15> `(userInfoEndpoint)authenticationMethod`: The authentication method used when sending the access token to the UserInfo Endpoint.
 The supported values are *header*, *form* and *query*.
@@ -100,7 +100,7 @@ The `ReactiveClientRegistrationRepository` serves as a repository for OAuth 2.0 
 Client registration information is ultimately stored and owned by the associated Authorization Server.
 This repository provides the ability to retrieve a sub-set of the primary client registration information, which is stored with the Authorization Server.
 
-Spring Boot 2.x auto-configuration binds each of the properties under `spring.security.oauth2.client.registration._[registrationId]_` to an instance of `ClientRegistration` and then composes each of the `ClientRegistration` instance(s) within a `ReactiveClientRegistrationRepository`.
+Spring Boot auto-configuration binds each of the properties under `spring.security.oauth2.client.registration._[registrationId]_` to an instance of `ClientRegistration` and then composes each of the `ClientRegistration` instance(s) within a `ReactiveClientRegistrationRepository`.
 
 [NOTE]
 The default implementation of `ReactiveClientRegistrationRepository` is `InMemoryReactiveClientRegistrationRepository`.
@@ -213,7 +213,7 @@ class OAuth2ClientController {
 ======
 
 [NOTE]
-Spring Boot 2.x auto-configuration registers an `ServerOAuth2AuthorizedClientRepository` and/or `ReactiveOAuth2AuthorizedClientService` `@Bean` in the `ApplicationContext`.
+Spring Boot auto-configuration registers an `ServerOAuth2AuthorizedClientRepository` and/or `ReactiveOAuth2AuthorizedClientService` `@Bean` in the `ApplicationContext`.
 However, the application may choose to override and register a custom `ServerOAuth2AuthorizedClientRepository` or `ReactiveOAuth2AuthorizedClientService` `@Bean`.
 
 The default implementation of `ReactiveOAuth2AuthorizedClientService` is `InMemoryReactiveOAuth2AuthorizedClientService`, which stores `OAuth2AuthorizedClient`(s) in-memory.

--- a/docs/modules/ROOT/pages/reactive/oauth2/login/core.adoc
+++ b/docs/modules/ROOT/pages/reactive/oauth2/login/core.adoc
@@ -1,9 +1,9 @@
 = Core Configuration
 
 [[webflux-oauth2-login-sample]]
-== Spring Boot 2.x Sample
+== Spring Boot Sample
 
-Spring Boot 2.x brings full auto-configuration capabilities for OAuth 2.0 Login.
+Spring Boot brings full auto-configuration capabilities for OAuth 2.0 Login.
 
 This section shows how to configure the {gh-samples-url}/boot/oauth2login-webflux[*OAuth 2.0 Login WebFlux sample*] by using _Google_ as the _Authentication Provider_ and covers the following topics:
 
@@ -80,7 +80,7 @@ spring:
 [[webflux-oauth2-login-sample-start]]
 === Boot the Application
 
-Launch the Spring Boot 2.x sample and go to `http://localhost:8080`.
+Launch the Spring Boot sample and go to `http://localhost:8080`.
 You are then redirected to the default _auto-generated_ login page, which displays a link for Google.
 
 Click on the Google link, and you are then redirected to Google for authentication.
@@ -93,12 +93,12 @@ At this point, the OAuth Client retrieves your email address and basic profile i
 
 
 [[oauth2login-boot-property-mappings]]
-== Spring Boot 2.x Property Mappings
+== Spring Boot Property Mappings
 
-The following table outlines the mapping of the Spring Boot 2.x OAuth Client properties to the xref:reactive/oauth2/client/core.adoc#oauth2Client-client-registration[ClientRegistration] properties.
+The following table outlines the mapping of the Spring Boot OAuth Client properties to the xref:reactive/oauth2/client/core.adoc#oauth2Client-client-registration[ClientRegistration] properties.
 
 |===
-|Spring Boot 2.x |ClientRegistration
+|Spring Boot |ClientRegistration
 
 |`spring.security.oauth2.client.registration._[registrationId]_`
 |`registrationId`
@@ -204,7 +204,7 @@ There are some OAuth 2.0 Providers that support multi-tenancy, which results in 
 
 For example, an OAuth Client registered with Okta is assigned to a specific sub-domain and have their own protocol endpoints.
 
-For these cases, Spring Boot 2.x provides the following base property for configuring custom provider properties: `spring.security.oauth2.client.provider._[providerId]_`.
+For these cases, Spring Boot provides the following base property for configuring custom provider properties: `spring.security.oauth2.client.provider._[providerId]_`.
 
 The following listing shows an example:
 
@@ -231,9 +231,9 @@ spring:
 
 
 [[webflux-oauth2-login-override-boot-autoconfig]]
-== Overriding Spring Boot 2.x Auto-configuration
+== Overriding Spring Boot Auto-configuration
 
-The Spring Boot 2.x auto-configuration class for OAuth Client support is `ReactiveOAuth2ClientAutoConfiguration`.
+The Spring Boot auto-configuration class for OAuth Client support is `ReactiveOAuth2ClientAutoConfiguration`.
 
 It performs the following tasks:
 
@@ -469,9 +469,9 @@ class OAuth2LoginConfig {
 
 
 [[webflux-oauth2-login-javaconfig-wo-boot]]
-== Java Configuration without Spring Boot 2.x
+== Java Configuration without Spring Boot
 
-If you are not able to use Spring Boot 2.x and would like to configure one of the pre-defined providers in `CommonOAuth2Provider` (for example, Google), apply the following configuration:
+If you are not able to use Spring Boot and would like to configure one of the pre-defined providers in `CommonOAuth2Provider` (for example, Google), apply the following configuration:
 
 .OAuth2 Login Configuration
 [tabs]

--- a/docs/modules/ROOT/pages/servlet/oauth2/client/client-authentication.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/client/client-authentication.adoc
@@ -18,7 +18,7 @@ is supplied by the `com.nimbusds.jose.jwk.JWK` resolver associated with `NimbusJ
 
 === Authenticate using `private_key_jwt`
 
-Given the following Spring Boot 2.x properties for an OAuth 2.0 Client registration:
+Given the following Spring Boot properties for an OAuth 2.0 Client registration:
 
 [source,yaml]
 ----
@@ -96,7 +96,7 @@ tokenResponseClient.setRequestEntityConverter(requestEntityConverter)
 
 === Authenticate using `client_secret_jwt`
 
-Given the following Spring Boot 2.x properties for an OAuth 2.0 Client registration:
+Given the following Spring Boot properties for an OAuth 2.0 Client registration:
 
 [source,yaml]
 ----

--- a/docs/modules/ROOT/pages/servlet/oauth2/client/core.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/client/core.adoc
@@ -60,7 +60,7 @@ The name may be used in certain scenarios, such as when displaying the name of t
 which contains the cryptographic key(s) used to verify the https://tools.ietf.org/html/rfc7515[JSON Web Signature (JWS)] of the ID Token and (optionally) the UserInfo Response.
 <12> `issuerUri`: Returns the issuer identifier URI for the OpenID Connect 1.0 provider or the OAuth 2.0 Authorization Server.
 <13> `configurationMetadata`: The https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig[OpenID Provider Configuration Information].
-This information is available only if the Spring Boot 2.x property `spring.security.oauth2.client.provider.[providerId].issuerUri` is configured.
+This information is available only if the Spring Boot property `spring.security.oauth2.client.provider.[providerId].issuerUri` is configured.
 <14> `(userInfoEndpoint)uri`: The UserInfo Endpoint URI used to access the claims and attributes of the authenticated end-user.
 <15> `(userInfoEndpoint)authenticationMethod`: The authentication method used when sending the access token to the UserInfo Endpoint.
 The supported values are *header*, *form*, and *query*.
@@ -103,7 +103,7 @@ Client registration information is ultimately stored and owned by the associated
 This repository provides the ability to retrieve a subset of the primary client registration information, which is stored with the Authorization Server.
 ====
 
-Spring Boot 2.x auto-configuration binds each of the properties under `spring.security.oauth2.client.registration._[registrationId]_` to an instance of `ClientRegistration` and then composes each of the `ClientRegistration` instance(s) within a `ClientRegistrationRepository`.
+Spring Boot auto-configuration binds each of the properties under `spring.security.oauth2.client.registration._[registrationId]_` to an instance of `ClientRegistration` and then composes each of the `ClientRegistration` instance(s) within a `ClientRegistrationRepository`.
 
 [NOTE]
 ====
@@ -231,7 +231,7 @@ class OAuth2ClientController {
 
 [NOTE]
 ====
-Spring Boot 2.x auto-configuration registers an `OAuth2AuthorizedClientRepository` or an `OAuth2AuthorizedClientService` `@Bean` in the `ApplicationContext`.
+Spring Boot auto-configuration registers an `OAuth2AuthorizedClientRepository` or an `OAuth2AuthorizedClientService` `@Bean` in the `ApplicationContext`.
 However, the application can override and register a custom `OAuth2AuthorizedClientRepository` or `OAuth2AuthorizedClientService` `@Bean`.
 ====
 

--- a/docs/modules/ROOT/pages/servlet/oauth2/login/core.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/login/core.adoc
@@ -1,9 +1,9 @@
 = Core Configuration
 
 [[oauth2login-sample-boot]]
-== Spring Boot 2.x Sample
+== Spring Boot Sample
 
-Spring Boot 2.x brings full auto-configuration capabilities for OAuth 2.0 Login.
+Spring Boot brings full auto-configuration capabilities for OAuth 2.0 Login.
 
 This section shows how to configure the {gh-samples-url}/servlet/spring-boot/java/oauth2/login[*OAuth 2.0 Login sample*] by using _Google_ as the _Authentication Provider_ and covers the following topics:
 
@@ -78,7 +78,7 @@ spring:
 [[oauth2login-sample-boot-application]]
 === Boot up the Application
 
-Launch the Spring Boot 2.x sample and go to `http://localhost:8080`.
+Launch the Spring Boot sample and go to `http://localhost:8080`.
 You are then redirected to the default _auto-generated_ login page, which displays a link for Google.
 
 Click on the Google link, and you are then redirected to Google for authentication.
@@ -91,12 +91,12 @@ At this point, the OAuth Client retrieves your email address and basic profile i
 
 
 [[oauth2login-boot-property-mappings]]
-== Spring Boot 2.x Property Mappings
+== Spring Boot Property Mappings
 
-The following table outlines the mapping of the Spring Boot 2.x OAuth Client properties to the xref:servlet/oauth2/client/index.adoc#oauth2Client-client-registration[ClientRegistration] properties.
+The following table outlines the mapping of the Spring Boot OAuth Client properties to the xref:servlet/oauth2/client/index.adoc#oauth2Client-client-registration[ClientRegistration] properties.
 
 |===
-|Spring Boot 2.x |ClientRegistration
+|Spring Boot |ClientRegistration
 
 |`spring.security.oauth2.client.registration._[registrationId]_`
 |`registrationId`
@@ -203,7 +203,7 @@ There are some OAuth 2.0 Providers that support multi-tenancy, which results in 
 
 For example, an OAuth Client registered with Okta is assigned to a specific sub-domain and have their own protocol endpoints.
 
-For these cases, Spring Boot 2.x provides the following base property for configuring custom provider properties: `spring.security.oauth2.client.provider._[providerId]_`.
+For these cases, Spring Boot provides the following base property for configuring custom provider properties: `spring.security.oauth2.client.provider._[providerId]_`.
 
 The following listing shows an example:
 
@@ -228,9 +228,9 @@ spring:
 <1> The base property (`spring.security.oauth2.client.provider.okta`) allows for custom configuration of protocol endpoint locations.
 
 [[oauth2login-override-boot-autoconfig]]
-== Overriding Spring Boot 2.x Auto-configuration
+== Overriding Spring Boot Auto-configuration
 
-The Spring Boot 2.x auto-configuration class for OAuth Client support is `OAuth2ClientAutoConfiguration`.
+The Spring Boot auto-configuration class for OAuth Client support is `OAuth2ClientAutoConfiguration`.
 
 It performs the following tasks:
 
@@ -457,9 +457,9 @@ class OAuth2LoginConfig {
 
 
 [[oauth2login-javaconfig-wo-boot]]
-== Java Configuration without Spring Boot 2.x
+== Java Configuration without Spring Boot
 
-If you are not able to use Spring Boot 2.x and would like to configure one of the pre-defined providers in `CommonOAuth2Provider` (for example, Google), apply the following configuration:
+If you are not able to use Spring Boot and would like to configure one of the pre-defined providers in `CommonOAuth2Provider` (for example, Google), apply the following configuration:
 
 .OAuth2 Login Configuration
 [tabs]


### PR DESCRIPTION
Closes gh-14917

I've found `Spring Boot 2.x` referenced in a few more doc files other than the ones mentioned in the issue, let me know if those should not be changed and I can revert them.