### PR TITLE
Fix  MethodAuthorizationDeniedPostProcessor does not exist in java doc

### DIFF
--- a/core/src/main/java/org/springframework/security/authorization/method/PostAuthorizeExpressionAttributeRegistry.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/PostAuthorizeExpressionAttributeRegistry.java
@@ -81,7 +81,7 @@ final class PostAuthorizeExpressionAttributeRegistry extends AbstractExpressionA
 
 	/**
 	 * Uses the provided {@link ApplicationContext} to resolve the
-	 * {@link MethodAuthorizationDeniedPostProcessor} from {@link PostAuthorize}
+	 * {@link MethodAuthorizationDeniedHandler} from {@link PostAuthorize}
 	 * @param context the {@link ApplicationContext} to use
 	 */
 	void setApplicationContext(ApplicationContext context) {


### PR DESCRIPTION
Closes gh-14954

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
