### PR TITLE
Minor Documentation update on import needed for using Kotlin DSL

### DIFF
--- a/docs/modules/ROOT/pages/reactive/configuration/webflux.adoc
+++ b/docs/modules/ROOT/pages/reactive/configuration/webflux.adoc
@@ -132,7 +132,7 @@ class HelloWebfluxSecurityConfig {
 ======
 
 [NOTE]
-Make sure that you import the `invoke` function in your Kotlin class, sometimes the IDE will not auto-import it causing compilation issues.
+Make sure to import the `org.springframework.security.config.annotation.web.invoke` function to enable the Kotlin DSL in your class, as the IDE will not always auto-import the method, causing compilation issues.
 
 This configuration explicitly sets up all the same things as our minimal configuration.
 From here, you can more easily make changes to the defaults.

--- a/docs/modules/ROOT/pages/servlet/configuration/kotlin.adoc
+++ b/docs/modules/ROOT/pages/servlet/configuration/kotlin.adoc
@@ -36,7 +36,7 @@ open fun filterChain(http: HttpSecurity): SecurityFilterChain {
 ----
 
 [NOTE]
-Make sure to import the `invoke` function in your class, as the IDE will not always auto-import the method, causing compilation issues.
+Make sure to import the `org.springframework.security.config.annotation.web.invoke` function to enable the Kotlin DSL in your class, as the IDE will not always auto-import the method, causing compilation issues.
 
 The default configuration (shown in the preceding listing):
 


### PR DESCRIPTION
Updates the documentation to provide a bit more explicit instruction on how to enable the Kotlin DSL. I found the existing reference to 

> import the `invoke` function

a bit less obvious then I would have thought, and despite being reasonably knowledgable, having done this thing before in the past, and having the code sample, it took me a few minutes to figure out exactly what it was referring to. 
