### PR TITLE
Assert WebSession is not null

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/server/WebSessionServerOAuth2AuthorizedClientRepository.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/server/WebSessionServerOAuth2AuthorizedClientRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,12 +96,9 @@ public final class WebSessionServerOAuth2AuthorizedClientRepository implements S
 
 	@SuppressWarnings("unchecked")
 	private Map<String, OAuth2AuthorizedClient> getAuthorizedClients(WebSession session) {
-		Map<String, OAuth2AuthorizedClient> authorizedClients = (session != null)
-				? (Map<String, OAuth2AuthorizedClient>) session.getAttribute(this.sessionAttributeName) : null;
-		if (authorizedClients == null) {
-			authorizedClients = new HashMap<>();
-		}
-		return authorizedClients;
+		Assert.notNull(session, "session cannot be null");
+		Map<String, OAuth2AuthorizedClient> authorizedClients = session.getAttribute(this.sessionAttributeName);
+		return (authorizedClients != null) ? authorizedClients : new HashMap<>();
 	}
 
 }

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/server/WebSessionServerOAuth2AuthorizedClientRepositoryTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/web/server/WebSessionServerOAuth2AuthorizedClientRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +25,12 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.registration.TestClientRegistrations;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.web.server.WebSession;
+import reactor.core.publisher.Mono;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Rob Winch
@@ -200,6 +202,26 @@ public class WebSessionServerOAuth2AuthorizedClientRepositoryTests {
 			.block();
 		assertThat(loadedAuthorizedClient2).isNotNull();
 		assertThat(loadedAuthorizedClient2).isSameAs(authorizedClient2);
+	}
+	
+	@Test
+	public void saveAuthorizedClientWhenSessionIsNullThenThrowIllegalArgumentException() {
+		MockServerWebExchange mockedExchange = mock(MockServerWebExchange.class);
+		when(mockedExchange.getSession()).thenReturn(Mono.empty());
+		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.registration1, this.principalName1,
+				mock(OAuth2AccessToken.class));
+		assertThatIllegalArgumentException().isThrownBy(
+				() -> authorizedClientRepository.saveAuthorizedClient(authorizedClient, null, mockedExchange).block())
+				.withMessage("session cannot be null");
+	}
+	
+	@Test
+	public void removeAuthorizedClientWhenSessionIsNullThenThrowIllegalArgumentException() {
+		MockServerWebExchange mockedExchange = mock(MockServerWebExchange.class);
+		when(mockedExchange.getSession()).thenReturn(Mono.empty());
+		assertThatIllegalArgumentException().isThrownBy(
+				() -> authorizedClientRepository.removeAuthorizedClient(this.registrationId1, null, mockedExchange).block())
+				.withMessage("session cannot be null");
 	}
 
 }


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->
### Original Code:
The getAuthorizedClients method retrieves a map of OAuth2 authorized clients from a WebSession. In the original code, if the session is null, the method assigns a default empty HashMap. This code does not explicitly assert that WebSession cannot be null, potentially leading to silent failures or unexpected behavior.

Closes #14975

### Suggested Refactoring:
To ensure robustness and improve error handling, you can refactor the method by adding an assertion to prevent a null session. This approach uses Assert.notNull to raise an exception with a clear error message if the WebSession is null, helping developers quickly identify and fix the problem.

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
