### PR TITLE
The SecuredAuthorizationManager can now find @Secured annotations on …

### DIFF
--- a/core/src/main/java/org/springframework/security/authorization/method/SecuredAuthorizationManager.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/SecuredAuthorizationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,14 +61,14 @@ public final class SecuredAuthorizationManager implements AuthorizationManager<M
 		@Override
 		AuthorizationManager<MethodInvocation> resolveManager(Method method, Class<?> targetClass) {
 			Method specificMethod = AopUtils.getMostSpecificMethod(method, targetClass);
-			Secured secured = findSecuredAnnotation(specificMethod);
+			Secured secured = findSecuredAnnotation(specificMethod, targetClass);
 			return (secured != null) ? AuthorityAuthorizationManager.hasAnyAuthority(secured.value()) : NULL_MANAGER;
 		}
 
-		private Secured findSecuredAnnotation(Method method) {
+		private Secured findSecuredAnnotation(Method method, Class<?> targetClass) {
 			Secured secured = AuthorizationAnnotationUtils.findUniqueAnnotation(method, Secured.class);
-			return (secured != null) ? secured
-					: AuthorizationAnnotationUtils.findUniqueAnnotation(method.getDeclaringClass(), Secured.class);
+			return (secured != null) ? secured : AuthorizationAnnotationUtils
+				.findUniqueAnnotation((targetClass != null) ? targetClass : method.getDeclaringClass(), Secured.class);
 		}
 
 	}

--- a/core/src/test/java/org/springframework/security/authorization/method/SecuredAuthorizationManagerTests.java
+++ b/core/src/test/java/org/springframework/security/authorization/method/SecuredAuthorizationManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -141,6 +141,14 @@ public class SecuredAuthorizationManagerTests {
 		assertThat(decision.isGranted()).isTrue();
 	}
 
+	@Test
+	public void checkSecuredAnnotationOnSubclassWhenMethodInSuperclassWasCalledThenApplies() throws Exception {
+		MockMethodInvocation methodInvocation = new MockMethodInvocation(new Service(), Service.class, "doSmth");
+		SecuredAuthorizationManager manager = new SecuredAuthorizationManager();
+		AuthorizationDecision decision = manager.check(TestAuthentication::authenticatedUser, methodInvocation);
+		assertThat(decision).isNotNull();
+	}
+
 	public static class TestClass implements InterfaceAnnotationsOne, InterfaceAnnotationsTwo {
 
 		public void doSomething() {
@@ -232,6 +240,18 @@ public class SecuredAuthorizationManagerTests {
 		public void inheritedAnnotations() {
 			super.inheritedAnnotations();
 		}
+
+	}
+
+	public abstract class AbstractService {
+
+		public void doSmth() {
+		}
+
+	}
+
+	@Secured("SECURE")
+	public class Service extends AbstractService {
 
 	}
 


### PR DESCRIPTION
…subclasses when a method in the superclass is called.

closes the issue #15002

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
