### PR TITLE
Add setter method for userDetailsChecker in CasAuthenticationProvider(#10277)

### DIFF
--- a/cas/src/main/java/org/springframework/security/cas/authentication/CasAuthenticationProvider.java
+++ b/cas/src/main/java/org/springframework/security/cas/authentication/CasAuthenticationProvider.java
@@ -56,6 +56,7 @@ import org.springframework.util.Assert;
  *
  * @author Ben Alex
  * @author Scott Battaglia
+ * @author Kim Youngwoong
  */
 public class CasAuthenticationProvider implements AuthenticationProvider, InitializingBean, MessageSourceAware {
 
@@ -63,7 +64,7 @@ public class CasAuthenticationProvider implements AuthenticationProvider, Initia
 
 	private AuthenticationUserDetailsService<CasAssertionAuthenticationToken> authenticationUserDetailsService;
 
-	private final UserDetailsChecker userDetailsChecker = new AccountStatusUserDetailsChecker();
+	private UserDetailsChecker userDetailsChecker = new AccountStatusUserDetailsChecker();
 
 	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
 
@@ -185,6 +186,17 @@ public class CasAuthenticationProvider implements AuthenticationProvider, Initia
 	public void setAuthenticationUserDetailsService(
 			final AuthenticationUserDetailsService<CasAssertionAuthenticationToken> authenticationUserDetailsService) {
 		this.authenticationUserDetailsService = authenticationUserDetailsService;
+	}
+
+	/**
+	 * Sets the UserDetailsChecker to be used for checking the status of retrieved user
+	 * details. This allows customization of the UserDetailsChecker implementation.
+	 * @param userDetailsChecker the UserDetailsChecker to be set
+	 * @since 6.4
+	 */
+	public void setUserDetailsChecker(final UserDetailsChecker userDetailsChecker) {
+		Assert.notNull(userDetailsChecker, "userDetailsChecker cannot be null");
+		this.userDetailsChecker = userDetailsChecker;
 	}
 
 	public void setServiceProperties(final ServiceProperties serviceProperties) {


### PR DESCRIPTION
This commit introduces a setter method for the userDetailsChecker property in the CasAuthenticationProvider class. Previously, the userDetailsChecker was initialized with a default AccountStatusUserDetailsChecker instance, limiting customization options. Now, users can inject their own UserDetailsChecker implementation through the setter method, providing greater flexibility in handling user details validation.

fixes: #10277
