### PR TITLE
Do Not Invalidate Current Session When Its Registered

### DIFF
--- a/web/src/main/java/org/springframework/security/web/server/authentication/InvalidateLeastUsedServerMaximumSessionsExceededHandler.java
+++ b/web/src/main/java/org/springframework/security/web/server/authentication/InvalidateLeastUsedServerMaximumSessionsExceededHandler.java
@@ -54,6 +54,7 @@ public final class InvalidateLeastUsedServerMaximumSessionsExceededHandler
 				maximumSessionsExceededBy);
 
 		return Flux.fromIterable(leastRecentlyUsedSessionsToInvalidate)
+			.filter(toInvalidate -> !toInvalidate.getSessionId().equals(context.getCurrentSession().getId()))
 			.flatMap((toInvalidate) -> toInvalidate.invalidate().thenReturn(toInvalidate))
 			.flatMap((toInvalidate) -> this.webSessionStore.removeSession(toInvalidate.getSessionId()))
 			.then();


### PR DESCRIPTION
this change prevents from deleting the current session, which ends up creating the need to log in two times.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
