### PR TITLE
Fix Kotlin example in authorize-http-requests.adoc

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authorization/authorize-http-requests.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/authorize-http-requests.adoc
@@ -185,15 +185,15 @@ Java::
 [source,java,role="primary"]
 ----
 @Bean
-SecurityFilterChain web(HttpSecurity http) throws Exception {
-	http
-		.authorizeHttpRequests((authorize) -> authorize
-			.requestMatchers("/endpoint").hasAuthority("USER")
-			.anyRequest().authenticated()
-		)
+public SecurityFilterChain web(HttpSecurity http) throws Exception {
+    http
+        .authorizeHttpRequests((authorize) -> authorize
+	    .requestMatchers("/endpoint").hasAuthority("USER")
+            .anyRequest().authenticated()
+        )
         // ...
-
-	return http.build();
+        
+    return http.build();
 }
 ----
 
@@ -202,14 +202,15 @@ Kotlin::
 [source,kotlin,role="secondary"]
 ----
 @Bean
-SecurityFilterChain web(HttpSecurity http) throws Exception {
-	http {
+fun web(http: HttpSecurity): SecurityFilterChain {
+    http {
         authorizeHttpRequests {
             authorize("/endpoint", hasAuthority("USER"))
             authorize(anyRequest, authenticated)
         }
-	}
-	return http.build();
+    }
+    
+    return http.build()
 }
 ----
 


### PR DESCRIPTION
- Consistency: Replaced mix of tabs/spaces with spaces indentation

---

Something was mixed-up with the code example at https://docs.spring.io/spring-security/reference/servlet/authorization/authorize-http-requests.html.
Not sure if it's perfect (Java has `// ...`, Kotlin and XML don't), but it should be an improvement 😄 