### PR TITLE
Fix Java example in multitenanci.adoc

### DIFF
--- a/docs/modules/ROOT/pages/servlet/oauth2/resource-server/multitenancy.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/resource-server/multitenancy.adoc
@@ -339,10 +339,10 @@ Java::
 [source,java,role="primary"]
 ----
 @Bean
-JWTProcessor jwtProcessor(JWTClaimSetJWSKeySelector keySelector) {
+JWTProcessor jwtProcessor(JWTClaimsSetAwareJWSKeySelector keySelector) {
 	ConfigurableJWTProcessor<SecurityContext> jwtProcessor =
             new DefaultJWTProcessor();
-	jwtProcessor.setJWTClaimSetJWSKeySelector(keySelector);
+	jwtProcessor.setJWTClaimsSetAwareJWSKeySelector(keySelector);
 	return jwtProcessor;
 }
 ----
@@ -419,7 +419,7 @@ Java::
 ----
 @Bean
 JwtDecoder jwtDecoder(JWTProcessor jwtProcessor, OAuth2TokenValidator<Jwt> jwtValidator) {
-	NimbusJwtDecoder decoder = new NimbusJwtDecoder(processor);
+	NimbusJwtDecoder decoder = new NimbusJwtDecoder(jwtProcessor);
 	OAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<>
 			(JwtValidators.createDefault(), jwtValidator);
 	decoder.setJwtValidator(validator);


### PR DESCRIPTION
- Corrected the Java example of the jwtProcessor function. The function parameter was changed to JWTClaimsSetAwareJWSKeySelector, as described in the section [Parsing the Claim Only Once](https://github.com/spring-projects/spring-security/blob/5d3c0621d1ba97e1b9710005e52e72c31f63349a/docs/modules/ROOT/pages/servlet/oauth2/resource-server/multitenancy.adoc?plain=1#L236).
- Fixed the Java example of the jwtDecoder function. The name of the variable used in the NimbusJwtDecoder constructor has been changed to jwtProcessor.