### PR TITLE
Fix Java example in multitenanci.adoc

### DIFF
--- a/docs/modules/ROOT/pages/servlet/oauth2/resource-server/multitenancy.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/resource-server/multitenancy.adoc
@@ -419,7 +419,7 @@ Java::
 ----
 @Bean
 JwtDecoder jwtDecoder(JWTProcessor jwtProcessor, OAuth2TokenValidator<Jwt> jwtValidator) {
-	NimbusJwtDecoder decoder = new NimbusJwtDecoder(processor);
+	NimbusJwtDecoder decoder = new NimbusJwtDecoder(jwtProcessor);
 	OAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<>
 			(JwtValidators.createDefault(), jwtValidator);
 	decoder.setJwtValidator(validator);


### PR DESCRIPTION
Fixed the Java example of the jwtDecoder function. The parameter called [_jwtProcessor_](https://github.com/spring-projects/spring-security/blob/752a56a9d9d88fb801fdca0e380d992fd2a75dca/docs/modules/ROOT/pages/servlet/oauth2/resource-server/multitenancy.adoc?plain=1#L421C36-L421C48) was received in the function, but in the function body and referenced the name [_processor_](https://github.com/spring-projects/spring-security/blob/752a56a9d9d88fb801fdca0e380d992fd2a75dca/docs/modules/ROOT/pages/servlet/oauth2/resource-server/multitenancy.adoc?plain=1#L422C50-L422C59), which is non-existent. The parameter in the method body has been changed to _jwtProcessor_ to match the received parameter.

This is a small correction, but I believe it optimizes the use of the example. :grin: