### PR TITLE
Update Kotlin example for MockMvc and Spring Security

### DIFF
--- a/docs/modules/ROOT/pages/servlet/test/mockmvc/setup.adoc
+++ b/docs/modules/ROOT/pages/servlet/test/mockmvc/setup.adoc
@@ -52,7 +52,7 @@ class CsrfShowcaseTests {
     @Autowired
     private lateinit var context: WebApplicationContext
 
-    private var mvc: MockMvc? = null
+    private lateinit var mvc: MockMvc
 
     @BeforeEach
     fun setup() {

--- a/docs/modules/ROOT/pages/servlet/test/mockmvc/setup.adoc
+++ b/docs/modules/ROOT/pages/servlet/test/mockmvc/setup.adoc
@@ -44,7 +44,7 @@ Kotlin::
 +
 [source,kotlin,role="secondary"]
 ----
-@ExtendWith(SpringExtension.class)
+@ExtendWith(SpringExtension::class)
 @ContextConfiguration(classes = [SecurityConfig::class])
 @WebAppConfiguration
 class CsrfShowcaseTests {


### PR DESCRIPTION
* Fix invalid Kotlin-syntax
* Use `lateinit` instead of allowing NullPointerExceptions.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
