### PR TITLE
Augment role hierarchy in `RoleHierarchyImpl` Builder

### DIFF
--- a/core/src/main/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImpl.java
+++ b/core/src/main/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImpl.java
@@ -290,6 +290,7 @@ public class RoleHierarchyImpl implements RoleHierarchy {
 		 * @param authority the highest authority in this branch
 		 * @return a {@link ImpliedRoles} to define the child roles for the
 		 * <code>authority</code>
+		 * @since 6.4
 		 */
 		public ImpliedRoles authority(String authority) {
 			Assert.hasText(authority, "authority must not be empty");

--- a/core/src/main/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImpl.java
+++ b/core/src/main/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImpl.java
@@ -307,11 +307,10 @@ public class RoleHierarchyImpl implements RoleHierarchy {
 		}
 
 		private Builder addHierarchy(String role, String... impliedRoles) {
-			Set<GrantedAuthority> withPrefix = new HashSet<>();
+			Set<GrantedAuthority> withPrefix = this.hierarchy.computeIfAbsent(role, r -> new HashSet<>());
 			for (String impliedRole : impliedRoles) {
 				withPrefix.add(new SimpleGrantedAuthority(this.rolePrefix.concat(impliedRole)));
 			}
-			this.hierarchy.put(role, withPrefix);
 			return this;
 		}
 

--- a/core/src/main/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImpl.java
+++ b/core/src/main/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -282,7 +282,18 @@ public class RoleHierarchyImpl implements RoleHierarchy {
 		 */
 		public ImpliedRoles role(String role) {
 			Assert.hasText(role, "role must not be empty");
-			return new ImpliedRoles(role);
+			return new ImpliedRoles(this.rolePrefix.concat(role));
+		}
+
+		/**
+		 * Creates a new hierarchy branch to define an authority and its child roles.
+		 * @param authority the highest authority in this branch
+		 * @return a {@link ImpliedRoles} to define the child roles for the
+		 * <code>authority</code>
+		 */
+		public ImpliedRoles authority(String authority) {
+			Assert.hasText(authority, "authority must not be empty");
+			return new ImpliedRoles(authority);
 		}
 
 		/**
@@ -299,7 +310,7 @@ public class RoleHierarchyImpl implements RoleHierarchy {
 			for (String impliedRole : impliedRoles) {
 				withPrefix.add(new SimpleGrantedAuthority(this.rolePrefix.concat(impliedRole)));
 			}
-			this.hierarchy.put(this.rolePrefix.concat(role), withPrefix);
+			this.hierarchy.put(role, withPrefix);
 			return this;
 		}
 

--- a/core/src/test/java/org/springframework/security/access/hierarchicalroles/HierarchicalRolesTestHelper.java
+++ b/core/src/test/java/org/springframework/security/access/hierarchicalroles/HierarchicalRolesTestHelper.java
@@ -24,6 +24,8 @@ import org.apache.commons.collections.CollectionUtils;
 
 import org.springframework.security.core.GrantedAuthority;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * Test helper class for the hierarchical roles tests.
  *
@@ -72,6 +74,39 @@ public abstract class HierarchicalRolesTestHelper {
 			authorities.add((GrantedAuthority) () -> role);
 		}
 		return authorities;
+	}
+
+	// Usage example:
+	// assertHierarchy(roleHierarchyImpl)
+	// .givesToAuthorities("C")
+	// .theseAuthorities("C", "ROLE_B", "ROLE_C", "ROLE_D", "ROLE_E", "ROLE_F");
+
+	public static AssertingHierarchy assertHierarchy(RoleHierarchyImpl hierarchy) {
+		return new AssertingHierarchy(hierarchy);
+	}
+
+	public static class AssertingHierarchy {
+		RoleHierarchyImpl hierarchy;
+		public AssertingHierarchy(RoleHierarchyImpl hierarchy) {
+			assertThat(hierarchy).isNotNull();
+			this.hierarchy = hierarchy;
+		}
+		public GivenAuthorities givesToAuthorities(String... authorities) {
+			return new GivenAuthorities(hierarchy.getReachableGrantedAuthorities(createAuthorityList(authorities)));
+		}
+	}
+
+	public static class GivenAuthorities {
+		Collection<GrantedAuthority> authorities;
+		public GivenAuthorities(Collection<GrantedAuthority> authorities) {
+			this.authorities = authorities;
+		}
+		public void theseAuthorities(String... expectedAuthorities) {
+			List<GrantedAuthority> expectedGrantedAuthorities = createAuthorityList(expectedAuthorities);
+			assertThat(
+					containTheSameGrantedAuthoritiesCompareByAuthorityString(authorities, expectedGrantedAuthorities))
+				.isTrue();
+		}
 	}
 
 }

--- a/core/src/test/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImplTests.java
+++ b/core/src/test/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImplTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -249,14 +249,23 @@ public class RoleHierarchyImplTests {
 			.implies("B")
 			.role("B")
 			.implies("C", "D")
+			.authority("C")
+			.implies("E", "F", "B")
 			.build();
-		List<GrantedAuthority> flatAuthorities = AuthorityUtils.createAuthorityList("ROLE_A");
-		List<GrantedAuthority> allAuthorities = AuthorityUtils.createAuthorityList("ROLE_A", "ROLE_B", "ROLE_C",
+		List<GrantedAuthority> flatAuthorities1 = AuthorityUtils.createAuthorityList("ROLE_A");
+		List<GrantedAuthority> allAuthorities1 = AuthorityUtils.createAuthorityList("ROLE_A", "ROLE_B", "ROLE_C",
 				"ROLE_D");
 
 		assertThat(roleHierarchyImpl).isNotNull();
-		assertThat(roleHierarchyImpl.getReachableGrantedAuthorities(flatAuthorities))
-			.containsExactlyInAnyOrderElementsOf(allAuthorities);
+		assertThat(roleHierarchyImpl.getReachableGrantedAuthorities(flatAuthorities1))
+			.containsExactlyInAnyOrderElementsOf(allAuthorities1);
+
+		List<GrantedAuthority> flatAuthorities2 = AuthorityUtils.createAuthorityList("C");
+		List<GrantedAuthority> allAuthorities2 = AuthorityUtils.createAuthorityList("C", "ROLE_B", "ROLE_C", "ROLE_D",
+				"ROLE_E", "ROLE_F");
+		assertThat(roleHierarchyImpl.getReachableGrantedAuthorities(flatAuthorities2))
+			.containsExactlyInAnyOrderElementsOf(allAuthorities2);
+
 	}
 
 	@Test
@@ -264,14 +273,24 @@ public class RoleHierarchyImplTests {
 		RoleHierarchyImpl roleHierarchyImpl = RoleHierarchyImpl.withRolePrefix("CUSTOM_PREFIX_")
 			.role("A")
 			.implies("B")
+			.role("B")
+			.implies("C", "D")
+			.authority("C")
+			.implies("E", "F", "B")
 			.build();
-		List<GrantedAuthority> flatAuthorities = AuthorityUtils.createAuthorityList("CUSTOM_PREFIX_A");
-		List<GrantedAuthority> allAuthorities = AuthorityUtils.createAuthorityList("CUSTOM_PREFIX_A",
-				"CUSTOM_PREFIX_B");
+		List<GrantedAuthority> flatAuthorities1 = AuthorityUtils.createAuthorityList("CUSTOM_PREFIX_A");
+		List<GrantedAuthority> allAuthorities1 = AuthorityUtils.createAuthorityList("CUSTOM_PREFIX_A",
+				"CUSTOM_PREFIX_B", "CUSTOM_PREFIX_C", "CUSTOM_PREFIX_D");
 
 		assertThat(roleHierarchyImpl).isNotNull();
-		assertThat(roleHierarchyImpl.getReachableGrantedAuthorities(flatAuthorities))
-			.containsExactlyInAnyOrderElementsOf(allAuthorities);
+		assertThat(roleHierarchyImpl.getReachableGrantedAuthorities(flatAuthorities1))
+			.containsExactlyInAnyOrderElementsOf(allAuthorities1);
+
+		List<GrantedAuthority> flatAuthorities2 = AuthorityUtils.createAuthorityList("C");
+		List<GrantedAuthority> allAuthorities2 = AuthorityUtils.createAuthorityList("C", "CUSTOM_PREFIX_B",
+				"CUSTOM_PREFIX_C", "CUSTOM_PREFIX_D", "CUSTOM_PREFIX_E", "CUSTOM_PREFIX_F");
+		assertThat(roleHierarchyImpl.getReachableGrantedAuthorities(flatAuthorities2))
+			.containsExactlyInAnyOrderElementsOf(allAuthorities2);
 	}
 
 	@Test

--- a/core/src/test/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImplTests.java
+++ b/core/src/test/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImplTests.java
@@ -281,6 +281,25 @@ public class RoleHierarchyImplTests {
 	}
 
 	@Test
+	public void testBuilderWithRepeatedRoleBuilder() {
+		RoleHierarchyImpl roleHierarchyImpl = RoleHierarchyImpl.withDefaultRolePrefix()
+			.role("A")
+			.implies("B")
+			.role("A")
+			.implies("C", "D")
+			.authority("A")
+			.implies("E")
+			.authority("A")
+			.implies("F", "G")
+			.build();
+
+		assertHierarchy(roleHierarchyImpl).givesToAuthorities("ROLE_A")
+			.theseAuthorities("ROLE_A", "ROLE_B", "ROLE_C", "ROLE_D");
+
+		assertHierarchy(roleHierarchyImpl).givesToAuthorities("A").theseAuthorities("A", "ROLE_E", "ROLE_F", "ROLE_G");
+	}
+
+	@Test
 	public void testBuilderThrowIllegalArgumentExceptionWhenPrefixRoleNull() {
 		assertThatIllegalArgumentException().isThrownBy(() -> RoleHierarchyImpl.withRolePrefix(null));
 	}

--- a/core/src/test/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImplTests.java
+++ b/core/src/test/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImplTests.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.springframework.security.access.hierarchicalroles.HierarchicalRolesTestHelper.assertHierarchy;
 
 /**
  * Tests for {@link RoleHierarchyImpl}.
@@ -252,20 +253,12 @@ public class RoleHierarchyImplTests {
 			.authority("C")
 			.implies("E", "F", "B")
 			.build();
-		List<GrantedAuthority> flatAuthorities1 = AuthorityUtils.createAuthorityList("ROLE_A");
-		List<GrantedAuthority> allAuthorities1 = AuthorityUtils.createAuthorityList("ROLE_A", "ROLE_B", "ROLE_C",
-				"ROLE_D");
 
-		assertThat(roleHierarchyImpl).isNotNull();
-		assertThat(roleHierarchyImpl.getReachableGrantedAuthorities(flatAuthorities1))
-			.containsExactlyInAnyOrderElementsOf(allAuthorities1);
+		assertHierarchy(roleHierarchyImpl).givesToAuthorities("ROLE_A")
+			.theseAuthorities("ROLE_A", "ROLE_B", "ROLE_C", "ROLE_D");
 
-		List<GrantedAuthority> flatAuthorities2 = AuthorityUtils.createAuthorityList("C");
-		List<GrantedAuthority> allAuthorities2 = AuthorityUtils.createAuthorityList("C", "ROLE_B", "ROLE_C", "ROLE_D",
-				"ROLE_E", "ROLE_F");
-		assertThat(roleHierarchyImpl.getReachableGrantedAuthorities(flatAuthorities2))
-			.containsExactlyInAnyOrderElementsOf(allAuthorities2);
-
+		assertHierarchy(roleHierarchyImpl).givesToAuthorities("C")
+			.theseAuthorities("C", "ROLE_B", "ROLE_C", "ROLE_D", "ROLE_E", "ROLE_F");
 	}
 
 	@Test
@@ -278,19 +271,13 @@ public class RoleHierarchyImplTests {
 			.authority("C")
 			.implies("E", "F", "B")
 			.build();
-		List<GrantedAuthority> flatAuthorities1 = AuthorityUtils.createAuthorityList("CUSTOM_PREFIX_A");
-		List<GrantedAuthority> allAuthorities1 = AuthorityUtils.createAuthorityList("CUSTOM_PREFIX_A",
-				"CUSTOM_PREFIX_B", "CUSTOM_PREFIX_C", "CUSTOM_PREFIX_D");
 
-		assertThat(roleHierarchyImpl).isNotNull();
-		assertThat(roleHierarchyImpl.getReachableGrantedAuthorities(flatAuthorities1))
-			.containsExactlyInAnyOrderElementsOf(allAuthorities1);
+		assertHierarchy(roleHierarchyImpl).givesToAuthorities("CUSTOM_PREFIX_A")
+			.theseAuthorities("CUSTOM_PREFIX_A", "CUSTOM_PREFIX_B", "CUSTOM_PREFIX_C", "CUSTOM_PREFIX_D");
 
-		List<GrantedAuthority> flatAuthorities2 = AuthorityUtils.createAuthorityList("C");
-		List<GrantedAuthority> allAuthorities2 = AuthorityUtils.createAuthorityList("C", "CUSTOM_PREFIX_B",
-				"CUSTOM_PREFIX_C", "CUSTOM_PREFIX_D", "CUSTOM_PREFIX_E", "CUSTOM_PREFIX_F");
-		assertThat(roleHierarchyImpl.getReachableGrantedAuthorities(flatAuthorities2))
-			.containsExactlyInAnyOrderElementsOf(allAuthorities2);
+		assertHierarchy(roleHierarchyImpl).givesToAuthorities("C")
+			.theseAuthorities("C", "CUSTOM_PREFIX_B", "CUSTOM_PREFIX_C", "CUSTOM_PREFIX_D", "CUSTOM_PREFIX_E",
+					"CUSTOM_PREFIX_F");
 	}
 
 	@Test

--- a/docs/modules/ROOT/pages/servlet/authorization/architecture.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/architecture.adoc
@@ -257,6 +257,7 @@ static RoleHierarchy roleHierarchy() {
         .role("ADMIN").implies("STAFF")
         .role("STAFF").implies("USER")
         .role("USER").implies("GUEST")
+        .authority("TEAM_ABC").implies("STAFF")
         .build();
 }
 
@@ -280,6 +281,7 @@ Xml::
 			ROLE_ADMIN > ROLE_STAFF
 			ROLE_STAFF > ROLE_USER
 			ROLE_USER > ROLE_GUEST
+			TEAM_ABC > ROLE_STAFF
 		</value>
 	</constructor-arg>
 </bean>


### PR DESCRIPTION
This change (as I have the code here) requires https://github.com/spring-projects/spring-security/pull/15272 to be merged (and this should be rebased before merging).

Assume this role mapping in text send to the `RoleHierarchyImpl`:
```
ROLE_X > ROLE_A
ROLE_X > ROLE_B
```

The expectation is that this code fragment of using the `RoleHierarchyImpl` Builder would yield the same effect:
```
.role("X").implies("A")
.role("X").implies("B")
```

The current behavior of the Builder is that this results in the role "X" ONLY being assigned the role "B" (the last one assigned).

With this change the the role "X" will be assigned BOTH the roles "A" and "B" making it the same as the text format again.

FYI: @marcusdacoregio 