### PR TITLE
Update prerequisites documentation with Java 17

### DIFF
--- a/docs/modules/ROOT/pages/prerequisites.adoc
+++ b/docs/modules/ROOT/pages/prerequisites.adoc
@@ -1,7 +1,7 @@
 [[prerequisites]]
 = Prerequisites
 
-Spring Security requires a Java 8 or higher Runtime Environment.
+Spring Security requires a Java 17 or higher Runtime Environment.
 
 As Spring Security aims to operate in a self-contained manner, you do not need to place any special configuration files in your Java Runtime Environment.
 In particular, you need not configure a special Java Authentication and Authorization Service (JAAS) policy file or place Spring Security into common classpath locations.


### PR DESCRIPTION
Raises the minimum version of the Java runtime for Spring Security from 8 to 17