### PR TITLE
Two small fixes to the Servlet's Authentication Events documentation

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/events.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/events.adoc
@@ -143,7 +143,7 @@ Java::
 @Bean
 public AuthenticationEventPublisher authenticationEventPublisher
         (ApplicationEventPublisher applicationEventPublisher) {
-    AuthenticationEventPublisher authenticationEventPublisher =
+    DefaultAuthenticationEventPublisher authenticationEventPublisher =
         new DefaultAuthenticationEventPublisher(applicationEventPublisher);
     authenticationEventPublisher.setDefaultAuthenticationFailureEvent
         (GenericAuthenticationFailureEvent.class);

--- a/docs/modules/ROOT/pages/servlet/authentication/events.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/events.adoc
@@ -146,7 +146,7 @@ public AuthenticationEventPublisher authenticationEventPublisher
     DefaultAuthenticationEventPublisher authenticationEventPublisher =
         new DefaultAuthenticationEventPublisher(applicationEventPublisher);
     authenticationEventPublisher.setDefaultAuthenticationFailureEvent
-        (GenericAuthenticationFailureEvent.class);
+        (AbstractAuthenticationFailureEvent.class);
     return authenticationEventPublisher;
 }
 ----
@@ -159,7 +159,7 @@ Kotlin::
 fun authenticationEventPublisher
         (applicationEventPublisher: ApplicationEventPublisher?): AuthenticationEventPublisher {
     val authenticationEventPublisher = DefaultAuthenticationEventPublisher(applicationEventPublisher)
-    authenticationEventPublisher.setDefaultAuthenticationFailureEvent(GenericAuthenticationFailureEvent::class.java)
+    authenticationEventPublisher.setDefaultAuthenticationFailureEvent(AbstractAuthenticationFailureEvent::class.java)
     return authenticationEventPublisher
 }
 ----


### PR DESCRIPTION
In https://docs.spring.io/spring-security/reference/servlet/authentication/events.html#_default_event, the given example does not work, as
* in the Java case, the assignment type `AuthenticationEventPublisher` does not have the expected method `setDefaultAuthenticationFailureEvent`, but `DefaultAuthenticationEventPublisher` has.
* in both the Java and Kotlin case the class `GenericAuthenticationFailureEvent` does not exist. `AbstractAuthenticationFailureEvent` could be used instead.