### PR TITLE
Add AssertingPartyMetadataRepository

### DIFF
--- a/config/src/main/java/org/springframework/security/config/saml2/RelyingPartyRegistrationsBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/saml2/RelyingPartyRegistrationsBeanDefinitionParser.java
@@ -39,6 +39,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.security.converter.RsaKeyConverters;
 import org.springframework.security.saml2.core.Saml2X509Credential;
+import org.springframework.security.saml2.provider.service.registration.AssertingPartyMetadata;
 import org.springframework.security.saml2.provider.service.registration.InMemoryRelyingPartyRegistrationRepository;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrations;
@@ -153,7 +154,7 @@ public final class RelyingPartyRegistrationsBeanDefinitionParser implements Bean
 	}
 
 	private static void addVerificationCredentials(Map<String, Object> assertingParty,
-			RelyingPartyRegistration.AssertingPartyDetails.Builder builder) {
+			AssertingPartyMetadata.Builder<?> builder) {
 		List<String> verificationCertificateLocations = (List<String>) assertingParty.get(ELT_VERIFICATION_CREDENTIAL);
 		List<Saml2X509Credential> verificationCredentials = new ArrayList<>();
 		for (String certificateLocation : verificationCertificateLocations) {
@@ -163,7 +164,7 @@ public final class RelyingPartyRegistrationsBeanDefinitionParser implements Bean
 	}
 
 	private static void addEncryptionCredentials(Map<String, Object> assertingParty,
-			RelyingPartyRegistration.AssertingPartyDetails.Builder builder) {
+			AssertingPartyMetadata.Builder<?> builder) {
 		List<String> encryptionCertificateLocations = (List<String>) assertingParty.get(ELT_ENCRYPTION_CREDENTIAL);
 		List<Saml2X509Credential> encryptionCredentials = new ArrayList<>();
 		for (String certificateLocation : encryptionCertificateLocations) {
@@ -220,8 +221,8 @@ public final class RelyingPartyRegistrationsBeanDefinitionParser implements Bean
 		}
 		else {
 			builder = RelyingPartyRegistration.withRegistrationId(registrationId)
-				.assertingPartyDetails((apBuilder) -> buildAssertingParty(relyingPartyRegistrationElt, assertingParties,
-						apBuilder, parserContext));
+				.assertingPartyMetadata((apBuilder) -> buildAssertingParty(relyingPartyRegistrationElt,
+						assertingParties, apBuilder, parserContext));
 		}
 		addRemainingProperties(relyingPartyRegistrationElt, builder);
 		return builder;
@@ -260,7 +261,7 @@ public final class RelyingPartyRegistrationsBeanDefinitionParser implements Bean
 	}
 
 	private static void buildAssertingParty(Element relyingPartyElt, Map<String, Map<String, Object>> assertingParties,
-			RelyingPartyRegistration.AssertingPartyDetails.Builder builder, ParserContext parserContext) {
+			AssertingPartyMetadata.Builder<?> builder, ParserContext parserContext) {
 		String assertingPartyId = relyingPartyElt.getAttribute(ATT_ASSERTING_PARTY_ID);
 		if (!assertingParties.containsKey(assertingPartyId)) {
 			Object source = parserContext.extractSource(relyingPartyElt);
@@ -293,7 +294,7 @@ public final class RelyingPartyRegistrationsBeanDefinitionParser implements Bean
 	}
 
 	private static void addSigningAlgorithms(Map<String, Object> assertingParty,
-			RelyingPartyRegistration.AssertingPartyDetails.Builder builder) {
+			AssertingPartyMetadata.Builder<?> builder) {
 		String signingAlgorithmsAttr = getAsString(assertingParty, ATT_SIGNING_ALGORITHMS);
 		if (StringUtils.hasText(signingAlgorithmsAttr)) {
 			List<String> signingAlgorithms = Arrays.asList(signingAlgorithmsAttr.split(","));

--- a/docs/modules/ROOT/pages/servlet/saml2/login/authentication-requests.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/login/authentication-requests.adoc
@@ -114,7 +114,7 @@ Java::
 ----
 RelyingPartyRegistration relyingPartyRegistration = RelyingPartyRegistration.withRegistrationId("okta")
         // ...
-        .assertingPartyDetails(party -> party
+        .assertingPartyMetadata(party -> party
             // ...
             .wantAuthnRequestsSigned(false)
         )
@@ -128,7 +128,7 @@ Kotlin::
 var relyingPartyRegistration: RelyingPartyRegistration =
     RelyingPartyRegistration.withRegistrationId("okta")
         // ...
-        .assertingPartyDetails { party: AssertingPartyDetails.Builder -> party
+        .assertingPartyMetadata { party: AssertingPartyMetadata.Builder -> party
                 // ...
                 .wantAuthnRequestsSigned(false)
         }
@@ -154,7 +154,7 @@ Java::
 String metadataLocation = "classpath:asserting-party-metadata.xml";
 RelyingPartyRegistration relyingPartyRegistration = RelyingPartyRegistrations.fromMetadataLocation(metadataLocation)
         // ...
-        .assertingPartyDetails((party) -> party
+        .assertingPartyMetadata((party) -> party
             // ...
             .signingAlgorithms((sign) -> sign.add(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA512))
         )
@@ -169,7 +169,7 @@ var metadataLocation = "classpath:asserting-party-metadata.xml"
 var relyingPartyRegistration: RelyingPartyRegistration =
     RelyingPartyRegistrations.fromMetadataLocation(metadataLocation)
         // ...
-        .assertingPartyDetails { party: AssertingPartyDetails.Builder -> party
+        .assertingPartyMetadata { party: AssertingPartyMetadata.Builder -> party
                 // ...
                 .signingAlgorithms { sign: MutableList<String?> ->
                     sign.add(
@@ -197,7 +197,7 @@ Java::
 ----
 RelyingPartyRegistration relyingPartyRegistration = RelyingPartyRegistration.withRegistrationId("okta")
         // ...
-        .assertingPartyDetails(party -> party
+        .assertingPartyMetadata(party -> party
             // ...
             .singleSignOnServiceBinding(Saml2MessageBinding.POST)
         )
@@ -211,7 +211,7 @@ Kotlin::
 var relyingPartyRegistration: RelyingPartyRegistration? =
     RelyingPartyRegistration.withRegistrationId("okta")
         // ...
-        .assertingPartyDetails { party: AssertingPartyDetails.Builder -> party
+        .assertingPartyMetadata { party: AssertingPartyMetadata.Builder -> party
             // ...
             .singleSignOnServiceBinding(Saml2MessageBinding.POST)
         }

--- a/docs/modules/ROOT/pages/servlet/saml2/login/overview.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/login/overview.adoc
@@ -484,7 +484,7 @@ public RelyingPartyRegistrationRepository relyingPartyRegistrations() throws Exc
     Saml2X509Credential credential = Saml2X509Credential.verification(certificate);
     RelyingPartyRegistration registration = RelyingPartyRegistration
             .withRegistrationId("example")
-            .assertingPartyDetails(party -> party
+            .assertingPartyMetadata(party -> party
                 .entityId("https://idp.example.com/issuer")
                 .singleSignOnServiceLocation("https://idp.example.com/SSO.saml2")
                 .wantAuthnRequestsSigned(false)
@@ -508,7 +508,7 @@ open fun relyingPartyRegistrations(): RelyingPartyRegistrationRepository {
     val credential: Saml2X509Credential = Saml2X509Credential.verification(certificate)
     val registration = RelyingPartyRegistration
         .withRegistrationId("example")
-        .assertingPartyDetails { party: AssertingPartyDetails.Builder ->
+        .assertingPartyMetadata { party: AssertingPartyMetadata.Builder ->
             party
                 .entityId("https://idp.example.com/issuer")
                 .singleSignOnServiceLocation("https://idp.example.com/SSO.saml2")
@@ -699,7 +699,7 @@ RelyingPartyRegistration relyingPartyRegistration = RelyingPartyRegistration.wit
         .entityId("{baseUrl}/{registrationId}")
         .decryptionX509Credentials(c -> c.add(relyingPartyDecryptingCredential()))
         .assertionConsumerServiceLocation("/my-login-endpoint/{registrationId}")
-        .assertingPartyDetails(party -> party
+        .assertingPartyMetadata(party -> party
                 .entityId("https://ap.example.org")
                 .verificationX509Credentials(c -> c.add(assertingPartyVerifyingCredential()))
                 .singleSignOnServiceLocation("https://ap.example.org/SSO.saml2")
@@ -718,7 +718,7 @@ val relyingPartyRegistration =
             c.add(relyingPartyDecryptingCredential())
         }
         .assertionConsumerServiceLocation("/my-login-endpoint/{registrationId}")
-        .assertingPartyDetails { party -> party
+        .assertingPartyMetadata { party -> party
                 .entityId("https://ap.example.org")
                 .verificationX509Credentials { c -> c.add(assertingPartyVerifyingCredential()) }
                 .singleSignOnServiceLocation("https://ap.example.org/SSO.saml2")
@@ -730,7 +730,7 @@ val relyingPartyRegistration =
 [TIP]
 ====
 The top-level metadata methods are details about the relying party.
-The methods inside `assertingPartyDetails` are details about the asserting party.
+The methods inside `AssertingPartyMetadata` are details about the asserting party.
 ====
 
 [NOTE]

--- a/docs/modules/ROOT/pages/servlet/saml2/logout.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/logout.adoc
@@ -339,7 +339,7 @@ It's common to need to set other values in the `<saml2:LogoutRequest>` than the 
 
 By default, Spring Security will issue a `<saml2:LogoutRequest>` and supply:
 
-* The `Destination` attribute - from `RelyingPartyRegistration#getAssertingPartyDetails#getSingleLogoutServiceLocation`
+* The `Destination` attribute - from `RelyingPartyRegistration#getAssertingPartyMetadata#getSingleLogoutServiceLocation`
 * The `ID` attribute - a GUID
 * The `<Issuer>` element - from `RelyingPartyRegistration#getEntityId`
 * The `<NameID>` element - from `Authentication#getName`
@@ -424,7 +424,7 @@ It's common to need to set other values in the `<saml2:LogoutResponse>` than the
 
 By default, Spring Security will issue a `<saml2:LogoutResponse>` and supply:
 
-* The `Destination` attribute - from `RelyingPartyRegistration#getAssertingPartyDetails#getSingleLogoutServiceResponseLocation`
+* The `Destination` attribute - from `RelyingPartyRegistration#getAssertingPartyMetadata#getSingleLogoutServiceResponseLocation`
 * The `ID` attribute - a GUID
 * The `<Issuer>` element - from `RelyingPartyRegistration#getEntityId`
 * The `<Status>` element - `SUCCESS`

--- a/docs/modules/ROOT/pages/servlet/saml2/metadata.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/metadata.adoc
@@ -27,10 +27,129 @@ Kotlin::
 [source,kotlin,role="secondary"]
 ----
 val details: OpenSamlAssertingPartyDetails =
-        registration.getAssertingPartyDetails() as OpenSamlAssertingPartyDetails;
-val openSamlEntityDescriptor: EntityDescriptor = details.getEntityDescriptor();
+        registration.getAssertingPartyDetails() as OpenSamlAssertingPartyDetails
+val openSamlEntityDescriptor: EntityDescriptor = details.getEntityDescriptor()
 ----
 ======
+
+=== Using `AssertingPartyMetadataRepository`
+
+You can also be more targeted than `RelyingPartyRegistrations` by using `AssertingPartyMetadataRepository`, an interface that allows for only retrieving the asserting party metadata.
+
+This allows three valuable features:
+
+* Implementations can refresh asserting party metadata in an expiry-aware fashion
+* Implementations of `RelyingPartyRegistrationRepository` can more easily articulate a relationship between a relying party and its one or many corresponding asserting parties
+* Implementations can verify metadata signatures
+
+For example, `OpenSamlAssertingPartyMetadataRepository` uses OpenSAML's `MetadataResolver`, and API whose implementations regularly refresh the underlying metadata in an expiry-aware fashion.
+
+This means that you can now create a refreshable `RelyingPartyRegistrationRepository` in just a few lines of code:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Component
+public class RefreshableRelyingPartyRegistrationRepository
+        implements IterableRelyingPartyRegistrationRepository {
+
+	private final AssertingPartyMetadataRepository metadata =
+            OpenSamlAssertingPartyMetadataRepository
+                .fromTrustedMetadataLocation("https://idp.example.org/metadata").build();
+
+	@Override
+    public RelyingPartyRegistration findByRegistrationId(String registrationId) {
+		AssertingPartyMetadata metadata = this.metadata.findByEntityId(registrationId);
+        if (metadata == null) {
+            return null;
+        }
+		return applyRelyingParty(metadata);
+    }
+
+	@Override
+    public Iterator<RelyingPartyRegistration> iterator() {
+		return StreamSupport.stream(this.metadata.spliterator(), false)
+            .map(this::applyRelyingParty).iterator();
+    }
+
+	private RelyingPartyRegistration applyRelyingParty(AssertingPartyMetadata metadata) {
+		AssertingPartyDetails details = (AssertingPartyDetails) metadata;
+		return RelyingPartyRegistration.withAssertingPartyDetails(details)
+            // apply any relying party configuration
+            .build();
+	}
+
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@Component
+class RefreshableRelyingPartyRegistrationRepository : IterableRelyingPartyRegistrationRepository {
+
+    private val metadata: AssertingPartyMetadataRepository =
+        OpenSamlAssertingPartyMetadataRepository.fromTrustedMetadataLocation(
+            "https://idp.example.org/metadata").build()
+
+    fun findByRegistrationId(registrationId:String?): RelyingPartyRegistration {
+        val metadata = this.metadata.findByEntityId(registrationId)
+        if (metadata == null) {
+            return null
+        }
+        return applyRelyingParty(metadata)
+    }
+
+    fun iterator(): Iterator<RelyingPartyRegistration> {
+        return StreamSupport.stream(this.metadata.spliterator(), false)
+            .map(this::applyRelyingParty).iterator()
+    }
+
+    private fun applyRelyingParty(metadata: AssertingPartyMetadata): RelyingPartyRegistration {
+        val details: AssertingPartyDetails = metadata as AssertingPartyDetails
+        return RelyingPartyRegistration.withAssertingPartyDetails(details)
+            // apply any relying party configuration
+            .build()
+    }
+ }
+----
+======
+
+[TIP]
+`OpenSamlAssertingPartyMetadataRepository` also ships with a constructor so you can provide a custom `MetadataResolver`. Since the underlying `MetadataResolver` is doing the expirying and refreshing, if you use the constructor directly, you will only get these features by providing an implementation that does so.
+
+=== Verifying Metadata Signatures
+
+You can also verify metadata signatures using `OpenSamlAssertingPartyMetadataRepository` by providing the appropriate set of ``Saml2X509Credential``s as follows:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+OpenSamlAssertingPartyMetadataRepository.withMetadataLocation("https://idp.example.org/metadata")
+    .verificationCredentials((c) -> c.add(myVerificationCredential))
+    .build();
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+OpenSamlAssertingPartyMetadataRepository.withMetadataLocation("https://idp.example.org/metadata")
+    .verificationCredentials({ c : Collection<Saml2X509Credential> ->
+        c.add(myVerificationCredential) })
+    .build()
+----
+======
+
+[NOTE]
+If no credentials are provided, the component will not perform signature validation.
 
 [[publishing-relying-party-metadata]]
 == Producing `<saml2:SPSSODescriptor>` Metadata

--- a/docs/modules/ROOT/pages/servlet/saml2/metadata.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/metadata.adoc
@@ -1,14 +1,14 @@
 [[servlet-saml2login-metadata]]
 = Saml 2.0 Metadata
 
-Spring Security can <<parsing-asserting-party-metadata,parse asserting party metadata>> to produce an `AssertingPartyDetails` instance as well as <<publishing-relying-party-metadata,publish relying party metadata>> from a `RelyingPartyRegistration` instance.
+Spring Security can <<parsing-asserting-party-metadata,parse asserting party metadata>> to produce an `AssertingPartyMetadata` instance as well as <<publishing-relying-party-metadata,publish relying party metadata>> from a `RelyingPartyRegistration` instance.
 
 [[parsing-asserting-party-metadata]]
 == Parsing `<saml2:IDPSSODescriptor>` metadata
 
 You can parse an asserting party's metadata xref:servlet/saml2/login/overview.adoc#servlet-saml2login-relyingpartyregistrationrepository[using `RelyingPartyRegistrations`].
 
-When using the OpenSAML vendor support, the resulting `AssertingPartyDetails` will be of type `OpenSamlAssertingPartyDetails`.
+When using the OpenSAML vendor support, the resulting `AssertingPartyMetadata` will be of type `OpenSamlAssertingPartyDetails`.
 This means you'll be able to do get the underlying OpenSAML XMLObject by doing the following:
 
 [tabs]
@@ -18,7 +18,7 @@ Java::
 [source,java,role="primary"]
 ----
 OpenSamlAssertingPartyDetails details = (OpenSamlAssertingPartyDetails)
-        registration.getAssertingPartyDetails();
+        registration.getAssertingPartyMetadata();
 EntityDescriptor openSamlEntityDescriptor = details.getEntityDescriptor();
 ----
 
@@ -27,7 +27,7 @@ Kotlin::
 [source,kotlin,role="secondary"]
 ----
 val details: OpenSamlAssertingPartyDetails =
-        registration.getAssertingPartyDetails() as OpenSamlAssertingPartyDetails
+        registration.getAssertingPartyMetadata() as OpenSamlAssertingPartyDetails
 val openSamlEntityDescriptor: EntityDescriptor = details.getEntityDescriptor()
 ----
 ======
@@ -76,8 +76,7 @@ public class RefreshableRelyingPartyRegistrationRepository
     }
 
 	private RelyingPartyRegistration applyRelyingParty(AssertingPartyMetadata metadata) {
-		AssertingPartyDetails details = (AssertingPartyDetails) metadata;
-		return RelyingPartyRegistration.withAssertingPartyDetails(details)
+		return RelyingPartyRegistration.withAssertingPartyMetadata(metadata)
             // apply any relying party configuration
             .build();
 	}
@@ -110,8 +109,8 @@ class RefreshableRelyingPartyRegistrationRepository : IterableRelyingPartyRegist
     }
 
     private fun applyRelyingParty(metadata: AssertingPartyMetadata): RelyingPartyRegistration {
-        val details: AssertingPartyDetails = metadata as AssertingPartyDetails
-        return RelyingPartyRegistration.withAssertingPartyDetails(details)
+        val details: AssertingPartyMetadata = metadata as AssertingPartyMetadata
+        return RelyingPartyRegistration.withAssertingPartyMetadata(details)
             // apply any relying party configuration
             .build()
     }

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/OpenSaml4AuthenticationProvider.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/OpenSaml4AuthenticationProvider.java
@@ -400,7 +400,7 @@ public final class OpenSaml4AuthenticationProvider implements AuthenticationProv
 				result = result.concat(new Saml2Error(Saml2ErrorCodes.INVALID_DESTINATION, message));
 			}
 			String assertingPartyEntityId = token.getRelyingPartyRegistration()
-				.getAssertingPartyDetails()
+				.getAssertingPartyMetadata()
 				.getEntityId();
 			if (!StringUtils.hasText(issuer) || !issuer.equals(assertingPartyEntityId)) {
 				String message = String.format("Invalid issuer [%s] for SAML response [%s]", issuer, response.getID());
@@ -775,7 +775,7 @@ public final class OpenSaml4AuthenticationProvider implements AuthenticationProv
 		RelyingPartyRegistration relyingPartyRegistration = token.getRelyingPartyRegistration();
 		String audience = relyingPartyRegistration.getEntityId();
 		String recipient = relyingPartyRegistration.getAssertionConsumerServiceLocation();
-		String assertingPartyEntityId = relyingPartyRegistration.getAssertingPartyDetails().getEntityId();
+		String assertingPartyEntityId = relyingPartyRegistration.getAssertingPartyMetadata().getEntityId();
 		Map<String, Object> params = new HashMap<>();
 		Assertion assertion = assertionToken.getAssertion();
 		if (assertionContainsInResponseTo(assertion)) {

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/OpenSamlSigningUtils.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/OpenSamlSigningUtils.java
@@ -96,7 +96,7 @@ final class OpenSamlSigningUtils {
 	private static SignatureSigningParameters resolveSigningParameters(
 			RelyingPartyRegistration relyingPartyRegistration) {
 		List<Credential> credentials = resolveSigningCredentials(relyingPartyRegistration);
-		List<String> algorithms = relyingPartyRegistration.getAssertingPartyDetails().getSigningAlgorithms();
+		List<String> algorithms = relyingPartyRegistration.getAssertingPartyMetadata().getSigningAlgorithms();
 		List<String> digests = Collections.singletonList(SignatureConstants.ALGO_ID_DIGEST_SHA256);
 		String canonicalization = SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS;
 		SignatureSigningParametersResolver resolver = new SAMLMetadataSignatureSigningParametersResolver();

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/OpenSamlVerificationUtils.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/OpenSamlVerificationUtils.java
@@ -73,11 +73,12 @@ final class OpenSamlVerificationUtils {
 
 	static SignatureTrustEngine trustEngine(RelyingPartyRegistration registration) {
 		Set<Credential> credentials = new HashSet<>();
-		Collection<Saml2X509Credential> keys = registration.getAssertingPartyDetails().getVerificationX509Credentials();
+		Collection<Saml2X509Credential> keys = registration.getAssertingPartyMetadata()
+			.getVerificationX509Credentials();
 		for (Saml2X509Credential key : keys) {
 			BasicX509Credential cred = new BasicX509Credential(key.getCertificate());
 			cred.setUsageType(UsageType.SIGNING);
-			cred.setEntityId(registration.getAssertingPartyDetails().getEntityId());
+			cred.setEntityId(registration.getAssertingPartyMetadata().getEntityId());
 			credentials.add(cred);
 		}
 		CredentialResolver credentialsResolver = new CollectionCredentialResolver(credentials);

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/Saml2PostAuthenticationRequest.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/Saml2PostAuthenticationRequest.java
@@ -50,7 +50,7 @@ public class Saml2PostAuthenticationRequest extends AbstractSaml2AuthenticationR
 	 * @since 5.7
 	 */
 	public static Builder withRelyingPartyRegistration(RelyingPartyRegistration registration) {
-		String location = registration.getAssertingPartyDetails().getSingleSignOnServiceLocation();
+		String location = registration.getAssertingPartyMetadata().getSingleSignOnServiceLocation();
 		return new Builder(registration).authenticationRequestUri(location);
 	}
 

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/Saml2RedirectAuthenticationRequest.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/Saml2RedirectAuthenticationRequest.java
@@ -73,7 +73,7 @@ public final class Saml2RedirectAuthenticationRequest extends AbstractSaml2Authe
 	 * @since 5.7
 	 */
 	public static Builder withRelyingPartyRegistration(RelyingPartyRegistration registration) {
-		String location = registration.getAssertingPartyDetails().getSingleSignOnServiceLocation();
+		String location = registration.getAssertingPartyMetadata().getSingleSignOnServiceLocation();
 		return new Builder(registration).authenticationRequestUri(location);
 	}
 

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/OpenSamlLogoutRequestValidator.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/OpenSamlLogoutRequestValidator.java
@@ -134,7 +134,7 @@ public final class OpenSamlLogoutRequestValidator implements Saml2LogoutRequestV
 				return;
 			}
 			String issuer = request.getIssuer().getValue();
-			if (!issuer.equals(registration.getAssertingPartyDetails().getEntityId())) {
+			if (!issuer.equals(registration.getAssertingPartyMetadata().getEntityId())) {
 				errors
 					.add(new Saml2Error(Saml2ErrorCodes.INVALID_ISSUER, "Failed to match issuer to configured issuer"));
 			}

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/OpenSamlLogoutResponseValidator.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/OpenSamlLogoutResponseValidator.java
@@ -132,7 +132,7 @@ public class OpenSamlLogoutResponseValidator implements Saml2LogoutResponseValid
 				return;
 			}
 			String issuer = response.getIssuer().getValue();
-			if (!issuer.equals(registration.getAssertingPartyDetails().getEntityId())) {
+			if (!issuer.equals(registration.getAssertingPartyMetadata().getEntityId())) {
 				errors
 					.add(new Saml2Error(Saml2ErrorCodes.INVALID_ISSUER, "Failed to match issuer to configured issuer"));
 			}

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/OpenSamlVerificationUtils.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/OpenSamlVerificationUtils.java
@@ -164,12 +164,12 @@ final class OpenSamlVerificationUtils {
 
 		private SignatureTrustEngine trustEngine(RelyingPartyRegistration registration) {
 			Set<Credential> credentials = new HashSet<>();
-			Collection<Saml2X509Credential> keys = registration.getAssertingPartyDetails()
+			Collection<Saml2X509Credential> keys = registration.getAssertingPartyMetadata()
 				.getVerificationX509Credentials();
 			for (Saml2X509Credential key : keys) {
 				BasicX509Credential cred = new BasicX509Credential(key.getCertificate());
 				cred.setUsageType(UsageType.SIGNING);
-				cred.setEntityId(registration.getAssertingPartyDetails().getEntityId());
+				cred.setEntityId(registration.getAssertingPartyMetadata().getEntityId());
 				credentials.add(cred);
 			}
 			CredentialResolver credentialsResolver = new CollectionCredentialResolver(credentials);

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/Saml2LogoutRequest.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/Saml2LogoutRequest.java
@@ -190,8 +190,8 @@ public final class Saml2LogoutRequest implements Serializable {
 
 		private Builder(RelyingPartyRegistration registration) {
 			this.registration = registration;
-			this.location = registration.getAssertingPartyDetails().getSingleLogoutServiceLocation();
-			this.binding = registration.getAssertingPartyDetails().getSingleLogoutServiceBinding();
+			this.location = registration.getAssertingPartyMetadata().getSingleLogoutServiceLocation();
+			this.binding = registration.getAssertingPartyMetadata().getSingleLogoutServiceBinding();
 		}
 
 		/**

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/Saml2LogoutResponse.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/logout/Saml2LogoutResponse.java
@@ -156,8 +156,8 @@ public final class Saml2LogoutResponse {
 		private Function<Map<String, String>, String> encoder = DEFAULT_ENCODER;
 
 		private Builder(RelyingPartyRegistration registration) {
-			this.location = registration.getAssertingPartyDetails().getSingleLogoutServiceResponseLocation();
-			this.binding = registration.getAssertingPartyDetails().getSingleLogoutServiceBinding();
+			this.location = registration.getAssertingPartyMetadata().getSingleLogoutServiceResponseLocation();
+			this.binding = registration.getAssertingPartyMetadata().getSingleLogoutServiceBinding();
 		}
 
 		/**

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/metadata/OpenSamlSigningUtils.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/metadata/OpenSamlSigningUtils.java
@@ -80,7 +80,13 @@ final class OpenSamlSigningUtils {
 	}
 
 	static <O extends SignableXMLObject> O sign(O object, RelyingPartyRegistration relyingPartyRegistration) {
-		SignatureSigningParameters parameters = resolveSigningParameters(relyingPartyRegistration);
+		List<String> algorithms = relyingPartyRegistration.getAssertingPartyDetails().getSigningAlgorithms();
+		List<Credential> credentials = resolveSigningCredentials(relyingPartyRegistration);
+		return sign(object, algorithms, credentials);
+	}
+
+	static <O extends SignableXMLObject> O sign(O object, List<String> algorithms, List<Credential> credentials) {
+		SignatureSigningParameters parameters = resolveSigningParameters(algorithms, credentials);
 		try {
 			SignatureSupport.signObject(object, parameters);
 			return object;
@@ -98,6 +104,11 @@ final class OpenSamlSigningUtils {
 			RelyingPartyRegistration relyingPartyRegistration) {
 		List<Credential> credentials = resolveSigningCredentials(relyingPartyRegistration);
 		List<String> algorithms = relyingPartyRegistration.getAssertingPartyDetails().getSigningAlgorithms();
+		return resolveSigningParameters(algorithms, credentials);
+	}
+
+	private static SignatureSigningParameters resolveSigningParameters(List<String> algorithms,
+			List<Credential> credentials) {
 		List<String> digests = Collections.singletonList(SignatureConstants.ALGO_ID_DIGEST_SHA256);
 		String canonicalization = SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS;
 		SignatureSigningParametersResolver resolver = new SAMLMetadataSignatureSigningParametersResolver();

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/metadata/OpenSamlSigningUtils.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/metadata/OpenSamlSigningUtils.java
@@ -80,7 +80,7 @@ final class OpenSamlSigningUtils {
 	}
 
 	static <O extends SignableXMLObject> O sign(O object, RelyingPartyRegistration relyingPartyRegistration) {
-		List<String> algorithms = relyingPartyRegistration.getAssertingPartyDetails().getSigningAlgorithms();
+		List<String> algorithms = relyingPartyRegistration.getAssertingPartyMetadata().getSigningAlgorithms();
 		List<Credential> credentials = resolveSigningCredentials(relyingPartyRegistration);
 		return sign(object, algorithms, credentials);
 	}
@@ -103,7 +103,7 @@ final class OpenSamlSigningUtils {
 	private static SignatureSigningParameters resolveSigningParameters(
 			RelyingPartyRegistration relyingPartyRegistration) {
 		List<Credential> credentials = resolveSigningCredentials(relyingPartyRegistration);
-		List<String> algorithms = relyingPartyRegistration.getAssertingPartyDetails().getSigningAlgorithms();
+		List<String> algorithms = relyingPartyRegistration.getAssertingPartyMetadata().getSigningAlgorithms();
 		return resolveSigningParameters(algorithms, credentials);
 	}
 

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/registration/AssertingPartyMetadata.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/registration/AssertingPartyMetadata.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.provider.service.registration;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.springframework.security.saml2.core.Saml2X509Credential;
+
+/**
+ * An interface representing SAML 2.0 Asserting Party metadata
+ *
+ * @author Josh Cummings
+ * @since 6.4
+ */
+public interface AssertingPartyMetadata {
+
+	/**
+	 * Get the asserting party's <a href=
+	 * "https://www.oasis-open.org/committees/download.php/51890/SAML%20MD%20simplified%20overview.pdf#2.9%20EntityDescriptor">EntityID</a>.
+	 *
+	 * <p>
+	 * Equivalent to the value found in the asserting party's &lt;EntityDescriptor
+	 * EntityID="..."/&gt;
+	 *
+	 * <p>
+	 * This value may contain a number of placeholders, which need to be resolved before
+	 * use. They are {@code baseUrl}, {@code registrationId}, {@code baseScheme},
+	 * {@code baseHost}, and {@code basePort}.
+	 * @return the asserting party's EntityID
+	 */
+	String getEntityId();
+
+	/**
+	 * Get the WantAuthnRequestsSigned setting, indicating the asserting party's
+	 * preference that relying parties should sign the AuthnRequest before sending.
+	 * @return the WantAuthnRequestsSigned value
+	 */
+	boolean getWantAuthnRequestsSigned();
+
+	/**
+	 * Get the list of org.opensaml.saml.ext.saml2alg.SigningMethod Algorithms for this
+	 * asserting party, in preference order.
+	 *
+	 * <p>
+	 * Equivalent to the values found in &lt;SigningMethod Algorithm="..."/&gt; in the
+	 * asserting party's &lt;IDPSSODescriptor&gt;.
+	 * @return the list of SigningMethod Algorithms
+	 * @since 5.5
+	 */
+	List<String> getSigningAlgorithms();
+
+	/**
+	 * Get all verification {@link Saml2X509Credential}s associated with this asserting
+	 * party
+	 * @return all verification {@link Saml2X509Credential}s associated with this
+	 * asserting party
+	 * @since 5.4
+	 */
+	Collection<Saml2X509Credential> getVerificationX509Credentials();
+
+	/**
+	 * Get all encryption {@link Saml2X509Credential}s associated with this asserting
+	 * party
+	 * @return all encryption {@link Saml2X509Credential}s associated with this asserting
+	 * party
+	 * @since 5.4
+	 */
+	Collection<Saml2X509Credential> getEncryptionX509Credentials();
+
+	/**
+	 * Get the <a href=
+	 * "https://www.oasis-open.org/committees/download.php/51890/SAML%20MD%20simplified%20overview.pdf#2.5%20Endpoint">SingleSignOnService</a>
+	 * Location.
+	 *
+	 * <p>
+	 * Equivalent to the value found in &lt;SingleSignOnService Location="..."/&gt; in the
+	 * asserting party's &lt;IDPSSODescriptor&gt;.
+	 * @return the SingleSignOnService Location
+	 */
+	String getSingleSignOnServiceLocation();
+
+	/**
+	 * Get the <a href=
+	 * "https://www.oasis-open.org/committees/download.php/51890/SAML%20MD%20simplified%20overview.pdf#2.5%20Endpoint">SingleSignOnService</a>
+	 * Binding.
+	 *
+	 * <p>
+	 * Equivalent to the value found in &lt;SingleSignOnService Binding="..."/&gt; in the
+	 * asserting party's &lt;IDPSSODescriptor&gt;.
+	 * @return the SingleSignOnService Location
+	 */
+	Saml2MessageBinding getSingleSignOnServiceBinding();
+
+	/**
+	 * Get the <a href=
+	 * "https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf#page=7">SingleLogoutService
+	 * Location</a>
+	 *
+	 * <p>
+	 * Equivalent to the value found in &lt;SingleLogoutService Location="..."/&gt; in the
+	 * asserting party's &lt;IDPSSODescriptor&gt;.
+	 * @return the SingleLogoutService Location
+	 * @since 5.6
+	 */
+	String getSingleLogoutServiceLocation();
+
+	/**
+	 * Get the <a href=
+	 * "https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf#page=7">SingleLogoutService
+	 * Response Location</a>
+	 *
+	 * <p>
+	 * Equivalent to the value found in &lt;SingleLogoutService Location="..."/&gt; in the
+	 * asserting party's &lt;IDPSSODescriptor&gt;.
+	 * @return the SingleLogoutService Response Location
+	 * @since 5.6
+	 */
+	String getSingleLogoutServiceResponseLocation();
+
+	/**
+	 * Get the <a href=
+	 * "https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf#page=7">SingleLogoutService
+	 * Binding</a>
+	 *
+	 * <p>
+	 * Equivalent to the value found in &lt;SingleLogoutService Binding="..."/&gt; in the
+	 * asserting party's &lt;IDPSSODescriptor&gt;.
+	 * @return the SingleLogoutService Binding
+	 * @since 5.6
+	 */
+	Saml2MessageBinding getSingleLogoutServiceBinding();
+
+	Builder<?> mutate();
+
+	interface Builder<B extends Builder<B>> {
+
+		/**
+		 * Set the asserting party's <a href=
+		 * "https://www.oasis-open.org/committees/download.php/51890/SAML%20MD%20simplified%20overview.pdf#2.9%20EntityDescriptor">EntityID</a>.
+		 * Equivalent to the value found in the asserting party's &lt;EntityDescriptor
+		 * EntityID="..."/&gt;
+		 * @param entityId the asserting party's EntityID
+		 * @return the {@link B} for further configuration
+		 */
+		B entityId(String entityId);
+
+		/**
+		 * Set the WantAuthnRequestsSigned setting, indicating the asserting party's
+		 * preference that relying parties should sign the AuthnRequest before sending.
+		 * @param wantAuthnRequestsSigned the WantAuthnRequestsSigned setting
+		 * @return the {@link B} for further configuration
+		 */
+		B wantAuthnRequestsSigned(boolean wantAuthnRequestsSigned);
+
+		/**
+		 * Apply this {@link Consumer} to the list of SigningMethod Algorithms
+		 * @param signingMethodAlgorithmsConsumer a {@link Consumer} of the list of
+		 * SigningMethod Algorithms
+		 * @return this {@link B} for further configuration
+		 * @since 5.5
+		 */
+		B signingAlgorithms(Consumer<List<String>> signingMethodAlgorithmsConsumer);
+
+		/**
+		 * Apply this {@link Consumer} to the list of {@link Saml2X509Credential}s
+		 * @param credentialsConsumer a {@link Consumer} of the {@link List} of
+		 * {@link Saml2X509Credential}s
+		 * @return the {@link RelyingPartyRegistration.Builder} for further configuration
+		 * @since 5.4
+		 */
+		B verificationX509Credentials(Consumer<Collection<Saml2X509Credential>> credentialsConsumer);
+
+		/**
+		 * Apply this {@link Consumer} to the list of {@link Saml2X509Credential}s
+		 * @param credentialsConsumer a {@link Consumer} of the {@link List} of
+		 * {@link Saml2X509Credential}s
+		 * @return the {@link RelyingPartyRegistration.Builder} for further configuration
+		 * @since 5.4
+		 */
+		B encryptionX509Credentials(Consumer<Collection<Saml2X509Credential>> credentialsConsumer);
+
+		/**
+		 * Set the <a href=
+		 * "https://www.oasis-open.org/committees/download.php/51890/SAML%20MD%20simplified%20overview.pdf#2.5%20Endpoint">SingleSignOnService</a>
+		 * Location.
+		 *
+		 * <p>
+		 * Equivalent to the value found in &lt;SingleSignOnService Location="..."/&gt; in
+		 * the asserting party's &lt;IDPSSODescriptor&gt;.
+		 * @param singleSignOnServiceLocation the SingleSignOnService Location
+		 * @return the {@link B} for further configuration
+		 */
+		B singleSignOnServiceLocation(String singleSignOnServiceLocation);
+
+		/**
+		 * Set the <a href=
+		 * "https://www.oasis-open.org/committees/download.php/51890/SAML%20MD%20simplified%20overview.pdf#2.5%20Endpoint">SingleSignOnService</a>
+		 * Binding.
+		 *
+		 * <p>
+		 * Equivalent to the value found in &lt;SingleSignOnService Binding="..."/&gt; in
+		 * the asserting party's &lt;IDPSSODescriptor&gt;.
+		 * @param singleSignOnServiceBinding the SingleSignOnService Binding
+		 * @return the {@link B} for further configuration
+		 */
+		B singleSignOnServiceBinding(Saml2MessageBinding singleSignOnServiceBinding);
+
+		/**
+		 * Set the <a href=
+		 * "https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf#page=7">SingleLogoutService
+		 * Location</a>
+		 *
+		 * <p>
+		 * Equivalent to the value found in &lt;SingleLogoutService Location="..."/&gt; in
+		 * the asserting party's &lt;IDPSSODescriptor&gt;.
+		 * @param singleLogoutServiceLocation the SingleLogoutService Location
+		 * @return the {@link B} for further configuration
+		 * @since 5.6
+		 */
+		B singleLogoutServiceLocation(String singleLogoutServiceLocation);
+
+		/**
+		 * Set the <a href=
+		 * "https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf#page=7">SingleLogoutService
+		 * Response Location</a>
+		 *
+		 * <p>
+		 * Equivalent to the value found in &lt;SingleLogoutService
+		 * ResponseLocation="..."/&gt; in the asserting party's &lt;IDPSSODescriptor&gt;.
+		 * @param singleLogoutServiceResponseLocation the SingleLogoutService Response
+		 * Location
+		 * @return the {@link B} for further configuration
+		 * @since 5.6
+		 */
+		B singleLogoutServiceResponseLocation(String singleLogoutServiceResponseLocation);
+
+		/**
+		 * Set the <a href=
+		 * "https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf#page=7">SingleLogoutService
+		 * Binding</a>
+		 *
+		 * <p>
+		 * Equivalent to the value found in &lt;SingleLogoutService Binding="..."/&gt; in
+		 * the asserting party's &lt;IDPSSODescriptor&gt;.
+		 * @param singleLogoutServiceBinding the SingleLogoutService Binding
+		 * @return the {@link B} for further configuration
+		 * @since 5.6
+		 */
+		B singleLogoutServiceBinding(Saml2MessageBinding singleLogoutServiceBinding);
+
+		/**
+		 * Creates an immutable ProviderDetails object representing the configuration for
+		 * an Identity Provider, IDP
+		 * @return immutable ProviderDetails object
+		 */
+		AssertingPartyMetadata build();
+
+	}
+
+}

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/registration/AssertingPartyMetadataRepository.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/registration/AssertingPartyMetadataRepository.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.provider.service.registration;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * A repository for retrieving SAML 2.0 Asserting Party Metadata
+ *
+ * @author Josh Cummings
+ * @since 6.4
+ * @see OpenSamlAssertingPartyMetadataRepository
+ * @see org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrations
+ */
+public interface AssertingPartyMetadataRepository extends Iterable<AssertingPartyMetadata> {
+
+	/**
+	 * Retrieve an {@link AssertingPartyMetadata} by its <a href=
+	 * "https://www.oasis-open.org/committees/download.php/51890/SAML%20MD%20simplified%20overview.pdf#2.9%20EntityDescriptor">EntityID</a>.
+	 * @param entityId the EntityID to lookup
+	 * @return the found {@link AssertingPartyMetadata}, or {@code null} otherwise
+	 */
+	@Nullable
+	default AssertingPartyMetadata findByEntityId(String entityId) {
+		for (AssertingPartyMetadata metadata : this) {
+			if (metadata.getEntityId().equals(entityId)) {
+				return metadata;
+			}
+		}
+		return null;
+	}
+
+}

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/registration/InMemoryRelyingPartyRegistrationRepository.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/registration/InMemoryRelyingPartyRegistrationRepository.java
@@ -69,7 +69,7 @@ public class InMemoryRelyingPartyRegistrationRepository implements IterableRelyi
 			Collection<RelyingPartyRegistration> rps) {
 		MultiValueMap<String, RelyingPartyRegistration> result = new LinkedMultiValueMap<>();
 		for (RelyingPartyRegistration rp : rps) {
-			result.add(rp.getAssertingPartyDetails().getEntityId(), rp);
+			result.add(rp.getAssertingPartyMetadata().getEntityId(), rp);
 		}
 		return Collections.unmodifiableMap(result);
 	}

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/registration/OpenSamlAssertingPartyMetadataRepository.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/registration/OpenSamlAssertingPartyMetadataRepository.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.provider.service.registration;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import javax.annotation.Nonnull;
+
+import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
+import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+import net.shibboleth.utilities.java.support.resolver.ResolverException;
+import org.opensaml.core.criterion.EntityIdCriterion;
+import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
+import org.opensaml.saml.criterion.EntityRoleCriterion;
+import org.opensaml.saml.metadata.IterableMetadataSource;
+import org.opensaml.saml.metadata.resolver.MetadataResolver;
+import org.opensaml.saml.metadata.resolver.filter.impl.SignatureValidationFilter;
+import org.opensaml.saml.metadata.resolver.impl.AbstractBatchMetadataResolver;
+import org.opensaml.saml.metadata.resolver.impl.ResourceBackedMetadataResolver;
+import org.opensaml.saml.metadata.resolver.index.MetadataIndex;
+import org.opensaml.saml.metadata.resolver.index.impl.RoleMetadataIndex;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.security.credential.impl.CollectionCredentialResolver;
+import org.opensaml.xmlsec.config.impl.DefaultSecurityConfigurationBootstrap;
+import org.opensaml.xmlsec.signature.support.SignatureTrustEngine;
+import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
+
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.security.saml2.Saml2Exception;
+import org.springframework.security.saml2.core.OpenSamlInitializationService;
+import org.springframework.security.saml2.core.Saml2X509Credential;
+import org.springframework.util.Assert;
+
+/**
+ * An implementation of {@link AssertingPartyMetadataRepository} that uses a
+ * {@link MetadataResolver} to retrieve {@link AssertingPartyMetadata} instances.
+ *
+ * <p>
+ * The {@link MetadataResolver} constructed in {@link #withTrustedMetadataLocation}
+ * provides expiry-aware refreshing.
+ *
+ * @author Josh Cummings
+ * @since 6.4
+ * @see AssertingPartyMetadataRepository
+ * @see RelyingPartyRegistrations
+ */
+public final class OpenSamlAssertingPartyMetadataRepository implements AssertingPartyMetadataRepository {
+
+	static {
+		OpenSamlInitializationService.initialize();
+	}
+
+	private final MetadataResolver metadataResolver;
+
+	private final Supplier<Iterator<EntityDescriptor>> descriptors;
+
+	/**
+	 * Construct an {@link OpenSamlAssertingPartyMetadataRepository} using the provided
+	 * {@link MetadataResolver}.
+	 *
+	 * <p>
+	 * The {@link MetadataResolver} should either be of type
+	 * {@link IterableMetadataSource} or it should have a {@link RoleMetadataIndex}
+	 * configured.
+	 * @param metadataResolver the {@link MetadataResolver} to use
+	 */
+	public OpenSamlAssertingPartyMetadataRepository(MetadataResolver metadataResolver) {
+		Assert.notNull(metadataResolver, "metadataResolver cannot be null");
+		if (isRoleIndexed(metadataResolver)) {
+			this.descriptors = this::allIndexedEntities;
+		}
+		else if (metadataResolver instanceof IterableMetadataSource source) {
+			this.descriptors = source::iterator;
+		}
+		else {
+			throw new IllegalArgumentException(
+					"metadataResolver must be an IterableMetadataSource or have a RoleMetadataIndex");
+		}
+		this.metadataResolver = metadataResolver;
+	}
+
+	private static boolean isRoleIndexed(MetadataResolver resolver) {
+		if (!(resolver instanceof AbstractBatchMetadataResolver batch)) {
+			return false;
+		}
+		for (MetadataIndex index : batch.getIndexes()) {
+			if (index instanceof RoleMetadataIndex) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private Iterator<EntityDescriptor> allIndexedEntities() {
+		CriteriaSet all = new CriteriaSet(new EntityRoleCriterion(IDPSSODescriptor.DEFAULT_ELEMENT_NAME));
+		try {
+			return this.metadataResolver.resolve(all).iterator();
+		}
+		catch (ResolverException ex) {
+			throw new Saml2Exception(ex);
+		}
+	}
+
+	@Override
+	@NonNull
+	public Iterator<AssertingPartyMetadata> iterator() {
+		Iterator<EntityDescriptor> descriptors = this.descriptors.get();
+		return new Iterator<>() {
+			@Override
+			public boolean hasNext() {
+				return descriptors.hasNext();
+			}
+
+			@Override
+			public AssertingPartyMetadata next() {
+				return OpenSamlAssertingPartyDetails.withEntityDescriptor(descriptors.next()).build();
+			}
+		};
+	}
+
+	@Nullable
+	@Override
+	public AssertingPartyMetadata findByEntityId(String entityId) {
+		CriteriaSet byEntityId = new CriteriaSet(new EntityIdCriterion(entityId));
+		EntityDescriptor descriptor = resolveSingle(byEntityId);
+		if (descriptor == null) {
+			return null;
+		}
+		return OpenSamlAssertingPartyDetails.withEntityDescriptor(descriptor).build();
+	}
+
+	private EntityDescriptor resolveSingle(CriteriaSet criteria) {
+		try {
+			return this.metadataResolver.resolveSingle(criteria);
+		}
+		catch (ResolverException ex) {
+			throw new Saml2Exception(ex);
+		}
+	}
+
+	/**
+	 * Use this trusted {@code metadataLocation} to retrieve refreshable, expiry-aware
+	 * SAML 2.0 Asserting Party (IDP) metadata.
+	 *
+	 * <p>
+	 * Valid locations can be classpath- or file-based or they can be HTTPS endpoints.
+	 * Some valid endpoints might include:
+	 *
+	 * <pre>
+	 *   metadataLocation = "classpath:asserting-party-metadata.xml";
+	 *   metadataLocation = "file:asserting-party-metadata.xml";
+	 *   metadataLocation = "https://ap.example.org/metadata";
+	 * </pre>
+	 *
+	 * <p>
+	 * Resolution of location is attempted immediately. To defer, wrap in
+	 * {@link CachingRelyingPartyRegistrationRepository}.
+	 * @param metadataLocation the classpath- or file-based locations or HTTPS endpoints
+	 * of the asserting party metadata file
+	 * @return the {@link MetadataLocationRepositoryBuilder} for further configuration
+	 */
+	public static MetadataLocationRepositoryBuilder withTrustedMetadataLocation(String metadataLocation) {
+		return new MetadataLocationRepositoryBuilder(metadataLocation, true);
+	}
+
+	/**
+	 * Use this {@code metadataLocation} to retrieve refreshable, expiry-aware SAML 2.0
+	 * Asserting Party (IDP) metadata. Verification credentials are required.
+	 *
+	 * <p>
+	 * Valid locations can be classpath- or file-based or they can be remote endpoints.
+	 * Some valid endpoints might include:
+	 *
+	 * <pre>
+	 *   metadataLocation = "classpath:asserting-party-metadata.xml";
+	 *   metadataLocation = "file:asserting-party-metadata.xml";
+	 *   metadataLocation = "https://ap.example.org/metadata";
+	 * </pre>
+	 *
+	 * <p>
+	 * Resolution of location is attempted immediately. To defer, wrap in
+	 * {@link CachingRelyingPartyRegistrationRepository}.
+	 * @param metadataLocation the classpath- or file-based locations or remote endpoints
+	 * of the asserting party metadata file
+	 * @return the {@link MetadataLocationRepositoryBuilder} for further configuration
+	 */
+	public static MetadataLocationRepositoryBuilder withMetadataLocation(String metadataLocation) {
+		return new MetadataLocationRepositoryBuilder(metadataLocation, false);
+	}
+
+	/**
+	 * A builder class for configuring {@link OpenSamlAssertingPartyMetadataRepository}
+	 * for a specific metadata location.
+	 *
+	 * @author Josh Cummings
+	 */
+	public static final class MetadataLocationRepositoryBuilder {
+
+		private final String metadataLocation;
+
+		private final boolean requireVerificationCredentials;
+
+		private final Collection<Credential> verificationCredentials = new ArrayList<>();
+
+		private ResourceLoader resourceLoader = new DefaultResourceLoader();
+
+		private MetadataLocationRepositoryBuilder(String metadataLocation, boolean trusted) {
+			this.metadataLocation = metadataLocation;
+			this.requireVerificationCredentials = !trusted;
+		}
+
+		/**
+		 * Apply this {@link Consumer} to the list of {@link Saml2X509Credential}s to use
+		 * for verifying metadata signatures.
+		 *
+		 * <p>
+		 * If no credentials are supplied, no signature verification is performed.
+		 * @param credentials a {@link Consumer} of the {@link Collection} of
+		 * {@link Saml2X509Credential}s
+		 * @return the {@link MetadataLocationRepositoryBuilder} for further configuration
+		 */
+		public MetadataLocationRepositoryBuilder verificationCredentials(Consumer<Collection<Credential>> credentials) {
+			credentials.accept(this.verificationCredentials);
+			return this;
+		}
+
+		/**
+		 * Use this {@link ResourceLoader} for resolving the {@code metadataLocation}
+		 * @param resourceLoader the {@link ResourceLoader} to use
+		 * @return the {@link MetadataLocationRepositoryBuilder} for further configuration
+		 */
+		public MetadataLocationRepositoryBuilder resourceLoader(ResourceLoader resourceLoader) {
+			this.resourceLoader = resourceLoader;
+			return this;
+		}
+
+		/**
+		 * Build the {@link OpenSamlAssertingPartyMetadataRepository}
+		 * @return the {@link OpenSamlAssertingPartyMetadataRepository}
+		 */
+		public OpenSamlAssertingPartyMetadataRepository build() {
+			ResourceBackedMetadataResolver metadataResolver = metadataResolver();
+			if (!this.verificationCredentials.isEmpty()) {
+				SignatureTrustEngine engine = new ExplicitKeySignatureTrustEngine(
+						new CollectionCredentialResolver(this.verificationCredentials),
+						DefaultSecurityConfigurationBootstrap.buildBasicInlineKeyInfoCredentialResolver());
+				SignatureValidationFilter filter = new SignatureValidationFilter(engine);
+				filter.setRequireSignedRoot(true);
+				metadataResolver.setMetadataFilter(filter);
+				return new OpenSamlAssertingPartyMetadataRepository(initialize(metadataResolver));
+			}
+			Assert.isTrue(!this.requireVerificationCredentials, "Verification credentials are required");
+			return new OpenSamlAssertingPartyMetadataRepository(initialize(metadataResolver));
+		}
+
+		private ResourceBackedMetadataResolver metadataResolver() {
+			Resource resource = this.resourceLoader.getResource(this.metadataLocation);
+			try {
+				return new ResourceBackedMetadataResolver(new SpringResource(resource));
+			}
+			catch (IOException ex) {
+				throw new Saml2Exception(ex);
+			}
+		}
+
+		private MetadataResolver initialize(ResourceBackedMetadataResolver metadataResolver) {
+			try {
+				metadataResolver.setId(this.getClass().getName() + ".metadataResolver");
+				metadataResolver.setParserPool(XMLObjectProviderRegistrySupport.getParserPool());
+				metadataResolver.setIndexes(Set.of(new RoleMetadataIndex()));
+				metadataResolver.initialize();
+				return metadataResolver;
+			}
+			catch (ComponentInitializationException ex) {
+				throw new Saml2Exception(ex);
+			}
+		}
+
+		private static final class SpringResource implements net.shibboleth.utilities.java.support.resource.Resource {
+
+			private final Resource resource;
+
+			SpringResource(Resource resource) {
+				this.resource = resource;
+			}
+
+			@Override
+			public boolean exists() {
+				return this.resource.exists();
+			}
+
+			@Override
+			public boolean isReadable() {
+				return this.resource.isReadable();
+			}
+
+			@Override
+			public boolean isOpen() {
+				return this.resource.isOpen();
+			}
+
+			@Override
+			public URL getURL() throws IOException {
+				return this.resource.getURL();
+			}
+
+			@Override
+			public URI getURI() throws IOException {
+				return this.resource.getURI();
+			}
+
+			@Override
+			public File getFile() throws IOException {
+				return this.resource.getFile();
+			}
+
+			@Nonnull
+			@Override
+			public InputStream getInputStream() throws IOException {
+				return this.resource.getInputStream();
+			}
+
+			@Override
+			public long contentLength() throws IOException {
+				return this.resource.contentLength();
+			}
+
+			@Override
+			public long lastModified() throws IOException {
+				return this.resource.lastModified();
+			}
+
+			@Override
+			public net.shibboleth.utilities.java.support.resource.Resource createRelativeResource(String relativePath)
+					throws IOException {
+				return new SpringResource(this.resource.createRelative(relativePath));
+			}
+
+			@Override
+			public String getFilename() {
+				return this.resource.getFilename();
+			}
+
+			@Override
+			public String getDescription() {
+				return this.resource.getDescription();
+			}
+
+		}
+
+	}
+
+}

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/registration/OpenSamlRelyingPartyRegistration.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/registration/OpenSamlRelyingPartyRegistration.java
@@ -36,7 +36,7 @@ import org.springframework.security.saml2.core.Saml2X509Credential;
  * 	    EntityDescriptor descriptor = openSamlRegistration.getAssertingPartyDetails.getEntityDescriptor();
  * 	}
  * </pre> do instead: <pre>
- * 	if (registration.getAssertingPartyDetails() instanceof openSamlAssertingPartyDetails) {
+ * 	if (registration.getAssertingPartyMetadata() instanceof openSamlAssertingPartyDetails) {
  * 	    EntityDescriptor descriptor = openSamlAssertingPartyDetails.getEntityDescriptor();
  * 	}
  * </pre>
@@ -168,6 +168,11 @@ public final class OpenSamlRelyingPartyRegistration extends RelyingPartyRegistra
 		@Override
 		public Builder assertingPartyDetails(Consumer<AssertingPartyDetails.Builder> assertingPartyDetails) {
 			return (Builder) super.assertingPartyDetails(assertingPartyDetails);
+		}
+
+		@Override
+		public Builder assertingPartyMetadata(Consumer<AssertingPartyMetadata.Builder<?>> assertingPartyMetadata) {
+			return (Builder) super.assertingPartyMetadata(assertingPartyMetadata);
 		}
 
 		/**

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/registration/RelyingPartyRegistration.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/registration/RelyingPartyRegistration.java
@@ -339,6 +339,25 @@ public class RelyingPartyRegistration {
 	}
 
 	/**
+	 * Creates a {@code RelyingPartyRegistration} {@link Builder} with a
+	 * {@code registrationId} equivalent to the asserting party entity id. Also
+	 * initializes to the contents of the given {@link AssertingPartyMetadata}.
+	 *
+	 * <p>
+	 * Presented as a convenience method when working with
+	 * {@link AssertingPartyMetadataRepository} return values. As such, only supports
+	 * {@link AssertingPartyMetadata} instances of type {@link AssertingPartyDetails}.
+	 * @param metadata the metadata used to initialize the
+	 * {@link RelyingPartyRegistration} {@link Builder}
+	 * @return {@link Builder} to create a {@link RelyingPartyRegistration} object
+	 * @since 6.4
+	 */
+	public static Builder withAssertingPartyMetadata(AssertingPartyMetadata metadata) {
+		Assert.isInstanceOf(AssertingPartyDetails.class, metadata, "metadata must be of type AssertingPartyDetails");
+		return withAssertingPartyDetails((AssertingPartyDetails) metadata);
+	}
+
+	/**
 	 * Creates a {@code RelyingPartyRegistration} {@link Builder} based on an existing
 	 * object
 	 * @param registration the {@code RelyingPartyRegistration}
@@ -380,7 +399,7 @@ public class RelyingPartyRegistration {
 	 *
 	 * @since 5.4
 	 */
-	public static class AssertingPartyDetails {
+	public static class AssertingPartyDetails implements AssertingPartyMetadata {
 
 		private final String entityId;
 
@@ -584,7 +603,7 @@ public class RelyingPartyRegistration {
 				.singleLogoutServiceBinding(this.singleLogoutServiceBinding);
 		}
 
-		public static class Builder {
+		public static class Builder implements AssertingPartyMetadata.Builder<Builder> {
 
 			private String entityId;
 

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/RelyingPartyRegistrationPlaceholderResolvers.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/RelyingPartyRegistrationPlaceholderResolvers.java
@@ -68,7 +68,7 @@ public final class RelyingPartyRegistrationPlaceholderResolvers {
 	 */
 	public static UriResolver uriResolver(HttpServletRequest request, RelyingPartyRegistration registration) {
 		String relyingPartyEntityId = registration.getEntityId();
-		String assertingPartyEntityId = registration.getAssertingPartyDetails().getEntityId();
+		String assertingPartyEntityId = registration.getAssertingPartyMetadata().getEntityId();
 		String registrationId = registration.getRegistrationId();
 		Map<String, String> uriVariables = uriVariables(request);
 		uriVariables.put("relyingPartyEntityId", StringUtils.hasText(relyingPartyEntityId) ? relyingPartyEntityId : "");

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/OpenSamlAuthenticationRequestResolver.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/OpenSamlAuthenticationRequestResolver.java
@@ -146,7 +146,7 @@ class OpenSamlAuthenticationRequestResolver {
 		Issuer iss = this.issuerBuilder.buildObject();
 		iss.setValue(entityId);
 		authnRequest.setIssuer(iss);
-		authnRequest.setDestination(registration.getAssertingPartyDetails().getSingleSignOnServiceLocation());
+		authnRequest.setDestination(registration.getAssertingPartyMetadata().getSingleSignOnServiceLocation());
 		authnRequest.setAssertionConsumerServiceURL(assertionConsumerServiceLocation);
 		if (registration.getNameIdFormat() != null) {
 			NameIDPolicy nameIdPolicy = this.nameIdPolicyBuilder.buildObject();
@@ -158,9 +158,9 @@ class OpenSamlAuthenticationRequestResolver {
 			authnRequest.setID("ARQ" + UUID.randomUUID().toString().substring(1));
 		}
 		String relayState = this.relayStateResolver.convert(request);
-		Saml2MessageBinding binding = registration.getAssertingPartyDetails().getSingleSignOnServiceBinding();
+		Saml2MessageBinding binding = registration.getAssertingPartyMetadata().getSingleSignOnServiceBinding();
 		if (binding == Saml2MessageBinding.POST) {
-			if (registration.getAssertingPartyDetails().getWantAuthnRequestsSigned()
+			if (registration.getAssertingPartyMetadata().getWantAuthnRequestsSigned()
 					|| registration.isAuthnRequestsSigned()) {
 				OpenSamlSigningUtils.sign(authnRequest, registration);
 			}
@@ -180,7 +180,7 @@ class OpenSamlAuthenticationRequestResolver {
 				.samlRequest(deflatedAndEncoded)
 				.relayState(relayState)
 				.id(authnRequest.getID());
-			if (registration.getAssertingPartyDetails().getWantAuthnRequestsSigned()
+			if (registration.getAssertingPartyMetadata().getWantAuthnRequestsSigned()
 					|| registration.isAuthnRequestsSigned()) {
 				OpenSamlSigningUtils.QueryParametersPartial parametersPartial = OpenSamlSigningUtils.sign(registration)
 					.param(Saml2ParameterNames.SAML_REQUEST, deflatedAndEncoded);

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/OpenSamlSigningUtils.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/OpenSamlSigningUtils.java
@@ -95,7 +95,7 @@ final class OpenSamlSigningUtils {
 	private static SignatureSigningParameters resolveSigningParameters(
 			RelyingPartyRegistration relyingPartyRegistration) {
 		List<Credential> credentials = resolveSigningCredentials(relyingPartyRegistration);
-		List<String> algorithms = relyingPartyRegistration.getAssertingPartyDetails().getSigningAlgorithms();
+		List<String> algorithms = relyingPartyRegistration.getAssertingPartyMetadata().getSigningAlgorithms();
 		List<String> digests = Collections.singletonList(SignatureConstants.ALGO_ID_DIGEST_SHA256);
 		String canonicalization = SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS;
 		SignatureSigningParametersResolver resolver = new SAMLMetadataSignatureSigningParametersResolver();

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/OpenSamlVerificationUtils.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/OpenSamlVerificationUtils.java
@@ -155,12 +155,12 @@ final class OpenSamlVerificationUtils {
 
 		private SignatureTrustEngine trustEngine(RelyingPartyRegistration registration) {
 			Set<Credential> credentials = new HashSet<>();
-			Collection<Saml2X509Credential> keys = registration.getAssertingPartyDetails()
+			Collection<Saml2X509Credential> keys = registration.getAssertingPartyMetadata()
 				.getVerificationX509Credentials();
 			for (Saml2X509Credential key : keys) {
 				BasicX509Credential cred = new BasicX509Credential(key.getCertificate());
 				cred.setUsageType(UsageType.SIGNING);
-				cred.setEntityId(registration.getAssertingPartyDetails().getEntityId());
+				cred.setEntityId(registration.getAssertingPartyMetadata().getEntityId());
 				credentials.add(cred);
 			}
 			CredentialResolver credentialsResolver = new CollectionCredentialResolver(credentials);

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/OpenSamlLogoutRequestResolver.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/OpenSamlLogoutRequestResolver.java
@@ -126,13 +126,13 @@ final class OpenSamlLogoutRequestResolver {
 		if (registration == null) {
 			return null;
 		}
-		if (registration.getAssertingPartyDetails().getSingleLogoutServiceLocation() == null) {
+		if (registration.getAssertingPartyMetadata().getSingleLogoutServiceLocation() == null) {
 			return null;
 		}
 		UriResolver uriResolver = RelyingPartyRegistrationPlaceholderResolvers.uriResolver(request, registration);
 		String entityId = uriResolver.resolve(registration.getEntityId());
 		LogoutRequest logoutRequest = this.logoutRequestBuilder.buildObject();
-		logoutRequest.setDestination(registration.getAssertingPartyDetails().getSingleLogoutServiceLocation());
+		logoutRequest.setDestination(registration.getAssertingPartyMetadata().getSingleLogoutServiceLocation());
 		Issuer issuer = this.issuerBuilder.buildObject();
 		issuer.setValue(entityId);
 		logoutRequest.setIssuer(issuer);
@@ -154,7 +154,7 @@ final class OpenSamlLogoutRequestResolver {
 		String relayState = this.relayStateResolver.convert(request);
 		Saml2LogoutRequest.Builder result = Saml2LogoutRequest.withRelyingPartyRegistration(registration)
 			.id(logoutRequest.getID());
-		if (registration.getAssertingPartyDetails().getSingleLogoutServiceBinding() == Saml2MessageBinding.POST) {
+		if (registration.getAssertingPartyMetadata().getSingleLogoutServiceBinding() == Saml2MessageBinding.POST) {
 			String xml = serialize(OpenSamlSigningUtils.sign(logoutRequest, registration));
 			String samlRequest = Saml2Utils.samlEncode(xml.getBytes(StandardCharsets.UTF_8));
 			return result.samlRequest(samlRequest).relayState(relayState).build();

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/OpenSamlLogoutResponseResolver.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/OpenSamlLogoutResponseResolver.java
@@ -143,13 +143,14 @@ final class OpenSamlLogoutResponseResolver {
 		if (registration == null) {
 			return null;
 		}
-		if (registration.getAssertingPartyDetails().getSingleLogoutServiceResponseLocation() == null) {
+		if (registration.getAssertingPartyMetadata().getSingleLogoutServiceResponseLocation() == null) {
 			return null;
 		}
 		UriResolver uriResolver = RelyingPartyRegistrationPlaceholderResolvers.uriResolver(request, registration);
 		String entityId = uriResolver.resolve(registration.getEntityId());
 		LogoutResponse logoutResponse = this.logoutResponseBuilder.buildObject();
-		logoutResponse.setDestination(registration.getAssertingPartyDetails().getSingleLogoutServiceResponseLocation());
+		logoutResponse
+			.setDestination(registration.getAssertingPartyMetadata().getSingleLogoutServiceResponseLocation());
 		Issuer issuer = this.issuerBuilder.buildObject();
 		issuer.setValue(entityId);
 		logoutResponse.setIssuer(issuer);
@@ -164,7 +165,7 @@ final class OpenSamlLogoutResponseResolver {
 		}
 		logoutResponseConsumer.accept(registration, logoutResponse);
 		Saml2LogoutResponse.Builder result = Saml2LogoutResponse.withRelyingPartyRegistration(registration);
-		if (registration.getAssertingPartyDetails().getSingleLogoutServiceBinding() == Saml2MessageBinding.POST) {
+		if (registration.getAssertingPartyMetadata().getSingleLogoutServiceBinding() == Saml2MessageBinding.POST) {
 			String xml = serialize(OpenSamlSigningUtils.sign(logoutResponse, registration));
 			String samlResponse = Saml2Utils.samlEncode(xml.getBytes(StandardCharsets.UTF_8));
 			result.samlResponse(samlResponse);

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/OpenSamlSigningUtils.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/OpenSamlSigningUtils.java
@@ -96,7 +96,7 @@ final class OpenSamlSigningUtils {
 	private static SignatureSigningParameters resolveSigningParameters(
 			RelyingPartyRegistration relyingPartyRegistration) {
 		List<Credential> credentials = resolveSigningCredentials(relyingPartyRegistration);
-		List<String> algorithms = relyingPartyRegistration.getAssertingPartyDetails().getSigningAlgorithms();
+		List<String> algorithms = relyingPartyRegistration.getAssertingPartyMetadata().getSigningAlgorithms();
 		List<String> digests = Collections.singletonList(SignatureConstants.ALGO_ID_DIGEST_SHA256);
 		String canonicalization = SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS;
 		SignatureSigningParametersResolver resolver = new SAMLMetadataSignatureSigningParametersResolver();

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2LogoutRequestResolver.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2LogoutRequestResolver.java
@@ -28,7 +28,7 @@ import org.springframework.security.saml2.provider.service.registration.RelyingP
  *
  * The returned logout request is suitable for sending to the asserting party based on,
  * for example, the location and binding specified in
- * {@link RelyingPartyRegistration#getAssertingPartyDetails()}.
+ * {@link RelyingPartyRegistration#getAssertingPartyMetadata()}.
  *
  * @author Josh Cummings
  * @since 5.6

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2LogoutResponseResolver.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2LogoutResponseResolver.java
@@ -28,7 +28,7 @@ import org.springframework.security.saml2.provider.service.registration.RelyingP
  *
  * The returned logout response is suitable for sending to the asserting party based on,
  * for example, the location and binding specified in
- * {@link RelyingPartyRegistration#getAssertingPartyDetails()}.
+ * {@link RelyingPartyRegistration#getAssertingPartyMetadata()}.
  *
  * @author Josh Cummings
  * @since 5.6

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/registration/OpenSamlAssertingPartyMetadataRepositoryTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/registration/OpenSamlAssertingPartyMetadataRepositoryTests.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.provider.service.registration;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import net.shibboleth.utilities.java.support.xml.SerializeSupport;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
+import org.opensaml.core.xml.io.Marshaller;
+import org.opensaml.core.xml.io.MarshallingException;
+import org.opensaml.saml.metadata.IterableMetadataSource;
+import org.opensaml.saml.metadata.resolver.MetadataResolver;
+import org.opensaml.saml.metadata.resolver.impl.FilesystemMetadataResolver;
+import org.opensaml.saml.metadata.resolver.index.impl.RoleMetadataIndex;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.security.credential.Credential;
+import org.w3c.dom.Element;
+
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.security.saml2.Saml2Exception;
+import org.springframework.security.saml2.core.OpenSamlInitializationService;
+import org.springframework.security.saml2.core.TestSaml2X509Credentials;
+import org.springframework.security.saml2.provider.service.authentication.TestOpenSamlObjects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ * Tests for {@link OpenSamlAssertingPartyMetadataRepository}
+ */
+public class OpenSamlAssertingPartyMetadataRepositoryTests {
+
+	static {
+		OpenSamlInitializationService.initialize();
+	}
+
+	private String metadata;
+
+	private String entitiesDescriptor;
+
+	@BeforeEach
+	public void setup() throws Exception {
+		ClassPathResource resource = new ClassPathResource("test-metadata.xml");
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(resource.getInputStream()))) {
+			this.metadata = reader.lines().collect(Collectors.joining());
+		}
+		resource = new ClassPathResource("test-entitiesdescriptor.xml");
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(resource.getInputStream()))) {
+			this.entitiesDescriptor = reader.lines().collect(Collectors.joining());
+		}
+	}
+
+	@Test
+	public void withMetadataUrlLocationWhenResolvableThenFindByEntityIdReturns() throws Exception {
+		try (MockWebServer server = new MockWebServer()) {
+			server.setDispatcher(new AlwaysDispatch(new MockResponse().setBody(this.metadata).setResponseCode(200)));
+			AssertingPartyMetadataRepository parties = OpenSamlAssertingPartyMetadataRepository
+				.withTrustedMetadataLocation(server.url("/").toString())
+				.build();
+			AssertingPartyMetadata party = parties.findByEntityId("https://idp.example.com/idp/shibboleth");
+			assertThat(party.getEntityId()).isEqualTo("https://idp.example.com/idp/shibboleth");
+			assertThat(party.getSingleSignOnServiceLocation())
+				.isEqualTo("https://idp.example.com/idp/profile/SAML2/POST/SSO");
+			assertThat(party.getSingleSignOnServiceBinding()).isEqualTo(Saml2MessageBinding.POST);
+			assertThat(party.getVerificationX509Credentials()).hasSize(1);
+			assertThat(party.getEncryptionX509Credentials()).hasSize(1);
+		}
+	}
+
+	@Test
+	public void withMetadataUrlLocationnWhenResolvableThenIteratorReturns() throws Exception {
+		try (MockWebServer server = new MockWebServer()) {
+			server.setDispatcher(
+					new AlwaysDispatch(new MockResponse().setBody(this.entitiesDescriptor).setResponseCode(200)));
+			List<AssertingPartyMetadata> parties = new ArrayList<>();
+			OpenSamlAssertingPartyMetadataRepository.withTrustedMetadataLocation(server.url("/").toString())
+				.build()
+				.iterator()
+				.forEachRemaining(parties::add);
+			assertThat(parties).hasSize(2);
+			assertThat(parties).extracting(AssertingPartyMetadata::getEntityId)
+				.contains("https://ap.example.org/idp/shibboleth", "https://idp.example.com/idp/shibboleth");
+		}
+	}
+
+	@Test
+	public void withMetadataUrlLocationWhenUnresolvableThenThrowsSaml2Exception() throws Exception {
+		try (MockWebServer server = new MockWebServer()) {
+			server.enqueue(new MockResponse().setBody(this.metadata).setResponseCode(200));
+			String url = server.url("/").toString();
+			server.shutdown();
+			assertThatExceptionOfType(Saml2Exception.class)
+				.isThrownBy(() -> OpenSamlAssertingPartyMetadataRepository.withTrustedMetadataLocation(url).build());
+		}
+	}
+
+	@Test
+	public void withMetadataUrlLocationWhenMalformedResponseThenSaml2Exception() throws Exception {
+		try (MockWebServer server = new MockWebServer()) {
+			server.setDispatcher(new AlwaysDispatch("malformed"));
+			String url = server.url("/").toString();
+			assertThatExceptionOfType(Saml2Exception.class)
+				.isThrownBy(() -> OpenSamlAssertingPartyMetadataRepository.withTrustedMetadataLocation(url).build());
+		}
+	}
+
+	@Test
+	public void fromMetadataFileLocationWhenResolvableThenFindByEntityIdReturns() {
+		File file = new File("src/test/resources/test-metadata.xml");
+		AssertingPartyMetadata party = OpenSamlAssertingPartyMetadataRepository
+			.withTrustedMetadataLocation("file:" + file.getAbsolutePath())
+			.build()
+			.findByEntityId("https://idp.example.com/idp/shibboleth");
+		assertThat(party.getEntityId()).isEqualTo("https://idp.example.com/idp/shibboleth");
+		assertThat(party.getSingleSignOnServiceLocation())
+			.isEqualTo("https://idp.example.com/idp/profile/SAML2/POST/SSO");
+		assertThat(party.getSingleSignOnServiceBinding()).isEqualTo(Saml2MessageBinding.POST);
+		assertThat(party.getVerificationX509Credentials()).hasSize(1);
+		assertThat(party.getEncryptionX509Credentials()).hasSize(1);
+	}
+
+	@Test
+	public void fromMetadataFileLocationWhenResolvableThenIteratorReturns() {
+		File file = new File("src/test/resources/test-entitiesdescriptor.xml");
+		Collection<AssertingPartyMetadata> parties = new ArrayList<>();
+		OpenSamlAssertingPartyMetadataRepository.withTrustedMetadataLocation("file:" + file.getAbsolutePath())
+			.build()
+			.iterator()
+			.forEachRemaining(parties::add);
+		assertThat(parties).hasSize(2);
+		assertThat(parties).extracting(AssertingPartyMetadata::getEntityId)
+			.contains("https://idp.example.com/idp/shibboleth", "https://ap.example.org/idp/shibboleth");
+	}
+
+	@Test
+	public void withMetadataFileLocationWhenNotFoundThenSaml2Exception() {
+		assertThatExceptionOfType(Saml2Exception.class).isThrownBy(
+				() -> OpenSamlAssertingPartyMetadataRepository.withTrustedMetadataLocation("file:path").build());
+	}
+
+	@Test
+	public void fromMetadataClasspathLocationWhenResolvableThenFindByEntityIdReturns() {
+		AssertingPartyMetadata party = OpenSamlAssertingPartyMetadataRepository
+			.withTrustedMetadataLocation("classpath:test-entitiesdescriptor.xml")
+			.build()
+			.findByEntityId("https://ap.example.org/idp/shibboleth");
+		assertThat(party.getEntityId()).isEqualTo("https://ap.example.org/idp/shibboleth");
+		assertThat(party.getSingleSignOnServiceLocation())
+			.isEqualTo("https://ap.example.org/idp/profile/SAML2/POST/SSO");
+		assertThat(party.getSingleSignOnServiceBinding()).isEqualTo(Saml2MessageBinding.POST);
+		assertThat(party.getVerificationX509Credentials()).hasSize(1);
+		assertThat(party.getEncryptionX509Credentials()).hasSize(1);
+	}
+
+	@Test
+	public void fromMetadataClasspathLocationWhenResolvableThenIteratorReturns() {
+		Collection<AssertingPartyMetadata> parties = new ArrayList<>();
+		OpenSamlAssertingPartyMetadataRepository.withTrustedMetadataLocation("classpath:test-entitiesdescriptor.xml")
+			.build()
+			.iterator()
+			.forEachRemaining(parties::add);
+		assertThat(parties).hasSize(2);
+		assertThat(parties).extracting(AssertingPartyMetadata::getEntityId)
+			.contains("https://idp.example.com/idp/shibboleth", "https://ap.example.org/idp/shibboleth");
+	}
+
+	@Test
+	public void withMetadataClasspathLocationWhenNotFoundThenSaml2Exception() {
+		assertThatExceptionOfType(Saml2Exception.class).isThrownBy(
+				() -> OpenSamlAssertingPartyMetadataRepository.withTrustedMetadataLocation("classpath:path").build());
+	}
+
+	@Test
+	public void withTrustedMetadataLocationWhenMatchingCredentialsThenVerifiesSignature() throws IOException {
+		RelyingPartyRegistration registration = TestRelyingPartyRegistrations.full().build();
+		EntityDescriptor descriptor = TestOpenSamlObjects.entityDescriptor(registration);
+		TestOpenSamlObjects.signed(descriptor, TestSaml2X509Credentials.assertingPartySigningCredential(),
+				descriptor.getEntityID());
+		String serialized = serialize(descriptor);
+		Credential credential = TestOpenSamlObjects
+			.getSigningCredential(TestSaml2X509Credentials.relyingPartyVerifyingCredential(), descriptor.getEntityID());
+		try (MockWebServer server = new MockWebServer()) {
+			server.start();
+			server.setDispatcher(new AlwaysDispatch(serialized));
+			AssertingPartyMetadataRepository parties = OpenSamlAssertingPartyMetadataRepository
+				.withTrustedMetadataLocation(server.url("/").toString())
+				.verificationCredentials((c) -> c.add(credential))
+				.build();
+			assertThat(parties.findByEntityId(registration.getAssertingPartyDetails().getEntityId())).isNotNull();
+		}
+	}
+
+	@Test
+	public void withTrustedMetadataLocationWhenMismatchingCredentialsThenSaml2Exception() throws IOException {
+		RelyingPartyRegistration registration = TestRelyingPartyRegistrations.full().build();
+		EntityDescriptor descriptor = TestOpenSamlObjects.entityDescriptor(registration);
+		TestOpenSamlObjects.signed(descriptor, TestSaml2X509Credentials.relyingPartySigningCredential(),
+				descriptor.getEntityID());
+		String serialized = serialize(descriptor);
+		Credential credential = TestOpenSamlObjects
+			.getSigningCredential(TestSaml2X509Credentials.relyingPartyVerifyingCredential(), descriptor.getEntityID());
+		try (MockWebServer server = new MockWebServer()) {
+			server.start();
+			server.setDispatcher(new AlwaysDispatch(serialized));
+			assertThatExceptionOfType(Saml2Exception.class).isThrownBy(() -> OpenSamlAssertingPartyMetadataRepository
+				.withTrustedMetadataLocation(server.url("/").toString())
+				.verificationCredentials((c) -> c.add(credential))
+				.build());
+		}
+	}
+
+	@Test
+	public void withTrustedMetadataLocationWhenNoCredentialsThenSkipsVerifySignature() throws IOException {
+		RelyingPartyRegistration registration = TestRelyingPartyRegistrations.full().build();
+		EntityDescriptor descriptor = TestOpenSamlObjects.entityDescriptor(registration);
+		TestOpenSamlObjects.signed(descriptor, TestSaml2X509Credentials.assertingPartySigningCredential(),
+				descriptor.getEntityID());
+		String serialized = serialize(descriptor);
+		try (MockWebServer server = new MockWebServer()) {
+			server.start();
+			server.setDispatcher(new AlwaysDispatch(serialized));
+			AssertingPartyMetadataRepository parties = OpenSamlAssertingPartyMetadataRepository
+				.withTrustedMetadataLocation(server.url("/").toString())
+				.build();
+			assertThat(parties.findByEntityId(registration.getAssertingPartyDetails().getEntityId())).isNotNull();
+		}
+	}
+
+	@Test
+	public void withTrustedMetadataLocationWhenCustomResourceLoaderThenUses() {
+		ResourceLoader resourceLoader = mock(ResourceLoader.class);
+		given(resourceLoader.getResource(any())).willReturn(new ClassPathResource("test-metadata.xml"));
+		AssertingPartyMetadata party = OpenSamlAssertingPartyMetadataRepository
+			.withTrustedMetadataLocation("classpath:wrong")
+			.resourceLoader(resourceLoader)
+			.build()
+			.iterator()
+			.next();
+		assertThat(party.getEntityId()).isEqualTo("https://idp.example.com/idp/shibboleth");
+		assertThat(party.getSingleSignOnServiceLocation())
+			.isEqualTo("https://idp.example.com/idp/profile/SAML2/POST/SSO");
+		assertThat(party.getSingleSignOnServiceBinding()).isEqualTo(Saml2MessageBinding.POST);
+		assertThat(party.getVerificationX509Credentials()).hasSize(1);
+		assertThat(party.getEncryptionX509Credentials()).hasSize(1);
+		verify(resourceLoader).getResource(any());
+	}
+
+	@Test
+	public void constructorWhenNoIndexAndNoIteratorThenException() {
+		MetadataResolver resolver = mock(MetadataResolver.class);
+		assertThatExceptionOfType(IllegalArgumentException.class)
+			.isThrownBy(() -> new OpenSamlAssertingPartyMetadataRepository(resolver));
+	}
+
+	@Test
+	public void constructorWhenIterableResolverThenUses() {
+		RelyingPartyRegistration registration = TestRelyingPartyRegistrations.full().build();
+		EntityDescriptor descriptor = TestOpenSamlObjects.entityDescriptor(registration);
+		MetadataResolver resolver = mock(MetadataResolver.class,
+				withSettings().extraInterfaces(IterableMetadataSource.class));
+		given(((IterableMetadataSource) resolver).iterator()).willReturn(List.of(descriptor).iterator());
+		AssertingPartyMetadataRepository parties = new OpenSamlAssertingPartyMetadataRepository(resolver);
+		parties.iterator()
+			.forEachRemaining((p) -> assertThat(p.getEntityId())
+				.isEqualTo(registration.getAssertingPartyDetails().getEntityId()));
+		verify(((IterableMetadataSource) resolver)).iterator();
+	}
+
+	@Test
+	public void constructorWhenIndexedResolverThenUses() throws Exception {
+		FilesystemMetadataResolver resolver = new FilesystemMetadataResolver(
+				new ClassPathResource("test-metadata.xml").getFile());
+		resolver.setIndexes(Set.of(new RoleMetadataIndex()));
+		resolver.setId("id");
+		resolver.setParserPool(XMLObjectProviderRegistrySupport.getParserPool());
+		resolver.initialize();
+		MetadataResolver spied = spy(resolver);
+		AssertingPartyMetadataRepository parties = new OpenSamlAssertingPartyMetadataRepository(spied);
+		parties.iterator()
+			.forEachRemaining((p) -> assertThat(p.getEntityId()).isEqualTo("https://idp.example.com/idp/shibboleth"));
+		verify(spied).resolve(any());
+	}
+
+	@Test
+	public void withMetadataLocationWhenNoCredentialsThenException() {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+				() -> OpenSamlAssertingPartyMetadataRepository.withMetadataLocation("classpath:test-metadata.xml")
+					.build());
+	}
+
+	@Test
+	public void withMetadataLocationWhenMatchingCredentialsThenVerifiesSignature() throws IOException {
+		RelyingPartyRegistration registration = TestRelyingPartyRegistrations.full().build();
+		EntityDescriptor descriptor = TestOpenSamlObjects.entityDescriptor(registration);
+		TestOpenSamlObjects.signed(descriptor, TestSaml2X509Credentials.assertingPartySigningCredential(),
+				descriptor.getEntityID());
+		String serialized = serialize(descriptor);
+		Credential credential = TestOpenSamlObjects
+			.getSigningCredential(TestSaml2X509Credentials.relyingPartyVerifyingCredential(), descriptor.getEntityID());
+		try (MockWebServer server = new MockWebServer()) {
+			server.start();
+			server.setDispatcher(new AlwaysDispatch(serialized));
+			AssertingPartyMetadataRepository parties = OpenSamlAssertingPartyMetadataRepository
+				.withMetadataLocation(server.url("/").toString())
+				.verificationCredentials((c) -> c.add(credential))
+				.build();
+			assertThat(parties.findByEntityId(registration.getAssertingPartyDetails().getEntityId())).isNotNull();
+		}
+	}
+
+	private static String serialize(XMLObject object) {
+		try {
+			Marshaller marshaller = XMLObjectProviderRegistrySupport.getMarshallerFactory().getMarshaller(object);
+			Element element = marshaller.marshall(object);
+			return SerializeSupport.nodeToString(element);
+		}
+		catch (MarshallingException ex) {
+			throw new Saml2Exception(ex);
+		}
+	}
+
+	private static final class AlwaysDispatch extends Dispatcher {
+
+		private final MockResponse response;
+
+		private AlwaysDispatch(String body) {
+			this.response = new MockResponse().setBody(body).setResponseCode(200);
+		}
+
+		private AlwaysDispatch(MockResponse response) {
+			this.response = response;
+		}
+
+		@Override
+		public MockResponse dispatch(RecordedRequest recordedRequest) throws InterruptedException {
+			return this.response;
+		}
+
+	}
+
+}

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/registration/RelyingPartyRegistrationTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/registration/RelyingPartyRegistrationTests.java
@@ -16,13 +16,19 @@
 
 package org.springframework.security.saml2.provider.service.registration;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Consumer;
+
 import org.junit.jupiter.api.Test;
 
 import org.springframework.security.saml2.core.Saml2X509Credential;
 import org.springframework.security.saml2.core.TestSaml2X509Credentials;
+import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration.AssertingPartyDetails;
 import org.springframework.security.saml2.provider.service.web.authentication.Saml2WebSsoAuthenticationFilter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class RelyingPartyRegistrationTests {
 
@@ -167,16 +173,16 @@ public class RelyingPartyRegistrationTests {
 	}
 
 	@Test
-	void withAssertingPartyMetadataWhenDetailsThenBuilderCopies() {
+	void withAssertingPartyMetadataWhenMetadataThenBuilderCopies() {
 		RelyingPartyRegistration registration = TestRelyingPartyRegistrations.relyingPartyRegistration()
 			.nameIdFormat("format")
-			.assertingPartyDetails((a) -> a.singleSignOnServiceBinding(Saml2MessageBinding.POST))
-			.assertingPartyDetails((a) -> a.wantAuthnRequestsSigned(false))
-			.assertingPartyDetails((a) -> a.signingAlgorithms((algs) -> algs.add("alg")))
+			.assertingPartyMetadata((a) -> a.singleSignOnServiceBinding(Saml2MessageBinding.POST))
+			.assertingPartyMetadata((a) -> a.wantAuthnRequestsSigned(false))
+			.assertingPartyMetadata((a) -> a.signingAlgorithms((algs) -> algs.add("alg")))
 			.assertionConsumerServiceBinding(Saml2MessageBinding.REDIRECT)
 			.build();
 		RelyingPartyRegistration copied = RelyingPartyRegistration
-			.withAssertingPartyMetadata(registration.getAssertingPartyDetails())
+			.withAssertingPartyMetadata(registration.getAssertingPartyMetadata())
 			.registrationId(registration.getRegistrationId())
 			.entityId(registration.getEntityId())
 			.signingX509Credentials((c) -> c.addAll(registration.getSigningX509Credentials()))
@@ -190,6 +196,162 @@ public class RelyingPartyRegistrationTests {
 			.authnRequestsSigned(registration.isAuthnRequestsSigned())
 			.build();
 		compareRegistrations(registration, copied);
+	}
+
+	@Test
+	void withAssertingPartyMetadataWhenMetadataThenDisallowsDetails() {
+		AssertingPartyMetadata metadata = new CustomAssertingPartyMetadata();
+		assertThatExceptionOfType(IllegalArgumentException.class)
+			.isThrownBy(() -> RelyingPartyRegistration.withAssertingPartyMetadata(metadata)
+				.assertingPartyDetails((a) -> a.entityId("entity-id"))
+				.build());
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+				() -> RelyingPartyRegistration.withAssertingPartyMetadata(metadata).build().getAssertingPartyDetails());
+	}
+
+	@Test
+	void withAssertingPartyMetadataWhenDetailsThenBuilderCopies() {
+		RelyingPartyRegistration registration = TestRelyingPartyRegistrations.relyingPartyRegistration()
+			.nameIdFormat("format")
+			.assertingPartyMetadata((a) -> a.singleSignOnServiceBinding(Saml2MessageBinding.POST))
+			.assertingPartyMetadata((a) -> a.wantAuthnRequestsSigned(false))
+			.assertingPartyMetadata((a) -> a.signingAlgorithms((algs) -> algs.add("alg")))
+			.assertionConsumerServiceBinding(Saml2MessageBinding.REDIRECT)
+			.build();
+		AssertingPartyDetails details = registration.getAssertingPartyDetails();
+		RelyingPartyRegistration copied = RelyingPartyRegistration.withAssertingPartyDetails(details)
+			.assertingPartyDetails((a) -> a.entityId(details.getEntityId()))
+			.registrationId(registration.getRegistrationId())
+			.entityId(registration.getEntityId())
+			.signingX509Credentials((c) -> c.addAll(registration.getSigningX509Credentials()))
+			.decryptionX509Credentials((c) -> c.addAll(registration.getDecryptionX509Credentials()))
+			.assertionConsumerServiceLocation(registration.getAssertionConsumerServiceLocation())
+			.assertionConsumerServiceBinding(registration.getAssertionConsumerServiceBinding())
+			.singleLogoutServiceLocation(registration.getSingleLogoutServiceLocation())
+			.singleLogoutServiceResponseLocation(registration.getSingleLogoutServiceResponseLocation())
+			.singleLogoutServiceBindings((c) -> c.addAll(registration.getSingleLogoutServiceBindings()))
+			.nameIdFormat(registration.getNameIdFormat())
+			.authnRequestsSigned(registration.isAuthnRequestsSigned())
+			.build();
+		compareRegistrations(registration, copied);
+	}
+
+	private static class CustomAssertingPartyMetadata implements AssertingPartyMetadata {
+
+		@Override
+		public String getEntityId() {
+			return "";
+		}
+
+		@Override
+		public boolean getWantAuthnRequestsSigned() {
+			return false;
+		}
+
+		@Override
+		public List<String> getSigningAlgorithms() {
+			return List.of();
+		}
+
+		@Override
+		public Collection<Saml2X509Credential> getVerificationX509Credentials() {
+			return List.of();
+		}
+
+		@Override
+		public Collection<Saml2X509Credential> getEncryptionX509Credentials() {
+			return List.of();
+		}
+
+		@Override
+		public String getSingleSignOnServiceLocation() {
+			return "";
+		}
+
+		@Override
+		public Saml2MessageBinding getSingleSignOnServiceBinding() {
+			return null;
+		}
+
+		@Override
+		public String getSingleLogoutServiceLocation() {
+			return "";
+		}
+
+		@Override
+		public String getSingleLogoutServiceResponseLocation() {
+			return "";
+		}
+
+		@Override
+		public Saml2MessageBinding getSingleLogoutServiceBinding() {
+			return null;
+		}
+
+		@Override
+		public Builder mutate() {
+			return new Builder();
+		}
+
+		private static class Builder implements AssertingPartyMetadata.Builder<Builder> {
+
+			@Override
+			public Builder entityId(String entityId) {
+				return this;
+			}
+
+			@Override
+			public Builder wantAuthnRequestsSigned(boolean wantAuthnRequestsSigned) {
+				return this;
+			}
+
+			@Override
+			public Builder signingAlgorithms(Consumer<List<String>> signingMethodAlgorithmsConsumer) {
+				return this;
+			}
+
+			@Override
+			public Builder verificationX509Credentials(Consumer<Collection<Saml2X509Credential>> credentialsConsumer) {
+				return this;
+			}
+
+			@Override
+			public Builder encryptionX509Credentials(Consumer<Collection<Saml2X509Credential>> credentialsConsumer) {
+				return this;
+			}
+
+			@Override
+			public Builder singleSignOnServiceLocation(String singleSignOnServiceLocation) {
+				return this;
+			}
+
+			@Override
+			public Builder singleSignOnServiceBinding(Saml2MessageBinding singleSignOnServiceBinding) {
+				return this;
+			}
+
+			@Override
+			public Builder singleLogoutServiceLocation(String singleLogoutServiceLocation) {
+				return this;
+			}
+
+			@Override
+			public Builder singleLogoutServiceResponseLocation(String singleLogoutServiceResponseLocation) {
+				return this;
+			}
+
+			@Override
+			public Builder singleLogoutServiceBinding(Saml2MessageBinding singleLogoutServiceBinding) {
+				return this;
+			}
+
+			@Override
+			public AssertingPartyMetadata build() {
+				return new CustomAssertingPartyMetadata();
+			}
+
+		}
+
 	}
 
 }

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/registration/RelyingPartyRegistrationTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/registration/RelyingPartyRegistrationTests.java
@@ -166,4 +166,30 @@ public class RelyingPartyRegistrationTests {
 			.containsExactly(encryptingCredential, altApCredential);
 	}
 
+	@Test
+	void withAssertingPartyMetadataWhenDetailsThenBuilderCopies() {
+		RelyingPartyRegistration registration = TestRelyingPartyRegistrations.relyingPartyRegistration()
+			.nameIdFormat("format")
+			.assertingPartyDetails((a) -> a.singleSignOnServiceBinding(Saml2MessageBinding.POST))
+			.assertingPartyDetails((a) -> a.wantAuthnRequestsSigned(false))
+			.assertingPartyDetails((a) -> a.signingAlgorithms((algs) -> algs.add("alg")))
+			.assertionConsumerServiceBinding(Saml2MessageBinding.REDIRECT)
+			.build();
+		RelyingPartyRegistration copied = RelyingPartyRegistration
+			.withAssertingPartyMetadata(registration.getAssertingPartyDetails())
+			.registrationId(registration.getRegistrationId())
+			.entityId(registration.getEntityId())
+			.signingX509Credentials((c) -> c.addAll(registration.getSigningX509Credentials()))
+			.decryptionX509Credentials((c) -> c.addAll(registration.getDecryptionX509Credentials()))
+			.assertionConsumerServiceLocation(registration.getAssertionConsumerServiceLocation())
+			.assertionConsumerServiceBinding(registration.getAssertionConsumerServiceBinding())
+			.singleLogoutServiceLocation(registration.getSingleLogoutServiceLocation())
+			.singleLogoutServiceResponseLocation(registration.getSingleLogoutServiceResponseLocation())
+			.singleLogoutServiceBindings((c) -> c.addAll(registration.getSingleLogoutServiceBindings()))
+			.nameIdFormat(registration.getNameIdFormat())
+			.authnRequestsSigned(registration.isAuthnRequestsSigned())
+			.build();
+		compareRegistrations(registration, copied);
+	}
+
 }


### PR DESCRIPTION
This PR introduces `OpenSamlAssertingPartyMetadataRepository`, a class that makes what is otherwise hidden behind `RelyingPartyRegistrations` configurable. For example, before this change, you would do:

```java
RelyingPartyRegistration.Builder builder = RelyingPartyRegistrations.fromMetadataLocation("uri");
```

With this change, you can do:

```java
var repository = OpenSamlAssertingPartyMetadataRepository.fromTrustedMetadataLocation("uri").build();
```

or

```java
var repository = new OpenSamlAssertingPartyMetadataRepository(myMetadataResolver);
```

or

```java
var repository = OpenSamlAssertingPartyMetadataRepository.withMetadataLocation("uri")
    .verificationCredentials((c) -> c.addAll(my, set, of, credentials)).build();
```

followed by:

```java
Collection<RelyingPartyRegistration.Builder> builders = StreamSupport.stream(repository.spliterator(), false)
    .map(RelyingPartyRegistration::withAssertingPartyMetadata);
```

`OpenSamlAssertingPartyMetadataRepository` uses an underlying `MetadataResolver` to refresh the metadata in an expiry-aware fashion. This can be used to back a `RelyingPartyRegistrationRepository` like so:

```java
@Component
public class RefreshableRelyingPartyRegistrationRepository implements IterableRelyingPartyRegistrationRepository {
    private final AssertingPartyMetadataRepository parties;

    // ...

    @Override 
    public RelyingPartyRegistration findByRegistrationId(String registrationId) {
        return applyRelyingParty(this.parties.findByEntityId(registrationId));
    }

    @Override 
    public Iterator<RelyingPartyRegistration> iterator() {
        return StreamSupport.stream(this.parties.spliterator(), false).map(this::applyRelyingParty).iterator();
    }

    private RelyingPartyRegistration applyRelyingParty(AssertingPartyMetadata metadata) {
        return RelyingPartyRegistration.withAssertingPartyMetadata(metadata)
            // apply relying party
            .build();
    }
}
```