### PR TITLE
Fix typos and formatting in documentation

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
@@ -240,7 +240,7 @@ static RoleHierarchy roleHierarchy() {
 
 Kotlin::
 +
-[source,java,role="secondary"]
+[source,kotlin,role="secondary"]
 ----
 companion object {
     @Bean

--- a/docs/modules/ROOT/pages/servlet/saml2/login/authentication-requests.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/login/authentication-requests.adoc
@@ -87,7 +87,7 @@ RelyingPartyRegistration relyingPartyRegistration = RelyingPartyRegistration.wit
 
 Kotlin::
 +
-[source,java,role="secondary"]
+[source,kotlin,role="secondary"]
 ----
 var relyingPartyRegistration: RelyingPartyRegistration =
     RelyingPartyRegistration.withRegistrationId("okta")
@@ -96,7 +96,7 @@ var relyingPartyRegistration: RelyingPartyRegistration =
                 // ...
                 .wantAuthnRequestsSigned(false)
         }
-        .build();
+        .build()
 ----
 ======
 
@@ -141,7 +141,7 @@ var relyingPartyRegistration: RelyingPartyRegistration =
                     )
                 }
         }
-        .build();
+        .build()
 ----
 ======
 

--- a/docs/modules/ROOT/pages/servlet/saml2/login/overview.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/login/overview.adoc
@@ -1000,12 +1000,12 @@ Collection<RelyingPartyRegistration> registrations = RelyingPartyRegistrations
             .entityId("https://example.org/saml2/sp")
             .build()
         )
-        .collect(Collectors.toList()));
+        .collect(Collectors.toList());
 ----
 
 Kotlin::
 +
-[source,java,role="secondary"]
+[source,kotlin,role="secondary"]
 ----
 var registrations: Collection<RelyingPartyRegistration> = RelyingPartyRegistrations
         .collectionFromMetadataLocation("https://example.org/saml2/idp/metadata.xml")
@@ -1015,7 +1015,7 @@ var registrations: Collection<RelyingPartyRegistration> = RelyingPartyRegistrati
             .assertionConsumerServiceLocation("{baseUrl}/login/saml2/sso")
             .build()
         }
-        .collect(Collectors.toList()));
+        .collect(Collectors.toList())
 ----
 ======
 


### PR DESCRIPTION
Hi Team,

This pr fixes a typo in the Spring Security documentation and updates the source block roles for consistency.

- Changed `.collect(Collectors.toList()));` to `.collect(Collectors.toList());`.
- Changed `[source,java,role="secondary"]` to `[source,kotlin,role="secondary"]` in the Kotlin example code block.

Thank you.