### PR TITLE
Update the OAuth2 jwt and opaque Resource Server documentation

### DIFF
--- a/docs/modules/ROOT/pages/servlet/oauth2/resource-server/jwt.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/resource-server/jwt.adoc
@@ -879,7 +879,9 @@ public class DirectlyConfiguredJwkSetUri {
                 .requestMatchers("/messages/**").access(hasScope("messages"))
                 .anyRequest().authenticated()
             )
-            .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt);
+            .oauth2ResourceServer(oauth2 -> oauth2
+                .jwt(Customizer.withDefaults())
+            );
         return http.build();
     }
 }

--- a/docs/modules/ROOT/pages/servlet/oauth2/resource-server/opaque-token.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/resource-server/opaque-token.adoc
@@ -204,7 +204,9 @@ public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         .authorizeHttpRequests(authorize -> authorize
             .anyRequest().authenticated()
         )
-        .oauth2ResourceServer(OAuth2ResourceServerConfigurer::opaqueToken);
+        .oauth2ResourceServer(oauth2 -> oauth2
+            .opaqueToken(Customizer.withDefaults())
+        );
     return http.build();
 }
 ----
@@ -564,7 +566,9 @@ public class MappedAuthorities {
                 .requestMatchers("/messages/**").access(hasScope("messages"))
                 .anyRequest().authenticated()
             )
-            .oauth2ResourceServer(OAuth2ResourceServerConfigurer::opaqueToken);
+            .oauth2ResourceServer(oauth2 -> oauth2
+                .opaqueToken(Customizer.withDefaults())
+            );
         return http.build();
     }
 }


### PR DESCRIPTION
Prefer usage of the Lambda DSL.
The `OAuth2ResourceServerConfigurer::opaqueToken` and `OAuth2ResourceServerConfigurer::jwt` methods are deprecated since Spring Security 6.1.
With Spring Security 6.3, it looks like both methods are not working.
