### PR TITLE
Add support for "audience" parameter in Token Exchange grant

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/TokenExchangeOAuth2AuthorizedClientProvider.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/TokenExchangeOAuth2AuthorizedClientProvider.java
@@ -49,6 +49,8 @@ public final class TokenExchangeOAuth2AuthorizedClientProvider implements OAuth2
 
 	private Function<OAuth2AuthorizationContext, OAuth2Token> actorTokenResolver = (context) -> null;
 
+	private Function<OAuth2AuthorizationContext, String> audienceResolver = (context) -> null;
+
 	private Duration clockSkew = Duration.ofSeconds(60);
 
 	private Clock clock = Clock.systemUTC();
@@ -85,8 +87,10 @@ public final class TokenExchangeOAuth2AuthorizedClientProvider implements OAuth2
 		}
 
 		OAuth2Token actorToken = this.actorTokenResolver.apply(context);
+		String audience = this.audienceResolver.apply(context);
+
 		TokenExchangeGrantRequest grantRequest = new TokenExchangeGrantRequest(clientRegistration, subjectToken,
-				actorToken);
+				actorToken, audience);
 		OAuth2AccessTokenResponse tokenResponse = getTokenResponse(clientRegistration, grantRequest);
 
 		return new OAuth2AuthorizedClient(clientRegistration, context.getPrincipal().getName(),
@@ -144,6 +148,15 @@ public final class TokenExchangeOAuth2AuthorizedClientProvider implements OAuth2
 	public void setActorTokenResolver(Function<OAuth2AuthorizationContext, OAuth2Token> actorTokenResolver) {
 		Assert.notNull(actorTokenResolver, "actorTokenResolver cannot be null");
 		this.actorTokenResolver = actorTokenResolver;
+	}
+
+	/**
+	 * Sets the resolver used for resolving the audience.
+	 * @param audienceResolver the resolver used for resolving the audience
+	 */
+	public void setAudienceResolver(Function<OAuth2AuthorizationContext, String> audienceResolver) {
+		Assert.notNull(audienceResolver, "audienceResolver cannot be null");
+		this.audienceResolver = audienceResolver;
 	}
 
 	/**

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/TokenExchangeGrantRequest.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/TokenExchangeGrantRequest.java
@@ -23,7 +23,7 @@ import org.springframework.util.Assert;
 
 /**
  * A Token Exchange Grant request that holds the {@link OAuth2Token subject token} and
- * optional {@link OAuth2Token actor token}.
+ * optional {@link OAuth2Token actor token} and audience.
  *
  * @author Steve Riesenberg
  * @since 6.3
@@ -43,20 +43,34 @@ public class TokenExchangeGrantRequest extends AbstractOAuth2AuthorizationGrantR
 
 	private final OAuth2Token actorToken;
 
+	private final String audience;
+
+	/**
+	 * Constructs a {@code TokenExchangeGrantRequest} using the provided parameters.
+	 * @param clientRegistration the client registration
+	 * @param subjectToken the subject token
+	 */
+	public TokenExchangeGrantRequest(ClientRegistration clientRegistration, OAuth2Token subjectToken,
+			OAuth2Token actorToken) {
+		this(clientRegistration, subjectToken,actorToken, null);
+	}
+
 	/**
 	 * Constructs a {@code TokenExchangeGrantRequest} using the provided parameters.
 	 * @param clientRegistration the client registration
 	 * @param subjectToken the subject token
 	 * @param actorToken the actor token
+	 * @param audience the audience
 	 */
 	public TokenExchangeGrantRequest(ClientRegistration clientRegistration, OAuth2Token subjectToken,
-			OAuth2Token actorToken) {
+			OAuth2Token actorToken, String audience) {
 		super(AuthorizationGrantType.TOKEN_EXCHANGE, clientRegistration);
 		Assert.isTrue(AuthorizationGrantType.TOKEN_EXCHANGE.equals(clientRegistration.getAuthorizationGrantType()),
 				"clientRegistration.authorizationGrantType must be AuthorizationGrantType.TOKEN_EXCHANGE");
 		Assert.notNull(subjectToken, "subjectToken cannot be null");
 		this.subjectToken = subjectToken;
 		this.actorToken = actorToken;
+		this.audience = audience;
 	}
 
 	/**
@@ -73,6 +87,14 @@ public class TokenExchangeGrantRequest extends AbstractOAuth2AuthorizationGrantR
 	 */
 	public OAuth2Token getActorToken() {
 		return this.actorToken;
+	}
+
+	/**
+	 * Returns the audience.
+	 * @return the audience
+	 */
+	public String getAudience() {
+		return this.audience;
 	}
 
 }

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/TokenExchangeGrantRequestEntityConverter.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/TokenExchangeGrantRequestEntityConverter.java
@@ -61,6 +61,10 @@ public class TokenExchangeGrantRequestEntityConverter
 			parameters.add(OAuth2ParameterNames.ACTOR_TOKEN, actorToken.getTokenValue());
 			parameters.add(OAuth2ParameterNames.ACTOR_TOKEN_TYPE, tokenType(actorToken));
 		}
+		String audience = grantRequest.getAudience();
+		if (audience != null) {
+			parameters.add(OAuth2ParameterNames.AUDIENCE, audience);
+		}
 		if (!CollectionUtils.isEmpty(clientRegistration.getScopes())) {
 			parameters.add(OAuth2ParameterNames.SCOPE,
 					StringUtils.collectionToDelimitedString(clientRegistration.getScopes(), " "));

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveTokenExchangeTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/WebClientReactiveTokenExchangeTokenResponseClient.java
@@ -73,6 +73,10 @@ public final class WebClientReactiveTokenExchangeTokenResponseClient
 			body.with(OAuth2ParameterNames.ACTOR_TOKEN, actorToken.getTokenValue());
 			body.with(OAuth2ParameterNames.ACTOR_TOKEN_TYPE, tokenType(actorToken));
 		}
+		String audience = grantRequest.getAudience();
+		if (audience != null) {
+			body.with(OAuth2ParameterNames.AUDIENCE, audience);
+		}
 		return body;
 	}
 


### PR DESCRIPTION
Following [the introduction of the support for Token Exchange in Spring Security 6.3](https://spring.io/blog/2024/03/19/token-exchange-support-in-spring-security-6-3-0-m3), this MR adds the ability to set the `audience` parameter in the request, as described in https://datatracker.ietf.org/doc/html/rfc8693#:~:text=%C2%B6-,audience,-OPTIONAL.%20The%20logical.

_Work in progress: unit tests need to be added._