### PR TITLE
Fix NPE when nameAttributeValue is null (#15338)

### DIFF
--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/user/DefaultOAuth2User.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/user/DefaultOAuth2User.java
@@ -69,7 +69,8 @@ public class DefaultOAuth2User implements OAuth2User, Serializable {
 			String nameAttributeKey) {
 		Assert.notEmpty(attributes, "attributes cannot be empty");
 		Assert.hasText(nameAttributeKey, "nameAttributeKey cannot be empty");
-		Assert.notNull(attributes.get(nameAttributeKey), "Attribute value for '" + nameAttributeKey + "' cannot be null");
+		Assert.notNull(attributes.get(nameAttributeKey),
+				"Attribute value for '" + nameAttributeKey + "' cannot be null");
 
 		this.authorities = (authorities != null)
 				? Collections.unmodifiableSet(new LinkedHashSet<>(this.sortAuthorities(authorities)))

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/user/DefaultOAuth2User.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/user/DefaultOAuth2User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import org.springframework.util.Assert;
  *
  * @author Joe Grandja
  * @author Eddú Meléndez
+ * @author Park Hyojong
  * @since 5.0
  * @see OAuth2User
  */
@@ -68,9 +69,8 @@ public class DefaultOAuth2User implements OAuth2User, Serializable {
 			String nameAttributeKey) {
 		Assert.notEmpty(attributes, "attributes cannot be empty");
 		Assert.hasText(nameAttributeKey, "nameAttributeKey cannot be empty");
-		if (!attributes.containsKey(nameAttributeKey)) {
-			throw new IllegalArgumentException("Missing attribute '" + nameAttributeKey + "' in attributes");
-		}
+		Assert.notNull(attributes.get(nameAttributeKey), "Attribute value for '" + nameAttributeKey + "' cannot be null");
+
 		this.authorities = (authorities != null)
 				? Collections.unmodifiableSet(new LinkedHashSet<>(this.sortAuthorities(authorities)))
 				: Collections.unmodifiableSet(new LinkedHashSet<>(AuthorityUtils.NO_AUTHORITIES));

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/user/DefaultOAuth2UserTests.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/user/DefaultOAuth2UserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  *
  * @author Vedran Pavic
  * @author Joe Grandja
+ * @author Park Hyojong
  */
 public class DefaultOAuth2UserTests {
 
@@ -57,6 +58,12 @@ public class DefaultOAuth2UserTests {
 	public void constructorWhenAttributesIsEmptyThenThrowIllegalArgumentException() {
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> new DefaultOAuth2User(AUTHORITIES, Collections.emptyMap(), ATTRIBUTE_NAME_KEY));
+	}
+
+	@Test
+	public void constructorWhenAttributeValueIsNullThenThrowIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> new DefaultOAuth2User(AUTHORITIES,
+				Collections.singletonMap(ATTRIBUTE_NAME_KEY, null), ATTRIBUTE_NAME_KEY));
 	}
 
 	@Test


### PR DESCRIPTION
This commit resolves NPEs that occur in DefaultOuth2User#getName.
If the attributes have a key, but the value comes in null, the NPE occurs, and we modified the case and added a related test case.

fixes: #15338