### PR TITLE
Clarify url Parameter Usage in AD Provider Constructor

### DIFF
--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/ad/ActiveDirectoryLdapAuthenticationProvider.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/ad/ActiveDirectoryLdapAuthenticationProvider.java
@@ -136,9 +136,11 @@ public final class ActiveDirectoryLdapAuthenticationProvider extends AbstractLda
 	ContextFactory contextFactory = new ContextFactory();
 
 	/**
-	 * @param domain the domain name (may be null or empty)
-	 * @param url an LDAP url (or multiple URLs)
-	 * @param rootDn the root DN (may be null or empty)
+	 * @param domain the domain name (can be null or empty)
+	 * @param url an LDAP url (or multiple space-delimited URLs).
+	 * @param rootDn the root DN (can be null or empty)
+	 * @see <a href="https://docs.oracle.com/javase/jndi/tutorial/ldap/misc/url.html">JNDI
+	 * URL format documentation</a>
 	 */
 	public ActiveDirectoryLdapAuthenticationProvider(String domain, String url, String rootDn) {
 		Assert.isTrue(StringUtils.hasText(url), "Url cannot be empty");


### PR DESCRIPTION
Updated javadocs for `ActiveDirectoryLdapAuthenticationProvider` as discussed in #7760. Closes #7760.