### PR TITLE
Differentiate cases when using default SecurityExpression and Authori…

### DIFF
--- a/core/src/main/java/org/springframework/security/authorization/method/ThrowingMethodAuthorizationDeniedHandler.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/ThrowingMethodAuthorizationDeniedHandler.java
@@ -20,6 +20,7 @@ import org.aopalliance.intercept.MethodInvocation;
 
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.security.authorization.AuthorizationResult;
+import org.springframework.security.authorization.ExpressionAuthorizationDecision;
 
 /**
  * An implementation of {@link MethodAuthorizationDeniedHandler} that throws
@@ -34,6 +35,11 @@ public final class ThrowingMethodAuthorizationDeniedHandler implements MethodAut
 	public Object handleDeniedInvocation(MethodInvocation methodInvocation, AuthorizationResult authorizationResult) {
 		if (authorizationResult instanceof AuthorizationDeniedException denied) {
 			throw denied;
+		}else if (authorizationResult instanceof ExpressionAuthorizationDecision decision) {
+			String expressionString = decision.getExpression().getExpressionString();
+			if ("isAuthenticated()".equals(expressionString) || "isFullyAuthenticated()".equals(expressionString)) {
+				throw new AuthorizationDeniedException("Insufficient Credentials", authorizationResult);
+			}
 		}
 		throw new AuthorizationDeniedException("Access Denied", authorizationResult);
 	}


### PR DESCRIPTION
- When the Authorization header is missing, the process does not proceed to AuthenticationProvider, which is supposed to result in a 401 error rather than a 403 error due to insufficient permissions.

- As it does not seem to be appropriate to directly throw an AuthenticationException from ThrowingMethodAuthorizationDeniedHandler, that codes only allows developers to distinguish and handle such cases in @ExceptionHandler.

- This issue was discovered during testing by calling oauth2/token with spring-security-oauth2-authorization-server(1.2.3).

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
