### PR TITLE
Add @FunctionalInterface to AuthenticationManager

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/AuthenticationManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/AuthenticationManager.java
@@ -23,7 +23,9 @@ import org.springframework.security.core.AuthenticationException;
  * Processes an {@link Authentication} request.
  *
  * @author Ben Alex
+ * @author KyeongHoon Lee
  */
+@FunctionalInterface
 public interface AuthenticationManager {
 
 	/**


### PR DESCRIPTION
Add @FunctionalInterface to AuthenticationManager.

AuthenticationManager is being implemented by using lambda. Therefore, It would be clear not to add more abstract functions, if @FunctionalInterface Annotation is added.

cc. https://github.com/spring-projects/spring-security/pull/15379