### PR TITLE
Remove duplicated "the" in JavaDoc

### DIFF
--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2RelyingPartyInitiatedLogoutSuccessHandler.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2RelyingPartyInitiatedLogoutSuccessHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import org.springframework.web.util.HtmlUtils;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
- * A success handler for issuing a SAML 2.0 Logout Request to the the SAML 2.0 Asserting
+ * A success handler for issuing a SAML 2.0 Logout Request to the SAML 2.0 Asserting
  * Party
  *
  * @author Josh Cummings

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2RelyingPartyInitiatedLogoutSuccessHandler.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/Saml2RelyingPartyInitiatedLogoutSuccessHandler.java
@@ -36,8 +36,7 @@ import org.springframework.web.util.HtmlUtils;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
- * A success handler for issuing a SAML 2.0 Logout Request to the SAML 2.0 Asserting
- * Party
+ * A success handler for issuing a SAML 2.0 Logout Request to the SAML 2.0 Asserting Party
  *
  * @author Josh Cummings
  * @since 5.6


### PR DESCRIPTION
This PR fixes a typo of "the the" to "the".
