### PR TITLE
Docs: Fix wrong annotation class name for Kotlin example

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
@@ -1053,7 +1053,7 @@ Kotlin::
 @Target(ElementType.METHOD, ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @PreAuthorize("hasRole('{value}')")
-annotation class IsAdmin(val value: String)
+annotation class HasRole(val value: String)
 ----
 ======
 


### PR DESCRIPTION
Fixed wrong annotation class name `IsAdmin` as `HasRole` for Kotlin example.