### PR TITLE
Post code suggestions on PRs with format issues

### DIFF
--- a/.github/workflows/pr-format-workflow.yml
+++ b/.github/workflows/pr-format-workflow.yml
@@ -1,0 +1,55 @@
+# Description: This workflow applies the formatter against the opened pull request and upload the patch.
+# Since this pull request receives untrusted code, we should **NOT** have any secrets in the environment.
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+---
+name: pr-format-workflow
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  upload-patch:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'spring-projects/spring-security' }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+      - name: Set up gradle
+        uses: spring-io/spring-gradle-build-action@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # Capture the PR number
+      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
+      - name: Create pr_number.txt
+        run: echo "${{ github.event.number }}" > pr_number.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: pr_number.txt
+      - name: Remove pr_number.txt
+        run: rm -f pr_number.txt
+
+      # Format code
+      - name: Format with Gradle
+        run: ./gradlew format
+
+      # Capture the diff
+      - name: Create patch
+        run: |
+          git diff | tee git-diff.patch
+      - uses: actions/upload-artifact@v4
+        with:
+          name: patch
+          path: git-diff.patch

--- a/.github/workflows/pr-suggestions-workflow.yml
+++ b/.github/workflows/pr-suggestions-workflow.yml
@@ -1,0 +1,59 @@
+# Description: This workflow is triggered when the `pr-format-workflow` completes to post suggestions on the PR.
+# Since this pull request has write permissions on the target repo, we should **NOT** execute any untrusted code.
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+---
+name: pr-suggestions-workflow
+
+on:
+  workflow_run:
+    workflows: ["pr-format-workflow"]
+    types:
+      - completed
+
+jobs:
+  post-suggestions:
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      pull-requests: write
+    env:
+      # https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
+      ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{github.event.workflow_run.head_branch}}
+          repository: ${{github.event.workflow_run.head_repository.full_name}}
+
+      # Download the patch
+      - uses: actions/download-artifact@v4
+        with:
+          name: patch
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Apply patch
+        run: |
+          git apply git-diff.patch --allow-empty
+          rm git-diff.patch
+
+      # Download the PR number
+      - uses: actions/download-artifact@v4
+        with:
+          name: pr_number
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Read pr_number.txt
+        run: |
+          PR_NUMBER=$(cat pr_number.txt)
+          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+          rm pr_number.txt
+
+      # Post suggestions as a comment on the PR
+      - uses: googleapis/code-suggester@v4
+        with:
+          command: review
+          pull_number: ${{ env.PR_NUMBER }}
+          git_dir: '.'


### PR DESCRIPTION
These two workflows together ensure that if a pull request comes in that has formatting issues, that a `github-actions` bot then posts a code suggestion comment for fix any offending lines. Those comments would look something like this

![image](https://github.com/user-attachments/assets/06b65775-351f-43f0-ba52-926e567b3aa4)

I've used this to good effect on the OpenRewrite GitHub org, where we run some additional automations for copyright headers and [coding best practices](https://docs.openrewrite.org/recipes/recipes/openrewritebestpractices).

This has been discussed over the past year or so with @rwinch (👋🏻 ), as a good first step towards gently enforcing standards, as opposed to an unfriendly failing build pipeline with delayed feedback.

The PR leverages https://github.com/googleapis/code-suggester to turn a git diff into code suggestion comments, which we've found to work well for smaller formatting issues. https://github.com/reviewdog/reviewdog could be a possible alternative, as well as others.

I've of course not been able to test these new workflows, as it requires them to be available on the main branch first, but I've done my best to match up with the existing [.github/workflows/pr-build-workflow.yml](https://github.com/spring-projects/spring-security/blob/main/.github/workflows/pr-build-workflow.yml) in terms of actions used. I figured to offer a first step PR here, but of course this [could be generalized](https://github.com/openrewrite/gh-automation/blob/main/.github/workflows/receive-pr.yml) if desired. 

No worries if you'd rather go a different direction. I figured a direct PR would be easier to review than yet another issues to discuss this once more.