### PR TITLE
Preserve custom user type in InMemoryUserDetailsManager

### DIFF
--- a/core/src/main/java/org/springframework/security/provisioning/InMemoryUserDetailsManager.java
+++ b/core/src/main/java/org/springframework/security/provisioning/InMemoryUserDetailsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.CredentialsContainer;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.core.userdetails.User;
@@ -96,7 +97,13 @@ public class InMemoryUserDetailsManager implements UserDetailsManager, UserDetai
 	@Override
 	public void createUser(UserDetails user) {
 		Assert.isTrue(!userExists(user.getUsername()), "user should not exist");
-		this.users.put(user.getUsername().toLowerCase(), new MutableUser(user));
+
+		if (user instanceof MutableUserDetails mutable) {
+			this.users.put(user.getUsername().toLowerCase(), mutable);
+		}
+		else {
+			this.users.put(user.getUsername().toLowerCase(), new MutableUser(user));
+		}
 	}
 
 	@Override
@@ -107,7 +114,13 @@ public class InMemoryUserDetailsManager implements UserDetailsManager, UserDetai
 	@Override
 	public void updateUser(UserDetails user) {
 		Assert.isTrue(userExists(user.getUsername()), "user should exist");
-		this.users.put(user.getUsername().toLowerCase(), new MutableUser(user));
+
+		if (user instanceof MutableUserDetails mutable) {
+			this.users.put(user.getUsername().toLowerCase(), mutable);
+		}
+		else {
+			this.users.put(user.getUsername().toLowerCase(), new MutableUser(user));
+		}
 	}
 
 	@Override
@@ -153,6 +166,9 @@ public class InMemoryUserDetailsManager implements UserDetailsManager, UserDetai
 		UserDetails user = this.users.get(username.toLowerCase());
 		if (user == null) {
 			throw new UsernameNotFoundException(username);
+		}
+		if (user instanceof CredentialsContainer) {
+			return user;
 		}
 		return new User(user.getUsername(), user.getPassword(), user.isEnabled(), user.isAccountNonExpired(),
 				user.isCredentialsNonExpired(), user.isAccountNonLocked(), user.getAuthorities());

--- a/core/src/test/java/org/springframework/security/provisioning/InMemoryUserDetailsManagerTests.java
+++ b/core/src/test/java/org/springframework/security/provisioning/InMemoryUserDetailsManagerTests.java
@@ -16,12 +16,15 @@
 
 package org.springframework.security.provisioning;
 
+import java.util.Collection;
 import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.security.authentication.TestAuthentication;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.CredentialsContainer;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.security.core.userdetails.PasswordEncodedUser;
@@ -106,6 +109,20 @@ public class InMemoryUserDetailsManagerTests {
 	}
 
 	@Test
+	public void createUserWhenInstanceOfMutableUserDetailsThenChangePasswordWorks() {
+		InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
+		CustomUser user = new CustomUser(User.withUserDetails(PasswordEncodedUser.user()).build());
+		Authentication authentication = TestAuthentication.authenticated(user);
+		SecurityContextHolderStrategy strategy = mock(SecurityContextHolderStrategy.class);
+		given(strategy.getContext()).willReturn(new SecurityContextImpl(authentication));
+		manager.setSecurityContextHolderStrategy(strategy);
+		manager.createUser(user);
+		String newPassword = "newPassword";
+		manager.changePassword(user.getPassword(), newPassword);
+		assertThat(manager.loadUserByUsername(user.getUsername()).getPassword()).isEqualTo(newPassword);
+	}
+
+	@Test
 	public void updateUserWhenUserDoesNotExistThenException() {
 		InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
 		assertThatIllegalArgumentException().isThrownBy(() -> manager.updateUser(this.user))
@@ -117,6 +134,59 @@ public class InMemoryUserDetailsManagerTests {
 		InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
 		assertThatExceptionOfType(UsernameNotFoundException.class)
 			.isThrownBy(() -> manager.loadUserByUsername(this.user.getUsername()));
+	}
+
+	@Test
+	public void loadUserByUsernameWhenNotInstanceOfCredentialsContainerThenReturnInstanceOfCredentialsContainer() {
+		MutableUser user = new MutableUser(User.withUserDetails(PasswordEncodedUser.user()).build());
+		InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager(user);
+		assertThat(user).isNotInstanceOf(CredentialsContainer.class);
+		assertThat(manager.loadUserByUsername(user.getUsername())).isInstanceOf(CredentialsContainer.class);
+	}
+
+	@Test
+	public void loadUserByUsernameWhenInstanceOfCredentialsContainerThenReturnInstance() {
+		CustomUser user = new CustomUser(User.withUserDetails(PasswordEncodedUser.user()).build());
+		InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager(user);
+		assertThat(manager.loadUserByUsername(user.getUsername())).isSameAs(user);
+	}
+
+	static class CustomUser implements MutableUserDetails, CredentialsContainer {
+
+		private final UserDetails delegate;
+
+		private String password;
+
+		CustomUser(UserDetails user) {
+			this.delegate = user;
+			this.password = user.getPassword();
+		}
+
+		@Override
+		public Collection<? extends GrantedAuthority> getAuthorities() {
+			return this.delegate.getAuthorities();
+		}
+
+		@Override
+		public String getPassword() {
+			return this.password;
+		}
+
+		@Override
+		public void setPassword(final String password) {
+			this.password = password;
+		}
+
+		@Override
+		public String getUsername() {
+			return this.delegate.getUsername();
+		}
+
+		@Override
+		public void eraseCredentials() {
+			this.password = null;
+		}
+
 	}
 
 }

--- a/core/src/test/java/org/springframework/security/provisioning/InMemoryUserDetailsManagerTests.java
+++ b/core/src/test/java/org/springframework/security/provisioning/InMemoryUserDetailsManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,10 @@ import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.security.core.userdetails.PasswordEncodedUser;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -95,6 +97,26 @@ public class InMemoryUserDetailsManagerTests {
 		manager.setSecurityContextHolderStrategy(strategy);
 		manager.changePassword("password", "newpassword");
 		verify(strategy).getContext();
+	}
+
+	@Test
+	public void createUserWhenUserAlreadyExistsThenException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.manager.createUser(this.user))
+			.withMessage("user should not exist");
+	}
+
+	@Test
+	public void updateUserWhenUserDoesNotExistThenException() {
+		InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
+		assertThatIllegalArgumentException().isThrownBy(() -> manager.updateUser(this.user))
+			.withMessage("user should exist");
+	}
+
+	@Test
+	public void loadUserByUsernameWhenUserNullThenException() {
+		InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
+		assertThatExceptionOfType(UsernameNotFoundException.class)
+			.isThrownBy(() -> manager.loadUserByUsername(this.user.getUsername()));
 	}
 
 }


### PR DESCRIPTION
This PR fixes issue gh-3192 by allowing `MutableUserDetails` to be stored and loaded inside the `InMemoryUserDetailsManager` instead of always wrapping it into `MutableUser`. The custom user type must implement `CredentialsContainer` in order to be returned by `loadUserByUsername()` and not transformed into `User`.

I wanted to write tests for the new cases, and I saw that methods were not previously covered so I wrote tests for all cases for `createUser()` and `loadUserByUsername()`. However, I have concerns about some tests:
`createUserWhenNotInstanceOfMutableUserDetailsThenShouldWrapIntoMutableUser` and
`createUserWhenInstanceOfMutableUserDetailsThenShouldNotWrapIntoMutableUser` can't directly access `Map<String, MutableUserDetails> users` to get the underlying user & type, so they are relying on `loadUserByUsername` to get the user and as such are not pure. 
If you think this can be improved somehow, I am open to feedback.