### PR TITLE
Use explicit types instead of var

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeAuthenticationProviderBeanManagerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeAuthenticationProviderBeanManagerConfigurer.java
@@ -86,19 +86,6 @@ class InitializeAuthenticationProviderBeanManagerConfigurer extends GlobalAuthen
 		}
 
 		/**
-		 * @return a bean of the requested class if there's just a single registered
-		 * component, null otherwise.
-		 */
-		private <T> T getBeanOrNull(Class<T> type) {
-			String[] beanNames = InitializeAuthenticationProviderBeanManagerConfigurer.this.context
-				.getBeanNamesForType(type);
-			if (beanNames.length != 1) {
-				return null;
-			}
-			return InitializeAuthenticationProviderBeanManagerConfigurer.this.context.getBean(beanNames[0], type);
-		}
-
-		/**
 		 * @return a list of beans of the requested class, along with their names. If
 		 * there are no registered beans of that type, the list is empty.
 		 */

--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeAuthenticationProviderBeanManagerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeAuthenticationProviderBeanManagerConfigurer.java
@@ -76,8 +76,8 @@ class InitializeAuthenticationProviderBeanManagerConfigurer extends GlobalAuthen
 						+ "using the DSL.", authenticationProviders.size(), beanNames));
 				return;
 			}
-			var authenticationProvider = authenticationProviders.get(0).getBean();
-			var authenticationProviderBeanName = authenticationProviders.get(0).getName();
+			AuthenticationProvider authenticationProvider = authenticationProviders.get(0).getBean();
+			String authenticationProviderBeanName = authenticationProviders.get(0).getName();
 
 			auth.authenticationProvider(authenticationProvider);
 			this.logger.info(LogMessage.format(

--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeUserDetailsBeanManagerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeUserDetailsBeanManagerConfigurer.java
@@ -89,8 +89,8 @@ class InitializeUserDetailsBeanManagerConfigurer extends GlobalAuthenticationCon
 						beanNames));
 				return;
 			}
-			var userDetailsService = userDetailsServices.get(0).getBean();
-			var userDetailsServiceBeanName = userDetailsServices.get(0).getName();
+			UserDetailsService userDetailsService = userDetailsServices.get(0).getBean();
+			String userDetailsServiceBeanName = userDetailsServices.get(0).getName();
 			PasswordEncoder passwordEncoder = getBeanOrNull(PasswordEncoder.class);
 			UserDetailsPasswordService passwordManager = getBeanOrNull(UserDetailsPasswordService.class);
 			CompromisedPasswordChecker passwordChecker = getBeanOrNull(CompromisedPasswordChecker.class);

--- a/config/src/test/java/org/springframework/security/config/annotation/configuration/AutowireBeanFactoryObjectPostProcessorTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/configuration/AutowireBeanFactoryObjectPostProcessorTests.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Modifier;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import org.springframework.aop.framework.ProxyFactory;
@@ -141,7 +142,7 @@ public class AutowireBeanFactoryObjectPostProcessorTests {
 
 	@Test
 	void postProcessWhenObjectIsCgLibProxyAndInNativeImageThenUseExistingBean() {
-		try (var detector = Mockito.mockStatic(NativeDetector.class)) {
+		try (MockedStatic<NativeDetector> detector = Mockito.mockStatic(NativeDetector.class)) {
 			given(NativeDetector.inNativeImage()).willReturn(true);
 
 			ProxyFactory proxyFactory = new ProxyFactory(new MyClass());
@@ -158,7 +159,7 @@ public class AutowireBeanFactoryObjectPostProcessorTests {
 
 	@Test
 	void postProcessWhenObjectIsCgLibProxyAndInNativeImageAndBeanDoesNotExistsThenIllegalStateException() {
-		try (var detector = Mockito.mockStatic(NativeDetector.class)) {
+		try (MockedStatic<NativeDetector> detector = Mockito.mockStatic(NativeDetector.class)) {
 			given(NativeDetector.inNativeImage()).willReturn(true);
 
 			ProxyFactory proxyFactory = new ProxyFactory(new MyClass());

--- a/ldap/src/integration-test/java/org/springframework/security/ldap/userdetails/LdapUserDetailsManagerTests.java
+++ b/ldap/src/integration-test/java/org/springframework/security/ldap/userdetails/LdapUserDetailsManagerTests.java
@@ -267,7 +267,7 @@ public class LdapUserDetailsManagerTests {
 
 	@Test
 	public void testRoleNamesStartWithCustomRolePrefix() {
-		var customPrefix = "GROUP_";
+		String customPrefix = "GROUP_";
 		this.mgr.setRolePrefix(customPrefix);
 
 		this.mgr.setUsernameMapper(new DefaultLdapUsernameToDnMapper("ou=people", "uid"));


### PR DESCRIPTION
- Removed usage of `var` in a few classes
- Removed unused method