### PR TITLE
Fix code format in OIDC Logout docs

### DIFF
--- a/docs/modules/ROOT/pages/reactive/oauth2/login/logout.adoc
+++ b/docs/modules/ROOT/pages/reactive/oauth2/login/logout.adoc
@@ -135,7 +135,7 @@ To enable this, you can stand up the Back-Channel Logout endpoint in the DSL lik
 ======
 Java::
 +
-[source=java,role="primary"]
+[source,java,role="primary"]
 ----
 @Bean
 public SecurityWebFilterChain filterChain(ServerHttpSecurity http) throws Exception {
@@ -153,7 +153,7 @@ public SecurityWebFilterChain filterChain(ServerHttpSecurity http) throws Except
 
 Kotlin::
 +
-[source=kotlin,role="secondary"]
+[source,kotlin,role="secondary"]
 ----
 @Bean
 open fun filterChain(http: ServerHttpSecurity): SecurityWebFilterChain {
@@ -209,7 +209,7 @@ You can achieve this by configuring a custom `ReactiveOidcSessionStrategy`, like
 ======
 Java::
 +
-[source=java,role="primary"]
+[source,java,role="primary"]
 ----
 @Component
 public final class MySpringDataOidcSessionStrategy implements OidcSessionStrategy {
@@ -238,7 +238,7 @@ public final class MySpringDataOidcSessionStrategy implements OidcSessionStrateg
 
 Kotlin::
 +
-[source=kotlin,role="secondary"]
+[source,kotlin,role="secondary"]
 ----
 @Component
 class MySpringDataOidcSessionStrategy: ReactiveOidcSessionStrategy {

--- a/docs/modules/ROOT/pages/servlet/oauth2/login/logout.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/login/logout.adoc
@@ -134,7 +134,7 @@ To enable this, you can stand up the Back-Channel Logout endpoint in the DSL lik
 ======
 Java::
 +
-[source=java,role="primary"]
+[source,java,role="primary"]
 ----
 @Bean
 public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -152,7 +152,7 @@ public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
 Kotlin::
 +
-[source=kotlin,role="secondary"]
+[source,kotlin,role="secondary"]
 ----
 @Bean
 open fun filterChain(http: HttpSecurity): SecurityFilterChain {
@@ -176,7 +176,7 @@ Then, you need a way listen to events published by Spring Security to remove old
 ======
 Java::
 +
-[source=java,role="primary"]
+[source,java,role="primary"]
 ----
 @Bean
 public HttpSessionEventPublisher sessionEventPublisher() {
@@ -186,7 +186,7 @@ public HttpSessionEventPublisher sessionEventPublisher() {
 
 Kotlin::
 +
-[source=kotlin,role="secondary"]
+[source,kotlin,role="secondary"]
 ----
 @Bean
 open fun sessionEventPublisher(): HttpSessionEventPublisher {
@@ -235,7 +235,7 @@ You can achieve this by configuring a custom `OidcSessionStrategy`, like so:
 ======
 Java::
 +
-[source=java,role="primary"]
+[source,java,role="primary"]
 ----
 @Component
 public final class MySpringDataOidcSessionStrategy implements OidcSessionStrategy {
@@ -264,7 +264,7 @@ public final class MySpringDataOidcSessionStrategy implements OidcSessionStrateg
 
 Kotlin::
 +
-[source=kotlin,role="secondary"]
+[source,kotlin,role="secondary"]
 ----
 @Component
 class MySpringDataOidcSessionStrategy: OidcSessionStrategy {


### PR DESCRIPTION

In OIDC Logout for servlets and reactive, example codes formatting is not working correctly. 

- syntax
- copy function

I fixed it. Thanks.
