### PR TITLE
Fix variable targetClassToUse is not passed into the synthesize method

### DIFF
--- a/core/src/main/java/org/springframework/security/authorization/method/PostAuthorizeExpressionAttributeRegistry.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/PostAuthorizeExpressionAttributeRegistry.java
@@ -78,7 +78,7 @@ final class PostAuthorizeExpressionAttributeRegistry extends AbstractExpressionA
 
 	private PostAuthorize findPostAuthorizeAnnotation(Method method, Class<?> targetClass) {
 		Class<?> targetClassToUse = targetClass(method, targetClass);
-		return this.postAuthorizeSynthesizer.synthesize(method, targetClass);
+		return this.postAuthorizeSynthesizer.synthesize(method, targetClassToUse);
 	}
 
 	/**


### PR DESCRIPTION
Closes gh-15567

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
