### PR TITLE
Use HTML templating in default UIs

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/DefaultLoginPageConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/DefaultLoginPageConfigurerTests.java
@@ -67,140 +67,142 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(SpringTestContextExtension.class)
 public class DefaultLoginPageConfigurerTests {
 
-	//@formatter:off
-	public static final String EXPECTED_HTML_HEAD = "  <head>\n"
-			+ "    <meta charset=\"utf-8\">\n"
-			+ "    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1, shrink-to-fit=no\">\n"
-			+ "    <meta name=\"description\" content=\"\">\n"
-			+ "    <meta name=\"author\" content=\"\">\n"
-			+ "    <title>Please sign in</title>\n"
-			+ "    <style>\n"
-			+ "    /* General layout */\n"
-			+ "    body {\n"
-			+ "      font-family: system-ui, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif;\n"
-			+ "      background-color: #eee;\n"
-			+ "      padding: 40px 0;\n"
-			+ "      margin: 0;\n"
-			+ "      line-height: 1.5;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    h2 {\n"
-			+ "      margin-top: 0;\n"
-			+ "      margin-bottom: 0.5rem;\n"
-			+ "      font-size: 2rem;\n"
-			+ "      font-weight: 500;\n"
-			+ "      line-height: 2rem;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    .content {\n"
-			+ "      margin-right: auto;\n"
-			+ "      margin-left: auto;\n"
-			+ "      padding-right: 15px;\n"
-			+ "      padding-left: 15px;\n"
-			+ "      width: 100%;\n"
-			+ "      box-sizing: border-box;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    @media (min-width: 800px) {\n"
-			+ "      .content {\n"
-			+ "        max-width: 760px;\n"
-			+ "      }\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    /* Components */\n"
-			+ "    a,\n"
-			+ "    a:visited {\n"
-			+ "      text-decoration: none;\n"
-			+ "      color: #06f;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    a:hover {\n"
-			+ "      text-decoration: underline;\n"
-			+ "      color: #003c97;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    input[type=\"text\"],\n"
-			+ "    input[type=\"password\"] {\n"
-			+ "      height: auto;\n"
-			+ "      width: 100%;\n"
-			+ "      font-size: 1rem;\n"
-			+ "      padding: 0.5rem;\n"
-			+ "      box-sizing: border-box;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    button {\n"
-			+ "      padding: 0.5rem 1rem;\n"
-			+ "      font-size: 1.25rem;\n"
-			+ "      line-height: 1.5;\n"
-			+ "      border: none;\n"
-			+ "      border-radius: 0.1rem;\n"
-			+ "      width: 100%;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    button.primary {\n"
-			+ "      color: #fff;\n"
-			+ "      background-color: #06f;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    .alert {\n"
-			+ "      padding: 0.75rem 1rem;\n"
-			+ "      margin-bottom: 1rem;\n"
-			+ "      line-height: 1.5;\n"
-			+ "      border-radius: 0.1rem;\n"
-			+ "      width: 100%;\n"
-			+ "      box-sizing: border-box;\n"
-			+ "      border-width: 1px;\n"
-			+ "      border-style: solid;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    .alert.alert-danger {\n"
-			+ "      color: #6b1922;\n"
-			+ "      background-color: #f7d5d7;\n"
-			+ "      border-color: #eab6bb;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    .alert.alert-success {\n"
-			+ "      color: #145222;\n"
-			+ "      background-color: #d1f0d9;\n"
-			+ "      border-color: #c2ebcb;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    .screenreader {\n"
-			+ "      position: absolute;\n"
-			+ "      clip: rect(0 0 0 0);\n"
-			+ "      height: 1px;\n"
-			+ "      width: 1px;\n"
-			+ "      padding: 0;\n"
-			+ "      border: 0;\n"
-			+ "      overflow: hidden;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    table {\n"
-			+ "      width: 100%;\n"
-			+ "      max-width: 100%;\n"
-			+ "      margin-bottom: 2rem;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    .table-striped tr:nth-of-type(2n + 1) {\n"
-			+ "      background-color: #e1e1e1;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    td {\n"
-			+ "      padding: 0.75rem;\n"
-			+ "      vertical-align: top;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    /* Login / logout layouts */\n"
-			+ "    .login-form,\n"
-			+ "    .logout-form {\n"
-			+ "      max-width: 340px;\n"
-			+ "      padding: 0 15px 15px 15px;\n"
-			+ "      margin: 0 auto 2rem auto;\n"
-			+ "      box-sizing: border-box;\n"
-			+ "    }\n"
-			+ "    </style>\n"
-			+ "  </head>\n";
-	//@formatter:on
+	public static final String EXPECTED_HTML_HEAD = """
+			<!DOCTYPE html>
+			<html lang="en">
+			  <head>
+			    <meta charset="utf-8">
+			    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+			    <meta name="description" content="">
+			    <meta name="author" content="">
+			    <title>Please sign in</title>
+			    <style>
+			    /* General layout */
+			    body {
+			      font-family: system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+			      background-color: #eee;
+			      padding: 40px 0;
+			      margin: 0;
+			      line-height: 1.5;
+			    }
+			\s\s\s\s
+			    h2 {
+			      margin-top: 0;
+			      margin-bottom: 0.5rem;
+			      font-size: 2rem;
+			      font-weight: 500;
+			      line-height: 2rem;
+			    }
+			\s\s\s\s
+			    .content {
+			      margin-right: auto;
+			      margin-left: auto;
+			      padding-right: 15px;
+			      padding-left: 15px;
+			      width: 100%;
+			      box-sizing: border-box;
+			    }
+			\s\s\s\s
+			    @media (min-width: 800px) {
+			      .content {
+			        max-width: 760px;
+			      }
+			    }
+			\s\s\s\s
+			    /* Components */
+			    a,
+			    a:visited {
+			      text-decoration: none;
+			      color: #06f;
+			    }
+			\s\s\s\s
+			    a:hover {
+			      text-decoration: underline;
+			      color: #003c97;
+			    }
+			\s\s\s\s
+			    input[type="text"],
+			    input[type="password"] {
+			      height: auto;
+			      width: 100%;
+			      font-size: 1rem;
+			      padding: 0.5rem;
+			      box-sizing: border-box;
+			    }
+			\s\s\s\s
+			    button {
+			      padding: 0.5rem 1rem;
+			      font-size: 1.25rem;
+			      line-height: 1.5;
+			      border: none;
+			      border-radius: 0.1rem;
+			      width: 100%;
+			    }
+			\s\s\s\s
+			    button.primary {
+			      color: #fff;
+			      background-color: #06f;
+			    }
+			\s\s\s\s
+			    .alert {
+			      padding: 0.75rem 1rem;
+			      margin-bottom: 1rem;
+			      line-height: 1.5;
+			      border-radius: 0.1rem;
+			      width: 100%;
+			      box-sizing: border-box;
+			      border-width: 1px;
+			      border-style: solid;
+			    }
+			\s\s\s\s
+			    .alert.alert-danger {
+			      color: #6b1922;
+			      background-color: #f7d5d7;
+			      border-color: #eab6bb;
+			    }
+			\s\s\s\s
+			    .alert.alert-success {
+			      color: #145222;
+			      background-color: #d1f0d9;
+			      border-color: #c2ebcb;
+			    }
+			\s\s\s\s
+			    .screenreader {
+			      position: absolute;
+			      clip: rect(0 0 0 0);
+			      height: 1px;
+			      width: 1px;
+			      padding: 0;
+			      border: 0;
+			      overflow: hidden;
+			    }
+			\s\s\s\s
+			    table {
+			      width: 100%;
+			      max-width: 100%;
+			      margin-bottom: 2rem;
+			    }
+			\s\s\s\s
+			    .table-striped tr:nth-of-type(2n + 1) {
+			      background-color: #e1e1e1;
+			    }
+			\s\s\s\s
+			    td {
+			      padding: 0.75rem;
+			      vertical-align: top;
+			    }
+			\s\s\s\s
+			    /* Login / logout layouts */
+			    .login-form,
+			    .logout-form {
+			      max-width: 340px;
+			      padding: 0 15px 15px 15px;
+			      margin: 0 auto 2rem auto;
+			      box-sizing: border-box;
+			    }
+			    </style>
+			  </head>
+			""";
 
 	public final SpringTestContext spring = new SpringTestContext(this);
 
@@ -222,26 +224,32 @@ public class DefaultLoginPageConfigurerTests {
 		this.mvc.perform(get("/login").sessionAttr(csrfAttributeName, csrfToken))
 				.andExpect((result) -> {
 					CsrfToken token = (CsrfToken) result.getRequest().getAttribute(CsrfToken.class.getName());
-					assertThat(result.getResponse().getContentAsString()).isEqualTo("<!DOCTYPE html>\n"
-						+ "<html lang=\"en\">\n"
-						+ EXPECTED_HTML_HEAD
-						+ "  <body>\n"
-						+ "     <div class=\"content\">\n"
-						+ "      <form class=\"login-form\" method=\"post\" action=\"/login\">\n"
-						+ "        <h2>Please sign in</h2>\n"
-						+ "        <p>\n"
-						+ "          <label for=\"username\" class=\"screenreader\">Username</label>\n"
-						+ "          <input type=\"text\" id=\"username\" name=\"username\" placeholder=\"Username\" required autofocus>\n"
-						+ "        </p>\n"
-						+ "        <p>\n"
-						+ "          <label for=\"password\" class=\"screenreader\">Password</label>\n"
-						+ "          <input type=\"password\" id=\"password\" name=\"password\" placeholder=\"Password\" required>\n"
-						+ "        </p>\n"
-						+ "<input name=\"" + token.getParameterName() + "\" type=\"hidden\" value=\"" + token.getToken() + "\" />\n"
-						+ "        <button type=\"submit\" class=\"primary\">Sign in</button>\n"
-						+ "      </form>\n"
-						+ "</div>\n"
-						+ "</body></html>");
+					assertThat(result.getResponse().getContentAsString()).isEqualTo(
+						EXPECTED_HTML_HEAD +
+						"""
+						  <body>
+						    <div class="content">
+						      <form class="login-form" method="post" action="/login">
+						        <h2>Please sign in</h2>
+						       \s
+						        <p>
+						          <label for="username" class="screenreader">Username</label>
+						          <input type="text" id="username" name="username" placeholder="Username" required autofocus>
+						        </p>
+						        <p>
+						          <label for="password" class="screenreader">Password</label>
+						          <input type="password" id="password" name="password" placeholder="Password" required>
+						        </p>
+
+						<input name="_csrf" type="hidden" value="%s" />
+						        <button type="submit" class="primary">Sign in</button>
+						      </form>
+
+
+
+						    </div>
+						  </body>
+						</html>""".formatted(token.getToken()));
 				});
 		// @formatter:on
 	}
@@ -263,25 +271,32 @@ public class DefaultLoginPageConfigurerTests {
 				.sessionAttr(csrfAttributeName, csrfToken))
 				.andExpect((result) -> {
 					CsrfToken token = (CsrfToken) result.getRequest().getAttribute(CsrfToken.class.getName());
-					assertThat(result.getResponse().getContentAsString()).isEqualTo("<!DOCTYPE html>\n"
-						+ "<html lang=\"en\">\n"
-						+ EXPECTED_HTML_HEAD
-						+ "  <body>\n"
-						+ "     <div class=\"content\">\n"
-						+ "      <form class=\"login-form\" method=\"post\" action=\"/login\">\n"
-						+ "        <h2>Please sign in</h2>\n"
-						+ "<div class=\"alert alert-danger\" role=\"alert\">Bad credentials</div>        <p>\n"
-						+ "          <label for=\"username\" class=\"screenreader\">Username</label>\n"
-						+ "          <input type=\"text\" id=\"username\" name=\"username\" placeholder=\"Username\" required autofocus>\n"
-						+ "        </p>\n" + "        <p>\n"
-						+ "          <label for=\"password\" class=\"screenreader\">Password</label>\n"
-						+ "          <input type=\"password\" id=\"password\" name=\"password\" placeholder=\"Password\" required>\n"
-						+ "        </p>\n"
-						+ "<input name=\"" + token.getParameterName() + "\" type=\"hidden\" value=\"" + token.getToken() + "\" />\n"
-						+ "        <button type=\"submit\" class=\"primary\">Sign in</button>\n"
-						+ "      </form>\n"
-						+ "</div>\n"
-						+ "</body></html>");
+					assertThat(result.getResponse().getContentAsString()).isEqualTo(
+						EXPECTED_HTML_HEAD +
+						"""
+						  <body>
+						    <div class="content">
+						      <form class="login-form" method="post" action="/login">
+						        <h2>Please sign in</h2>
+						        <div class="alert alert-danger" role="alert">Bad credentials</div>
+						        <p>
+						          <label for="username" class="screenreader">Username</label>
+						          <input type="text" id="username" name="username" placeholder="Username" required autofocus>
+						        </p>
+						        <p>
+						          <label for="password" class="screenreader">Password</label>
+						          <input type="password" id="password" name="password" placeholder="Password" required>
+						        </p>
+
+						<input name="_csrf" type="hidden" value="%s" />
+						        <button type="submit" class="primary">Sign in</button>
+						      </form>
+
+
+
+						    </div>
+						  </body>
+						</html>""".formatted(token.getToken()));
 				});
 		// @formatter:on
 	}
@@ -307,26 +322,32 @@ public class DefaultLoginPageConfigurerTests {
 		this.mvc.perform(get("/login?logout").sessionAttr(csrfAttributeName, csrfToken))
 				.andExpect((result) -> {
 					CsrfToken token = (CsrfToken) result.getRequest().getAttribute(CsrfToken.class.getName());
-					assertThat(result.getResponse().getContentAsString()).isEqualTo("<!DOCTYPE html>\n"
-						+ "<html lang=\"en\">\n"
-						+ EXPECTED_HTML_HEAD
-						+ "  <body>\n"
-						+ "     <div class=\"content\">\n"
-						+ "      <form class=\"login-form\" method=\"post\" action=\"/login\">\n"
-						+ "        <h2>Please sign in</h2>\n"
-						+ "<div class=\"alert alert-success\" role=\"alert\">You have been signed out</div>        <p>\n"
-						+ "          <label for=\"username\" class=\"screenreader\">Username</label>\n"
-						+ "          <input type=\"text\" id=\"username\" name=\"username\" placeholder=\"Username\" required autofocus>\n"
-						+ "        </p>\n"
-						+ "        <p>\n"
-						+ "          <label for=\"password\" class=\"screenreader\">Password</label>\n"
-						+ "          <input type=\"password\" id=\"password\" name=\"password\" placeholder=\"Password\" required>\n"
-						+ "        </p>\n"
-						+ "<input name=\"" + token.getParameterName() + "\" type=\"hidden\" value=\"" + token.getToken() + "\" />\n"
-						+ "        <button type=\"submit\" class=\"primary\">Sign in</button>\n"
-						+ "      </form>\n"
-						+ "</div>\n"
-						+ "</body></html>");
+					assertThat(result.getResponse().getContentAsString()).isEqualTo(
+						EXPECTED_HTML_HEAD +
+						"""
+						  <body>
+						    <div class="content">
+						      <form class="login-form" method="post" action="/login">
+						        <h2>Please sign in</h2>
+						        <div class="alert alert-success" role="alert">You have been signed out</div>
+						        <p>
+						          <label for="username" class="screenreader">Username</label>
+						          <input type="text" id="username" name="username" placeholder="Username" required autofocus>
+						        </p>
+						        <p>
+						          <label for="password" class="screenreader">Password</label>
+						          <input type="password" id="password" name="password" placeholder="Password" required>
+						        </p>
+
+						<input name="_csrf" type="hidden" value="%s" />
+						        <button type="submit" class="primary">Sign in</button>
+						      </form>
+
+
+
+						    </div>
+						  </body>
+						</html>""".formatted(token.getToken()));
 				});
 		// @formatter:on
 	}
@@ -352,27 +373,32 @@ public class DefaultLoginPageConfigurerTests {
 		this.mvc.perform(get("/login").sessionAttr(csrfAttributeName, csrfToken))
 				.andExpect((result) -> {
 					CsrfToken token = (CsrfToken) result.getRequest().getAttribute(CsrfToken.class.getName());
-					assertThat(result.getResponse().getContentAsString()).isEqualTo("<!DOCTYPE html>\n"
-						+ "<html lang=\"en\">\n"
-						+ EXPECTED_HTML_HEAD
-						+ "  <body>\n"
-						+ "     <div class=\"content\">\n"
-						+ "      <form class=\"login-form\" method=\"post\" action=\"/login\">\n"
-						+ "        <h2>Please sign in</h2>\n"
-						+ "        <p>\n"
-						+ "          <label for=\"username\" class=\"screenreader\">Username</label>\n"
-						+ "          <input type=\"text\" id=\"username\" name=\"username\" placeholder=\"Username\" required autofocus>\n"
-						+ "        </p>\n"
-						+ "        <p>\n"
-						+ "          <label for=\"password\" class=\"screenreader\">Password</label>\n"
-						+ "          <input type=\"password\" id=\"password\" name=\"password\" placeholder=\"Password\" required>\n"
-						+ "        </p>\n"
-						+ "<p><input type='checkbox' name='remember-me'/> Remember me on this computer.</p>\n"
-						+ "<input name=\"" + token.getParameterName() + "\" type=\"hidden\" value=\"" + token.getToken() + "\" />\n"
-						+ "        <button type=\"submit\" class=\"primary\">Sign in</button>\n"
-						+ "      </form>\n"
-						+ "</div>\n"
-						+ "</body></html>");
+					assertThat(result.getResponse().getContentAsString()).isEqualTo(
+						EXPECTED_HTML_HEAD +
+						"""
+						  <body>
+						    <div class="content">
+						      <form class="login-form" method="post" action="/login">
+						        <h2>Please sign in</h2>
+						       \s
+						        <p>
+						          <label for="username" class="screenreader">Username</label>
+						          <input type="text" id="username" name="username" placeholder="Username" required autofocus>
+						        </p>
+						        <p>
+						          <label for="password" class="screenreader">Password</label>
+						          <input type="password" id="password" name="password" placeholder="Password" required>
+						        </p>
+						<p><input type='checkbox' name='remember-me'/> Remember me on this computer.</p>
+						<input name="_csrf" type="hidden" value="%s" />
+						        <button type="submit" class="primary">Sign in</button>
+						      </form>
+
+
+
+						    </div>
+						  </body>
+						</html>""".formatted(token.getToken()));
 				});
 		// @formatter:on
 	}

--- a/config/src/test/java/org/springframework/security/config/http/FormLoginBeanDefinitionParserTests.java
+++ b/config/src/test/java/org/springframework/security/config/http/FormLoginBeanDefinitionParserTests.java
@@ -45,140 +45,142 @@ public class FormLoginBeanDefinitionParserTests {
 
 	private static final String CONFIG_LOCATION_PREFIX = "classpath:org/springframework/security/config/http/FormLoginBeanDefinitionParserTests";
 
-	//@formatter:off
-	public static final String EXPECTED_HTML_HEAD = "  <head>\n"
-			+ "    <meta charset=\"utf-8\">\n"
-			+ "    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1, shrink-to-fit=no\">\n"
-			+ "    <meta name=\"description\" content=\"\">\n"
-			+ "    <meta name=\"author\" content=\"\">\n"
-			+ "    <title>Please sign in</title>\n"
-			+ "    <style>\n"
-			+ "    /* General layout */\n"
-			+ "    body {\n"
-			+ "      font-family: system-ui, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif;\n"
-			+ "      background-color: #eee;\n"
-			+ "      padding: 40px 0;\n"
-			+ "      margin: 0;\n"
-			+ "      line-height: 1.5;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    h2 {\n"
-			+ "      margin-top: 0;\n"
-			+ "      margin-bottom: 0.5rem;\n"
-			+ "      font-size: 2rem;\n"
-			+ "      font-weight: 500;\n"
-			+ "      line-height: 2rem;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    .content {\n"
-			+ "      margin-right: auto;\n"
-			+ "      margin-left: auto;\n"
-			+ "      padding-right: 15px;\n"
-			+ "      padding-left: 15px;\n"
-			+ "      width: 100%;\n"
-			+ "      box-sizing: border-box;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    @media (min-width: 800px) {\n"
-			+ "      .content {\n"
-			+ "        max-width: 760px;\n"
-			+ "      }\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    /* Components */\n"
-			+ "    a,\n"
-			+ "    a:visited {\n"
-			+ "      text-decoration: none;\n"
-			+ "      color: #06f;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    a:hover {\n"
-			+ "      text-decoration: underline;\n"
-			+ "      color: #003c97;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    input[type=\"text\"],\n"
-			+ "    input[type=\"password\"] {\n"
-			+ "      height: auto;\n"
-			+ "      width: 100%;\n"
-			+ "      font-size: 1rem;\n"
-			+ "      padding: 0.5rem;\n"
-			+ "      box-sizing: border-box;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    button {\n"
-			+ "      padding: 0.5rem 1rem;\n"
-			+ "      font-size: 1.25rem;\n"
-			+ "      line-height: 1.5;\n"
-			+ "      border: none;\n"
-			+ "      border-radius: 0.1rem;\n"
-			+ "      width: 100%;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    button.primary {\n"
-			+ "      color: #fff;\n"
-			+ "      background-color: #06f;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    .alert {\n"
-			+ "      padding: 0.75rem 1rem;\n"
-			+ "      margin-bottom: 1rem;\n"
-			+ "      line-height: 1.5;\n"
-			+ "      border-radius: 0.1rem;\n"
-			+ "      width: 100%;\n"
-			+ "      box-sizing: border-box;\n"
-			+ "      border-width: 1px;\n"
-			+ "      border-style: solid;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    .alert.alert-danger {\n"
-			+ "      color: #6b1922;\n"
-			+ "      background-color: #f7d5d7;\n"
-			+ "      border-color: #eab6bb;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    .alert.alert-success {\n"
-			+ "      color: #145222;\n"
-			+ "      background-color: #d1f0d9;\n"
-			+ "      border-color: #c2ebcb;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    .screenreader {\n"
-			+ "      position: absolute;\n"
-			+ "      clip: rect(0 0 0 0);\n"
-			+ "      height: 1px;\n"
-			+ "      width: 1px;\n"
-			+ "      padding: 0;\n"
-			+ "      border: 0;\n"
-			+ "      overflow: hidden;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    table {\n"
-			+ "      width: 100%;\n"
-			+ "      max-width: 100%;\n"
-			+ "      margin-bottom: 2rem;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    .table-striped tr:nth-of-type(2n + 1) {\n"
-			+ "      background-color: #e1e1e1;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    td {\n"
-			+ "      padding: 0.75rem;\n"
-			+ "      vertical-align: top;\n"
-			+ "    }\n"
-			+ "    \n"
-			+ "    /* Login / logout layouts */\n"
-			+ "    .login-form,\n"
-			+ "    .logout-form {\n"
-			+ "      max-width: 340px;\n"
-			+ "      padding: 0 15px 15px 15px;\n"
-			+ "      margin: 0 auto 2rem auto;\n"
-			+ "      box-sizing: border-box;\n"
-			+ "    }\n"
-			+ "    </style>\n"
-			+ "  </head>\n";
-	//@formatter:on
+	public static final String EXPECTED_HTML_HEAD = """
+			<!DOCTYPE html>
+			<html lang="en">
+			  <head>
+			    <meta charset="utf-8">
+			    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+			    <meta name="description" content="">
+			    <meta name="author" content="">
+			    <title>Please sign in</title>
+			    <style>
+			    /* General layout */
+			    body {
+			      font-family: system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+			      background-color: #eee;
+			      padding: 40px 0;
+			      margin: 0;
+			      line-height: 1.5;
+			    }
+			\s\s\s\s
+			    h2 {
+			      margin-top: 0;
+			      margin-bottom: 0.5rem;
+			      font-size: 2rem;
+			      font-weight: 500;
+			      line-height: 2rem;
+			    }
+			\s\s\s\s
+			    .content {
+			      margin-right: auto;
+			      margin-left: auto;
+			      padding-right: 15px;
+			      padding-left: 15px;
+			      width: 100%;
+			      box-sizing: border-box;
+			    }
+			\s\s\s\s
+			    @media (min-width: 800px) {
+			      .content {
+			        max-width: 760px;
+			      }
+			    }
+			\s\s\s\s
+			    /* Components */
+			    a,
+			    a:visited {
+			      text-decoration: none;
+			      color: #06f;
+			    }
+			\s\s\s\s
+			    a:hover {
+			      text-decoration: underline;
+			      color: #003c97;
+			    }
+			\s\s\s\s
+			    input[type="text"],
+			    input[type="password"] {
+			      height: auto;
+			      width: 100%;
+			      font-size: 1rem;
+			      padding: 0.5rem;
+			      box-sizing: border-box;
+			    }
+			\s\s\s\s
+			    button {
+			      padding: 0.5rem 1rem;
+			      font-size: 1.25rem;
+			      line-height: 1.5;
+			      border: none;
+			      border-radius: 0.1rem;
+			      width: 100%;
+			    }
+			\s\s\s\s
+			    button.primary {
+			      color: #fff;
+			      background-color: #06f;
+			    }
+			\s\s\s\s
+			    .alert {
+			      padding: 0.75rem 1rem;
+			      margin-bottom: 1rem;
+			      line-height: 1.5;
+			      border-radius: 0.1rem;
+			      width: 100%;
+			      box-sizing: border-box;
+			      border-width: 1px;
+			      border-style: solid;
+			    }
+			\s\s\s\s
+			    .alert.alert-danger {
+			      color: #6b1922;
+			      background-color: #f7d5d7;
+			      border-color: #eab6bb;
+			    }
+			\s\s\s\s
+			    .alert.alert-success {
+			      color: #145222;
+			      background-color: #d1f0d9;
+			      border-color: #c2ebcb;
+			    }
+			\s\s\s\s
+			    .screenreader {
+			      position: absolute;
+			      clip: rect(0 0 0 0);
+			      height: 1px;
+			      width: 1px;
+			      padding: 0;
+			      border: 0;
+			      overflow: hidden;
+			    }
+			\s\s\s\s
+			    table {
+			      width: 100%;
+			      max-width: 100%;
+			      margin-bottom: 2rem;
+			    }
+			\s\s\s\s
+			    .table-striped tr:nth-of-type(2n + 1) {
+			      background-color: #e1e1e1;
+			    }
+			\s\s\s\s
+			    td {
+			      padding: 0.75rem;
+			      vertical-align: top;
+			    }
+			\s\s\s\s
+			    /* Login / logout layouts */
+			    .login-form,
+			    .logout-form {
+			      max-width: 340px;
+			      padding: 0 15px 15px 15px;
+			      margin: 0 auto 2rem auto;
+			      box-sizing: border-box;
+			    }
+			    </style>
+			  </head>
+			""";
 
 	public final SpringTestContext spring = new SpringTestContext(this);
 
@@ -188,27 +190,30 @@ public class FormLoginBeanDefinitionParserTests {
 	@Test
 	public void getLoginWhenAutoConfigThenShowsDefaultLoginPage() throws Exception {
 		this.spring.configLocations(this.xml("Simple")).autowire();
-		// @formatter:off
-		String expectedContent = "<!DOCTYPE html>\n"
-				+ "<html lang=\"en\">\n"
-				+ EXPECTED_HTML_HEAD
-				+ "  <body>\n"
-				+ "     <div class=\"content\">\n"
-				+ "      <form class=\"login-form\" method=\"post\" action=\"/login\">\n"
-				+ "        <h2>Please sign in</h2>\n"
-				+ "        <p>\n"
-				+ "          <label for=\"username\" class=\"screenreader\">Username</label>\n"
-				+ "          <input type=\"text\" id=\"username\" name=\"username\" placeholder=\"Username\" required autofocus>\n"
-				+ "        </p>\n"
-				+ "        <p>\n"
-				+ "          <label for=\"password\" class=\"screenreader\">Password</label>\n"
-				+ "          <input type=\"password\" id=\"password\" name=\"password\" placeholder=\"Password\" required>\n"
-				+ "        </p>\n"
-				+ "        <button type=\"submit\" class=\"primary\">Sign in</button>\n"
-				+ "      </form>\n"
-				+ "</div>\n"
-				+ "</body></html>";
-		// @formatter:on
+		String expectedContent = EXPECTED_HTML_HEAD + """
+				  <body>
+				    <div class="content">
+				      <form class="login-form" method="post" action="/login">
+				        <h2>Please sign in</h2>
+				       \s
+				        <p>
+				          <label for="username" class="screenreader">Username</label>
+				          <input type="text" id="username" name="username" placeholder="Username" required autofocus>
+				        </p>
+				        <p>
+				          <label for="password" class="screenreader">Password</label>
+				          <input type="password" id="password" name="password" placeholder="Password" required>
+				        </p>
+
+
+				        <button type="submit" class="primary">Sign in</button>
+				      </form>
+
+
+
+				    </div>
+				  </body>
+				</html>""";
 		this.mvc.perform(get("/login")).andExpect(content().string(expectedContent));
 	}
 
@@ -221,31 +226,32 @@ public class FormLoginBeanDefinitionParserTests {
 	@Test
 	public void getLoginWhenConfiguredWithCustomAttributesThenLoginPageReflects() throws Exception {
 		this.spring.configLocations(this.xml("WithCustomAttributes")).autowire();
-		// @formatter:off
-		String expectedContent = "<!DOCTYPE html>\n"
-				+ "<html lang=\"en\">\n"
-				+ EXPECTED_HTML_HEAD
-				+ "  <body>\n"
-				+ "     <div class=\"content\">\n"
-				+ "      <form class=\"login-form\" method=\"post\" action=\"/signin\">\n"
-				+ "        <h2>Please sign in</h2>\n"
-				+ "        <p>\n"
-				+ "          <label for=\"username\" class=\"screenreader\">Username</label>\n"
-				+ "          <input type=\"text\" id=\"username\" name=\"custom_user\" placeholder=\"Username\" required autofocus>\n"
-				+ "        </p>\n"
-				+ "        <p>\n"
-				+ "          <label for=\"password\" class=\"screenreader\">Password</label>\n"
-				+ "          <input type=\"password\" id=\"password\" name=\"custom_pass\" placeholder=\"Password\" required>\n"
-				+ "        </p>\n"
-				+ "        <button type=\"submit\" class=\"primary\">Sign in</button>\n"
-				+ "      </form>\n"
-				+ "</div>\n"
-				+ "</body></html>";
-		this.mvc.perform(get("/login"))
-				.andExpect(content().string(expectedContent));
-		this.mvc.perform(get("/logout"))
-				.andExpect(status().is3xxRedirection());
-		// @formatter:on
+		String expectedContent = EXPECTED_HTML_HEAD + """
+				  <body>
+				    <div class="content">
+				      <form class="login-form" method="post" action="/signin">
+				        <h2>Please sign in</h2>
+				       \s
+				        <p>
+				          <label for="username" class="screenreader">Username</label>
+				          <input type="text" id="username" name="custom_user" placeholder="Username" required autofocus>
+				        </p>
+				        <p>
+				          <label for="password" class="screenreader">Password</label>
+				          <input type="password" id="password" name="custom_pass" placeholder="Password" required>
+				        </p>
+
+
+				        <button type="submit" class="primary">Sign in</button>
+				      </form>
+
+
+
+				    </div>
+				  </body>
+				</html>""";
+		this.mvc.perform(get("/login")).andExpect(content().string(expectedContent));
+		this.mvc.perform(get("/logout")).andExpect(status().is3xxRedirection());
 	}
 
 	@Test

--- a/web/src/main/java/org/springframework/security/web/authentication/ui/DefaultLogoutPageGeneratingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/ui/DefaultLogoutPageGeneratingFilter.java
@@ -61,30 +61,13 @@ public class DefaultLogoutPageGeneratingFilter extends OncePerRequestFilter {
 	}
 
 	private void renderLogout(HttpServletRequest request, HttpServletResponse response) throws IOException {
-		StringBuilder sb = new StringBuilder();
-		sb.append("<!DOCTYPE html>\n");
-		sb.append("<html lang=\"en\">\n");
-		sb.append("  <head>\n");
-		sb.append("    <meta charset=\"utf-8\">\n");
-		sb.append("    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1, shrink-to-fit=no\">\n");
-		sb.append("    <meta name=\"description\" content=\"\">\n");
-		sb.append("    <meta name=\"author\" content=\"\">\n");
-		sb.append("    <title>Confirm Log Out?</title>\n");
-		sb.append(CssUtils.getCssStyleBlock().indent(4));
-		sb.append("  </head>\n");
-		sb.append("  <body>\n");
-		sb.append("     <div class=\"content\">\n");
-		sb.append("      <form class=\"logout-form\" method=\"post\" action=\"" + request.getContextPath()
-				+ "/logout\">\n");
-		sb.append("        <h2>Are you sure you want to log out?</h2>\n");
-		sb.append(renderHiddenInputs(request));
-		sb.append("        <button class=\"primary\" type=\"submit\">Log Out</button>\n");
-		sb.append("      </form>\n");
-		sb.append("    </div>\n");
-		sb.append("  </body>\n");
-		sb.append("</html>");
+		String renderedPage = HtmlTemplates.fromTemplate(LOGOUT_PAGE_TEMPLATE)
+			.withRawHtml("cssStyle", CssUtils.getCssStyleBlock().indent(4))
+			.withValue("contextPath", request.getContextPath())
+			.withRawHtml("hiddenInputs", renderHiddenInputs(request).indent(8))
+			.render();
 		response.setContentType("text/html;charset=UTF-8");
-		response.getWriter().write(sb.toString());
+		response.getWriter().write(renderedPage);
 	}
 
 	/**
@@ -101,13 +84,39 @@ public class DefaultLogoutPageGeneratingFilter extends OncePerRequestFilter {
 	private String renderHiddenInputs(HttpServletRequest request) {
 		StringBuilder sb = new StringBuilder();
 		for (Map.Entry<String, String> input : this.resolveHiddenInputs.apply(request).entrySet()) {
-			sb.append("<input name=\"");
-			sb.append(input.getKey());
-			sb.append("\" type=\"hidden\" value=\"");
-			sb.append(input.getValue());
-			sb.append("\" />\n");
+			String inputElement = HtmlTemplates.fromTemplate(HIDDEN_HTML_INPUT_TEMPLATE)
+				.withValue("name", input.getKey())
+				.withValue("value", input.getValue())
+				.render();
+			sb.append(inputElement);
 		}
 		return sb.toString();
 	}
+
+	private static final String LOGOUT_PAGE_TEMPLATE = """
+			<!DOCTYPE html>
+			<html lang="en">
+			  <head>
+			    <meta charset="utf-8">
+			    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+			    <meta name="description" content="">
+			    <meta name="author" content="">
+			    <title>Confirm Log Out?</title>
+			{{cssStyle}}
+			  </head>
+			  <body>
+			    <div class="content">
+			      <form class="logout-form" method="post" action="{{contextPath}}/logout">
+			        <h2>Are you sure you want to log out?</h2>
+			{{hiddenInputs}}
+			        <button class="primary" type="submit">Log Out</button>
+			      </form>
+			    </div>
+			  </body>
+			</html>""";
+
+	private static final String HIDDEN_HTML_INPUT_TEMPLATE = """
+			<input name="{{name}}" type="hidden" value="{{value}}" />
+			""";
 
 }

--- a/web/src/main/java/org/springframework/security/web/authentication/ui/HtmlTemplates.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/ui/HtmlTemplates.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication.ui;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.HtmlUtils;
+
+/**
+ * Render HTML templates using string substitution. Intended for internal use. Variables
+ * can be templated using double curly-braces: {@code {{name}}}.
+ *
+ * @author Daniel Garnier-Moiroux
+ * @since 6.4
+ */
+final class HtmlTemplates {
+
+	private HtmlTemplates() {
+	}
+
+	static Builder fromTemplate(String template) {
+		return new Builder(template);
+	}
+
+	static final class Builder {
+
+		private final String template;
+
+		private final Map<String, String> values = new HashMap<>();
+
+		private Builder(String template) {
+			this.template = template;
+		}
+
+		/**
+		 * HTML-escape, and inject value {@code value} in every {@code {{key}}}
+		 * placeholder.
+		 * @param key the placeholder name
+		 * @param value the value to inject
+		 * @return this instance for further templating
+		 */
+		Builder withValue(String key, String value) {
+			this.values.put(key, HtmlUtils.htmlEscape(value));
+			return this;
+		}
+
+		/**
+		 * Inject value {@code value} in every {@code {{key}}} placeholder without
+		 * HTML-escaping. Useful for injecting "sub-templates".
+		 * @param key the placeholder name
+		 * @param value the value to inject
+		 * @return this instance for further templating
+		 */
+		Builder withRawHtml(String key, String value) {
+			if (!value.isEmpty() && value.charAt(value.length() - 1) == '\n') {
+				value = value.substring(0, value.length() - 1);
+			}
+			this.values.put(key, value);
+			return this;
+		}
+
+		/**
+		 * Render the template. All placeholders MUST have a corresponding value. If a
+		 * placeholder does not have a corresponding value, throws
+		 * {@link IllegalStateException}.
+		 * @return the rendered template
+		 */
+		String render() {
+			String template = this.template;
+			for (String key : this.values.keySet()) {
+				String pattern = Pattern.quote("{{" + key + "}}");
+				template = template.replaceAll(pattern, this.values.get(key));
+			}
+
+			String unusedPlaceholders = Pattern.compile("\\{\\{([a-zA-Z0-9]+)}}")
+				.matcher(template)
+				.results()
+				.map((result) -> result.group(1))
+				.collect(Collectors.joining(", "));
+			if (StringUtils.hasLength(unusedPlaceholders)) {
+				throw new IllegalStateException("Unused placeholders in template: [%s]".formatted(unusedPlaceholders));
+			}
+
+			return template;
+		}
+
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/server/ui/HtmlTemplates.java
+++ b/web/src/main/java/org/springframework/security/web/server/ui/HtmlTemplates.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.server.ui;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.HtmlUtils;
+
+/**
+ * Render HTML templates using string substitution. Intended for internal use. Variables
+ * can be templated using double curly-braces: {@code {{name}}}.
+ *
+ * @author Daniel Garnier-Moiroux
+ * @since 6.4
+ * @see org.springframework.security.web.authentication.ui.HtmlTemplates
+ */
+final class HtmlTemplates {
+
+	private HtmlTemplates() {
+	}
+
+	static Builder fromTemplate(String template) {
+		return new Builder(template);
+	}
+
+	static final class Builder {
+
+		private final String template;
+
+		private final Map<String, String> values = new HashMap<>();
+
+		private Builder(String template) {
+			this.template = template;
+		}
+
+		/**
+		 * HTML-escape, and inject value {@code value} in every {@code {{key}}}
+		 * placeholder.
+		 * @param key the placeholder name
+		 * @param value the value to inject
+		 * @return this instance for further templating
+		 */
+		Builder withValue(String key, String value) {
+			this.values.put(key, HtmlUtils.htmlEscape(value));
+			return this;
+		}
+
+		/**
+		 * Inject value {@code value} in every {@code {{key}}} placeholder without
+		 * HTML-escaping. Useful for injecting "sub-templates".
+		 * @param key the placeholder name
+		 * @param value the value to inject
+		 * @return this instance for further templating
+		 */
+		Builder withRawHtml(String key, String value) {
+			if (!value.isEmpty() && value.charAt(value.length() - 1) == '\n') {
+				value = value.substring(0, value.length() - 1);
+			}
+			this.values.put(key, value);
+			return this;
+		}
+
+		/**
+		 * Render the template. All placeholders MUST have a corresponding value. If a
+		 * placeholder does not have a corresponding value, throws
+		 * {@link IllegalStateException}.
+		 * @return the rendered template
+		 */
+		String render() {
+			String template = this.template;
+			for (String key : this.values.keySet()) {
+				String pattern = Pattern.quote("{{" + key + "}}");
+				template = template.replaceAll(pattern, this.values.get(key));
+			}
+
+			String unusedPlaceholders = Pattern.compile("\\{\\{([a-zA-Z0-9]+)}}")
+				.matcher(template)
+				.results()
+				.map((result) -> result.group(1))
+				.collect(Collectors.joining(", "));
+			if (StringUtils.hasLength(unusedPlaceholders)) {
+				throw new IllegalStateException("Unused placeholders in template: [%s]".formatted(unusedPlaceholders));
+			}
+
+			return template;
+		}
+
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/server/ui/LoginPageGeneratingWebFilter.java
+++ b/web/src/main/java/org/springframework/security/web/server/ui/LoginPageGeneratingWebFilter.java
@@ -19,6 +19,7 @@ package org.springframework.security.web.server.ui;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import reactor.core.publisher.Mono;
 
@@ -37,7 +38,6 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
-import org.springframework.web.util.HtmlUtils;
 
 /**
  * Generates a default log in page used for authenticating users.
@@ -89,80 +89,61 @@ public class LoginPageGeneratingWebFilter implements WebFilter {
 	private byte[] createPage(ServerWebExchange exchange, String csrfTokenHtmlInput) {
 		MultiValueMap<String, String> queryParams = exchange.getRequest().getQueryParams();
 		String contextPath = exchange.getRequest().getPath().contextPath().value();
-		StringBuilder page = new StringBuilder();
-		page.append("<!DOCTYPE html>\n");
-		page.append("<html lang=\"en\">\n");
-		page.append("  <head>\n");
-		page.append("    <meta charset=\"utf-8\">\n");
-		page.append("    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1, shrink-to-fit=no\">\n");
-		page.append("    <meta name=\"description\" content=\"\">\n");
-		page.append("    <meta name=\"author\" content=\"\">\n");
-		page.append("    <title>Please sign in</title>\n");
-		page.append(CssUtils.getCssStyleBlock().indent(4));
-		page.append("  </head>\n");
-		page.append("  <body>\n");
-		page.append("     <div class=\"content\">\n");
-		page.append(formLogin(queryParams, contextPath, csrfTokenHtmlInput));
-		page.append(oauth2LoginLinks(queryParams, contextPath, this.oauth2AuthenticationUrlToClientName));
-		page.append("    </div>\n");
-		page.append("  </body>\n");
-		page.append("</html>");
-		return page.toString().getBytes(Charset.defaultCharset());
+
+		return HtmlTemplates.fromTemplate(LOGIN_PAGE_TEMPLATE)
+			.withRawHtml("cssStyle", CssUtils.getCssStyleBlock().indent(4))
+			.withRawHtml("formLogin", formLogin(queryParams, contextPath, csrfTokenHtmlInput))
+			.withRawHtml("oauth2Login", oauth2Login(queryParams, contextPath, this.oauth2AuthenticationUrlToClientName))
+			.render()
+			.getBytes(Charset.defaultCharset());
 	}
 
 	private String formLogin(MultiValueMap<String, String> queryParams, String contextPath, String csrfTokenHtmlInput) {
 		if (!this.formLoginEnabled) {
 			return "";
 		}
+
 		boolean isError = queryParams.containsKey("error");
 		boolean isLogoutSuccess = queryParams.containsKey("logout");
-		StringBuilder page = new StringBuilder();
-		page.append("      <form class=\"login-form\" method=\"post\" action=\"" + contextPath + "/login\">\n");
-		page.append("        <h2>Please sign in</h2>\n");
-		page.append(createError(isError));
-		page.append(createLogoutSuccess(isLogoutSuccess));
-		page.append("        <p>\n");
-		page.append("          <label for=\"username\" class=\"screenreader\">Username</label>\n");
-		page.append("          <input type=\"text\" id=\"username\" name=\"username\" "
-				+ "placeholder=\"Username\" required autofocus>\n");
-		page.append("        </p>\n" + "        <p>\n");
-		page.append("          <label for=\"password\" class=\"screenreader\">Password</label>\n");
-		page.append("          <input type=\"password\" id=\"password\" name=\"password\" "
-				+ "placeholder=\"Password\" required>\n");
-		page.append("        </p>\n");
-		page.append(csrfTokenHtmlInput);
-		page.append("        <button class=\"primary\" type=\"submit\">Sign in</button>\n");
-		page.append("      </form>\n");
-		return page.toString();
+
+		return HtmlTemplates.fromTemplate(LOGIN_FORM_TEMPLATE)
+			.withValue("loginUrl", contextPath + "/login")
+			.withRawHtml("errorMessage", createError(isError))
+			.withRawHtml("logoutMessage", createLogoutSuccess(isLogoutSuccess))
+			.withRawHtml("csrf", csrfTokenHtmlInput)
+			.render();
 	}
 
-	private static String oauth2LoginLinks(MultiValueMap<String, String> queryParams, String contextPath,
+	private static String oauth2Login(MultiValueMap<String, String> queryParams, String contextPath,
 			Map<String, String> oauth2AuthenticationUrlToClientName) {
 		if (oauth2AuthenticationUrlToClientName.isEmpty()) {
 			return "";
 		}
 		boolean isError = queryParams.containsKey("error");
-		StringBuilder sb = new StringBuilder();
-		sb.append("<div class=\"content\"><h2>Login with OAuth 2.0</h2>");
-		sb.append(createError(isError));
-		sb.append("<table class=\"table table-striped\">\n");
-		for (Map.Entry<String, String> clientAuthenticationUrlToClientName : oauth2AuthenticationUrlToClientName
-			.entrySet()) {
-			sb.append(" <tr><td>");
-			String url = clientAuthenticationUrlToClientName.getKey();
-			sb.append("<a href=\"").append(contextPath).append(url).append("\">");
-			String clientName = HtmlUtils.htmlEscape(clientAuthenticationUrlToClientName.getValue());
-			sb.append(clientName);
-			sb.append("</a>");
-			sb.append("</td></tr>\n");
-		}
-		sb.append("</table></div>\n");
-		return sb.toString();
+
+		String oauth2Rows = oauth2AuthenticationUrlToClientName.entrySet()
+			.stream()
+			.map((urlToName) -> oauth2LoginLink(contextPath, urlToName.getKey(), urlToName.getValue()))
+			.collect(Collectors.joining("\n"))
+			.indent(2);
+		return HtmlTemplates.fromTemplate(OAUTH2_LOGIN_TEMPLATE)
+			.withRawHtml("errorMessage", createError(isError))
+			.withRawHtml("oauth2Rows", oauth2Rows)
+			.render();
+	}
+
+	private static String oauth2LoginLink(String contextPath, String url, String clientName) {
+		return HtmlTemplates.fromTemplate(OAUTH2_ROW_TEMPLATE)
+			.withValue("url", contextPath + url)
+			.withValue("clientName", clientName)
+			.render();
 	}
 
 	private static String csrfToken(CsrfToken token) {
-		return "          <input type=\"hidden\" name=\"" + token.getParameterName() + "\" value=\"" + token.getToken()
-				+ "\">\n";
+		return HtmlTemplates.fromTemplate(CSRF_INPUT_TEMPLATE)
+			.withValue("name", token.getParameterName())
+			.withValue("value", token.getToken())
+			.render();
 	}
 
 	private static String createError(boolean isError) {
@@ -173,5 +154,54 @@ public class LoginPageGeneratingWebFilter implements WebFilter {
 		return isLogoutSuccess ? "<div class=\"alert alert-success\" role=\"alert\">You have been signed out</div>"
 				: "";
 	}
+
+	private static final String LOGIN_PAGE_TEMPLATE = """
+			<!DOCTYPE html>
+			<html lang="en">
+			  <head>
+			    <meta charset="utf-8">
+			    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+			    <meta name="description" content="">
+			    <meta name="author" content="">
+			    <title>Please sign in</title>
+			{{cssStyle}}
+			  </head>
+			  <body>
+			    <div class="content">
+			{{formLogin}}
+			{{oauth2Login}}
+			    </div>
+			  </body>
+			</html>""";
+
+	private static final String LOGIN_FORM_TEMPLATE = """
+			      <form class="login-form" method="post" action="{{loginUrl}}">
+			        <h2>Please sign in</h2>
+			{{errorMessage}}{{logoutMessage}}
+			        <p>
+			          <label for="username" class="screenreader">Username</label>
+			          <input type="text" id="username" name="username" placeholder="Username" required autofocus>
+			        </p>
+			        <p>
+			          <label for="password" class="screenreader">Password</label>
+			          <input type="password" id="password" name="password" placeholder="Password" required>
+			        </p>
+			{{csrf}}
+			        <button type="submit" class="primary">Sign in</button>
+			      </form>""";
+
+	private static final String CSRF_INPUT_TEMPLATE = """
+			<input name="{{name}}" type="hidden" value="{{value}}" />
+			""";
+
+	private static final String OAUTH2_LOGIN_TEMPLATE = """
+			<h2>Login with OAuth 2.0</h2>
+			{{errorMessage}}
+			<table class="table table-striped">
+			{{oauth2Rows}}
+			</table>""";
+
+	private static final String OAUTH2_ROW_TEMPLATE = """
+			<tr><td><a href="{{url}}">{{clientName}}</a></td></tr>""";
 
 }

--- a/web/src/main/java/org/springframework/security/web/server/ui/LogoutPageGeneratingWebFilter.java
+++ b/web/src/main/java/org/springframework/security/web/server/ui/LogoutPageGeneratingWebFilter.java
@@ -70,33 +70,45 @@ public class LogoutPageGeneratingWebFilter implements WebFilter {
 	}
 
 	private static byte[] createPage(String csrfTokenHtmlInput, String contextPath) {
-		StringBuilder page = new StringBuilder();
-		page.append("<!DOCTYPE html>\n");
-		page.append("<html lang=\"en\">\n");
-		page.append("  <head>\n");
-		page.append("    <meta charset=\"utf-8\">\n");
-		page.append("    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1, shrink-to-fit=no\">\n");
-		page.append("    <meta name=\"description\" content=\"\">\n");
-		page.append("    <meta name=\"author\" content=\"\">\n");
-		page.append("    <title>Confirm Log Out?</title>\n");
-		page.append(CssUtils.getCssStyleBlock().indent(4));
-		page.append("  </head>\n");
-		page.append("  <body>\n");
-		page.append("     <div class=\"content\">\n");
-		page.append("      <form class=\"logout-form\" method=\"post\" action=\"" + contextPath + "/logout\">\n");
-		page.append("        <h2>Are you sure you want to log out?</h2>\n");
-		page.append(csrfTokenHtmlInput);
-		page.append("        <button class=\"primary\" type=\"submit\">Log Out</button>\n");
-		page.append("      </form>\n");
-		page.append("    </div>\n");
-		page.append("  </body>\n");
-		page.append("</html>");
-		return page.toString().getBytes(Charset.defaultCharset());
+		return HtmlTemplates.fromTemplate(LOGOUT_PAGE_TEMPLATE)
+			.withRawHtml("cssStyle", CssUtils.getCssStyleBlock().indent(4))
+			.withValue("contextPath", contextPath)
+			.withRawHtml("csrf", csrfTokenHtmlInput.indent(8))
+			.render()
+			.getBytes(Charset.defaultCharset());
 	}
 
 	private static String csrfToken(CsrfToken token) {
-		return "          <input type=\"hidden\" name=\"" + token.getParameterName() + "\" value=\"" + token.getToken()
-				+ "\">\n";
+		return HtmlTemplates.fromTemplate(CSRF_INPUT_TEMPLATE)
+			.withValue("name", token.getParameterName())
+			.withValue("value", token.getToken())
+			.render();
 	}
+
+	private static final String LOGOUT_PAGE_TEMPLATE = """
+			<!DOCTYPE html>
+			<html lang="en">
+			  <head>
+			    <meta charset="utf-8">
+			    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+			    <meta name="description" content="">
+			    <meta name="author" content="">
+			    <title>Confirm Log Out?</title>
+			{{cssStyle}}
+			  </head>
+			  <body>
+			    <div class="content">
+			      <form class="logout-form" method="post" action="{{contextPath}}/logout">
+			        <h2>Are you sure you want to log out?</h2>
+			{{csrf}}
+			        <button class="primary" type="submit">Log Out</button>
+			      </form>
+			    </div>
+			  </body>
+			</html>""";
+
+	private static final String CSRF_INPUT_TEMPLATE = """
+			<input name="{{name}}" type="hidden" value="{{value}}" />
+			""";
 
 }

--- a/web/src/test/java/org/springframework/security/web/authentication/DefaultLoginPageGeneratingFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/DefaultLoginPageGeneratingFilterTests.java
@@ -16,10 +16,12 @@
 
 package org.springframework.security.web.authentication;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Locale;
 
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.context.support.MessageSourceAccessor;
@@ -195,15 +197,204 @@ public class DefaultLoginPageGeneratingFilterTests {
 		filter.doFilter(new MockHttpServletRequest("GET", "/login"), response, this.chain);
 		assertThat(response.getContentAsString()).contains("Request a One-Time Token");
 		assertThat(response.getContentAsString()).contains("""
-				<form id="ott-form" class="login-form" method="post" action="/ott/authenticate">
+				      <form id="ott-form" class="login-form" method="post" action="/ott/authenticate">
 				        <h2>Request a One-Time Token</h2>
-				<p>
+				     \s
+				        <p>
 				          <label for="ott-username" class="screenreader">Username</label>
 				          <input type="text" id="ott-username" name="username" placeholder="Username" required>
 				        </p>
-				          <button class="primary" type="submit" form="ott-form">Send Token</button>
+				     \s
+				        <button class="primary" type="submit" form="ott-form">Send Token</button>
 				      </form>
 				""");
+	}
+
+	@Test
+	void generatesThenRenders() throws ServletException, IOException {
+		DefaultLoginPageGeneratingFilter filter = new DefaultLoginPageGeneratingFilter(
+				new UsernamePasswordAuthenticationFilter());
+		filter.setLoginPageUrl(DefaultLoginPageGeneratingFilter.DEFAULT_LOGIN_PAGE_URL);
+		filter.setSaml2LoginEnabled(true);
+		String clientName = "Google < > \" \' &";
+		filter.setSaml2AuthenticationUrlToProviderName(Collections.singletonMap("/saml/sso/google", clientName));
+		filter.setOauth2LoginEnabled(true);
+		clientName = "Google < > \" \' &";
+		filter.setOauth2AuthenticationUrlToClientName(
+				Collections.singletonMap("/oauth2/authorization/google", clientName));
+
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/login");
+		request.setQueryString("error");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		request.getSession()
+			.setAttribute(WebAttributes.AUTHENTICATION_EXCEPTION, new BadCredentialsException("Bad credentials"));
+		filter.doFilter(request, response, this.chain);
+		assertThat(response.getContentAsString()).isEqualTo("""
+				<!DOCTYPE html>
+				<html lang="en">
+				  <head>
+				    <meta charset="utf-8">
+				    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+				    <meta name="description" content="">
+				    <meta name="author" content="">
+				    <title>Please sign in</title>
+				    <style>
+				    /* General layout */
+				    body {
+				      font-family: system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+				      background-color: #eee;
+				      padding: 40px 0;
+				      margin: 0;
+				      line-height: 1.5;
+				    }
+				\s\s\s\s
+				    h2 {
+				      margin-top: 0;
+				      margin-bottom: 0.5rem;
+				      font-size: 2rem;
+				      font-weight: 500;
+				      line-height: 2rem;
+				    }
+				\s\s\s\s
+				    .content {
+				      margin-right: auto;
+				      margin-left: auto;
+				      padding-right: 15px;
+				      padding-left: 15px;
+				      width: 100%;
+				      box-sizing: border-box;
+				    }
+				\s\s\s\s
+				    @media (min-width: 800px) {
+				      .content {
+				        max-width: 760px;
+				      }
+				    }
+				\s\s\s\s
+				    /* Components */
+				    a,
+				    a:visited {
+				      text-decoration: none;
+				      color: #06f;
+				    }
+				\s\s\s\s
+				    a:hover {
+				      text-decoration: underline;
+				      color: #003c97;
+				    }
+				\s\s\s\s
+				    input[type="text"],
+				    input[type="password"] {
+				      height: auto;
+				      width: 100%;
+				      font-size: 1rem;
+				      padding: 0.5rem;
+				      box-sizing: border-box;
+				    }
+				\s\s\s\s
+				    button {
+				      padding: 0.5rem 1rem;
+				      font-size: 1.25rem;
+				      line-height: 1.5;
+				      border: none;
+				      border-radius: 0.1rem;
+				      width: 100%;
+				    }
+				\s\s\s\s
+				    button.primary {
+				      color: #fff;
+				      background-color: #06f;
+				    }
+				\s\s\s\s
+				    .alert {
+				      padding: 0.75rem 1rem;
+				      margin-bottom: 1rem;
+				      line-height: 1.5;
+				      border-radius: 0.1rem;
+				      width: 100%;
+				      box-sizing: border-box;
+				      border-width: 1px;
+				      border-style: solid;
+				    }
+				\s\s\s\s
+				    .alert.alert-danger {
+				      color: #6b1922;
+				      background-color: #f7d5d7;
+				      border-color: #eab6bb;
+				    }
+				\s\s\s\s
+				    .alert.alert-success {
+				      color: #145222;
+				      background-color: #d1f0d9;
+				      border-color: #c2ebcb;
+				    }
+				\s\s\s\s
+				    .screenreader {
+				      position: absolute;
+				      clip: rect(0 0 0 0);
+				      height: 1px;
+				      width: 1px;
+				      padding: 0;
+				      border: 0;
+				      overflow: hidden;
+				    }
+				\s\s\s\s
+				    table {
+				      width: 100%;
+				      max-width: 100%;
+				      margin-bottom: 2rem;
+				    }
+				\s\s\s\s
+				    .table-striped tr:nth-of-type(2n + 1) {
+				      background-color: #e1e1e1;
+				    }
+				\s\s\s\s
+				    td {
+				      padding: 0.75rem;
+				      vertical-align: top;
+				    }
+				\s\s\s\s
+				    /* Login / logout layouts */
+				    .login-form,
+				    .logout-form {
+				      max-width: 340px;
+				      padding: 0 15px 15px 15px;
+				      margin: 0 auto 2rem auto;
+				      box-sizing: border-box;
+				    }
+				    </style>
+				  </head>
+				  <body>
+				    <div class="content">
+				      <form class="login-form" method="post" action="null">
+				        <h2>Please sign in</h2>
+				        <div class="alert alert-danger" role="alert">Bad credentials</div>
+				        <p>
+				          <label for="username" class="screenreader">Username</label>
+				          <input type="text" id="username" name="username" placeholder="Username" required autofocus>
+				        </p>
+				        <p>
+				          <label for="password" class="screenreader">Password</label>
+				          <input type="password" id="password" name="password" placeholder="Password" required>
+				        </p>
+
+
+				        <button type="submit" class="primary">Sign in</button>
+				      </form>
+
+				<h2>Login with OAuth 2.0</h2>
+				<div class="alert alert-danger" role="alert">Bad credentials</div>
+				<table class="table table-striped">
+				  <tr><td><a href="/oauth2/authorization/google">Google &lt; &gt; &quot; &#39; &amp;</a></td></tr>
+				</table>
+				<h2>Login with SAML 2.0</h2>
+				<div class="alert alert-danger" role="alert">Bad credentials</div>
+				<table class="table table-striped">
+				  <tr><td><a href="/saml/sso/google">Google &lt; &gt; &quot; &#39; &amp;</a></td></tr>
+				</table>
+				    </div>
+				  </body>
+				</html>""");
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/authentication/ui/DefaultLogoutPageGeneratingFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/ui/DefaultLogoutPageGeneratingFilterTests.java
@@ -59,4 +59,156 @@ public class DefaultLogoutPageGeneratingFilterTests {
 			.andExpect(content().string(containsString("action=\"/context/logout\"")));
 	}
 
+	@Test
+	void doFilterWhenRequestContextAndHiddenInputsSetThenRendered() throws Exception {
+		this.filter.setResolveHiddenInputs((r) -> Collections.singletonMap("_csrf", "csrf-token-1"));
+		MockMvc mockMvc = MockMvcBuilders.standaloneSetup(new Object()).addFilters(this.filter).build();
+
+		mockMvc.perform(get("/context/logout").contextPath("/context")).andExpect(content().string("""
+				<!DOCTYPE html>
+				<html lang="en">
+				  <head>
+				    <meta charset="utf-8">
+				    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+				    <meta name="description" content="">
+				    <meta name="author" content="">
+				    <title>Confirm Log Out?</title>
+				    <style>
+				    /* General layout */
+				    body {
+				      font-family: system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+				      background-color: #eee;
+				      padding: 40px 0;
+				      margin: 0;
+				      line-height: 1.5;
+				    }
+				\s\s\s\s
+				    h2 {
+				      margin-top: 0;
+				      margin-bottom: 0.5rem;
+				      font-size: 2rem;
+				      font-weight: 500;
+				      line-height: 2rem;
+				    }
+				\s\s\s\s
+				    .content {
+				      margin-right: auto;
+				      margin-left: auto;
+				      padding-right: 15px;
+				      padding-left: 15px;
+				      width: 100%;
+				      box-sizing: border-box;
+				    }
+				\s\s\s\s
+				    @media (min-width: 800px) {
+				      .content {
+				        max-width: 760px;
+				      }
+				    }
+				\s\s\s\s
+				    /* Components */
+				    a,
+				    a:visited {
+				      text-decoration: none;
+				      color: #06f;
+				    }
+				\s\s\s\s
+				    a:hover {
+				      text-decoration: underline;
+				      color: #003c97;
+				    }
+				\s\s\s\s
+				    input[type="text"],
+				    input[type="password"] {
+				      height: auto;
+				      width: 100%;
+				      font-size: 1rem;
+				      padding: 0.5rem;
+				      box-sizing: border-box;
+				    }
+				\s\s\s\s
+				    button {
+				      padding: 0.5rem 1rem;
+				      font-size: 1.25rem;
+				      line-height: 1.5;
+				      border: none;
+				      border-radius: 0.1rem;
+				      width: 100%;
+				    }
+				\s\s\s\s
+				    button.primary {
+				      color: #fff;
+				      background-color: #06f;
+				    }
+				\s\s\s\s
+				    .alert {
+				      padding: 0.75rem 1rem;
+				      margin-bottom: 1rem;
+				      line-height: 1.5;
+				      border-radius: 0.1rem;
+				      width: 100%;
+				      box-sizing: border-box;
+				      border-width: 1px;
+				      border-style: solid;
+				    }
+				\s\s\s\s
+				    .alert.alert-danger {
+				      color: #6b1922;
+				      background-color: #f7d5d7;
+				      border-color: #eab6bb;
+				    }
+				\s\s\s\s
+				    .alert.alert-success {
+				      color: #145222;
+				      background-color: #d1f0d9;
+				      border-color: #c2ebcb;
+				    }
+				\s\s\s\s
+				    .screenreader {
+				      position: absolute;
+				      clip: rect(0 0 0 0);
+				      height: 1px;
+				      width: 1px;
+				      padding: 0;
+				      border: 0;
+				      overflow: hidden;
+				    }
+				\s\s\s\s
+				    table {
+				      width: 100%;
+				      max-width: 100%;
+				      margin-bottom: 2rem;
+				    }
+				\s\s\s\s
+				    .table-striped tr:nth-of-type(2n + 1) {
+				      background-color: #e1e1e1;
+				    }
+				\s\s\s\s
+				    td {
+				      padding: 0.75rem;
+				      vertical-align: top;
+				    }
+				\s\s\s\s
+				    /* Login / logout layouts */
+				    .login-form,
+				    .logout-form {
+				      max-width: 340px;
+				      padding: 0 15px 15px 15px;
+				      margin: 0 auto 2rem auto;
+				      box-sizing: border-box;
+				    }
+				    </style>
+				  </head>
+				  <body>
+				    <div class="content">
+				      <form class="logout-form" method="post" action="/context/logout">
+				        <h2>Are you sure you want to log out?</h2>
+				        <input name="_csrf" type="hidden" value="csrf-token-1" />
+				        <button class="primary" type="submit">Log Out</button>
+				      </form>
+				    </div>
+				  </body>
+				</html>"""));
+	}
+
 }

--- a/web/src/test/java/org/springframework/security/web/authentication/ui/DefaultOneTimeTokenSubmitPageGeneratingFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/ui/DefaultOneTimeTokenSubmitPageGeneratingFilterTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.security.web.authentication.ui;
 
+import java.util.Map;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -72,8 +74,7 @@ class DefaultOneTimeTokenSubmitPageGeneratingFilterTests {
 		this.filter.setLoginProcessingUrl("/login/another");
 		this.filter.doFilterInternal(this.request, this.response, this.filterChain);
 		String response = this.response.getContentAsString();
-		assertThat(response).contains(
-				"<form class=\"login-form\" action=\"/login/another\" method=\"post\">\t<h2>Please input the token</h2>");
+		assertThat(response).contains("<form class=\"login-form\" action=\"/login/another\" method=\"post\">");
 	}
 
 	@Test
@@ -83,6 +84,170 @@ class DefaultOneTimeTokenSubmitPageGeneratingFilterTests {
 		String response = this.response.getContentAsString();
 		assertThat(response).contains(
 				"<input type=\"text\" id=\"token\" name=\"token\" value=\"this&lt;&gt;!@#&quot;\" placeholder=\"Token\" required=\"true\" autofocus=\"autofocus\"/>");
+	}
+
+	@Test
+	void filterThenRenders() throws Exception {
+		this.request.setParameter("token", "this<>!@#\"");
+		this.filter.setLoginProcessingUrl("/login/another");
+		this.filter.setResolveHiddenInputs((request) -> Map.of("_csrf", "csrf-token-value"));
+		this.filter.doFilterInternal(this.request, this.response, this.filterChain);
+		String response = this.response.getContentAsString();
+		assertThat(response).isEqualTo(
+				"""
+						<!DOCTYPE html>
+						<html lang="en">
+						  <head>
+						    <title>One-Time Token Login</title>
+						    <meta charset="utf-8"/>
+						    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+						    <meta http-equiv="Content-Security-Policy" content="script-src 'sha256-oZhLbc2kO8b8oaYLrUc7uye1MgVKMyLtPqWR4WtKF+c='"/>
+						    <style>
+						    /* General layout */
+						    body {
+						      font-family: system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+						      background-color: #eee;
+						      padding: 40px 0;
+						      margin: 0;
+						      line-height: 1.5;
+						    }
+						   \s
+						    h2 {
+						      margin-top: 0;
+						      margin-bottom: 0.5rem;
+						      font-size: 2rem;
+						      font-weight: 500;
+						      line-height: 2rem;
+						    }
+						   \s
+						    .content {
+						      margin-right: auto;
+						      margin-left: auto;
+						      padding-right: 15px;
+						      padding-left: 15px;
+						      width: 100%;
+						      box-sizing: border-box;
+						    }
+						   \s
+						    @media (min-width: 800px) {
+						      .content {
+						        max-width: 760px;
+						      }
+						    }
+						   \s
+						    /* Components */
+						    a,
+						    a:visited {
+						      text-decoration: none;
+						      color: #06f;
+						    }
+						   \s
+						    a:hover {
+						      text-decoration: underline;
+						      color: #003c97;
+						    }
+						   \s
+						    input[type="text"],
+						    input[type="password"] {
+						      height: auto;
+						      width: 100%;
+						      font-size: 1rem;
+						      padding: 0.5rem;
+						      box-sizing: border-box;
+						    }
+						   \s
+						    button {
+						      padding: 0.5rem 1rem;
+						      font-size: 1.25rem;
+						      line-height: 1.5;
+						      border: none;
+						      border-radius: 0.1rem;
+						      width: 100%;
+						    }
+						   \s
+						    button.primary {
+						      color: #fff;
+						      background-color: #06f;
+						    }
+						   \s
+						    .alert {
+						      padding: 0.75rem 1rem;
+						      margin-bottom: 1rem;
+						      line-height: 1.5;
+						      border-radius: 0.1rem;
+						      width: 100%;
+						      box-sizing: border-box;
+						      border-width: 1px;
+						      border-style: solid;
+						    }
+						   \s
+						    .alert.alert-danger {
+						      color: #6b1922;
+						      background-color: #f7d5d7;
+						      border-color: #eab6bb;
+						    }
+						   \s
+						    .alert.alert-success {
+						      color: #145222;
+						      background-color: #d1f0d9;
+						      border-color: #c2ebcb;
+						    }
+						   \s
+						    .screenreader {
+						      position: absolute;
+						      clip: rect(0 0 0 0);
+						      height: 1px;
+						      width: 1px;
+						      padding: 0;
+						      border: 0;
+						      overflow: hidden;
+						    }
+						   \s
+						    table {
+						      width: 100%;
+						      max-width: 100%;
+						      margin-bottom: 2rem;
+						    }
+						   \s
+						    .table-striped tr:nth-of-type(2n + 1) {
+						      background-color: #e1e1e1;
+						    }
+						   \s
+						    td {
+						      padding: 0.75rem;
+						      vertical-align: top;
+						    }
+						   \s
+						    /* Login / logout layouts */
+						    .login-form,
+						    .logout-form {
+						      max-width: 340px;
+						      padding: 0 15px 15px 15px;
+						      margin: 0 auto 2rem auto;
+						      box-sizing: border-box;
+						    }
+						    </style>
+						  </head>
+						  <body>
+						    <noscript>
+						      <p>
+						        <strong>Note:</strong> Since your browser does not support JavaScript, you must press the Sign In button once to proceed.
+						      </p>
+						    </noscript>
+						    <div class="container">
+						      <form class="login-form" action="/login/another" method="post">
+						        <h2>Please input the token</h2>
+						        <p>
+						          <label for="token" class="screenreader">Token</label>
+						          <input type="text" id="token" name="token" value="this&lt;&gt;!@#&quot;" placeholder="Token" required="true" autofocus="autofocus"/>
+						        </p>
+						        <button class="primary" type="submit">Sign in</button>
+						<input name="_csrf" type="hidden" value="csrf-token-value" />
+						      </form>
+						    </div>
+						  </body>
+						</html>
+						""");
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/authentication/ui/HtmlTemplatesTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/ui/HtmlTemplatesTests.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication.ui;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * @author Daniel Garnier-Moiroux
+ * @since 6.4
+ */
+class HtmlTemplatesTests {
+
+	@Test
+	void processTemplateWhenNoVariablesThenRendersTemplate() {
+		String template = """
+				<ul>
+					<li>Lorem ipsum dolor sit amet</li>
+					<li>consectetur adipiscing elit</li>
+					<li>sed do eiusmod tempor incididunt ut labore</li>
+					<li>et dolore magna aliqua</li>
+				</ul>
+				""";
+
+		assertThat(HtmlTemplates.fromTemplate(template).render()).isEqualTo(template);
+	}
+
+	@Test
+	void renderWhenVariablesThenRendersTemplate() {
+		String template = """
+				<ul>
+					<li>{{one}}</li>
+					<li>{{two}}</li>
+				</ul>
+				""";
+
+		String renderedTemplate = HtmlTemplates.fromTemplate(template)
+			.withValue("one", "Lorem ipsum dolor sit amet")
+			.withValue("two", "consectetur adipiscing elit")
+			.render();
+
+		assertThat(renderedTemplate).isEqualTo("""
+				<ul>
+					<li>Lorem ipsum dolor sit amet</li>
+					<li>consectetur adipiscing elit</li>
+				</ul>
+				""");
+	}
+
+	@Test
+	void renderWhenVariablesThenEscapedAndRender() {
+		String template = "<p>{{content}}</p>";
+
+		String renderedTemplate = HtmlTemplates.fromTemplate(template)
+			.withValue("content", "The <a> tag is very common in HTML.")
+			.render();
+
+		assertThat(renderedTemplate).isEqualTo("<p>The &lt;a&gt; tag is very common in HTML.</p>");
+	}
+
+	@Test
+	void renderWhenRawHtmlVariablesThenRendersTemplate() {
+		String template = """
+				<p>
+					The {{title}} is a placeholder text used in print.
+				</p>
+				""";
+
+		String renderedTemplate = HtmlTemplates.fromTemplate(template)
+			.withRawHtml("title", "<strong>Lorem Ipsum</strong>")
+			.render();
+
+		assertThat(renderedTemplate).isEqualTo("""
+				<p>
+					The <strong>Lorem Ipsum</strong> is a placeholder text used in print.
+				</p>
+				""");
+	}
+
+	@Test
+	void renderWhenRawHtmlVariablesThenTrimsTrailingNewline() {
+		String template = """
+				<ul>
+				{{content}}
+				</ul>
+				""";
+
+		String renderedTemplate = HtmlTemplates.fromTemplate(template)
+			.withRawHtml("content", "<li>Lorem ipsum dolor sit amet</li>".indent(2))
+			.render();
+
+		assertThat(renderedTemplate).isEqualTo("""
+				<ul>
+				  <li>Lorem ipsum dolor sit amet</li>
+				</ul>
+				""");
+	}
+
+	@Test
+	void renderWhenEmptyVariablesThenRender() {
+		String template = """
+				<li>One: {{one}}</li>
+				{{two}}
+				""";
+
+		String renderedTemplate = HtmlTemplates.fromTemplate(template)
+			.withValue("one", "")
+			.withRawHtml("two", "")
+			.render();
+
+		assertThat(renderedTemplate).isEqualTo("""
+				<li>One: </li>
+
+				""");
+	}
+
+	@Test
+	void renderWhenMissingVariablesThenThrows() {
+		String template = """
+				<li>One: {{one}}</li>
+				<li>Two: {{two}}</li>
+				{{three}}
+				""";
+
+		HtmlTemplates.Builder templateBuilder = HtmlTemplates.fromTemplate(template)
+			.withValue("one", "Lorem ipsum dolor sit amet");
+		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(templateBuilder::render)
+			.withMessage("Unused placeholders in template: [two, three]");
+	}
+
+}

--- a/web/src/test/java/org/springframework/security/web/server/ui/LoginPageGeneratingWebFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/ui/LoginPageGeneratingWebFilterTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.security.web.server.ui;
 
+import java.util.Collections;
+
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
@@ -43,6 +45,177 @@ public class LoginPageGeneratingWebFilterTests {
 		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/login"));
 		filter.filter(exchange, (e) -> Mono.empty()).block();
 		assertThat(exchange.getResponse().getBodyAsString().block()).contains("action=\"/login\"");
+	}
+
+	@Test
+	void filtersThenRendersPage() {
+		String clientName = "Google < > \" \' &";
+		LoginPageGeneratingWebFilter filter = new LoginPageGeneratingWebFilter();
+		filter.setOauth2AuthenticationUrlToClientName(
+				Collections.singletonMap("/oauth2/authorization/google", clientName));
+		filter.setFormLoginEnabled(true);
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("/test/login").contextPath("/test"));
+		filter.filter(exchange, (e) -> Mono.empty()).block();
+		assertThat(exchange.getResponse().getBodyAsString().block()).isEqualTo("""
+				<!DOCTYPE html>
+				<html lang="en">
+				  <head>
+				    <meta charset="utf-8">
+				    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+				    <meta name="description" content="">
+				    <meta name="author" content="">
+				    <title>Please sign in</title>
+				    <style>
+				    /* General layout */
+				    body {
+				      font-family: system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+				      background-color: #eee;
+				      padding: 40px 0;
+				      margin: 0;
+				      line-height: 1.5;
+				    }
+				\s\s\s\s
+				    h2 {
+				      margin-top: 0;
+				      margin-bottom: 0.5rem;
+				      font-size: 2rem;
+				      font-weight: 500;
+				      line-height: 2rem;
+				    }
+				\s\s\s\s
+				    .content {
+				      margin-right: auto;
+				      margin-left: auto;
+				      padding-right: 15px;
+				      padding-left: 15px;
+				      width: 100%;
+				      box-sizing: border-box;
+				    }
+				\s\s\s\s
+				    @media (min-width: 800px) {
+				      .content {
+				        max-width: 760px;
+				      }
+				    }
+				\s\s\s\s
+				    /* Components */
+				    a,
+				    a:visited {
+				      text-decoration: none;
+				      color: #06f;
+				    }
+				\s\s\s\s
+				    a:hover {
+				      text-decoration: underline;
+				      color: #003c97;
+				    }
+				\s\s\s\s
+				    input[type="text"],
+				    input[type="password"] {
+				      height: auto;
+				      width: 100%;
+				      font-size: 1rem;
+				      padding: 0.5rem;
+				      box-sizing: border-box;
+				    }
+				\s\s\s\s
+				    button {
+				      padding: 0.5rem 1rem;
+				      font-size: 1.25rem;
+				      line-height: 1.5;
+				      border: none;
+				      border-radius: 0.1rem;
+				      width: 100%;
+				    }
+				\s\s\s\s
+				    button.primary {
+				      color: #fff;
+				      background-color: #06f;
+				    }
+				\s\s\s\s
+				    .alert {
+				      padding: 0.75rem 1rem;
+				      margin-bottom: 1rem;
+				      line-height: 1.5;
+				      border-radius: 0.1rem;
+				      width: 100%;
+				      box-sizing: border-box;
+				      border-width: 1px;
+				      border-style: solid;
+				    }
+				\s\s\s\s
+				    .alert.alert-danger {
+				      color: #6b1922;
+				      background-color: #f7d5d7;
+				      border-color: #eab6bb;
+				    }
+				\s\s\s\s
+				    .alert.alert-success {
+				      color: #145222;
+				      background-color: #d1f0d9;
+				      border-color: #c2ebcb;
+				    }
+				\s\s\s\s
+				    .screenreader {
+				      position: absolute;
+				      clip: rect(0 0 0 0);
+				      height: 1px;
+				      width: 1px;
+				      padding: 0;
+				      border: 0;
+				      overflow: hidden;
+				    }
+				\s\s\s\s
+				    table {
+				      width: 100%;
+				      max-width: 100%;
+				      margin-bottom: 2rem;
+				    }
+				\s\s\s\s
+				    .table-striped tr:nth-of-type(2n + 1) {
+				      background-color: #e1e1e1;
+				    }
+				\s\s\s\s
+				    td {
+				      padding: 0.75rem;
+				      vertical-align: top;
+				    }
+				\s\s\s\s
+				    /* Login / logout layouts */
+				    .login-form,
+				    .logout-form {
+				      max-width: 340px;
+				      padding: 0 15px 15px 15px;
+				      margin: 0 auto 2rem auto;
+				      box-sizing: border-box;
+				    }
+				    </style>
+				  </head>
+				  <body>
+				    <div class="content">
+				      <form class="login-form" method="post" action="/test/login">
+				        <h2>Please sign in</h2>
+
+				        <p>
+				          <label for="username" class="screenreader">Username</label>
+				          <input type="text" id="username" name="username" placeholder="Username" required autofocus>
+				        </p>
+				        <p>
+				          <label for="password" class="screenreader">Password</label>
+				          <input type="password" id="password" name="password" placeholder="Password" required>
+				        </p>
+
+				        <button type="submit" class="primary">Sign in</button>
+				      </form>
+				<h2>Login with OAuth 2.0</h2>
+
+				<table class="table table-striped">
+				  <tr><td><a href="/test/oauth2/authorization/google">Google &lt; &gt; &quot; &#39; &amp;</a></td></tr>
+				</table>
+				    </div>
+				  </body>
+				</html>""");
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/server/ui/LogoutPageGeneratingWebFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/ui/LogoutPageGeneratingWebFilterTests.java
@@ -43,4 +43,12 @@ public class LogoutPageGeneratingWebFilterTests {
 		assertThat(exchange.getResponse().getBodyAsString().block()).contains("action=\"/logout\"");
 	}
 
+	@Test
+	void filterThenRendersPage() {
+		LogoutPageGeneratingWebFilter filter = new LogoutPageGeneratingWebFilter();
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("/test/logout").contextPath("/test"));
+		filter.filter(exchange, (e) -> Mono.empty()).block();
+	}
+
 }

--- a/web/src/test/java/org/springframework/security/web/server/ui/LogoutPageGeneratingWebFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/ui/LogoutPageGeneratingWebFilterTests.java
@@ -49,6 +49,151 @@ public class LogoutPageGeneratingWebFilterTests {
 		MockServerWebExchange exchange = MockServerWebExchange
 			.from(MockServerHttpRequest.get("/test/logout").contextPath("/test"));
 		filter.filter(exchange, (e) -> Mono.empty()).block();
+		assertThat(exchange.getResponse().getBodyAsString().block()).isEqualTo("""
+				<!DOCTYPE html>
+				<html lang="en">
+				  <head>
+				    <meta charset="utf-8">
+				    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+				    <meta name="description" content="">
+				    <meta name="author" content="">
+				    <title>Confirm Log Out?</title>
+				    <style>
+				    /* General layout */
+				    body {
+				      font-family: system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+				      background-color: #eee;
+				      padding: 40px 0;
+				      margin: 0;
+				      line-height: 1.5;
+				    }
+				\s\s\s\s
+				    h2 {
+				      margin-top: 0;
+				      margin-bottom: 0.5rem;
+				      font-size: 2rem;
+				      font-weight: 500;
+				      line-height: 2rem;
+				    }
+				\s\s\s\s
+				    .content {
+				      margin-right: auto;
+				      margin-left: auto;
+				      padding-right: 15px;
+				      padding-left: 15px;
+				      width: 100%;
+				      box-sizing: border-box;
+				    }
+				\s\s\s\s
+				    @media (min-width: 800px) {
+				      .content {
+				        max-width: 760px;
+				      }
+				    }
+				\s\s\s\s
+				    /* Components */
+				    a,
+				    a:visited {
+				      text-decoration: none;
+				      color: #06f;
+				    }
+				\s\s\s\s
+				    a:hover {
+				      text-decoration: underline;
+				      color: #003c97;
+				    }
+				\s\s\s\s
+				    input[type="text"],
+				    input[type="password"] {
+				      height: auto;
+				      width: 100%;
+				      font-size: 1rem;
+				      padding: 0.5rem;
+				      box-sizing: border-box;
+				    }
+				\s\s\s\s
+				    button {
+				      padding: 0.5rem 1rem;
+				      font-size: 1.25rem;
+				      line-height: 1.5;
+				      border: none;
+				      border-radius: 0.1rem;
+				      width: 100%;
+				    }
+				\s\s\s\s
+				    button.primary {
+				      color: #fff;
+				      background-color: #06f;
+				    }
+				\s\s\s\s
+				    .alert {
+				      padding: 0.75rem 1rem;
+				      margin-bottom: 1rem;
+				      line-height: 1.5;
+				      border-radius: 0.1rem;
+				      width: 100%;
+				      box-sizing: border-box;
+				      border-width: 1px;
+				      border-style: solid;
+				    }
+				\s\s\s\s
+				    .alert.alert-danger {
+				      color: #6b1922;
+				      background-color: #f7d5d7;
+				      border-color: #eab6bb;
+				    }
+				\s\s\s\s
+				    .alert.alert-success {
+				      color: #145222;
+				      background-color: #d1f0d9;
+				      border-color: #c2ebcb;
+				    }
+				\s\s\s\s
+				    .screenreader {
+				      position: absolute;
+				      clip: rect(0 0 0 0);
+				      height: 1px;
+				      width: 1px;
+				      padding: 0;
+				      border: 0;
+				      overflow: hidden;
+				    }
+				\s\s\s\s
+				    table {
+				      width: 100%;
+				      max-width: 100%;
+				      margin-bottom: 2rem;
+				    }
+				\s\s\s\s
+				    .table-striped tr:nth-of-type(2n + 1) {
+				      background-color: #e1e1e1;
+				    }
+				\s\s\s\s
+				    td {
+				      padding: 0.75rem;
+				      vertical-align: top;
+				    }
+				\s\s\s\s
+				    /* Login / logout layouts */
+				    .login-form,
+				    .logout-form {
+				      max-width: 340px;
+				      padding: 0 15px 15px 15px;
+				      margin: 0 auto 2rem auto;
+				      box-sizing: border-box;
+				    }
+				    </style>
+				  </head>
+				  <body>
+				    <div class="content">
+				      <form class="logout-form" method="post" action="/test/logout">
+				        <h2>Are you sure you want to log out?</h2>
+
+				        <button class="primary" type="submit">Log Out</button>
+				      </form>
+				    </div>
+				  </body>
+				</html>""");
 	}
 
 }


### PR DESCRIPTION
reviewer: @rwinch 

Some notes:
- ~I have not updated the tests, they still use string concatenation sometimes. I'd rather not use the templating in the tests themselves.~ Using text blocks and constants in tests.
- I have added tests that render the full document and assert equality. While they are brittle, they allow to iterate much faster by seeing what's broken.
- ~For context, checktyle / SpringLeadingWhitespace breaks when using space-indented text-blocks. There is an open issue in [spring-javaformat](https://github.com/spring-io/spring-javaformat/issues/421) ; `//@formatter:off` does not suppress the error. I have re-indented all text blocks with tabs. If we really prefer spaces, then we would need file-wide checkstyle suppressions.~ This is is Fixed in spring-javaformat 0.0.43