### PR TITLE
Fixed an error in the Servlet API Integration documentation

### DIFF
--- a/docs/modules/ROOT/pages/reactive/integrations/observability.adoc
+++ b/docs/modules/ROOT/pages/reactive/integrations/observability.adoc
@@ -127,7 +127,7 @@ public class MyApplication {
 	}
 
 	@Bean
-	ObservationRegistry<ObservationRegistry> observationRegistry() {
+	ObservationRegistry observationRegistry() {
 		ObservationRegistry registry = ObservationRegistry.create();
 		registry.observationConfig().observationHandler(new ObservationTextPublisher());
 		return registry;
@@ -157,7 +157,7 @@ class MyApplication {
 	}
 
 	@Bean
-	fun observationRegistry(): ObservationRegistry<ObservationRegistry> {
+	fun observationRegistry(): ObservationRegistry {
 		ObservationRegistry registry = ObservationRegistry.create()
 		registry.observationConfig().observationHandler(ObservationTextPublisher())
 		return registry

--- a/docs/modules/ROOT/pages/servlet/integrations/observability.adoc
+++ b/docs/modules/ROOT/pages/servlet/integrations/observability.adoc
@@ -132,7 +132,7 @@ public class MyApplication {
 	}
 
 	@Bean
-	ObservationRegistry<ObservationRegistry> observationRegistry() {
+	ObservationRegistry observationRegistry() {
 		ObservationRegistry registry = ObservationRegistry.create();
 		registry.observationConfig().observationHandler(new ObservationTextPublisher());
 		return registry;
@@ -162,7 +162,7 @@ class MyApplication {
 	}
 
 	@Bean
-	fun observationRegistry(): ObservationRegistry<ObservationRegistry> {
+	fun observationRegistry(): ObservationRegistry {
 		ObservationRegistry registry = ObservationRegistry.create()
 		registry.observationConfig().observationHandler(ObservationTextPublisher())
 		return registry

--- a/docs/modules/ROOT/pages/servlet/integrations/servlet-api.adoc
+++ b/docs/modules/ROOT/pages/servlet/integrations/servlet-api.adoc
@@ -90,8 +90,8 @@ The following section describes the Servlet 3 methods with which Spring Security
 
 
 [[servletapi-authenticate]]
-=== HttpServletRequest.authenticate(HttpServletRequest,HttpServletResponse)
-You can use the https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html#authenticate%28javax.servlet.http.HttpServletResponse%29[`HttpServletRequest.authenticate(HttpServletRequest,HttpServletResponse)`] method to ensure that a user is authenticated.
+=== HttpServletRequest.authenticate(HttpServletResponse)
+You can use the https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html#authenticate%28javax.servlet.http.HttpServletResponse%29[`HttpServletRequest.authenticate(HttpServletResponse)`] method to ensure that a user is authenticated.
 If they are not authenticated, the configured `AuthenticationEntryPoint` is used to request the user to authenticate (redirect to the login page).
 
 


### PR DESCRIPTION
In the ```Servlet 3+ Integration``` section of the ```Servlet API Integration``` document, there is an error in the method signature. The correct method signature should be [**HttpServletRequest.authenticate(HttpServletResponse)**](https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html#authenticate%28javax.servlet.http.HttpServletResponse%29).
