### PR TITLE
Remove the need for @JsonSerialize when serializing authorization proxy objects with Jackson

### DIFF
--- a/core/src/main/java/org/springframework/security/authorization/method/AuthorizationAdvisorProxyFactory.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/AuthorizationAdvisorProxyFactory.java
@@ -171,6 +171,7 @@ public final class AuthorizationAdvisorProxyFactory
 		for (Advisor advisor : this.advisors) {
 			factory.addAdvisors(advisor);
 		}
+		factory.setOpaque(true);
 		factory.setProxyTargetClass(!Modifier.isFinal(target.getClass().getModifiers()));
 		return factory.getProxy();
 	}
@@ -357,6 +358,7 @@ public final class AuthorizationAdvisorProxyFactory
 				ProxyFactory factory = new ProxyFactory();
 				factory.setTargetClass(targetClass);
 				factory.setInterfaces(ClassUtils.getAllInterfacesForClass(targetClass));
+				factory.setOpaque(true);
 				factory.setProxyTargetClass(!Modifier.isFinal(targetClass.getModifiers()));
 				for (Advisor advisor : proxyFactory) {
 					factory.addAdvisors(advisor);

--- a/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
@@ -2227,37 +2227,6 @@ class UserController  {
 ----
 ======
 
-If you are using Jackson, though, this may result in a serialization error like the following:
-
-[source,bash]
-====
-com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Direct self-reference leading to cycle
-====
-
-This is due to how Jackson works with CGLIB proxies.
-To address this, add the following annotation to the top of the `User` class:
-
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-@JsonSerialize(as = User.class)
-public class User {
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@JsonSerialize(`as` = User::class)
-class User
-----
-======
-
 Finally, you will need to publish a <<custom_advice, custom interceptor>> to catch the `AccessDeniedException` thrown for each field, which you can do like so:
 
 [tabs]


### PR DESCRIPTION
Closes gh-15661

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
