### PR TITLE
Fixed typo in the Servlet API Integration documentation

### DIFF
--- a/docs/modules/ROOT/pages/servlet/integrations/servlet-api.adoc
+++ b/docs/modules/ROOT/pages/servlet/integrations/servlet-api.adoc
@@ -90,8 +90,8 @@ The following section describes the Servlet 3 methods with which Spring Security
 
 
 [[servletapi-authenticate]]
-=== HttpServletRequest.authenticate(HttpServletRequest,HttpServletResponse)
-You can use the https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html#authenticate%28javax.servlet.http.HttpServletResponse%29[`HttpServletRequest.authenticate(HttpServletRequest,HttpServletResponse)`] method to ensure that a user is authenticated.
+=== HttpServletRequest.authenticate(HttpServletResponse)
+You can use the https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html#authenticate%28javax.servlet.http.HttpServletResponse%29[`HttpServletRequest.authenticate(HttpServletResponse)`] method to ensure that a user is authenticated.
 If they are not authenticated, the configured `AuthenticationEntryPoint` is used to request the user to authenticate (redirect to the login page).
 
 


### PR DESCRIPTION
In the [```Servlet 3+ Integration```](https://docs.spring.io/spring-security/reference/6.3/servlet/integrations/servlet-api.html#servletapi-authenticate) section of the ```Servlet API Integration``` document, there is an error in the method signature. The correct method signature should be [HttpServletRequest.authenticate(HttpServletResponse)](https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html#authenticate%28javax.servlet.http.HttpServletResponse%29).
