### PR TITLE
Fixed typos in the Servlet and Reactive Observability documents

### DIFF
--- a/docs/modules/ROOT/pages/reactive/integrations/observability.adoc
+++ b/docs/modules/ROOT/pages/reactive/integrations/observability.adoc
@@ -127,7 +127,7 @@ public class MyApplication {
 	}
 
 	@Bean
-	ObservationRegistry<ObservationRegistry> observationRegistry() {
+	ObservationRegistry observationRegistry() {
 		ObservationRegistry registry = ObservationRegistry.create();
 		registry.observationConfig().observationHandler(new ObservationTextPublisher());
 		return registry;
@@ -157,7 +157,7 @@ class MyApplication {
 	}
 
 	@Bean
-	fun observationRegistry(): ObservationRegistry<ObservationRegistry> {
+	fun observationRegistry(): ObservationRegistry {
 		ObservationRegistry registry = ObservationRegistry.create()
 		registry.observationConfig().observationHandler(ObservationTextPublisher())
 		return registry

--- a/docs/modules/ROOT/pages/servlet/integrations/observability.adoc
+++ b/docs/modules/ROOT/pages/servlet/integrations/observability.adoc
@@ -132,7 +132,7 @@ public class MyApplication {
 	}
 
 	@Bean
-	ObservationRegistry<ObservationRegistry> observationRegistry() {
+	ObservationRegistry observationRegistry() {
 		ObservationRegistry registry = ObservationRegistry.create();
 		registry.observationConfig().observationHandler(new ObservationTextPublisher());
 		return registry;
@@ -162,7 +162,7 @@ class MyApplication {
 	}
 
 	@Bean
-	fun observationRegistry(): ObservationRegistry<ObservationRegistry> {
+	fun observationRegistry(): ObservationRegistry {
 		ObservationRegistry registry = ObservationRegistry.create()
 		registry.observationConfig().observationHandler(ObservationTextPublisher())
 		return registry


### PR DESCRIPTION
In the [```Manual Configuration```](https://docs.spring.io/spring-security/reference/6.3/servlet/integrations/observability.html#observability-tracing-manual-configuration) section of the ```Servlet and Reactive Observability``` documents, the ```ObservationRegistry``` class is incorrectly written: [Type 'io. micrometer. observation. ObservationRegistry' does not have type parameters](https://javadoc.io/doc/io.micrometer/micrometer-observation/1.13.2/io/micrometer/observation/ObservationRegistry.html).
