### PR TITLE
Fix adding more implied roles in the RoleHierarchy Builder.

### DIFF
--- a/core/src/main/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImpl.java
+++ b/core/src/main/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -295,11 +295,11 @@ public class RoleHierarchyImpl implements RoleHierarchy {
 		}
 
 		private Builder addHierarchy(String role, String... impliedRoles) {
-			Set<GrantedAuthority> withPrefix = new HashSet<>();
+			Set<GrantedAuthority> withPrefix = this.hierarchy.computeIfAbsent(this.rolePrefix.concat(role),
+					(r) -> new HashSet<>());
 			for (String impliedRole : impliedRoles) {
 				withPrefix.add(new SimpleGrantedAuthority(this.rolePrefix.concat(impliedRole)));
 			}
-			this.hierarchy.put(this.rolePrefix.concat(role), withPrefix);
 			return this;
 		}
 

--- a/core/src/test/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImplTests.java
+++ b/core/src/test/java/org/springframework/security/access/hierarchicalroles/RoleHierarchyImplTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -250,6 +250,24 @@ public class RoleHierarchyImplTests {
 			.role("B")
 			.implies("C", "D")
 			.build();
+		List<GrantedAuthority> flatAuthorities = AuthorityUtils.createAuthorityList("ROLE_A");
+		List<GrantedAuthority> allAuthorities = AuthorityUtils.createAuthorityList("ROLE_A", "ROLE_B", "ROLE_C",
+				"ROLE_D");
+
+		assertThat(roleHierarchyImpl).isNotNull();
+		assertThat(roleHierarchyImpl.getReachableGrantedAuthorities(flatAuthorities))
+			.containsExactlyInAnyOrderElementsOf(allAuthorities);
+	}
+
+	@Test
+	public void testBuilderWithRepeatedRoleBuilder() {
+		RoleHierarchyImpl roleHierarchyImpl = RoleHierarchyImpl.withDefaultRolePrefix()
+			.role("A")
+			.implies("B")
+			.role("A") // Adding more implied roles to the existing role 'A'
+			.implies("C", "D")
+			.build();
+
 		List<GrantedAuthority> flatAuthorities = AuthorityUtils.createAuthorityList("ROLE_A");
 		List<GrantedAuthority> allAuthorities = AuthorityUtils.createAuthorityList("ROLE_A", "ROLE_B", "ROLE_C",
 				"ROLE_D");


### PR DESCRIPTION
_[ As requested by @marcusdacoregio in this [comment](https://github.com/spring-projects/spring-security/pull/15272#issuecomment-2317889390) ]_

When defining a RoleHierarchy you can use the text format and the Builder model.

In the text format you can specify
```
   ROLE_A > ROLE_B
   ROLE_A > ROLE_C
```
which gives 'A' both 'B' and 'C'

The same specification in the Builder
```
RoleHierarchyImpl.withDefaultRolePrefix()
    .role("A").implies("B")
    .role("A").implies("C")
    .build();

```
which gives 'A' only 'C'

Rootcause: doing `implies` wipes any previous specifications for the same source role.

This fixes that and makes the Builder behave the same as the text format.