### PR TITLE
Address unnecessary method invocation in AbstractRequestMatcherRegistry

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/AbstractRequestMatcherRegistry.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/AbstractRequestMatcherRegistry.java
@@ -628,7 +628,8 @@ public abstract class AbstractRequestMatcherRegistry<C> {
 		public boolean matches(HttpServletRequest request) {
 			String name = request.getHttpServletMapping().getServletName();
 			ServletRegistration registration = this.servletContext.getServletRegistration(name);
-			Assert.notNull(registration, () -> computeErrorMessage(this.servletContext.getServletRegistrations().values()));
+			Assert.notNull(registration,
+					() -> computeErrorMessage(this.servletContext.getServletRegistrations().values()));
 			try {
 				Class<?> clazz = Class.forName(registration.getClassName());
 				return DispatcherServlet.class.isAssignableFrom(clazz);

--- a/config/src/main/java/org/springframework/security/config/annotation/web/AbstractRequestMatcherRegistry.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/AbstractRequestMatcherRegistry.java
@@ -628,7 +628,7 @@ public abstract class AbstractRequestMatcherRegistry<C> {
 		public boolean matches(HttpServletRequest request) {
 			String name = request.getHttpServletMapping().getServletName();
 			ServletRegistration registration = this.servletContext.getServletRegistration(name);
-			Assert.notNull(registration, computeErrorMessage(this.servletContext.getServletRegistrations().values()));
+			Assert.notNull(registration, () -> computeErrorMessage(this.servletContext.getServletRegistrations().values()));
 			try {
 				Class<?> clazz = Class.forName(registration.getClassName());
 				return DispatcherServlet.class.isAssignableFrom(clazz);


### PR DESCRIPTION
Closes gh-15714

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
