### PR TITLE
Corrected AuthenticationEventPublisher Type

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/events.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/events.adoc
@@ -107,7 +107,7 @@ public AuthenticationEventPublisher authenticationEventPublisher
     Map<Class<? extends AuthenticationException>,
         Class<? extends AbstractAuthenticationFailureEvent>> mapping =
             Collections.singletonMap(FooException.class, FooEvent.class);
-    AuthenticationEventPublisher authenticationEventPublisher =
+    DefaultAuthenticationEventPublisher authenticationEventPublisher =
         new DefaultAuthenticationEventPublisher(applicationEventPublisher);
     authenticationEventPublisher.setAdditionalExceptionMappings(mapping);
     return authenticationEventPublisher;


### PR DESCRIPTION
The [AuthenticationEventPublisher](https://docs.spring.io/spring-security/site/docs/6.3.3/api/org/springframework/security/authentication/AuthenticationEventPublisher.html) interface does not provide the ```setAdditionalExceptionMappings(Map<Class<? extends AuthenticationException)``` method, and it is located in the [DefaultAuthenticationEventPublisher](https://docs.spring.io/spring-security/site/docs/6.3.3/api/org/springframework/security/authentication/DefaultAuthenticationEventPublisher.html) implementation class.
