### PR TITLE
Correct Title in logout.adoc

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/logout.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/logout.adoc
@@ -315,7 +315,7 @@ javadoc:org.springframework.security.web.authentication.logout.LogoutSuccessHand
 For example, instead of redirecting, you may want to only return a status code.
 In this case, you can provide a success handler instance, like so:
 
-.Using Clear-Site-Data to Clear Cookies
+.Customizing Logout Success to Return HTTP Status Code
 [tabs]
 ======
 Java::


### PR DESCRIPTION
Corrected the title error of the sample code in [Customizing Logout Success](https://docs.spring.io/spring-security/reference/6.3/servlet/authentication/logout.html#customizing-logout-success) section of ```Handling Logouts``` document.
