### PR TITLE
Fix getBeansWithName in global authentication configurers

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeAuthenticationProviderBeanManagerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeAuthenticationProviderBeanManagerConfigurer.java
@@ -94,7 +94,7 @@ class InitializeAuthenticationProviderBeanManagerConfigurer extends GlobalAuthen
 			String[] beanNames = InitializeAuthenticationProviderBeanManagerConfigurer.this.context
 				.getBeanNamesForType(type);
 			for (String beanName : beanNames) {
-				T bean = InitializeAuthenticationProviderBeanManagerConfigurer.this.context.getBean(beanNames[0], type);
+				T bean = InitializeAuthenticationProviderBeanManagerConfigurer.this.context.getBean(beanName, type);
 				beanWithNames.add(new BeanWithName<T>(bean, beanName));
 			}
 			return beanWithNames;

--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeUserDetailsBeanManagerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeUserDetailsBeanManagerConfigurer.java
@@ -135,7 +135,7 @@ class InitializeUserDetailsBeanManagerConfigurer extends GlobalAuthenticationCon
 			List<BeanWithName<T>> beanWithNames = new ArrayList<>();
 			String[] beanNames = InitializeUserDetailsBeanManagerConfigurer.this.context.getBeanNamesForType(type);
 			for (String beanName : beanNames) {
-				T bean = InitializeUserDetailsBeanManagerConfigurer.this.context.getBean(beanNames[0], type);
+				T bean = InitializeUserDetailsBeanManagerConfigurer.this.context.getBean(beanName, type);
 				beanWithNames.add(new BeanWithName<T>(bean, beanName));
 			}
 			return beanWithNames;


### PR DESCRIPTION
There was a small bug with `getBeansWithName` in both `InitializeAuthenticationProviderBeanManagerConfigurer` and `InitializeUserDetailsBeanManagerConfigurer`, where we returned a list containing n copies of the same bean.

This did not have any functional impact as we only ever use the list when there is only one element in it.

---

Please merge forward to main.