### PR TITLE
Spring security 6.1 : CVE-2024-29857, CVE-2024-34447 org.bouncycastle.bcpkix.jdk15on:1.70

### DIFF
--- a/crypto/spring-security-crypto.gradle
+++ b/crypto/spring-security-crypto.gradle
@@ -3,8 +3,8 @@ apply plugin: 'io.spring.convention.spring-module'
 dependencies {
 	management platform(project(":spring-security-dependencies"))
 	optional 'org.springframework:spring-jcl'
-	optional 'org.bouncycastle:bcpkix-jdk15on'
-	
+	optional 'org.bouncycastle:bcpkix-jdk18on'
+
 	testImplementation "org.assertj:assertj-core"
 	testImplementation "org.junit.jupiter:junit-jupiter-api"
 	testImplementation "org.junit.jupiter:junit-jupiter-params"

--- a/dependencies/spring-security-dependencies.gradle
+++ b/dependencies/spring-security-dependencies.gradle
@@ -57,8 +57,8 @@ dependencies {
 		api libs.org.aspectj.aspectjrt
 		api libs.org.aspectj.aspectjweaver
 		api libs.org.assertj.assertj.core
-		api libs.org.bouncycastle.bcpkix.jdk15on
-		api libs.org.bouncycastle.bcprov.jdk15on
+		api libs.org.bouncycastle.bcpkix.jdk18on
+		api libs.org.bouncycastle.bcprov.jdk18on
 		api libs.org.eclipse.jetty.jetty.server
 		api libs.org.eclipse.jetty.jetty.servlet
 		api libs.org.hamcrest

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ jakarta-websocket = "2.1.1"
 org-apache-directory-server = "1.5.5"
 org-apache-maven-resolver = "1.8.2"
 org-aspectj = "1.9.22.1"
-org-bouncycastle = "1.70"
+org-bouncycastle = "1.78.1"
 org-eclipse-jetty = "11.0.21"
 org-jetbrains-kotlin = "1.8.22"
 org-jetbrains-kotlinx = "1.6.4"
@@ -62,8 +62,8 @@ org-apereo-cas-client-cas-client-core = "org.apereo.cas.client:cas-client-core:4
 org-aspectj-aspectjrt = { module = "org.aspectj:aspectjrt", version.ref = "org-aspectj" }
 org-aspectj-aspectjweaver = { module = "org.aspectj:aspectjweaver", version.ref = "org-aspectj" }
 org-assertj-assertj-core = "org.assertj:assertj-core:3.24.2"
-org-bouncycastle-bcpkix-jdk15on = { module = "org.bouncycastle:bcpkix-jdk15on", version.ref = "org-bouncycastle" }
-org-bouncycastle-bcprov-jdk15on = { module = "org.bouncycastle:bcprov-jdk15on", version.ref = "org-bouncycastle" }
+org-bouncycastle-bcpkix-jdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "org-bouncycastle" }
+org-bouncycastle-bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "org-bouncycastle" }
 org-eclipse-jetty-jetty-server = { module = "org.eclipse.jetty:jetty-server", version.ref = "org-eclipse-jetty" }
 org-eclipse-jetty-jetty-servlet = { module = "org.eclipse.jetty:jetty-servlet", version.ref = "org-eclipse-jetty" }
 org-hamcrest = "org.hamcrest:hamcrest:2.2"


### PR DESCRIPTION
Update dependencies:
 from org.bouncycastle.bcpkix.jdk15on:1.70
 to org.bouncycastle.bcpkix.jdk18on:1.78.1

 from org.bouncycastle.bcprov.jdk15on:1.70
 to   org.bouncycastle.bcprov.jdk18on:1.78.1

 Closes gh-15780

Spring security 6.1 is in Enterprise support but we do need to update the dependency of org.bouncycastle.bcpkix.jdk15on to org.bouncycastle.bcpkix.jdk18on in order to be able to fix the https://github.com/advisories/GHSA-8xfc-gm6g-vgpv and https://github.com/advisories/GHSA-4h8f-2wvx-gg5w.

CVEs revealed by OWASP.

see : https://nvd.nist.gov/vuln/detail/CVE-2024-29857 and https://nvd.nist.gov/vuln/detail/CVE-2024-34447
