### PR TITLE
Expose getRequiresAuthenticationRequestMatcher to subclass

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/preauth/AbstractPreAuthenticatedProcessingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/preauth/AbstractPreAuthenticatedProcessingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -337,6 +337,10 @@ public abstract class AbstractPreAuthenticatedProcessingFilter extends GenericFi
 	public void setRequiresAuthenticationRequestMatcher(RequestMatcher requiresAuthenticationRequestMatcher) {
 		Assert.notNull(requiresAuthenticationRequestMatcher, "requestMatcher cannot be null");
 		this.requiresAuthenticationRequestMatcher = requiresAuthenticationRequestMatcher;
+	}
+
+	protected RequestMatcher getRequiresAuthenticationRequestMatcher() {
+		return this.requiresAuthenticationRequestMatcher;
 	}
 
 	/**


### PR DESCRIPTION
Closes gh-15785

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
