### PR TITLE
Remove trailing spaces in default UIs

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/DefaultLoginPageConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/DefaultLoginPageConfigurerTests.java
@@ -105,7 +105,7 @@ public class DefaultLoginPageConfigurerTests {
 						    <div class="content">
 						      <form class="login-form" method="post" action="/login">
 						        <h2>Please sign in</h2>
-						       \s
+
 						        <p>
 						          <label for="username" class="screenreader">Username</label>
 						          <input type="text" id="username" name="username" placeholder="Username" required autofocus>
@@ -160,7 +160,7 @@ public class DefaultLoginPageConfigurerTests {
 						    <div class="content">
 						      <form class="login-form" method="post" action="/login">
 						        <h2>Please sign in</h2>
-						        <div class="alert alert-danger" role="alert">Bad credentials</div>
+						<div class="alert alert-danger" role="alert">Bad credentials</div>
 						        <p>
 						          <label for="username" class="screenreader">Username</label>
 						          <input type="text" id="username" name="username" placeholder="Username" required autofocus>
@@ -219,7 +219,7 @@ public class DefaultLoginPageConfigurerTests {
 						    <div class="content">
 						      <form class="login-form" method="post" action="/login">
 						        <h2>Please sign in</h2>
-						        <div class="alert alert-success" role="alert">You have been signed out</div>
+						<div class="alert alert-success" role="alert">You have been signed out</div>
 						        <p>
 						          <label for="username" class="screenreader">Username</label>
 						          <input type="text" id="username" name="username" placeholder="Username" required autofocus>
@@ -286,7 +286,7 @@ public class DefaultLoginPageConfigurerTests {
 						    <div class="content">
 						      <form class="login-form" method="post" action="/login">
 						        <h2>Please sign in</h2>
-						       \s
+
 						        <p>
 						          <label for="username" class="screenreader">Username</label>
 						          <input type="text" id="username" name="username" placeholder="Username" required autofocus>

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ott/OneTimeTokenLoginConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ott/OneTimeTokenLoginConfigurerTests.java
@@ -150,7 +150,7 @@ public class OneTimeTokenLoginConfigurerTests {
 						    <div class="content">
 						      <form class="login-form" method="post" action="/login">
 						        <h2>Please sign in</h2>
-						       \s
+
 						        <p>
 						          <label for="username" class="screenreader">Username</label>
 						          <input type="text" id="username" name="username" placeholder="Username" required autofocus>
@@ -165,12 +165,12 @@ public class OneTimeTokenLoginConfigurerTests {
 						      </form>
 						      <form id="ott-form" class="login-form" method="post" action="/ott/generate">
 						        <h2>Request a One-Time Token</h2>
-						     \s
+
 						        <p>
 						          <label for="ott-username" class="screenreader">Username</label>
 						          <input type="text" id="ott-username" name="username" placeholder="Username" required>
 						        </p>
-						      <input name="_csrf" type="hidden" value="%s" />
+						<input name="_csrf" type="hidden" value="%s" />
 						        <button class="primary" type="submit" form="ott-form">Send Token</button>
 						      </form>
 

--- a/config/src/test/java/org/springframework/security/config/http/FormLoginBeanDefinitionParserTests.java
+++ b/config/src/test/java/org/springframework/security/config/http/FormLoginBeanDefinitionParserTests.java
@@ -68,7 +68,7 @@ public class FormLoginBeanDefinitionParserTests {
 				    <div class="content">
 				      <form class="login-form" method="post" action="/login">
 				        <h2>Please sign in</h2>
-				       \s
+
 				        <p>
 				          <label for="username" class="screenreader">Username</label>
 				          <input type="text" id="username" name="username" placeholder="Username" required autofocus>
@@ -115,7 +115,7 @@ public class FormLoginBeanDefinitionParserTests {
 				    <div class="content">
 				      <form class="login-form" method="post" action="/signin">
 				        <h2>Please sign in</h2>
-				       \s
+
 				        <p>
 				          <label for="username" class="screenreader">Username</label>
 				          <input type="text" id="username" name="custom_user" placeholder="Username" required autofocus>

--- a/web/src/main/java/org/springframework/security/web/authentication/ui/DefaultLoginPageGeneratingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/ui/DefaultLoginPageGeneratingFilter.java
@@ -407,7 +407,7 @@ public class DefaultLoginPageGeneratingFilter extends GenericFilterBean {
 	private static final String LOGIN_FORM_TEMPLATE = """
 			      <form class="login-form" method="post" action="{{loginUrl}}">
 			        <h2>Please sign in</h2>
-			        {{errorMessage}}{{logoutMessage}}
+			{{errorMessage}}{{logoutMessage}}
 			        <p>
 			          <label for="username" class="screenreader">Username</label>
 			          <input type="text" id="username" name="{{usernameParameter}}" placeholder="Username" required autofocus>
@@ -450,12 +450,12 @@ public class DefaultLoginPageGeneratingFilter extends GenericFilterBean {
 	private static final String ONE_TIME_TEMPLATE = """
 			      <form id="ott-form" class="login-form" method="post" action="{{generateOneTimeTokenUrl}}">
 			        <h2>Request a One-Time Token</h2>
-			      {{errorMessage}}{{logoutMessage}}
+			{{errorMessage}}{{logoutMessage}}
 			        <p>
 			          <label for="ott-username" class="screenreader">Username</label>
 			          <input type="text" id="ott-username" name="username" placeholder="Username" required>
 			        </p>
-			      {{hiddenInputs}}
+			{{hiddenInputs}}
 			        <button class="primary" type="submit" form="ott-form">Send Token</button>
 			      </form>
 			""";

--- a/web/src/test/java/org/springframework/security/web/authentication/DefaultLoginPageGeneratingFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/DefaultLoginPageGeneratingFilterTests.java
@@ -199,12 +199,12 @@ public class DefaultLoginPageGeneratingFilterTests {
 		assertThat(response.getContentAsString()).contains("""
 				      <form id="ott-form" class="login-form" method="post" action="/ott/authenticate">
 				        <h2>Request a One-Time Token</h2>
-				     \s
+
 				        <p>
 				          <label for="ott-username" class="screenreader">Username</label>
 				          <input type="text" id="ott-username" name="username" placeholder="Username" required>
 				        </p>
-				     \s
+
 				        <button class="primary" type="submit" form="ott-form">Send Token</button>
 				      </form>
 				""");
@@ -244,7 +244,7 @@ public class DefaultLoginPageGeneratingFilterTests {
 				    <div class="content">
 				      <form class="login-form" method="post" action="null">
 				        <h2>Please sign in</h2>
-				        <div class="alert alert-danger" role="alert">Bad credentials</div>
+				<div class="alert alert-danger" role="alert">Bad credentials</div>
 				        <p>
 				          <label for="username" class="screenreader">Username</label>
 				          <input type="text" id="username" name="username" placeholder="Username" required autofocus>


### PR DESCRIPTION
Following gh-15723, default UIs had blank lines with only spaces. These get deleted by the spring-javaformat plugin. In order to avoid this behavior, an extra `\s` had been inserted in the tests. The reason for those `\s` is not obvious.

This commit cleans up the `\s` but changing the HTML templates.
