### PR TITLE
CVE-2024-29857, CVE-2024-34447 & CVE-2023-2976 : 

### DIFF
--- a/crypto/spring-security-crypto.gradle
+++ b/crypto/spring-security-crypto.gradle
@@ -3,8 +3,8 @@ apply plugin: 'io.spring.convention.spring-module'
 dependencies {
 	management platform(project(":spring-security-dependencies"))
 	optional 'org.springframework:spring-jcl'
-	optional 'org.bouncycastle:bcpkix-jdk15on'
-	
+	optional 'org.bouncycastle:bcpkix-jdk18on'
+
 	testImplementation "org.assertj:assertj-core"
 	testImplementation "org.junit.jupiter:junit-jupiter-api"
 	testImplementation "org.junit.jupiter:junit-jupiter-params"

--- a/dependencies/spring-security-dependencies.gradle
+++ b/dependencies/spring-security-dependencies.gradle
@@ -57,8 +57,8 @@ dependencies {
 		api libs.org.aspectj.aspectjrt
 		api libs.org.aspectj.aspectjweaver
 		api libs.org.assertj.assertj.core
-		api libs.org.bouncycastle.bcpkix.jdk15on
-		api libs.org.bouncycastle.bcprov.jdk15on
+		api libs.org.bouncycastle.bcpkix.jdk18on
+		api libs.org.bouncycastle.bcprov.jdk18on
 		api libs.org.eclipse.jetty.jetty.server
 		api libs.org.eclipse.jetty.jetty.servlet
 		api libs.org.hamcrest

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ org-eclipse-jetty = "11.0.21"
 org-jetbrains-kotlin = "1.8.22"
 org-jetbrains-kotlinx = "1.6.4"
 org-mockito = "4.8.1"
-org-opensaml = "4.1.1"
+org-opensaml = "4.3.2"
 org-springframework = "6.0.20"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ jakarta-websocket = "2.1.1"
 org-apache-directory-server = "1.5.5"
 org-apache-maven-resolver = "1.8.2"
 org-aspectj = "1.9.22.1"
-org-bouncycastle = "1.70"
+org-bouncycastle = "1.78.1"
 org-eclipse-jetty = "11.0.21"
 org-jetbrains-kotlin = "1.8.22"
 org-jetbrains-kotlinx = "1.6.4"
@@ -62,8 +62,8 @@ org-apereo-cas-client-cas-client-core = "org.apereo.cas.client:cas-client-core:4
 org-aspectj-aspectjrt = { module = "org.aspectj:aspectjrt", version.ref = "org-aspectj" }
 org-aspectj-aspectjweaver = { module = "org.aspectj:aspectjweaver", version.ref = "org-aspectj" }
 org-assertj-assertj-core = "org.assertj:assertj-core:3.24.2"
-org-bouncycastle-bcpkix-jdk15on = { module = "org.bouncycastle:bcpkix-jdk15on", version.ref = "org-bouncycastle" }
-org-bouncycastle-bcprov-jdk15on = { module = "org.bouncycastle:bcprov-jdk15on", version.ref = "org-bouncycastle" }
+org-bouncycastle-bcpkix-jdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "org-bouncycastle" }
+org-bouncycastle-bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "org-bouncycastle" }
 org-eclipse-jetty-jetty-server = { module = "org.eclipse.jetty:jetty-server", version.ref = "org-eclipse-jetty" }
 org-eclipse-jetty-jetty-servlet = { module = "org.eclipse.jetty:jetty-servlet", version.ref = "org-eclipse-jetty" }
 org-hamcrest = "org.hamcrest:hamcrest:2.2"

--- a/saml2/saml2-service-provider/spring-security-saml2-service-provider.gradle
+++ b/saml2/saml2-service-provider/spring-security-saml2-service-provider.gradle
@@ -15,6 +15,15 @@ dependencies {
 
 	optional 'com.fasterxml.jackson.core:jackson-databind'
 
+	dependencies {
+		implementation 'org.opensaml:opensaml-core'
+		constraints {
+			implementation('com.google.guava:guava:32.0.1-jre') {
+				because 'CVE-2023-2976'
+			}
+		}
+	}
+
 	testImplementation 'com.squareup.okhttp3:mockwebserver'
 	testImplementation "org.assertj:assertj-core"
 	testImplementation "org.skyscreamer:jsonassert"


### PR DESCRIPTION
The CVE-2024-29857 and CVE-2024-34447 are fixed, except for "spring-security-cas".

because of the dependency "org.apereo.cas.client:cas-client-core", the highest available version is 4.0.4.

CVE-2023-2976 : The dependency opensaml-core:4.3.2 bring a vulnerability with guava:31.1-jre, I override the dependency using the 32.0.1 version.

