### PR TITLE
Docs ->  Servlet Applications Authentication  -> Form Login & Persistence 

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/passwords/form.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/passwords/form.adoc
@@ -26,7 +26,7 @@ image:{icondir}/number_4.png[] The browser requests the login page to which it w
 image:{icondir}/number_5.png[] Something within the application, must <<servlet-authentication-form-custom,render the login page>>.
 
 [[servlet-authentication-usernamepasswordauthenticationfilter]]
-When the username and password are submitted, the `UsernamePasswordAuthenticationFilter` authenticates the username and password.
+When the username and password are submitted, the `UsernamePasswordAuthenticationFilter` creates a `UsernamePasswordAuthenticationToken` which is a type of https://docs.spring.io/spring-security/reference/servlet/authentication/architecture.html#servlet-authentication-authentication[Authentication], by extracting the username and password from the `HttpServletRequest` instance.
 The `UsernamePasswordAuthenticationFilter` extends xref:servlet/authentication/architecture.adoc#servlet-authentication-abstractprocessingfilter[AbstractAuthenticationProcessingFilter], so the following diagram should look pretty similar:
 
 .Authenticating Username and Password

--- a/docs/modules/ROOT/pages/servlet/authentication/persistence.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/persistence.adoc
@@ -197,13 +197,14 @@ image:{icondir}/number_1.png[] Before running the rest of the application, `Secu
 
 image:{icondir}/number_2.png[] Next, the application is ran.
 
-image:{icondir}/number_3.png[] Finally, if the `SecurityContext` has changed, we save the `SecurityContext` using the `SecurityContextPersistenceRepository`.
+image:{icondir}/number_3.png[] Finally, if the `SecurityContext` has changed, we save the `SecurityContext` using the `SecurityContextRepository`.
 This means that when using `SecurityContextPersistenceFilter`, just setting the `SecurityContextHolder` will ensure that the `SecurityContext` is persisted using `SecurityContextRepository`.
 
 In some cases a response is committed and written to the client before the `SecurityContextPersistenceFilter` method completes.
 For example, if a redirect is sent to the client the response is immediately written back to the client.
 This means that establishing an `HttpSession` would not be possible in step 3 because the session id could not be included in the already written response.
-Another situation that can happen is that if a client authenticates successfully, the response is committed before `SecurityContextPersistenceFilter` completes, and the client makes a second request before the `SecurityContextPersistenceFilter` completes the wrong authentication could be present in the second request.
+Another situation that can happen is that if a client authenticates successfully, the response is committed before `SecurityContextPersistenceFilter` completes, and the client makes a second request before the `SecurityContextPersistenceFilter` completes. the wrong authentication could be present in the second request.
+
 
 To avoid these problems, the `SecurityContextPersistenceFilter` wraps both the `HttpServletRequest` and the `HttpServletResponse` to detect if the `SecurityContext` has changed and if so save the `SecurityContext` just before the response is committed.
 


### PR DESCRIPTION
### FormLogin docs change
**`UsernamePasswordAuthenticationFilter` Definition raises confusion**

as written in the docs : "When the username and password are submitted, the `UsernamePasswordAuthenticationFilter` authenticates the username and password.", It states that `UsernamePasswordAuthenticationFilter ` is responsible for Authenticating users and populating the `SecurityContext`. instead as stated later we read : "`UsernamePasswordAuthenticationFilter` creates a `UsernamePasswordAuthenticationToken`, which is a type of [Authentication](https://docs.spring.io/spring-security/reference/servlet/authentication/architecture.html#servlet-authentication-authentication), by extracting the username and password from the HttpServletRequest instance."
I think we should change the docs so it wouldn't raise any confusions. 

### Wrong Class reference 
**`SecurityContextPersistenceRepository`** is not a recognized class, it's a typo for `SecurityContextRepository`

