### PR TITLE
Complete HttpSecurity Deprecation notices

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
@@ -1112,7 +1112,8 @@ public final class HttpSecurity extends AbstractConfiguredSecurityBuilder<Defaul
 	 * </pre>
 	 * @return the {@link ExpressionUrlAuthorizationConfigurer} for further customizations
 	 * @throws Exception
-	 * @deprecated For removal in 7.0. Use {@link #authorizeHttpRequests(Customizer)} instead
+	 * @deprecated For removal in 7.0. Use {@link #authorizeHttpRequests(Customizer)}
+	 * instead
 	 */
 	@Deprecated(since = "6.1", forRemoval = true)
 	public ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry authorizeRequests()
@@ -1227,7 +1228,8 @@ public final class HttpSecurity extends AbstractConfiguredSecurityBuilder<Defaul
 	 * for the {@link ExpressionUrlAuthorizationConfigurer.ExpressionInterceptUrlRegistry}
 	 * @return the {@link HttpSecurity} for further customizations
 	 * @throws Exception
-	 * @deprecated For removal in 7.0. Use {@link #authorizeHttpRequests(Customizer)} instead
+	 * @deprecated For removal in 7.0. Use {@link #authorizeHttpRequests(Customizer)}
+	 * instead
 	 */
 	@Deprecated(since = "6.1", forRemoval = true)
 	public HttpSecurity authorizeRequests(

--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
@@ -1112,9 +1112,9 @@ public final class HttpSecurity extends AbstractConfiguredSecurityBuilder<Defaul
 	 * </pre>
 	 * @return the {@link ExpressionUrlAuthorizationConfigurer} for further customizations
 	 * @throws Exception
-	 * @deprecated For removal in 7.0. Use {@link #authorizeHttpRequests()} instead
+	 * @deprecated For removal in 7.0. Use {@link #authorizeHttpRequests(Customizer)} instead
 	 */
-	@Deprecated
+	@Deprecated(since = "6.1", forRemoval = true)
 	public ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry authorizeRequests()
 			throws Exception {
 		ApplicationContext context = getContext();
@@ -1227,9 +1227,9 @@ public final class HttpSecurity extends AbstractConfiguredSecurityBuilder<Defaul
 	 * for the {@link ExpressionUrlAuthorizationConfigurer.ExpressionInterceptUrlRegistry}
 	 * @return the {@link HttpSecurity} for further customizations
 	 * @throws Exception
-	 * @deprecated For removal in 7.0. Use {@link #authorizeHttpRequests} instead
+	 * @deprecated For removal in 7.0. Use {@link #authorizeHttpRequests(Customizer)} instead
 	 */
-	@Deprecated
+	@Deprecated(since = "6.1", forRemoval = true)
 	public HttpSecurity authorizeRequests(
 			Customizer<ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry> authorizeRequestsCustomizer)
 			throws Exception {


### PR DESCRIPTION
This is a follow-up to https://github.com/spring-projects/spring-security/pull/13010

At that time, existing deprecation notices were upgraded to 'for removal', yet:
1. The annotation itself was not updated to reflect 'for removal'
2. Further, they both suggest migrating to a method that is _also_ deprecated and slated for removal.

Those two issues combine to create a humorous situation where a deprecation _**warning**_ turns into a deprecation _**error**_ if you follow the advice.
