### PR TITLE
Remove unnecessary parentheses and add static final field MockPortResolver#getServerPort

### DIFF
--- a/web/src/test/java/org/springframework/security/MockPortResolver.java
+++ b/web/src/test/java/org/springframework/security/MockPortResolver.java
@@ -24,8 +24,11 @@ import org.springframework.security.web.PortResolver;
  * Always returns the constructor-specified HTTP and HTTPS ports.
  *
  * @author Ben Alex
+ * @author nomoreFt
  */
 public class MockPortResolver implements PortResolver {
+
+	private static final String HTTPS_SCHEME = "https";
 
 	private int http = 80;
 
@@ -38,7 +41,7 @@ public class MockPortResolver implements PortResolver {
 
 	@Override
 	public int getServerPort(ServletRequest request) {
-		if ((request.getScheme() != null) && request.getScheme().equals("https")) {
+		if (request.getScheme() != null && HTTPS_SCHEME.equals(request.getScheme())) {
 			return this.https;
 		}
 		else {


### PR DESCRIPTION
### Description:
This pull request simplifies the MockPortResolver class by:

* Removing unnecessary parentheses to enhance code readability.
* Adding a static final field for the "https" scheme to improve maintainability and avoid duplication.