### PR TITLE
Fix DefaultLoginPageConfigurerTests localization failure on system language different than english

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/DefaultLoginPageConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/DefaultLoginPageConfigurerTests.java
@@ -22,12 +22,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.config.ObjectPostProcessor;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.test.SpringTestContext;
 import org.springframework.security.config.test.SpringTestContextExtension;
+import org.springframework.security.core.SpringSecurityMessageSource;
 import org.springframework.security.core.userdetails.PasswordEncodedUser;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
@@ -74,6 +76,8 @@ public class DefaultLoginPageConfigurerTests {
 
 	@Autowired
 	MockMvc mvc;
+
+	MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
 
 	@Test
 	public void getWhenFormLoginEnabledThenRedirectsToLoginPage() throws Exception {
@@ -144,6 +148,8 @@ public class DefaultLoginPageConfigurerTests {
 		this.mvc.perform(get("/login?error").session((MockHttpSession) mvcResult.getRequest().getSession())
 				.sessionAttr(csrfAttributeName, csrfToken))
 				.andExpect((result) -> {
+					String badCredentialsLocalizedMessage = this.messages
+							.getMessage("AbstractUserDetailsAuthenticationProvider.badCredentials", "Bad credentials");
 					CsrfToken token = (CsrfToken) result.getRequest().getAttribute(CsrfToken.class.getName());
 					assertThat(result.getResponse().getContentAsString()).isEqualTo("""
 						<!DOCTYPE html>
@@ -160,7 +166,7 @@ public class DefaultLoginPageConfigurerTests {
 						    <div class="content">
 						      <form class="login-form" method="post" action="/login">
 						        <h2>Please sign in</h2>
-						<div class="alert alert-danger" role="alert">Bad credentials</div>
+						<div class="alert alert-danger" role="alert">%s</div>
 						        <p>
 						          <label for="username" class="screenreader">Username</label>
 						          <input type="text" id="username" name="username" placeholder="Username" required autofocus>
@@ -178,7 +184,7 @@ public class DefaultLoginPageConfigurerTests {
 
 						    </div>
 						  </body>
-						</html>""".formatted(token.getToken()));
+						</html>""".formatted(badCredentialsLocalizedMessage, token.getToken()));
 				});
 		// @formatter:on
 	}


### PR DESCRIPTION
The PR aims to fix the `DefaultLoginPageConfigurerTests.loginPageWhenErrorThenDefaultLoginPageWithError()` failure given the system language is set to something else than english.

When asserting the Bad credentials login page, the expected template contains the hardcoded "Bad credentials" message.
When the system language is other than english, this test fails locally as the actual code will produce the localized version of this page.

This PR fixes the issue adding the localized message to the expected page template in order to make sure that it will match the actual response regardless the locale setting.
