### PR TITLE
Fix BearerTokenAuthenticationToken instance creation validation

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/BearerTokenAuthenticationToken.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/BearerTokenAuthenticationToken.java
@@ -47,7 +47,7 @@ public class BearerTokenAuthenticationToken extends AbstractAuthenticationToken 
 	 */
 	public BearerTokenAuthenticationToken(String token) {
 		super(Collections.emptyList());
-		Assert.hasText(token, "token cannot be empty");
+		Assert.notNull(token, "token cannot be null");
 		this.token = token;
 	}
 


### PR DESCRIPTION
Closes gh-15885

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
