### PR TITLE
Improve readibility of empty collection checks

### DIFF
--- a/acl/src/main/java/org/springframework/security/acls/domain/AclImpl.java
+++ b/acl/src/main/java/org/springframework/security/acls/domain/AclImpl.java
@@ -202,7 +202,7 @@ public class AclImpl implements Acl, MutableAcl, AuditableAcl, OwnershipAcl {
 	public boolean isSidLoaded(List<Sid> sids) {
 		// If loadedSides is null, this indicates all SIDs were loaded
 		// Also return true if the caller didn't specify a SID to find
-		if ((this.loadedSids == null) || (sids == null) || (sids.size() == 0)) {
+		if ((this.loadedSids == null) || (sids == null) || sids.isEmpty()) {
 			return true;
 		}
 

--- a/acl/src/main/java/org/springframework/security/acls/domain/DefaultPermissionFactory.java
+++ b/acl/src/main/java/org/springframework/security/acls/domain/DefaultPermissionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -140,7 +140,7 @@ public class DefaultPermissionFactory implements PermissionFactory {
 
 	@Override
 	public List<Permission> buildFromNames(List<String> names) {
-		if ((names == null) || (names.size() == 0)) {
+		if ((names == null) || names.isEmpty()) {
 			return Collections.emptyList();
 		}
 		List<Permission> permissions = new ArrayList<>(names.size());

--- a/config/src/main/java/org/springframework/security/config/http/UserDetailsServiceFactoryBean.java
+++ b/config/src/main/java/org/springframework/security/config/http/UserDetailsServiceFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,10 +101,10 @@ public class UserDetailsServiceFactoryBean implements ApplicationContextAware {
 	 */
 	private UserDetailsService getUserDetailsService() {
 		Map<String, ?> beans = getBeansOfType(CachingUserDetailsService.class);
-		if (beans.size() == 0) {
+		if (beans.isEmpty()) {
 			beans = getBeansOfType(UserDetailsService.class);
 		}
-		if (beans.size() == 0) {
+		if (beans.isEmpty()) {
 			throw new ApplicationContextException("No UserDetailsService registered.");
 		}
 		if (beans.size() > 1) {
@@ -124,7 +124,7 @@ public class UserDetailsServiceFactoryBean implements ApplicationContextAware {
 		// Check ancestor bean factories if they exist and the current one has none of the
 		// required type
 		BeanFactory parent = this.beanFactory.getParentBeanFactory();
-		while (parent != null && beans.size() == 0) {
+		while (parent != null && beans.isEmpty()) {
 			if (parent instanceof ListableBeanFactory) {
 				beans = ((ListableBeanFactory) parent).getBeansOfType(type);
 			}

--- a/core/src/main/java/org/springframework/security/access/intercept/RunAsManagerImpl.java
+++ b/core/src/main/java/org/springframework/security/access/intercept/RunAsManagerImpl.java
@@ -80,7 +80,7 @@ public class RunAsManagerImpl implements RunAsManager, InitializingBean {
 				newAuthorities.add(extraAuthority);
 			}
 		}
-		if (newAuthorities.size() == 0) {
+		if (newAuthorities.isEmpty()) {
 			return null;
 		}
 		// Add existing authorities

--- a/core/src/main/java/org/springframework/security/core/userdetails/jdbc/JdbcDaoImpl.java
+++ b/core/src/main/java/org/springframework/security/core/userdetails/jdbc/JdbcDaoImpl.java
@@ -182,7 +182,7 @@ public class JdbcDaoImpl extends JdbcDaoSupport implements UserDetailsService, M
 	@Override
 	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 		List<UserDetails> users = loadUsersByUsername(username);
-		if (users.size() == 0) {
+		if (users.isEmpty()) {
 			this.logger.debug("Query returned no results for user '" + username + "'");
 			throw new UsernameNotFoundException(this.messages.getMessage("JdbcDaoImpl.notFound",
 					new Object[] { username }, "Username {0} not found"));
@@ -197,7 +197,7 @@ public class JdbcDaoImpl extends JdbcDaoSupport implements UserDetailsService, M
 		}
 		List<GrantedAuthority> dbAuths = new ArrayList<>(dbAuthsSet);
 		addCustomAuthorities(user.getUsername(), dbAuths);
-		if (dbAuths.size() == 0) {
+		if (dbAuths.isEmpty()) {
 			this.logger.debug("User '" + username + "' has no authorities and will be treated as 'not found'");
 			throw new UsernameNotFoundException(this.messages.getMessage("JdbcDaoImpl.noAuthority",
 					new Object[] { username }, "User {0} has no GrantedAuthority"));

--- a/ldap/src/test/java/org/apache/directory/server/core/avltree/ArrayMarshaller.java
+++ b/ldap/src/test/java/org/apache/directory/server/core/avltree/ArrayMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ public class ArrayMarshaller<E> implements Marshaller<ArrayTree<E>> {
 	 * @param tree the tree to be marshalled
 	 */
 	public byte[] serialize(ArrayTree<E> tree) {
-		if ((tree == null) || (tree.size() == 0)) {
+		if ((tree == null) || tree.isEmpty()) {
 			return EMPTY_TREE;
 		}
 

--- a/taglibs/src/main/java/org/springframework/security/taglibs/authz/AbstractAuthorizeTag.java
+++ b/taglibs/src/main/java/org/springframework/security/taglibs/authz/AbstractAuthorizeTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the original author or authors.
+ * Copyright 2004-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -207,7 +207,7 @@ public abstract class AbstractAuthorizeTag {
 		ApplicationContext ctx = SecurityWebApplicationContextUtils
 			.findRequiredWebApplicationContext(getServletContext());
 		Map<String, WebInvocationPrivilegeEvaluator> wipes = ctx.getBeansOfType(WebInvocationPrivilegeEvaluator.class);
-		if (wipes.size() == 0) {
+		if (wipes.isEmpty()) {
 			throw new IOException(
 					"No visible WebInvocationPrivilegeEvaluator instance could be found in the application "
 							+ "context. There must be at least one in order to support the use of URL access checks in 'authorize' tags.");

--- a/taglibs/src/main/java/org/springframework/security/taglibs/authz/AccessControlListTag.java
+++ b/taglibs/src/main/java/org/springframework/security/taglibs/authz/AccessControlListTag.java
@@ -163,7 +163,7 @@ public class AccessControlListTag extends TagSupport {
 			.getParent()) {
 			map.putAll(context.getBeansOfType(type));
 		}
-		if (map.size() == 0) {
+		if (map.isEmpty()) {
 			return null;
 		}
 		if (map.size() == 1) {

--- a/web/src/main/java/org/springframework/security/web/FilterChainProxy.java
+++ b/web/src/main/java/org/springframework/security/web/FilterChainProxy.java
@@ -211,7 +211,7 @@ public class FilterChainProxy extends GenericFilterBean {
 		FirewalledRequest firewallRequest = this.firewall.getFirewalledRequest((HttpServletRequest) request);
 		HttpServletResponse firewallResponse = this.firewall.getFirewalledResponse((HttpServletResponse) response);
 		List<Filter> filters = getFilters(firewallRequest);
-		if (filters == null || filters.size() == 0) {
+		if (filters == null || filters.isEmpty()) {
 			if (logger.isTraceEnabled()) {
 				logger.trace(LogMessage.of(() -> "No security for " + requestLine(firewallRequest)));
 			}


### PR DESCRIPTION
In the current codebase, we're using .size() == 0 to check if Lists and Maps are empty. I propose changing this to .isEmpty().

Reasons for the proposed change:
1. Improved readability: .isEmpty() more clearly expresses the intent of checking whether a collection is empty.
2. Adherence to Java Collections Framework conventions: isEmpty() is the standard method for checking if a collection is empty.

If there's a specific reason for using `size() == 0` instead of `isEmpty()`, could you please share the rationale?