### PR TITLE
Catch base64 decode exception

### DIFF
--- a/web/src/main/java/org/springframework/security/web/savedrequest/CookieRequestCache.java
+++ b/web/src/main/java/org/springframework/security/web/savedrequest/CookieRequestCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,6 +74,9 @@ public class CookieRequestCache implements RequestCache {
 			return null;
 		}
 		String originalURI = decodeCookie(savedRequestCookie.getValue());
+		if (originalURI == null) {
+			return null;
+		}
 		UriComponents uriComponents = UriComponentsBuilder.fromUriString(originalURI).build();
 		DefaultSavedRequest.Builder builder = new DefaultSavedRequest.Builder();
 		int port = getPort(uriComponents);
@@ -123,8 +126,14 @@ public class CookieRequestCache implements RequestCache {
 		return Base64.getEncoder().encodeToString(cookieValue.getBytes());
 	}
 
-	private static String decodeCookie(String encodedCookieValue) {
-		return new String(Base64.getDecoder().decode(encodedCookieValue.getBytes()));
+	private String decodeCookie(String encodedCookieValue) {
+		try {
+			return new String(Base64.getDecoder().decode(encodedCookieValue.getBytes()));
+		}
+		catch (IllegalArgumentException ex) {
+			this.logger.debug("Failed decode cookie value " + encodedCookieValue);
+			return null;
+		}
 	}
 
 	private static String getCookiePath(HttpServletRequest request) {

--- a/web/src/test/java/org/springframework/security/web/savedrequest/CookieRequestCacheTests.java
+++ b/web/src/test/java/org/springframework/security/web/savedrequest/CookieRequestCacheTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -211,6 +211,16 @@ public class CookieRequestCacheTests {
 
 	private static String decodeCookie(String encodedCookieValue) {
 		return new String(Base64.getDecoder().decode(encodedCookieValue.getBytes()));
+	}
+
+	// gh-15905
+	@Test
+	public void illegalCookieValueReturnNull() {
+		CookieRequestCache cookieRequestCache = new CookieRequestCache();
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setCookies(new Cookie(DEFAULT_COOKIE_NAME, "123^456"));
+		SavedRequest savedRequest = cookieRequestCache.getRequest(request, new MockHttpServletResponse());
+		assertThat(savedRequest).isNull();
 	}
 
 }


### PR DESCRIPTION
Closes gh-15905

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->

This is also aligned with `CookieServerRequestCache`

```
onErrorResume(IllegalArgumentException.class, (ex) -> Mono.empty())
```
