### PR TITLE
Polish use getBeanProvider instead of getBeanNamesForType and getBean

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/AuthenticationConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/AuthenticationConfiguration.java
@@ -143,10 +143,8 @@ public class AuthenticationConfiguration {
 	}
 
 	private AuthenticationEventPublisher getAuthenticationEventPublisher(ApplicationContext context) {
-		if (context.getBeanNamesForType(AuthenticationEventPublisher.class).length > 0) {
-			return context.getBean(AuthenticationEventPublisher.class);
-		}
-		return this.objectPostProcessor.postProcess(new DefaultAuthenticationEventPublisher());
+		return context.getBeanProvider(AuthenticationEventPublisher.class)
+			.getIfUnique(() -> this.objectPostProcessor.postProcess(new DefaultAuthenticationEventPublisher()));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configuration/HttpSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configuration/HttpSecurityConfiguration.java
@@ -142,10 +142,8 @@ class HttpSecurityConfiguration {
 	}
 
 	private AuthenticationEventPublisher getAuthenticationEventPublisher() {
-		if (this.context.getBeanNamesForType(AuthenticationEventPublisher.class).length > 0) {
-			return this.context.getBean(AuthenticationEventPublisher.class);
-		}
-		return this.objectPostProcessor.postProcess(new DefaultAuthenticationEventPublisher());
+		return this.context.getBeanProvider(AuthenticationEventPublisher.class)
+			.getIfUnique(() -> this.objectPostProcessor.postProcess(new DefaultAuthenticationEventPublisher()));
 	}
 
 	private void applyDefaultConfigurers(HttpSecurity http) throws Exception {

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -363,12 +363,8 @@ public final class OAuth2ResourceServerConfigurer<H extends HttpSecurityBuilder<
 
 	BearerTokenResolver getBearerTokenResolver() {
 		if (this.bearerTokenResolver == null) {
-			if (this.context.getBeanNamesForType(BearerTokenResolver.class).length > 0) {
-				this.bearerTokenResolver = this.context.getBean(BearerTokenResolver.class);
-			}
-			else {
-				this.bearerTokenResolver = new DefaultBearerTokenResolver();
-			}
+			this.bearerTokenResolver = this.context.getBeanProvider(BearerTokenResolver.class)
+				.getIfUnique(DefaultBearerTokenResolver::new);
 		}
 		return this.bearerTokenResolver;
 	}
@@ -422,12 +418,8 @@ public final class OAuth2ResourceServerConfigurer<H extends HttpSecurityBuilder<
 
 		Converter<Jwt, ? extends AbstractAuthenticationToken> getJwtAuthenticationConverter() {
 			if (this.jwtAuthenticationConverter == null) {
-				if (this.context.getBeanNamesForType(JwtAuthenticationConverter.class).length > 0) {
-					this.jwtAuthenticationConverter = this.context.getBean(JwtAuthenticationConverter.class);
-				}
-				else {
-					this.jwtAuthenticationConverter = new JwtAuthenticationConverter();
-				}
+				this.jwtAuthenticationConverter = this.context.getBeanProvider(JwtAuthenticationConverter.class)
+					.getIfUnique(JwtAuthenticationConverter::new);
 			}
 			return this.jwtAuthenticationConverter;
 		}
@@ -527,10 +519,7 @@ public final class OAuth2ResourceServerConfigurer<H extends HttpSecurityBuilder<
 			if (this.authenticationConverter != null) {
 				return this.authenticationConverter;
 			}
-			if (this.context.getBeanNamesForType(OpaqueTokenAuthenticationConverter.class).length > 0) {
-				return this.context.getBean(OpaqueTokenAuthenticationConverter.class);
-			}
-			return null;
+			return this.context.getBeanProvider(OpaqueTokenAuthenticationConverter.class).getIfUnique(() -> null);
 		}
 
 		AuthenticationProvider getAuthenticationProvider() {

--- a/config/src/main/java/org/springframework/security/config/annotation/web/socket/MessageMatcherAuthorizationManagerConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/socket/MessageMatcherAuthorizationManagerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,11 +29,15 @@ final class MessageMatcherAuthorizationManagerConfiguration {
 	@Scope("prototype")
 	MessageMatcherDelegatingAuthorizationManager.Builder messageAuthorizationManagerBuilder(
 			ApplicationContext context) {
-		return MessageMatcherDelegatingAuthorizationManager.builder()
-			.simpDestPathMatcher(
-					() -> (context.getBeanNamesForType(SimpAnnotationMethodMessageHandler.class).length > 0)
-							? context.getBean(SimpAnnotationMethodMessageHandler.class).getPathMatcher()
-							: new AntPathMatcher());
+		return MessageMatcherDelegatingAuthorizationManager.builder().simpDestPathMatcher(() -> {
+			SimpAnnotationMethodMessageHandler messageHandler = context
+				.getBeanProvider(SimpAnnotationMethodMessageHandler.class)
+				.getIfUnique();
+			if (messageHandler == null) {
+				return new AntPathMatcher();
+			}
+			return messageHandler.getPathMatcher();
+		});
 	}
 
 }

--- a/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -1834,13 +1835,6 @@ public class ServerHttpSecurity {
 		catch (Exception ex) {
 			return null;
 		}
-	}
-
-	private <T> String[] getBeanNamesForTypeOrEmpty(Class<T> beanClass) {
-		if (this.context == null) {
-			return new String[0];
-		}
-		return this.context.getBeanNamesForType(beanClass);
 	}
 
 	protected void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
@@ -5376,16 +5370,9 @@ public class ServerHttpSecurity {
 			}
 
 			protected Converter<Jwt, ? extends Mono<? extends AbstractAuthenticationToken>> getJwtAuthenticationConverter() {
-				if (this.jwtAuthenticationConverter != null) {
-					return this.jwtAuthenticationConverter;
-				}
-
-				if (getBeanNamesForTypeOrEmpty(ReactiveJwtAuthenticationConverter.class).length > 0) {
-					return getBean(ReactiveJwtAuthenticationConverter.class);
-				}
-				else {
-					return new ReactiveJwtAuthenticationConverter();
-				}
+				return Objects.requireNonNullElseGet(this.jwtAuthenticationConverter,
+						() -> ServerHttpSecurity.this.context.getBeanProvider(ReactiveJwtAuthenticationConverter.class)
+							.getIfUnique(ReactiveJwtAuthenticationConverter::new));
 			}
 
 			private ReactiveAuthenticationManager getAuthenticationManager() {


### PR DESCRIPTION
1. Use getBeanProvider instead of the similar code below

```
	if (this.context.getBeanNamesForType(A.class).length > 0) {
		this.bearerTokenResolver = this.context.getBean(A.class);
	}
	else {
		this.bearerTokenResolver = new A();
	}
```

2. In addition, also can avoid run error when define multiple Bean in contexts