### PR TITLE
Make RequestMatcherDelegatingAuthorizationManager post-processable

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/AuthorizeHttpRequestsConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/AuthorizeHttpRequestsConfigurer.java
@@ -171,7 +171,8 @@ public final class AuthorizeHttpRequestsConfigurer<H extends HttpSecurityBuilder
 			Assert.state(this.mappingCount > 0,
 					"At least one mapping is required (for example, authorizeHttpRequests().anyRequest().authenticated())");
 			ObservationRegistry registry = getObservationRegistry();
-			RequestMatcherDelegatingAuthorizationManager manager = postProcess(this.managerBuilder.build());
+			AuthorizationManager<HttpServletRequest> manager = postProcess(
+					(AuthorizationManager<HttpServletRequest>) this.managerBuilder.build());
 			if (registry.isNoop()) {
 				return manager;
 			}

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/AuthorizeHttpRequestsConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/AuthorizeHttpRequestsConfigurerTests.java
@@ -153,6 +153,7 @@ public class AuthorizeHttpRequestsConfigurerTests {
 		this.spring.register(ObjectPostProcessorConfig.class).autowire();
 		ObjectPostProcessor objectPostProcessor = this.spring.getContext().getBean(ObjectPostProcessor.class);
 		verify(objectPostProcessor).postProcess(any(RequestMatcherDelegatingAuthorizationManager.class));
+		verify(objectPostProcessor).postProcess(any(AuthorizationManager.class));
 		verify(objectPostProcessor).postProcess(any(AuthorizationFilter.class));
 	}
 


### PR DESCRIPTION
Fix extensibility issue since [RequestMatcherDelegatingAuthorizationManager](https://github.com/spring-projects/spring-security/blob/main/web/src/main/java/org/springframework/security/web/access/intercept/RequestMatcherDelegatingAuthorizationManager.java) is `final` and does not expose any public methods other than what is available through [AuthorizationManager](https://github.com/spring-projects/spring-security/blob/main/core/src/main/java/org/springframework/security/authorization/AuthorizationManager.java). Fixes #15948

Allows the following:

```java 
http.authorizeHttpRequests((authorize) -> authorize
    .requestMatchers("/assets/**", "/logout").permitAll()
    .anyRequest().permitAll().withObjectPostProcessor(new ObjectPostProcessor<AuthorizationManager<HttpServletRequest>>() {
        @Override
         public <O extends AuthorizationManager<HttpServletRequest>> O postProcess(O object) {
            return (O) new WrappedRequestMatcherDelegatingAuthorizationManager(context, object);
        }
    })
);
```

which opens up the possibility to provide additional security checks such as Controller annotations by wrapping the current manager and using the outcome of is authorization check to be compared against other checks.

This works similar to what is already possible with the ObjectPostProcessor for [AuthorizationFilter](https://github.com/spring-projects/spring-security/blob/main/web/src/main/java/org/springframework/security/web/access/intercept/AuthorizationFilter.java) except unlike [RequestMatcherDelegatingAuthorizationManager](https://github.com/spring-projects/spring-security/blob/main/web/src/main/java/org/springframework/security/web/access/intercept/RequestMatcherDelegatingAuthorizationManager.java), [AuthorizationFilter](https://github.com/spring-projects/spring-security/blob/main/web/src/main/java/org/springframework/security/web/access/intercept/AuthorizationFilter.java) is not `final` and can be extended. 

There is no benefit in post processing a `final` class that doesn't not expose any additional information that is not already provided by it's interface [AuthorizationManager<HttpServletRequest>](https://github.com/spring-projects/spring-security/blob/main/core/src/main/java/org/springframework/security/authorization/AuthorizationManager.java)

Alternatively, you could just remove `final` from 
https://github.com/spring-projects/spring-security/blob/8a972917fadb730264ee0d7da06e61d13837df2a/web/src/main/java/org/springframework/security/web/access/intercept/RequestMatcherDelegatingAuthorizationManager.java#L49
but either solution works. 