### PR TITLE
github-actions: configure PR workflow to publish anonymous build scans

### DIFF
--- a/.github/workflows/pr-build-workflow.yml
+++ b/.github/workflows/pr-build-workflow.yml
@@ -2,9 +2,6 @@ name: PR Build
 
 on: pull_request
 
-env:
-  DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_SECRET_ACCESS_KEY }}
-
 permissions:
   contents: read
 
@@ -21,7 +18,7 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - name: Build with Gradle
-        run: ./gradlew clean build -PskipCheckExpectedBranchVersion --continue
+        run: ./gradlew clean build -PskipCheckExpectedBranchVersion --continue --scan
   generate-docs:
     name: Generate Docs
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Enable build scans on the PR workflow. Build scans should be anonymous according to our [develocity-conventions](https://github.com/spring-io/develocity-conventions?tab=readme-ov-file#anonymous-publication)
- Remove the (unmapped) `DEVELOCITY_ACCESS_KEY`