### PR TITLE
Fix saml2 authentication guide docs

### DIFF
--- a/docs/modules/ROOT/pages/servlet/saml2/login/authentication.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/login/authentication.adoc
@@ -139,7 +139,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         OpenSaml4AuthenticationProvider authenticationProvider = new OpenSaml4AuthenticationProvider();
         authenticationProvider.setAssertionValidator(OpenSaml4AuthenticationProvider
-                .createDefaultAssertionValidator(assertionToken -> {
+                .createDefaultAssertionValidatorWithParameters(assertionToken -> {
                     Map<String, Object> params = new HashMap<>();
                     params.put(CLOCK_SKEW, Duration.ofMinutes(10).toMillis());
                     // ... other validation parameters
@@ -171,7 +171,7 @@ open class SecurityConfig {
         val authenticationProvider = OpenSaml4AuthenticationProvider()
         authenticationProvider.setAssertionValidator(
             OpenSaml4AuthenticationProvider
-                .createDefaultAssertionValidator(Converter<OpenSaml4AuthenticationProvider.AssertionToken, ValidationContext> {
+                .createDefaultAssertionValidatorWithParameters(Converter<OpenSaml4AuthenticationProvider.AssertionToken, ValidationContext> {
                     val params: MutableMap<String, Any> = HashMap()
                     params[CLOCK_SKEW] =
                         Duration.ofMinutes(10).toMillis()


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->

Currently, this method([createDefaultAssertionValidator](https://github.com/spring-projects/spring-security/blob/51c06a53faf821396fbd0f9c166c7cad19f7cbfb/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/authentication/OpenSaml4AuthenticationProvider.java#L489)) of deprecated is recommended in this saml2 document. 
I have corrected this.