### PR TITLE
Do not validate parameters in `ServerBearerTokenAuthenticationConverter` and `DefaultBearerTokenResolver` if not enabled

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
@@ -1560,12 +1560,15 @@ public class OAuth2ResourceServerConfigurerTests {
 		@Bean
 		SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 			// @formatter:off
+			DefaultBearerTokenResolver defaultBearerTokenResolver = new DefaultBearerTokenResolver();
+			defaultBearerTokenResolver.setAllowUriQueryParameter(true);
 			http
 				.authorizeRequests()
 					.requestMatchers("/requires-read-scope").access("hasAuthority('SCOPE_message:read')")
 					.anyRequest().authenticated()
 					.and()
 				.oauth2ResourceServer()
+					.bearerTokenResolver(defaultBearerTokenResolver)
 					.jwt()
 						.jwkSetUri(this.jwkSetUri);
 			return http.build();

--- a/config/src/test/resources/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParserTests-JwkSetUri.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParserTests-JwkSetUri.xml
@@ -25,10 +25,15 @@
 
 	<c:property-placeholder local-override="true"/>
 
+	<b:bean id="bearerTokenResolver"
+			class="org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver">
+		<b:property name="allowUriQueryParameter" value="true"/>
+	</b:bean>
+
 	<http>
 		<intercept-url pattern="/**" access="authenticated"/>
 		<intercept-url pattern="/requires-read-scope" access="hasAuthority('SCOPE_message:read')"/>
-		<oauth2-resource-server>
+		<oauth2-resource-server bearer-token-resolver-ref="bearerTokenResolver">
 			<jwt jwk-set-uri="${jwk-set-uri:https://idp.example.org}"/>
 		</oauth2-resource-server>
 	</http>

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
@@ -53,8 +53,8 @@ public final class DefaultBearerTokenResolver implements BearerTokenResolver {
 	@Override
 	public String resolve(final HttpServletRequest request) {
 		final String authorizationHeaderToken = resolveFromAuthorizationHeader(request);
-		final String parameterToken = isParameterTokenEnabledForRequest(request)
-				? resolveFromRequestParameters(request) : null;
+		final String parameterToken = resolveFromRequestParameters(request);
+
 		if (authorizationHeaderToken != null) {
 			if (parameterToken != null) {
 				BearerTokenError error = BearerTokenErrors
@@ -65,7 +65,7 @@ public final class DefaultBearerTokenResolver implements BearerTokenResolver {
 		}
 		if (parameterToken != null && !StringUtils.hasText(parameterToken)) {
 			BearerTokenError error = BearerTokenErrors
-											 .invalidRequest("The requested token parameter is an empty string");
+				.invalidRequest("The requested token parameter is an empty string");
 			throw new OAuth2AuthenticationException(error);
 		}
 		return parameterToken;
@@ -119,7 +119,10 @@ public final class DefaultBearerTokenResolver implements BearerTokenResolver {
 		return matcher.group("token");
 	}
 
-	private static String resolveFromRequestParameters(HttpServletRequest request) {
+	private String resolveFromRequestParameters(HttpServletRequest request) {
+		if (!isParameterTokenEnabledForRequest(request)) {
+			return null;
+		}
 		String[] values = request.getParameterValues(ACCESS_TOKEN_PARAMETER_NAME);
 		if (values == null || values.length == 0) {
 			return null;

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ public final class DefaultBearerTokenResolver implements BearerTokenResolver {
 	@Override
 	public String resolve(final HttpServletRequest request) {
 		final String authorizationHeaderToken = resolveFromAuthorizationHeader(request);
-		final String parameterToken = isParameterTokenSupportedForRequest(request)
+		final String parameterToken = isParameterTokenEnabledForRequest(request)
 				? resolveFromRequestParameters(request) : null;
 		if (authorizationHeaderToken != null) {
 			if (parameterToken != null) {
@@ -63,10 +63,7 @@ public final class DefaultBearerTokenResolver implements BearerTokenResolver {
 			}
 			return authorizationHeaderToken;
 		}
-		if (parameterToken != null && isParameterTokenEnabledForRequest(request)) {
-			return parameterToken;
-		}
-		return null;
+		return parameterToken;
 	}
 
 	/**
@@ -127,10 +124,6 @@ public final class DefaultBearerTokenResolver implements BearerTokenResolver {
 		}
 		BearerTokenError error = BearerTokenErrors.invalidRequest("Found multiple bearer tokens in the request");
 		throw new OAuth2AuthenticationException(error);
-	}
-
-	private boolean isParameterTokenSupportedForRequest(final HttpServletRequest request) {
-		return isFormEncodedRequest(request) || isGetRequest(request);
 	}
 
 	private static boolean isGetRequest(HttpServletRequest request) {

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverter.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverter.java
@@ -79,7 +79,7 @@ public class ServerBearerTokenAuthenticationConverter implements ServerAuthentic
 		}
 		if (parameterToken != null && !StringUtils.hasText(parameterToken)) {
 			BearerTokenError error = BearerTokenErrors
-											 .invalidRequest("The requested token parameter is an empty string");
+				.invalidRequest("The requested token parameter is an empty string");
 			throw new OAuth2AuthenticationException(error);
 		}
 		return parameterToken;

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverter.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,13 +77,13 @@ public class ServerBearerTokenAuthenticationConverter implements ServerAuthentic
 			}
 			return authorizationHeaderToken;
 		}
-		if (parameterToken != null && isParameterTokenSupportedForRequest(request)) {
-			return parameterToken;
-		}
-		return null;
+		return parameterToken;
 	}
 
-	private static String resolveAccessTokenFromRequest(ServerHttpRequest request) {
+	private String resolveAccessTokenFromRequest(ServerHttpRequest request) {
+		if (!isParameterTokenSupportedForRequest(request)) {
+			return null;
+		}
 		List<String> parameterTokens = request.getQueryParams().get("access_token");
 		if (CollectionUtils.isEmpty(parameterTokens)) {
 			return null;

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
@@ -239,7 +239,6 @@ public class DefaultBearerTokenResolverTests {
 
 	@Test
 	public void resolveWhenFormParameterIsPresentAndNotSupportedThenTokenIsNotResolved() {
-		this.resolver.setAllowFormEncodedBodyParameter(false);
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("POST");
 		request.setContentType("application/x-www-form-urlencoded");
@@ -269,7 +268,6 @@ public class DefaultBearerTokenResolverTests {
 	// gh-16038
 	@Test
 	void resolveWhenRequestContainsTwoAccessTokenFormParametersAndSupportIsDisabledThenTokenIsNotResolved() {
-		this.resolver.setAllowFormEncodedBodyParameter(false);
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("POST");
 		request.setContentType("application/x-www-form-urlencoded");
@@ -279,11 +277,9 @@ public class DefaultBearerTokenResolverTests {
 
 	// gh-16038
 	@Test
-	void resolveWhenRequestContainsTwoAccessTokenQueryParameterAndSupportIsDisabledThenTokenIsNotResolved() {
-		this.resolver.setAllowUriQueryParameter(false);
+	void resolveWhenRequestContainsTwoAccessTokenQueryParametersAndSupportIsDisabledThenTokenIsNotResolved() {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("GET");
-		request.setQueryString("access_token=" + TEST_TOKEN);
 		request.addParameter("access_token", "token1", "token2");
 		assertThat(this.resolver.resolve(request)).isNull();
 	}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,6 +107,7 @@ public class DefaultBearerTokenResolverTests {
 
 	@Test
 	public void resolveWhenValidHeaderIsPresentTogetherWithFormParameterThenAuthenticationExceptionIsThrown() {
+		this.resolver.setAllowFormEncodedBodyParameter(true);
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addHeader("Authorization", "Bearer " + TEST_TOKEN);
 		request.setMethod("POST");
@@ -118,6 +119,7 @@ public class DefaultBearerTokenResolverTests {
 
 	@Test
 	public void resolveWhenValidHeaderIsPresentTogetherWithQueryParameterThenAuthenticationExceptionIsThrown() {
+		this.resolver.setAllowUriQueryParameter(true);
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addHeader("Authorization", "Bearer " + TEST_TOKEN);
 		request.setMethod("GET");
@@ -130,6 +132,7 @@ public class DefaultBearerTokenResolverTests {
 	// gh-10326
 	@Test
 	public void resolveWhenRequestContainsTwoAccessTokenQueryParametersThenAuthenticationExceptionIsThrown() {
+		this.resolver.setAllowUriQueryParameter(true);
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("GET");
 		request.addParameter("access_token", "token1", "token2");
@@ -140,6 +143,7 @@ public class DefaultBearerTokenResolverTests {
 	// gh-10326
 	@Test
 	public void resolveWhenRequestContainsTwoAccessTokenFormParametersThenAuthenticationExceptionIsThrown() {
+		this.resolver.setAllowFormEncodedBodyParameter(true);
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("POST");
 		request.setContentType("application/x-www-form-urlencoded");
@@ -232,6 +236,7 @@ public class DefaultBearerTokenResolverTests {
 
 	@Test
 	public void resolveWhenFormParameterIsPresentAndNotSupportedThenTokenIsNotResolved() {
+		this.resolver.setAllowFormEncodedBodyParameter(false);
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("POST");
 		request.setContentType("application/x-www-form-urlencoded");
@@ -255,6 +260,28 @@ public class DefaultBearerTokenResolverTests {
 		request.setMethod("GET");
 		request.setQueryString("access_token=" + TEST_TOKEN);
 		request.addParameter("access_token", TEST_TOKEN);
+		assertThat(this.resolver.resolve(request)).isNull();
+	}
+
+	// gh-16038
+	@Test
+	void resolveWhenRequestContainsTwoAccessTokenFormParametersAndSupportIsDisabledThenTokenIsNotResolved() {
+		this.resolver.setAllowFormEncodedBodyParameter(false);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("POST");
+		request.setContentType("application/x-www-form-urlencoded");
+		request.addParameter("access_token", "token1", "token2");
+		assertThat(this.resolver.resolve(request)).isNull();
+	}
+
+	// gh-16038
+	@Test
+	void resolveWhenRequestContainsTwoAccessTokenQueryParameterAndSupportIsDisabledThenTokenIsNotResolved() {
+		this.resolver.setAllowUriQueryParameter(false);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("GET");
+		request.setQueryString("access_token=" + TEST_TOKEN);
+		request.addParameter("access_token", "token1", "token2");
 		assertThat(this.resolver.resolve(request)).isNull();
 	}
 

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverterTests.java
@@ -219,12 +219,12 @@ public class ServerBearerTokenAuthenticationConverterTests {
 
 	}
 
-	//gh-16038
+	// gh-16038
 	@Test
 	void resoleWhenAllowUriQueryParameterIsFalseThenQueryParameterIsIgnored() {
 		this.converter.setAllowUriQueryParameter(false);
 		MockServerHttpRequest.BaseBuilder<?> request = MockServerHttpRequest.get("/")
-																			.queryParam("access_token", TEST_TOKEN);
+			.queryParam("access_token", TEST_TOKEN);
 		assertThat(convertToToken(request)).isNull();
 	}
 

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverterTests.java
@@ -221,14 +221,6 @@ public class ServerBearerTokenAuthenticationConverterTests {
 
 	// gh-16038
 	@Test
-	void resoleWhenAllowUriQueryParameterIsFalseThenQueryParameterIsIgnored() {
-		MockServerHttpRequest.BaseBuilder<?> request = MockServerHttpRequest.get("/")
-			.queryParam("access_token", TEST_TOKEN);
-		assertThat(convertToToken(request)).isNull();
-	}
-
-	// gh-16038
-	@Test
 	void resolveWhenRequestContainsTwoAccessTokenQueryParametersAndSupportIsDisabledThenTokenIsNotResolved() {
 		MockServerHttpRequest.BaseBuilder<?> request = MockServerHttpRequest.get("/")
 			 .queryParam("access_token", TEST_TOKEN, TEST_TOKEN);

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -157,6 +157,7 @@ public class ServerBearerTokenAuthenticationConverterTests {
 	@Test
 	public void resolveWhenValidHeaderIsPresentTogetherWithQueryParameterThenAuthenticationExceptionIsThrown() {
 		// @formatter:off
+		this.converter.setAllowUriQueryParameter(true);
 		MockServerHttpRequest.BaseBuilder<?> request = MockServerHttpRequest.get("/")
 				.queryParam("access_token", TEST_TOKEN)
 				.header(HttpHeaders.AUTHORIZATION, "Bearer " + TEST_TOKEN);
@@ -205,6 +206,7 @@ public class ServerBearerTokenAuthenticationConverterTests {
 
 	@Test
 	void resolveWhenQueryParameterHasMultipleAccessTokensThenOAuth2AuthenticationException() {
+		this.converter.setAllowUriQueryParameter(true);
 		MockServerHttpRequest.BaseBuilder<?> request = MockServerHttpRequest.get("/")
 			.queryParam("access_token", TEST_TOKEN, TEST_TOKEN);
 		assertThatExceptionOfType(OAuth2AuthenticationException.class).isThrownBy(() -> convertToToken(request))
@@ -215,6 +217,15 @@ public class ServerBearerTokenAuthenticationConverterTests {
 				assertThat(error.getHttpStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
 			});
 
+	}
+
+	//gh-16038
+	@Test
+	void resoleWhenAllowUriQueryParameterIsFalseThenQueryParameterIsIgnored() {
+		this.converter.setAllowUriQueryParameter(false);
+		MockServerHttpRequest.BaseBuilder<?> request = MockServerHttpRequest.get("/")
+																			.queryParam("access_token", TEST_TOKEN);
+		assertThat(convertToToken(request)).isNull();
 	}
 
 	private BearerTokenAuthenticationToken convertToToken(MockServerHttpRequest.BaseBuilder<?> request) {

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverterTests.java
@@ -222,7 +222,6 @@ public class ServerBearerTokenAuthenticationConverterTests {
 	// gh-16038
 	@Test
 	void resoleWhenAllowUriQueryParameterIsFalseThenQueryParameterIsIgnored() {
-		this.converter.setAllowUriQueryParameter(false);
 		MockServerHttpRequest.BaseBuilder<?> request = MockServerHttpRequest.get("/")
 			.queryParam("access_token", TEST_TOKEN);
 		assertThat(convertToToken(request)).isNull();

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverterTests.java
@@ -223,7 +223,7 @@ public class ServerBearerTokenAuthenticationConverterTests {
 	@Test
 	void resolveWhenRequestContainsTwoAccessTokenQueryParametersAndSupportIsDisabledThenTokenIsNotResolved() {
 		MockServerHttpRequest.BaseBuilder<?> request = MockServerHttpRequest.get("/")
-			 .queryParam("access_token", TEST_TOKEN, TEST_TOKEN);
+			.queryParam("access_token", TEST_TOKEN, TEST_TOKEN);
 		assertThat(convertToToken(request)).isNull();
 	}
 

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverterTests.java
@@ -227,6 +227,14 @@ public class ServerBearerTokenAuthenticationConverterTests {
 		assertThat(convertToToken(request)).isNull();
 	}
 
+	// gh-16038
+	@Test
+	void resolveWhenRequestContainsTwoAccessTokenQueryParametersAndSupportIsDisabledThenTokenIsNotResolved() {
+		MockServerHttpRequest.BaseBuilder<?> request = MockServerHttpRequest.get("/")
+			 .queryParam("access_token", TEST_TOKEN, TEST_TOKEN);
+		assertThat(convertToToken(request)).isNull();
+	}
+
 	private BearerTokenAuthenticationToken convertToToken(MockServerHttpRequest.BaseBuilder<?> request) {
 		return convertToToken(request.build());
 	}


### PR DESCRIPTION
Closes issue: https://github.com/spring-projects/spring-security/issues/16038 
