### PR TITLE
Add getDelegate() method to ObservationAuthenticationManager

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/ObservationAuthenticationManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/ObservationAuthenticationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,16 @@ public final class ObservationAuthenticationManager implements AuthenticationMan
 	public void setObservationConvention(ObservationConvention<AuthenticationObservationContext> convention) {
 		Assert.notNull(convention, "The observation convention cannot be null");
 		this.convention = convention;
+	}
+
+	/**
+	 * Gets the delegate
+	 * @return The delegate
+	 *
+	 * @since 6.4
+	 */
+	public AuthenticationManager getDelegate() {
+		return this.delegate;
 	}
 
 }

--- a/core/src/test/java/org/springframework/security/authentication/ObservationAuthenticationManagerTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/ObservationAuthenticationManagerTests.java
@@ -99,4 +99,9 @@ public class ObservationAuthenticationManagerTests {
 			.isThrownBy(() -> this.tested.setObservationConvention(null));
 	}
 
+	@Test
+	void getDelegate() {
+		assertThat(this.tested.getDelegate()).isSameAs(this.authenticationManager);
+	}
+
 }


### PR DESCRIPTION
Add a getDelegate() method to ObservationAuthenticationManager to get the underlying AuthenticationManager.

This may be useful when configuring security if you need to get the ProviderManager to customize it. If you try to get it from HttpSecurity.getSharedObject(AuthenticationManager.class) but the ProviderManager has been wrapped with an ObservationAuthenticationManager then there's no easy way to get the ProviderManager otherwise.