### PR TITLE
Fix logoutRequestRepository not set on Saml2RelyingPartyInitiatedLogoutSuccessHandler

### DIFF
--- a/config/src/main/java/org/springframework/security/config/http/Saml2LogoutBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/http/Saml2LogoutBeanDefinitionParser.java
@@ -146,6 +146,7 @@ final class Saml2LogoutBeanDefinitionParser implements BeanDefinitionParser {
 		BeanMetadataElement saml2LogoutRequestSuccessHandler = BeanDefinitionBuilder
 			.rootBeanDefinition(Saml2RelyingPartyInitiatedLogoutSuccessHandler.class)
 			.addConstructorArgValue(logoutRequestResolver)
+			.addPropertyValue("logoutRequestRepository", logoutRequestRepository)
 			.getBeanDefinition();
 		this.logoutFilter = BeanDefinitionBuilder.rootBeanDefinition(LogoutFilter.class)
 			.addConstructorArgValue(saml2LogoutRequestSuccessHandler)


### PR DESCRIPTION
When using XML to configure Spring Security for SAML, the `logoutRequestRepository` is not set on the `Saml2RelyingPartyInitiatedLogoutSuccessHandler` like it should be. See how it is properly set using [the Java DSL](https://github.com/spring-projects/spring-security/blob/2639ac6545af018fbae413f769011a923389a5c0/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurer.java#L294-L304) (:
~~~java
private Saml2RelyingPartyInitiatedLogoutFilter createRelyingPartyLogoutFilter(
		RelyingPartyRegistrationRepository registrations) {
	LogoutHandler[] logoutHandlers = this.logoutHandlers.toArray(new LogoutHandler[0]);
	Saml2RelyingPartyInitiatedLogoutSuccessHandler logoutRequestSuccessHandler = createSaml2LogoutRequestSuccessHandler(
			registrations);
	logoutRequestSuccessHandler.setLogoutRequestRepository(this.logoutRequestConfigurer.logoutRequestRepository);
	Saml2RelyingPartyInitiatedLogoutFilter logoutFilter = new Saml2RelyingPartyInitiatedLogoutFilter(
			logoutRequestSuccessHandler, logoutHandlers);
	logoutFilter.setLogoutRequestMatcher(createLogoutMatcher());
	return postProcess(logoutFilter);
}
~~~

Without this fix, SAML configurations that use custom logout request repositories do not work for RP-initiated logouts. 