### PR TITLE
Always return current ClientRegistration in `loadAuthorizedClient`

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/InMemoryOAuth2AuthorizedClientService.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/InMemoryOAuth2AuthorizedClientService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,13 @@ public final class InMemoryOAuth2AuthorizedClientService implements OAuth2Author
 		if (registration == null) {
 			return null;
 		}
-		return (T) this.authorizedClients.get(new OAuth2AuthorizedClientId(clientRegistrationId, principalName));
+		OAuth2AuthorizedClient cachedAuthorizedClient = this.authorizedClients
+			.get(new OAuth2AuthorizedClientId(clientRegistrationId, principalName));
+		if (cachedAuthorizedClient == null) {
+			return null;
+		}
+		return (T) new OAuth2AuthorizedClient(registration, cachedAuthorizedClient.getPrincipalName(),
+				cachedAuthorizedClient.getAccessToken(), cachedAuthorizedClient.getRefreshToken());
 	}
 
 	@Override

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/InMemoryReactiveOAuth2AuthorizedClientService.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/InMemoryReactiveOAuth2AuthorizedClientService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,8 +62,19 @@ public final class InMemoryReactiveOAuth2AuthorizedClientService implements Reac
 		Assert.hasText(clientRegistrationId, "clientRegistrationId cannot be empty");
 		Assert.hasText(principalName, "principalName cannot be empty");
 		return (Mono<T>) this.clientRegistrationRepository.findByRegistrationId(clientRegistrationId)
-			.map((clientRegistration) -> new OAuth2AuthorizedClientId(clientRegistrationId, principalName))
-			.flatMap((identifier) -> Mono.justOrEmpty(this.authorizedClients.get(identifier)));
+			.mapNotNull((clientRegistration) -> {
+				OAuth2AuthorizedClientId id = new OAuth2AuthorizedClientId(clientRegistrationId, principalName);
+				OAuth2AuthorizedClient cachedAuthorizedClient = this.authorizedClients.get(id);
+				if (cachedAuthorizedClient == null) {
+					return null;
+				}
+			// @formatter:off
+				return new OAuth2AuthorizedClient(clientRegistration,
+					cachedAuthorizedClient.getPrincipalName(),
+					cachedAuthorizedClient.getAccessToken(),
+					cachedAuthorizedClient.getRefreshToken());
+			// @formatter:on
+			});
 	}
 
 	@Override


### PR DESCRIPTION
This changes `InMemoryOAuth2AuthorizedClientService.loadAuthorizedClient` (and its reactive counterpart) to always return `OAuth2AuthorizedClient` instances containing the current `ClientRegistration` as obtained from the `ClientRegistrationRepository`.

Before this change, the first `ClientRegistration` instance was cached, with the effect that any changes made in the `ClientRegistrationRepository` (such as a new client secret) would not have taken effect.

Closes gh-15511

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
