### PR TITLE
Cleanup in DefaultBearerTokenResolver.java

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
@@ -53,8 +53,8 @@ public final class DefaultBearerTokenResolver implements BearerTokenResolver {
 	@Override
 	public String resolve(final HttpServletRequest request) {
 		final String authorizationHeaderToken = resolveFromAuthorizationHeader(request);
-		final String parameterToken = isParameterTokenSupportedForRequest(request)
-				? resolveFromRequestParameters(request) : null;
+		final boolean isParameterTokenSupported = isParameterTokenSupportedForRequest(request);
+		final String parameterToken = isParameterTokenSupported ? resolveFromRequestParameters(request) : null;
 		if (authorizationHeaderToken != null) {
 			if (parameterToken != null) {
 				BearerTokenError error = BearerTokenErrors
@@ -63,7 +63,7 @@ public final class DefaultBearerTokenResolver implements BearerTokenResolver {
 			}
 			return authorizationHeaderToken;
 		}
-		if (parameterToken != null && isParameterTokenEnabledForRequest(request)) {
+		if (parameterToken != null && isParameterTokenSupported) {
 			if (!StringUtils.hasText(parameterToken)) {
 				BearerTokenError error = BearerTokenErrors
 					.invalidRequest("The requested token parameter is an empty string");


### PR DESCRIPTION
`isParameterTokenSupportedForRequest()` only really needs to be called once, but the result needs to be used a second time later in the function. Super simple cleanup, but I happened to be reading this code anyhow and figured why not? 😅
