### PR TITLE
Add Dark Mode CSS Style for CSRF and Method Security diagrams

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
@@ -115,6 +115,7 @@ open class MyCustomerService {
 
 A given invocation to `MyCustomerService#readCustomer` may look something like this when Method Security <<activate-method-security,is activated>>:
 
+[.invert-dark]
 image::{figures}/methodsecurity.png[]
 
 1. Spring AOP invokes its proxy method for `readCustomer`. Among the proxy's other advisors, it invokes an javadoc:org.springframework.security.authorization.method.AuthorizationManagerBeforeMethodInterceptor[] that matches <<annotation-method-pointcuts,the `@PreAuthorize` pointcut>>

--- a/docs/modules/ROOT/pages/servlet/exploits/csrf.adoc
+++ b/docs/modules/ROOT/pages/servlet/exploits/csrf.adoc
@@ -82,6 +82,7 @@ To learn more about CSRF protection for your application, consider the following
 CSRF protection is provided by several components that are composed within the javadoc:org.springframework.security.web.csrf.CsrfFilter[]:
 
 .`CsrfFilter` Components
+[.invert-dark]
 image::{figures}/csrf.png[]
 
 CSRF protection is divided into two parts:
@@ -90,6 +91,7 @@ CSRF protection is divided into two parts:
 2. Determine if the request requires CSRF protection, load and validate the token, and <<csrf-access-denied-handler,handle `AccessDeniedException`>>.
 
 .`CsrfFilter` Processing
+[.invert-dark]
 image::{figures}/csrf-processing.png[]
 
 * image:{icondir}/number_1.png[] First, the javadoc:org.springframework.security.web.csrf.DeferredCsrfToken[] is loaded, which holds a reference to the <<csrf-token-repository,`CsrfTokenRepository`>> so that the persisted `CsrfToken` can be loaded later (in image:{icondir}/number_4.png[]).


### PR DESCRIPTION
This pull request resolves issue #16151 by addressing the dark mode rendering issues on the **Cross Site Request Forgery (CSRF)** and **Method Security** documentation pages.

### Changes:
- Added the `[.invert-dark]` attribute to the .adoc files for the affected pages.
- Ensured that images now render clearly in both light and dark modes by applying the `dark mode CSS styles`.

These changes provide a consistent and improved user experience across themes. Feedback and suggestions are welcome!