### PR TITLE
Address BouncyCastle's deprecated AESFastEngine usage

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/encrypt/BouncyCastleAesCbcBytesEncryptor.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/encrypt/BouncyCastleAesCbcBytesEncryptor.java
@@ -18,6 +18,7 @@ package org.springframework.security.crypto.encrypt;
 
 import org.bouncycastle.crypto.BufferedBlockCipher;
 import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.bouncycastle.crypto.engines.AESEngine;
 import org.bouncycastle.crypto.modes.CBCBlockCipher;
 import org.bouncycastle.crypto.paddings.PKCS7Padding;
 import org.bouncycastle.crypto.paddings.PaddedBufferedBlockCipher;
@@ -45,23 +46,21 @@ public class BouncyCastleAesCbcBytesEncryptor extends BouncyCastleAesBytesEncryp
 	}
 
 	@Override
-	@SuppressWarnings("deprecation")
 	public byte[] encrypt(byte[] bytes) {
 		byte[] iv = this.ivGenerator.generateKey();
 		PaddedBufferedBlockCipher blockCipher = new PaddedBufferedBlockCipher(
-				new CBCBlockCipher(new org.bouncycastle.crypto.engines.AESFastEngine()), new PKCS7Padding());
+				CBCBlockCipher.newInstance(AESEngine.newInstance()), new PKCS7Padding());
 		blockCipher.init(true, new ParametersWithIV(this.secretKey, iv));
 		byte[] encrypted = process(blockCipher, bytes);
 		return (iv != null) ? EncodingUtils.concatenate(iv, encrypted) : encrypted;
 	}
 
 	@Override
-	@SuppressWarnings("deprecation")
 	public byte[] decrypt(byte[] encryptedBytes) {
 		byte[] iv = EncodingUtils.subArray(encryptedBytes, 0, this.ivGenerator.getKeyLength());
 		encryptedBytes = EncodingUtils.subArray(encryptedBytes, this.ivGenerator.getKeyLength(), encryptedBytes.length);
 		PaddedBufferedBlockCipher blockCipher = new PaddedBufferedBlockCipher(
-				new CBCBlockCipher(new org.bouncycastle.crypto.engines.AESFastEngine()), new PKCS7Padding());
+				CBCBlockCipher.newInstance(AESEngine.newInstance()), new PKCS7Padding());
 		blockCipher.init(false, new ParametersWithIV(this.secretKey, iv));
 		return process(blockCipher, encryptedBytes);
 	}

--- a/crypto/src/main/java/org/springframework/security/crypto/encrypt/BouncyCastleAesGcmBytesEncryptor.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/encrypt/BouncyCastleAesGcmBytesEncryptor.java
@@ -17,6 +17,7 @@
 package org.springframework.security.crypto.encrypt;
 
 import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.bouncycastle.crypto.engines.AESEngine;
 import org.bouncycastle.crypto.modes.AEADBlockCipher;
 import org.bouncycastle.crypto.modes.GCMBlockCipher;
 import org.bouncycastle.crypto.params.AEADParameters;
@@ -44,21 +45,19 @@ public class BouncyCastleAesGcmBytesEncryptor extends BouncyCastleAesBytesEncryp
 	}
 
 	@Override
-	@SuppressWarnings("deprecation")
 	public byte[] encrypt(byte[] bytes) {
 		byte[] iv = this.ivGenerator.generateKey();
-		GCMBlockCipher blockCipher = new GCMBlockCipher(new org.bouncycastle.crypto.engines.AESFastEngine());
+		GCMBlockCipher blockCipher = (GCMBlockCipher) GCMBlockCipher.newInstance(AESEngine.newInstance());
 		blockCipher.init(true, new AEADParameters(this.secretKey, 128, iv, null));
 		byte[] encrypted = process(blockCipher, bytes);
 		return (iv != null) ? EncodingUtils.concatenate(iv, encrypted) : encrypted;
 	}
 
 	@Override
-	@SuppressWarnings("deprecation")
 	public byte[] decrypt(byte[] encryptedBytes) {
 		byte[] iv = EncodingUtils.subArray(encryptedBytes, 0, this.ivGenerator.getKeyLength());
 		encryptedBytes = EncodingUtils.subArray(encryptedBytes, this.ivGenerator.getKeyLength(), encryptedBytes.length);
-		GCMBlockCipher blockCipher = new GCMBlockCipher(new org.bouncycastle.crypto.engines.AESFastEngine());
+		GCMBlockCipher blockCipher = (GCMBlockCipher) GCMBlockCipher.newInstance(AESEngine.newInstance());
 		blockCipher.init(false, new AEADParameters(this.secretKey, 128, iv, null));
 		return process(blockCipher, encryptedBytes);
 	}

--- a/crypto/src/test/java/org/springframework/security/crypto/encrypt/BouncyCastleAesBytesEncryptorEquivalencyTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/encrypt/BouncyCastleAesBytesEncryptorEquivalencyTests.java
@@ -23,8 +23,6 @@ import java.util.Random;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.security.crypto.codec.Hex;
@@ -91,64 +89,6 @@ public class BouncyCastleAesBytesEncryptorEquivalencyTests {
 		BytesEncryptor jceEncryptor = new AesBytesEncryptor(this.password, this.salt, KeyGenerators.secureRandom(16),
 				CipherAlgorithm.GCM);
 		testCompatibility(bcEncryptor, jceEncryptor);
-	}
-
-	@Test
-	public void bouncyCastleAesGcmWithAESFastEngineCompatible() throws Exception {
-		CryptoAssumptions.assumeGCMJCE();
-		BytesEncryptor fastEngineEncryptor = BouncyCastleAesGcmBytesEncryptor.withAESFastEngine(this.password,
-				this.salt, KeyGenerators.secureRandom(16));
-		BytesEncryptor defaultEngineEncryptor = new BouncyCastleAesGcmBytesEncryptor(this.password, this.salt,
-				KeyGenerators.secureRandom(16));
-		testCompatibility(fastEngineEncryptor, defaultEngineEncryptor);
-	}
-
-	@Test
-	public void bouncyCastleAesCbcWithAESFastEngineCompatible() throws Exception {
-		CryptoAssumptions.assumeCBCJCE();
-		BytesEncryptor fastEngineEncryptor = BouncyCastleAesCbcBytesEncryptor.withAESFastEngine(this.password,
-				this.salt, KeyGenerators.secureRandom(16));
-		BytesEncryptor defaultEngineEncryptor = new BouncyCastleAesCbcBytesEncryptor(this.password, this.salt,
-				KeyGenerators.secureRandom(16));
-		testCompatibility(fastEngineEncryptor, defaultEngineEncryptor);
-	}
-
-	/**
-	 * Comment out @Disabled below to compare relative speed of deprecated AESFastEngine
-	 * with the default AESEngine.
-	 */
-	@Disabled
-	@RepeatedTest(100)
-	public void bouncyCastleAesGcmWithAESFastEngineSpeedTest() throws Exception {
-		CryptoAssumptions.assumeGCMJCE();
-		BytesEncryptor defaultEngineEncryptor = new BouncyCastleAesGcmBytesEncryptor(this.password, this.salt,
-				KeyGenerators.secureRandom(16));
-		BytesEncryptor fastEngineEncryptor = BouncyCastleAesGcmBytesEncryptor.withAESFastEngine(this.password,
-				this.salt, KeyGenerators.secureRandom(16));
-		long defaultNanos = testSpeed(defaultEngineEncryptor);
-		long fastNanos = testSpeed(fastEngineEncryptor);
-		System.out.println(nanosToReadableString("AES GCM w/Default Engine", defaultNanos));
-		System.out.println(nanosToReadableString("AES GCM w/   Fast Engine", fastNanos));
-		assertThat(fastNanos).isLessThan(defaultNanos);
-	}
-
-	/**
-	 * Comment out @Disabled below to compare relative speed of deprecated AESFastEngine
-	 * with the default AESEngine.
-	 */
-	@Disabled
-	@RepeatedTest(100)
-	public void bouncyCastleAesCbcWithAESFastEngineSpeedTest() throws Exception {
-		CryptoAssumptions.assumeCBCJCE();
-		BytesEncryptor defaultEngineEncryptor = new BouncyCastleAesCbcBytesEncryptor(this.password, this.salt,
-				KeyGenerators.secureRandom(16));
-		BytesEncryptor fastEngineEncryptor = BouncyCastleAesCbcBytesEncryptor.withAESFastEngine(this.password,
-				this.salt, KeyGenerators.secureRandom(16));
-		long defaultNanos = testSpeed(defaultEngineEncryptor);
-		long fastNanos = testSpeed(fastEngineEncryptor);
-		System.out.println(nanosToReadableString("AES CBC w/Default Engine", defaultNanos));
-		System.out.println(nanosToReadableString("AES CBC w/   Fast Engine", fastNanos));
-		assertThat(fastNanos).isLessThan(defaultNanos);
 	}
 
 	private void testEquivalence(BytesEncryptor left, BytesEncryptor right) {


### PR DESCRIPTION
- Update AESEngine to use the default AES engine, following BouncyCastle's recommendations (see release-1-56 of changelog: https://www.bouncycastle.org/download/bouncy-castle-java/?filter=java%3Drelease-1-56).
- Migrate to the latest API 'newInstance()' method to allow removal of method level @SuppressWarnings("deprecation")
- Remove @SuppressWarnings("deprecation"), as it is not needed anymore

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
