### PR TITLE
Gh 16165: Fix OAuth2 documentation: Correct OAuth2ClientHttpRequestInterceptor usage

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
@@ -115,6 +115,7 @@ open class MyCustomerService {
 
 A given invocation to `MyCustomerService#readCustomer` may look something like this when Method Security <<activate-method-security,is activated>>:
 
+[.invert-dark]
 image::{figures}/methodsecurity.png[]
 
 1. Spring AOP invokes its proxy method for `readCustomer`. Among the proxy's other advisors, it invokes an javadoc:org.springframework.security.authorization.method.AuthorizationManagerBeforeMethodInterceptor[] that matches <<annotation-method-pointcuts,the `@PreAuthorize` pointcut>>

--- a/docs/modules/ROOT/pages/servlet/exploits/csrf.adoc
+++ b/docs/modules/ROOT/pages/servlet/exploits/csrf.adoc
@@ -82,6 +82,7 @@ To learn more about CSRF protection for your application, consider the following
 CSRF protection is provided by several components that are composed within the javadoc:org.springframework.security.web.csrf.CsrfFilter[]:
 
 .`CsrfFilter` Components
+[.invert-dark]
 image::{figures}/csrf.png[]
 
 CSRF protection is divided into two parts:
@@ -90,6 +91,7 @@ CSRF protection is divided into two parts:
 2. Determine if the request requires CSRF protection, load and validate the token, and <<csrf-access-denied-handler,handle `AccessDeniedException`>>.
 
 .`CsrfFilter` Processing
+[.invert-dark]
 image::{figures}/csrf-processing.png[]
 
 * image:{icondir}/number_1.png[] First, the javadoc:org.springframework.security.web.csrf.DeferredCsrfToken[] is loaded, which holds a reference to the <<csrf-token-repository,`CsrfTokenRepository`>> so that the persisted `CsrfToken` can be loaded later (in image:{icondir}/number_4.png[]).

--- a/docs/modules/ROOT/pages/servlet/oauth2/index.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/index.adoc
@@ -1,2067 +1,1 @@
-= OAuth2
-
-Spring Security provides comprehensive OAuth 2.0 support.
-This section discusses how to integrate OAuth 2.0 into your servlet based application.
-
-[[oauth2-overview]]
-== Overview
-
-Spring Security's OAuth 2.0 support consists of two primary feature sets:
-
-* <<oauth2-resource-server>>
-* <<oauth2-client>>
-
-[NOTE]
-====
-<<oauth2-client-log-users-in,OAuth2 Login>> is a very powerful OAuth2 Client feature that deserves its own section in the reference documentation.
-However, it does not exist as a standalone feature and requires OAuth2 Client in order to function.
-====
-
-These feature sets cover the _resource server_ and _client_ roles defined in the https://tools.ietf.org/html/rfc6749#section-1.1[OAuth 2.0 Authorization Framework], while the _authorization server_ role is covered by https://docs.spring.io/spring-authorization-server/reference/index.html[Spring Authorization Server], which is a separate project built on xref:index.adoc[Spring Security].
-
-The _resource server_ and _client_ roles in OAuth2 are typically represented by one or more server-side applications.
-Additionally, the _authorization server_ role can be represented by one or more third parties (as is the case when centralizing identity management and/or authentication within an organization) *-or-* it can be represented by an application (as is the case with Spring Authorization Server).
-
-For example, a typical OAuth2-based microservices architecture might consist of a single user-facing client application, several backend resource servers providing REST APIs and a third party authorization server for managing users and authentication concerns.
-It is also common to have a single application representing only one of these roles with the need to integrate with one or more third parties that are providing the other roles.
-
-Spring Security handles these scenarios and more.
-The following sections cover the roles provided by Spring Security and contain examples for common scenarios.
-
-[[oauth2-resource-server]]
-== OAuth2 Resource Server
-
-[NOTE]
-====
-This section contains a summary of OAuth2 Resource Server features with examples.
-See xref:servlet/oauth2/resource-server/index.adoc[OAuth 2.0 Resource Server] for complete reference documentation.
-====
-
-To get started, add the `spring-security-oauth2-resource-server` dependency to your project.
-When using Spring Boot, add the following starter:
-
-.OAuth2 Client with Spring Boot
-[tabs]
-======
-Gradle::
-+
-[source,gradle,role="primary"]
-----
-implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
-----
-
-Maven::
-+
-[source,maven,role="secondary"]
-----
-<dependency>
-	<groupId>org.springframework.boot</groupId>
-	<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
-</dependency>
-----
-======
-
-[TIP]
-====
-See xref:getting-spring-security.adoc[] for additional options when not using Spring Boot.
-====
-
-Consider the following use cases for OAuth2 Resource Server:
-
-* I want to <<oauth2-resource-server-access-token,protect access to the API using OAuth2>> (authorization server provides JWT or opaque access token)
-* I want to <<oauth2-resource-server-custom-jwt,protect access to the API using a JWT>> (custom token)
-
-[[oauth2-resource-server-access-token]]
-=== Protect Access with an OAuth2 Access Token
-
-It is very common to protect access to an API using OAuth2 access tokens.
-In most cases, Spring Security requires only minimal configuration to secure an application with OAuth2.
-
-There are two types of `Bearer` tokens supported by Spring Security which each use a different component for validation:
-
-* <<oauth2-resource-server-access-token-jwt,JWT support>> uses a `JwtDecoder` bean to validate signatures and decode tokens
-* <<oauth2-resource-server-access-token-opaque,Opaque token support>> uses an `OpaqueTokenIntrospector` bean to introspect tokens
-
-[[oauth2-resource-server-access-token-jwt]]
-==== JWT Support
-
-The following example configures a `JwtDecoder` bean using Spring Boot configuration properties:
-
-[source,yaml]
-----
-spring:
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          issuer-uri: https://my-auth-server.com
-----
-
-When using Spring Boot, this is all that is required.
-The default arrangement provided by Spring Boot is equivalent to the following:
-
-.Configure Resource Server with JWTs
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-@Configuration
-@EnableWebSecurity
-public class SecurityConfig {
-
-	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http
-			.authorizeHttpRequests((authorize) -> authorize
-				.anyRequest().authenticated()
-			)
-			.oauth2ResourceServer((oauth2) -> oauth2
-				.jwt(Customizer.withDefaults())
-			);
-		return http.build();
-	}
-
-	@Bean
-	public JwtDecoder jwtDecoder() {
-		return JwtDecoders.fromIssuerLocation("https://my-auth-server.com");
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-import org.springframework.security.config.annotation.web.invoke
-
-@Configuration
-@EnableWebSecurity
-class SecurityConfig {
-
-	@Bean
-	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-		http {
-			authorizeHttpRequests {
-				authorize(anyRequest, authenticated)
-			}
-			oauth2ResourceServer {
-				jwt { }
-			}
-		}
-
-		return http.build()
-	}
-
-	@Bean
-	fun jwtDecoder(): JwtDecoder {
-		return JwtDecoders.fromIssuerLocation("https://my-auth-server.com")
-	}
-
-}
-----
-=====
-
-[[oauth2-resource-server-access-token-opaque]]
-==== Opaque Token Support
-
-The following example configures an `OpaqueTokenIntrospector` bean using Spring Boot configuration properties:
-
-[source,yaml]
-----
-spring:
-  security:
-    oauth2:
-      resourceserver:
-        opaquetoken:
-          introspection-uri: https://my-auth-server.com/oauth2/introspect
-          client-id: my-client-id
-          client-secret: my-client-secret
-----
-
-When using Spring Boot, this is all that is required.
-The default arrangement provided by Spring Boot is equivalent to the following:
-
-.Configure Resource Server with Opaque Tokens
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-@Configuration
-@EnableWebSecurity
-public class SecurityConfig {
-
-	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http
-			.authorizeHttpRequests((authorize) -> authorize
-				.anyRequest().authenticated()
-			)
-			.oauth2ResourceServer((oauth2) -> oauth2
-				.opaqueToken(Customizer.withDefaults())
-			);
-		return http.build();
-	}
-
-	@Bean
-	public OpaqueTokenIntrospector opaqueTokenIntrospector() {
-		return new SpringOpaqueTokenIntrospector(
-			"https://my-auth-server.com/oauth2/introspect", "my-client-id", "my-client-secret");
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-import org.springframework.security.config.annotation.web.invoke
-
-@Configuration
-@EnableWebSecurity
-class SecurityConfig {
-
-	@Bean
-	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-		http {
-			authorizeHttpRequests {
-				authorize(anyRequest, authenticated)
-			}
-			oauth2ResourceServer {
-				opaqueToken { }
-			}
-		}
-
-		return http.build()
-	}
-
-	@Bean
-	fun opaqueTokenIntrospector(): OpaqueTokenIntrospector {
-		return SpringOpaqueTokenIntrospector(
-			"https://my-auth-server.com/oauth2/introspect", "my-client-id", "my-client-secret"
-		)
-	}
-
-}
-----
-=====
-
-[[oauth2-resource-server-custom-jwt]]
-=== Protect Access with a custom JWT
-
-It is a fairly common goal to protect access to an API using JWTs, particularly when the frontend is developed as a single-page application.
-The OAuth2 Resource Server support in Spring Security can be used for any type of `Bearer` token, including a custom JWT.
-
-All that is required to protect an API using JWTs is a `JwtDecoder` bean, which is used to validate signatures and decode tokens.
-Spring Security will automatically use the provided bean to configure protection within the `SecurityFilterChain`.
-
-The following example configures a `JwtDecoder` bean using Spring Boot configuration properties:
-
-[source,yaml]
-----
-spring:
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          public-key-location: classpath:my-public-key.pub
-----
-
-[NOTE]
-====
-You can provide the public key as a classpath resource (called `my-public-key.pub` in this example).
-====
-
-When using Spring Boot, this is all that is required.
-The default arrangement provided by Spring Boot is equivalent to the following:
-
-.Configure Resource Server with Custom JWTs
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-@Configuration
-@EnableWebSecurity
-public class SecurityConfig {
-
-	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http
-			.authorizeHttpRequests((authorize) -> authorize
-				.anyRequest().authenticated()
-			)
-			.oauth2ResourceServer((oauth2) -> oauth2
-				.jwt(Customizer.withDefaults())
-			);
-		return http.build();
-	}
-
-	@Bean
-	public JwtDecoder jwtDecoder() {
-		return NimbusJwtDecoder.withPublicKey(publicKey()).build();
-	}
-
-	private RSAPublicKey publicKey() {
-		// ...
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-import org.springframework.security.config.annotation.web.invoke
-
-@Configuration
-@EnableWebSecurity
-class SecurityConfig {
-
-	@Bean
-	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-		http {
-			authorizeHttpRequests {
-				authorize(anyRequest, authenticated)
-			}
-			oauth2ResourceServer {
-				jwt { }
-			}
-		}
-
-		return http.build()
-	}
-
-	@Bean
-	fun jwtDecoder(): JwtDecoder {
-		return NimbusJwtDecoder.withPublicKey(publicKey()).build()
-	}
-
-	private fun publicKey(): RSAPublicKey {
-		// ...
-	}
-
-}
-----
-=====
-
-[NOTE]
-====
-Spring Security does not provide an endpoint for minting tokens.
-However, Spring Security does provide the `JwtEncoder` interface along with one implementation, which is `NimbusJwtEncoder`.
-====
-
-[[oauth2-client]]
-== OAuth2 Client
-
-[NOTE]
-====
-This section contains a summary of OAuth2 Client features with examples.
-See xref:servlet/oauth2/client/index.adoc[OAuth 2.0 Client] and xref:servlet/oauth2/login/index.adoc[OAuth 2.0 Login] for complete reference documentation.
-====
-
-To get started, add the `spring-security-oauth2-client` dependency to your project.
-When using Spring Boot, add the following starter:
-
-.OAuth2 Client with Spring Boot
-[tabs]
-======
-Gradle::
-+
-[source,gradle,role="primary"]
-----
-implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-----
-
-Maven::
-+
-[source,maven,role="secondary"]
-----
-<dependency>
-	<groupId>org.springframework.boot</groupId>
-	<artifactId>spring-boot-starter-oauth2-client</artifactId>
-</dependency>
-----
-======
-
-[TIP]
-====
-See xref:getting-spring-security.adoc[] for additional options when not using Spring Boot.
-====
-
-Consider the following use cases for OAuth2 Client:
-
-* I want to <<oauth2-client-log-users-in,log users in using OAuth 2.0 or OpenID Connect 1.0>>
-* I want to <<oauth2-client-access-protected-resources,use `RestClient` to obtain an access token for users>> in order to access a third-party API
-* I want to <<oauth2-client-access-protected-resources-webclient,use `WebClient` to obtain an access token for users>> in order to access a third-party API
-* I want to <<oauth2-client-access-protected-resources-current-user,do both>> (log users in _and_ access a third-party API)
-* I want to <<oauth2-client-client-credentials,use the `client_credentials` grant type>> to obtain a single token per application
-* I want to <<oauth2-client-enable-extension-grant-type,enable an extension grant type>>
-* I want to <<oauth2-client-customize-existing-grant-type,customize an existing grant type>>
-* I want to <<oauth2-client-customize-request-parameters,customize token request parameters>>
-* I want to <<oauth2-client-customize-rest-operations,customize the `RestOperations` used by OAuth2 Client components>>
-
-[[oauth2-client-log-users-in]]
-=== Log Users In with OAuth2
-
-It is very common to require users to log in via OAuth2.
-https://openid.net/specs/openid-connect-core-1_0.html[OpenID Connect 1.0] provides a special token called the `id_token` which is designed to provide an OAuth2 Client with the ability to perform user identity verification and log users in.
-In certain cases, OAuth2 can be used directly to log users in (as is the case with popular social login providers that do not implement OpenID Connect such as GitHub and Facebook).
-
-The following example configures the application to act as an OAuth2 Client capable of logging users in with OAuth2 or OpenID Connect:
-
-.Configure OAuth2 Login
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-@Configuration
-@EnableWebSecurity
-public class SecurityConfig {
-
-	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http
-			// ...
-			.oauth2Login(Customizer.withDefaults());
-		return http.build();
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-import org.springframework.security.config.annotation.web.invoke
-
-@Configuration
-@EnableWebSecurity
-class SecurityConfig {
-
-	@Bean
-	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-		http {
-			// ...
-			oauth2Login { }
-		}
-
-		return http.build()
-	}
-
-}
-----
-=====
-
-In addition to the above configuration, the application requires at least one `ClientRegistration` to be configured through the use of a `ClientRegistrationRepository` bean.
-The following example configures an `InMemoryClientRegistrationRepository` bean using Spring Boot configuration properties:
-
-[source,yaml]
-----
-spring:
-  security:
-    oauth2:
-      client:
-        registration:
-          my-oidc-client:
-            provider: my-oidc-provider
-            client-id: my-client-id
-            client-secret: my-client-secret
-            authorization-grant-type: authorization_code
-            scope: openid,profile
-        provider:
-          my-oidc-provider:
-            issuer-uri: https://my-oidc-provider.com
-----
-
-With the above configuration, the application now supports two additional endpoints:
-
-1. The login endpoint (e.g. `/oauth2/authorization/my-oidc-client`) is used to initiate login and perform a redirect to the third party authorization server.
-2. The redirection endpoint (e.g. `/login/oauth2/code/my-oidc-client`) is used by the authorization server to redirect back to the client application, and will contain a `code` parameter used to obtain an `id_token` and/or `access_token` via the access token request.
-
-[NOTE]
-====
-The presence of the `openid` scope in the above configuration indicates that OpenID Connect 1.0 should be used.
-This instructs Spring Security to use OIDC-specific components (such as `OidcUserService`) during request processing.
-Without this scope, Spring Security will use OAuth2-specific components (such as `DefaultOAuth2UserService`) instead.
-====
-
-[[oauth2-client-access-protected-resources]]
-=== Access Protected Resources
-
-Making requests to a third party API that is protected by OAuth2 is a core use case of OAuth2 Client.
-This is accomplished by authorizing a client (represented by the `OAuth2AuthorizedClient` class in Spring Security) and accessing protected resources by placing a `Bearer` token in the `Authorization` header of an outbound request.
-
-The following example configures the application to act as an OAuth2 Client capable of requesting protected resources from a third party API:
-
-.Configure OAuth2 Client
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-@Configuration
-@EnableWebSecurity
-public class SecurityConfig {
-
-	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http
-			// ...
-			.oauth2Client(Customizer.withDefaults());
-		return http.build();
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-import org.springframework.security.config.annotation.web.invoke
-
-@Configuration
-@EnableWebSecurity
-class SecurityConfig {
-
-	@Bean
-	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-		http {
-			// ...
-			oauth2Client { }
-		}
-
-		return http.build()
-	}
-
-}
-----
-=====
-
-[NOTE]
-====
-The above example does not provide a way to log users in.
-You can use any other login mechanism (such as `formLogin()`).
-See the <<oauth2-client-access-protected-resources-current-user,next section>> for an example combining `oauth2Client()` with `oauth2Login()`.
-====
-
-In addition to the above configuration, the application requires at least one `ClientRegistration` to be configured through the use of a `ClientRegistrationRepository` bean.
-The following example configures an `InMemoryClientRegistrationRepository` bean using Spring Boot configuration properties:
-
-[source,yaml]
-----
-spring:
-  security:
-    oauth2:
-      client:
-        registration:
-          my-oauth2-client:
-            provider: my-auth-server
-            client-id: my-client-id
-            client-secret: my-client-secret
-            authorization-grant-type: authorization_code
-            scope: message.read,message.write
-        provider:
-          my-auth-server:
-            issuer-uri: https://my-auth-server.com
-----
-
-In addition to configuring Spring Security to support OAuth2 Client features, you will also need to decide how you will be accessing protected resources and configure your application accordingly.
-Spring Security provides implementations of `OAuth2AuthorizedClientManager` for obtaining access tokens that can be used to access protected resources.
-
-[TIP]
-====
-Spring Security registers a default `OAuth2AuthorizedClientManager` bean for you when one does not exist.
-====
-
-The easiest way to use an `OAuth2AuthorizedClientManager` is via a `ClientHttpRequestInterceptor` that intercepts requests through a `RestClient`, which is already available when `spring-web` is on the classpath.
-
-The following example uses the default `OAuth2AuthorizedClientManager` to configure a `RestClient` capable of accessing protected resources by placing `Bearer` tokens in the `Authorization` header of each request:
-
-.Configure `RestClient` with `ClientHttpRequestInterceptor`
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-@Configuration
-public class RestClientConfig {
-
-	@Bean
-	public RestClient restClient(OAuth2AuthorizedClientManager authorizedClientManager) {
-		OAuth2ClientHttpRequestInterceptor requestInterceptor =
-				new OAuth2ClientHttpRequestInterceptor(authorizedClientManager);
-		return RestClient.builder()
-				.requestInterceptor(requestInterceptor)
-				.build();
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Configuration
-class RestClientConfig {
-
-	@Bean
-	fun restClient(authorizedClientManager: OAuth2AuthorizedClientManager): RestClient {
-		val requestInterceptor = OAuth2ClientHttpRequestInterceptor(authorizedClientManager)
-		return RestClient.builder()
-			.requestInterceptor(requestInterceptor)
-			.build()
-	}
-
-}
-----
-=====
-
-This configured `RestClient` can be used as in the following example:
-
-[[oauth2-client-accessing-protected-resources-example]]
-.Use `RestClient` to Access Protected Resources
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-import static org.springframework.security.oauth2.client.web.client.RequestAttributeClientRegistrationIdResolver.clientRegistrationId;
-
-@RestController
-public class MessagesController {
-
-	private final RestClient restClient;
-
-	public MessagesController(RestClient restClient) {
-		this.restClient = restClient;
-	}
-
-	@GetMapping("/messages")
-	public ResponseEntity<List<Message>> messages() {
-		Message[] messages = this.restClient.get()
-				.uri("http://localhost:8090/messages")
-				.attributes(clientRegistrationId("my-oauth2-client"))
-				.retrieve()
-				.body(Message[].class);
-		return ResponseEntity.ok(Arrays.asList(messages));
-	}
-
-	public record Message(String message) {
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-import org.springframework.security.oauth2.client.web.client.RequestAttributeClientRegistrationIdResolver.clientRegistrationId
-import org.springframework.web.client.body
-
-@RestController
-class MessagesController(private val restClient: RestClient) {
-
-	@GetMapping("/messages")
-	fun messages(): ResponseEntity<List<Message>> {
-		val messages = restClient.get()
-			.uri("http://localhost:8090/messages")
-			.attributes(clientRegistrationId("my-oauth2-client"))
-			.retrieve()
-			.body<Array<Message>>()!!
-			.toList()
-		return ResponseEntity.ok(messages)
-	}
-
-	data class Message(val message: String)
-
-}
-----
-=====
-
-[[oauth2-client-access-protected-resources-webclient]]
-=== Access Protected Resources with `WebClient`
-
-Making requests to a third party API that is protected by OAuth2 is a core use case of OAuth2 Client.
-This is accomplished by authorizing a client (represented by the `OAuth2AuthorizedClient` class in Spring Security) and accessing protected resources by placing a `Bearer` token in the `Authorization` header of an outbound request.
-
-The following example configures the application to act as an OAuth2 Client capable of requesting protected resources from a third party API:
-
-.Configure OAuth2 Client
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-@Configuration
-@EnableWebSecurity
-public class SecurityConfig {
-
-	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http
-			// ...
-			.oauth2Client(Customizer.withDefaults());
-		return http.build();
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-import org.springframework.security.config.annotation.web.invoke
-
-@Configuration
-@EnableWebSecurity
-class SecurityConfig {
-
-	@Bean
-	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-		http {
-			// ...
-			oauth2Client { }
-		}
-
-		return http.build()
-	}
-
-}
-----
-=====
-
-[NOTE]
-====
-The above example does not provide a way to log users in.
-You can use any other login mechanism (such as `formLogin()`).
-See the <<oauth2-client-access-protected-resources-current-user,previous section>> for an example combining `oauth2Client()` with `oauth2Login()`.
-====
-
-In addition to the above configuration, the application requires at least one `ClientRegistration` to be configured through the use of a `ClientRegistrationRepository` bean.
-The following example configures an `InMemoryClientRegistrationRepository` bean using Spring Boot configuration properties:
-
-[source,yaml]
-----
-spring:
-  security:
-    oauth2:
-      client:
-        registration:
-          my-oauth2-client:
-            provider: my-auth-server
-            client-id: my-client-id
-            client-secret: my-client-secret
-            authorization-grant-type: authorization_code
-            scope: message.read,message.write
-        provider:
-          my-auth-server:
-            issuer-uri: https://my-auth-server.com
-----
-
-In addition to configuring Spring Security to support OAuth2 Client features, you will also need to decide how you will be accessing protected resources and configure your application accordingly.
-Spring Security provides implementations of `OAuth2AuthorizedClientManager` for obtaining access tokens that can be used to access protected resources.
-
-[TIP]
-====
-Spring Security registers a default `OAuth2AuthorizedClientManager` bean for you when one does not exist.
-====
-
-<<oauth2-client-access-protected-resources,Instead of configuring a `RestClient`>>, another way to use an `OAuth2AuthorizedClientManager` is via an `ExchangeFilterFunction` that intercepts requests through a `WebClient`.
-To use `WebClient`, you will need to add the `spring-webflux` dependency along with a reactive client implementation:
-
-.Add Spring WebFlux Dependency
-[tabs]
-======
-Gradle::
-+
-[source,gradle,role="primary"]
-----
-implementation 'org.springframework:spring-webflux'
-implementation 'io.projectreactor.netty:reactor-netty'
-----
-
-Maven::
-+
-[source,maven,role="secondary"]
-----
-<dependency>
-	<groupId>org.springframework</groupId>
-	<artifactId>spring-webflux</artifactId>
-</dependency>
-<dependency>
-	<groupId>io.projectreactor.netty</groupId>
-	<artifactId>reactor-netty</artifactId>
-</dependency>
-----
-======
-
-The following example uses the default `OAuth2AuthorizedClientManager` to configure a `WebClient` capable of accessing protected resources by placing `Bearer` tokens in the `Authorization` header of each request:
-
-.Configure `WebClient` with `ExchangeFilterFunction`
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-@Configuration
-public class WebClientConfig {
-
-	@Bean
-	public WebClient webClient(OAuth2AuthorizedClientManager authorizedClientManager) {
-		ServletOAuth2AuthorizedClientExchangeFilterFunction filter =
-				new ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager);
-		return WebClient.builder()
-				.apply(filter.oauth2Configuration())
-				.build();
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Configuration
-class WebClientConfig {
-
-	@Bean
-	fun webClient(authorizedClientManager: OAuth2AuthorizedClientManager): WebClient {
-		val filter = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
-		return WebClient.builder()
-			.apply(filter.oauth2Configuration())
-			.build()
-	}
-
-}
-----
-=====
-
-This configured `WebClient` can be used as in the following example:
-
-.Use `WebClient` to Access Protected Resources
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-import static org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction.clientRegistrationId;
-
-@RestController
-public class MessagesController {
-
-	private final WebClient webClient;
-
-	public MessagesController(WebClient webClient) {
-		this.webClient = webClient;
-	}
-
-	@GetMapping("/messages")
-	public ResponseEntity<List<Message>> messages() {
-		return this.webClient.get()
-				.uri("http://localhost:8090/messages")
-				.attributes(clientRegistrationId("my-oauth2-client"))
-				.retrieve()
-				.toEntityList(Message.class)
-				.block();
-	}
-
-	public record Message(String message) {
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction.clientRegistrationId
-
-@RestController
-class MessagesController(private val webClient: WebClient) {
-
-	@GetMapping("/messages")
-	fun messages(): ResponseEntity<List<Message>> {
-		return webClient.get()
-			.uri("http://localhost:8090/messages")
-			.attributes(clientRegistrationId("my-oauth2-client"))
-			.retrieve()
-			.toEntityList<Message>()
-			.block()!!
-	}
-
-	data class Message(val message: String)
-
-}
-----
-=====
-
-[[oauth2-client-access-protected-resources-current-user]]
-=== Access Protected Resources for the Current User
-
-When a user is logged in via OAuth2 or OpenID Connect, the authorization server may provide an access token that can be used directly to access protected resources.
-This is convenient because it only requires a single `ClientRegistration` to be configured for both use cases simultaneously.
-
-[NOTE]
-====
-This section combines <<oauth2-client-log-users-in>> and <<oauth2-client-access-protected-resources>> into a single configuration.
-Other advanced scenarios exist, such as configuring one `ClientRegistration` for login and another for accessing protected resources.
-All such scenarios would use the same basic configuration.
-====
-
-The following example configures the application to act as an OAuth2 Client capable of logging the user in _and_ requesting protected resources from a third party API:
-
-.Configure OAuth2 Login and OAuth2 Client
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-@Configuration
-@EnableWebSecurity
-public class SecurityConfig {
-
-	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http
-			// ...
-			.oauth2Login(Customizer.withDefaults())
-			.oauth2Client(Customizer.withDefaults());
-		return http.build();
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-import org.springframework.security.config.annotation.web.invoke
-
-@Configuration
-@EnableWebSecurity
-class SecurityConfig {
-
-	@Bean
-	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-		http {
-			// ...
-			oauth2Login { }
-			oauth2Client { }
-		}
-
-		return http.build()
-	}
-
-}
-----
-=====
-
-In addition to the above configuration, the application requires at least one `ClientRegistration` to be configured through the use of a `ClientRegistrationRepository` bean.
-The following example configures an `InMemoryClientRegistrationRepository` bean using Spring Boot configuration properties:
-
-[source,yaml]
-----
-spring:
-  security:
-    oauth2:
-      client:
-        registration:
-          my-combined-client:
-            provider: my-auth-server
-            client-id: my-client-id
-            client-secret: my-client-secret
-            authorization-grant-type: authorization_code
-            scope: openid,profile,message.read,message.write
-        provider:
-          my-auth-server:
-            issuer-uri: https://my-auth-server.com
-----
-
-[NOTE]
-====
-The main difference between the previous examples (<<oauth2-client-log-users-in>>,  <<oauth2-client-access-protected-resources>>) and this one is what is configured via the `scope` property, which combines the standard scopes `openid` and `profile` with the custom scopes `message.read` and `message.write`.
-====
-
-In addition to configuring Spring Security to support OAuth2 Client features, you will also need to decide how you will be accessing protected resources and configure your application accordingly.
-Spring Security provides implementations of `OAuth2AuthorizedClientManager` for obtaining access tokens that can be used to access protected resources.
-
-[TIP]
-====
-Spring Security registers a default `OAuth2AuthorizedClientManager` bean for you when one does not exist.
-====
-
-The easiest way to use an `OAuth2AuthorizedClientManager` is via a `ClientHttpRequestInterceptor` that intercepts requests through a `RestClient`, which is already available when `spring-web` is on the classpath.
-
-The following example uses the default `OAuth2AuthorizedClientManager` to configure a `RestClient` capable of accessing protected resources by placing `Bearer` tokens in the `Authorization` header of each request:
-
-.Configure `RestClient` with `ClientHttpRequestInterceptor`
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-@Configuration
-public class RestClientConfig {
-
-	@Bean
-	public RestClient restClient(OAuth2AuthorizedClientManager authorizedClientManager) {
-		OAuth2ClientHttpRequestInterceptor requestInterceptor =
-				new OAuth2ClientHttpRequestInterceptor(authorizedClientManager, clientRegistrationIdResolver());
-		return RestClient.builder()
-				.requestInterceptor(requestInterceptor)
-				.build();
-	}
-
-	private static ClientRegistrationIdResolver clientRegistrationIdResolver() {
-		return (request) -> {
-			Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-			return (authentication instanceof OAuth2AuthenticationToken principal)
-				? principal.getAuthorizedClientRegistrationId()
-				: null;
-		};
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Configuration
-class RestClientConfig {
-
-	@Bean
-	fun restClient(authorizedClientManager: OAuth2AuthorizedClientManager): RestClient {
-		val requestInterceptor = OAuth2ClientHttpRequestInterceptor(authorizedClientManager, clientRegistrationIdResolver())
-		return RestClient.builder()
-			.requestInterceptor(requestInterceptor)
-			.build()
-	}
-
-	private fun clientRegistrationIdResolver(): OAuth2ClientHttpRequestInterceptor.ClientRegistrationIdResolver {
-		return OAuth2ClientHttpRequestInterceptor.ClientRegistrationIdResolver { request ->
-			val authentication = SecurityContextHolder.getContext().authentication
-			if (authentication is OAuth2AuthenticationToken) {
-				authentication.authorizedClientRegistrationId
-			} else {
-				null
-			}
-		}
-	}
-
-}
-----
-=====
-
-This configured `RestClient` can be used as in the following example:
-
-[[oauth2-client-accessing-protected-resources-current-user-example]]
-.Use `RestClient` to Access Protected Resources (Current User)
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-@RestController
-public class MessagesController {
-
-	private final RestClient restClient;
-
-	public MessagesController(RestClient restClient) {
-		this.restClient = restClient;
-	}
-
-	@GetMapping("/messages")
-	public ResponseEntity<List<Message>> messages() {
-		Message[] messages = this.restClient.get()
-				.uri("http://localhost:8090/messages")
-				.retrieve()
-				.body(Message[].class);
-		return ResponseEntity.ok(Arrays.asList(messages));
-	}
-
-	public record Message(String message) {
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-import org.springframework.web.client.body
-
-@RestController
-class MessagesController(private val restClient: RestClient) {
-
-	@GetMapping("/messages")
-	fun messages(): ResponseEntity<List<Message>> {
-		val messages = restClient.get()
-			.uri("http://localhost:8090/messages")
-			.retrieve()
-			.body<Array<Message>>()!!
-			.toList()
-		return ResponseEntity.ok(messages)
-	}
-
-	data class Message(val message: String)
-
-}
-----
-=====
-
-[NOTE]
-====
-Unlike the <<oauth2-client-accessing-protected-resources-example,previous example>>, notice that we do not need to tell Spring Security about the `clientRegistrationId` we'd like to use.
-This is because it can be derived from the currently logged in user.
-====
-
-[[oauth2-client-client-credentials]]
-=== Use the Client Credentials Grant
-
-[NOTE]
-====
-This section focuses on additional considerations for the client credentials grant type.
-See <<oauth2-client-access-protected-resources>> for general setup and usage with all grant types.
-====
-
-The https://tools.ietf.org/html/rfc6749#section-1.3.4[client credentials grant] allows a client to obtain an `access_token` on behalf of itself.
-The client credentials grant is a simple flow that does not involve a resource owner (i.e. a user).
-
-[WARNING]
-====
-It is important to note that typical use of the client credentials grant implies that any request (or user) can potentially obtain an access token and make protected resources requests to a resource server.
-Exercise caution when designing applications to ensure that users cannot make unauthorized requests since every request will be able to obtain an access token.
-====
-
-When obtaining access tokens within a web application where users can log in, the default behavior of Spring Security is to obtain an access token per user.
-
-[NOTE]
-====
-By default, access tokens are scoped to the principal name of the current user which means every user will receive a unique access token.
-====
-
-Clients using the client credentials grant typically require access tokens to be scoped to the application instead of to individual users so there is only one access token per application.
-In order to scope access tokens to the application, you will need to set a strategy for resolving a custom principal name.
-The following example does this by configuring a `RestClient` with the `RequestAttributePrincipalResolver`:
-
-.Configure `RestClient` for `client_credentials`
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-@Configuration
-public class RestClientConfig {
-
-	@Bean
-	public RestClient restClient(OAuth2AuthorizedClientManager authorizedClientManager) {
-		OAuth2ClientHttpRequestInterceptor requestInterceptor =
-				new OAuth2ClientHttpRequestInterceptor(authorizedClientManager);
-		requestInterceptor.setPrincipalResolver(new RequestAttributePrincipalResolver());
-		return RestClient.builder()
-				.requestInterceptor(requestInterceptor)
-				.build();
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Configuration
-class RestClientConfig {
-
-	@Bean
-	fun restClient(authorizedClientManager: OAuth2AuthorizedClientManager): RestClient {
-		val requestInterceptor = OAuth2ClientHttpRequestInterceptor(authorizedClientManager)
-		requestInterceptor.setPrincipalResolver(RequestAttributePrincipalResolver())
-		return RestClient.builder()
-			.requestInterceptor(requestInterceptor)
-			.build()
-	}
-
-}
-----
-=====
-
-With the above configuration in place, a principal name can be specified for each request.
-The following example demonstrates how to scope access tokens to the application by specifying a principal name:
-
-.Scope Access Tokens to the Application
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-import static org.springframework.security.oauth2.client.web.client.RequestAttributeClientRegistrationIdResolver.clientRegistrationId;
-import static org.springframework.security.oauth2.client.web.client.RequestAttributePrincipalResolver.principal;
-
-@RestController
-public class MessagesController {
-
-	private final RestClient restClient;
-
-	public MessagesController(RestClient restClient) {
-		this.restClient = restClient;
-	}
-
-	@GetMapping("/messages")
-	public ResponseEntity<List<Message>> messages() {
-		Message[] messages = this.restClient.get()
-				.uri("http://localhost:8090/messages")
-				.attributes(clientRegistrationId("my-oauth2-client"))
-				.attributes(principal("my-application"))
-				.retrieve()
-				.body(Message[].class);
-		return ResponseEntity.ok(Arrays.asList(messages));
-	}
-
-	public record Message(String message) {
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-import org.springframework.security.oauth2.client.web.client.RequestAttributeClientRegistrationIdResolver.clientRegistrationId
-import org.springframework.security.oauth2.client.web.client.RequestAttributePrincipalResolver.principal
-import org.springframework.web.client.body
-
-@RestController
-class MessagesController(private val restClient: RestClient) {
-
-	@GetMapping("/messages")
-	fun messages(): ResponseEntity<List<Message>> {
-		val messages = restClient.get()
-			.uri("http://localhost:8090/messages")
-			.attributes(clientRegistrationId("my-oauth2-client"))
-			.attributes(principal("my-application"))
-			.retrieve()
-			.body<Array<Message>>()!!
-			.toList()
-		return ResponseEntity.ok(messages)
-	}
-
-	data class Message(val message: String)
-
-}
-----
-=====
-
-[NOTE]
-====
-When specifying a principal name via attributes as in the above example, there will only be a single access token and it will be used for all requests.
-====
-
-[[oauth2-client-enable-extension-grant-type]]
-=== Enable an Extension Grant Type
-
-A common use case involves enabling and/or configuring an extension grant type.
-For example, Spring Security provides support for the `jwt-bearer` and `token-exchange` grant types, but does not enable them by default because they are not part of the core OAuth 2.0 specification.
-
-With Spring Security 6.2 and later, we can simply publish a bean for one or more `OAuth2AuthorizedClientProvider` and they will be picked up automatically.
-The following example simply enables the `jwt-bearer` grant type:
-
-.Enable `jwt-bearer` Grant Type
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-@Configuration
-public class SecurityConfig {
-
-	@Bean
-	public OAuth2AuthorizedClientProvider jwtBearer() {
-		return new JwtBearerOAuth2AuthorizedClientProvider();
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Configuration
-class SecurityConfig {
-
-	@Bean
-	fun jwtBearer(): OAuth2AuthorizedClientProvider {
-		return JwtBearerOAuth2AuthorizedClientProvider()
-	}
-
-}
-----
-=====
-
-A default `OAuth2AuthorizedClientManager` will be published automatically by Spring Security when one is not already provided.
-
-[TIP]
-====
-Any custom `OAuth2AuthorizedClientProvider` bean will also be picked up and applied to the provided `OAuth2AuthorizedClientManager` after the default grant types.
-====
-
-In order to achieve the above configuration prior to Spring Security 6.2, we had to publish this bean ourselves and ensure we re-enabled default grant types as well.
-To understand what is being configured behind the scenes, here's what the configuration might have looked like:
-
-.Enable `jwt-bearer` Grant Type (prior to 6.2)
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-@Configuration
-public class SecurityConfig {
-
-	@Bean
-	public OAuth2AuthorizedClientManager authorizedClientManager(
-			ClientRegistrationRepository clientRegistrationRepository,
-			OAuth2AuthorizedClientRepository authorizedClientRepository) {
-
-		OAuth2AuthorizedClientProvider authorizedClientProvider =
-			OAuth2AuthorizedClientProviderBuilder.builder()
-				.authorizationCode()
-				.refreshToken()
-				.clientCredentials()
-				.password()
-				.provider(new JwtBearerOAuth2AuthorizedClientProvider())
-				.build();
-
-		DefaultOAuth2AuthorizedClientManager authorizedClientManager =
-			new DefaultOAuth2AuthorizedClientManager(
-				clientRegistrationRepository, authorizedClientRepository);
-		authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider);
-
-		return authorizedClientManager;
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Configuration
-class SecurityConfig {
-
-	@Bean
-	fun authorizedClientManager(
-		clientRegistrationRepository: ClientRegistrationRepository,
-		authorizedClientRepository: OAuth2AuthorizedClientRepository
-	): OAuth2AuthorizedClientManager {
-		val authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder()
-			.authorizationCode()
-			.refreshToken()
-			.clientCredentials()
-			.password()
-			.provider(JwtBearerOAuth2AuthorizedClientProvider())
-			.build()
-
-		val authorizedClientManager = DefaultOAuth2AuthorizedClientManager(
-			clientRegistrationRepository, authorizedClientRepository
-		)
-		authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider)
-
-		return authorizedClientManager
-	}
-
-}
-----
-=====
-
-[[oauth2-client-customize-existing-grant-type]]
-=== Customize an Existing Grant Type
-
-The ability to <<oauth2-client-enable-extension-grant-type,enable extension grant types>> by publishing a bean also provides the opportunity for customizing an existing grant type without the need to re-define the defaults.
-For example, if we want to customize the clock skew of the `OAuth2AuthorizedClientProvider` for the `client_credentials` grant, we can simply publish a bean like so:
-
-.Customize Client Credentials Grant Type
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-@Configuration
-public class SecurityConfig {
-
-	@Bean
-	public OAuth2AuthorizedClientProvider clientCredentials() {
-		ClientCredentialsOAuth2AuthorizedClientProvider authorizedClientProvider =
-				new ClientCredentialsOAuth2AuthorizedClientProvider();
-		authorizedClientProvider.setClockSkew(Duration.ofMinutes(5));
-
-		return authorizedClientProvider;
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Configuration
-class SecurityConfig {
-
-	@Bean
-	fun clientCredentials(): OAuth2AuthorizedClientProvider {
-		val authorizedClientProvider = ClientCredentialsOAuth2AuthorizedClientProvider()
-		authorizedClientProvider.setClockSkew(Duration.ofMinutes(5))
-		return authorizedClientProvider
-	}
-
-}
-----
-=====
-
-[[oauth2-client-customize-request-parameters]]
-=== Customize Token Request Parameters
-
-The need to customize request parameters when obtaining an access token is fairly common.
-For example, let's say we want to add a custom `audience` parameter to the token request because the provider requires this parameter for the `authorization_code` grant.
-
-With Spring Security 6.2 and later, we can simply publish a bean of type `OAuth2AccessTokenResponseClient` with the generic type `OAuth2AuthorizationCodeGrantRequest` and it will be used by Spring Security to configure OAuth2 Client components.
-
-The following example customizes token request parameters for the `authorization_code` grant without the DSL:
-
-.Customize Token Request Parameters for Authorization Code Grant
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-@Configuration
-public class SecurityConfig {
-
-	@Bean
-	public OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> authorizationCodeAccessTokenResponseClient() {
-		OAuth2AuthorizationCodeGrantRequestEntityConverter requestEntityConverter =
-			new OAuth2AuthorizationCodeGrantRequestEntityConverter();
-		requestEntityConverter.addParametersConverter(parametersConverter());
-
-		DefaultAuthorizationCodeTokenResponseClient accessTokenResponseClient =
-			new DefaultAuthorizationCodeTokenResponseClient();
-		accessTokenResponseClient.setRequestEntityConverter(requestEntityConverter);
-
-		return accessTokenResponseClient;
-	}
-
-	private static Converter<OAuth2AuthorizationCodeGrantRequest, MultiValueMap<String, String>> parametersConverter() {
-		return (grantRequest) -> {
-			MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
-			parameters.set("audience", "xyz_value");
-
-			return parameters;
-		};
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Configuration
-class SecurityConfig {
-
-	@Bean
-	fun authorizationCodeAccessTokenResponseClient(): OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> {
-		val requestEntityConverter = OAuth2AuthorizationCodeGrantRequestEntityConverter()
-		requestEntityConverter.addParametersConverter(parametersConverter())
-
-		val accessTokenResponseClient = DefaultAuthorizationCodeTokenResponseClient()
-		accessTokenResponseClient.setRequestEntityConverter(requestEntityConverter)
-
-		return accessTokenResponseClient
-	}
-
-	private fun parametersConverter(): Converter<OAuth2AuthorizationCodeGrantRequest, MultiValueMap<String, String>> {
-		return Converter<OAuth2AuthorizationCodeGrantRequest, MultiValueMap<String, String>> { grantRequest ->
-			LinkedMultiValueMap<String, String>().also { parameters ->
-				parameters["audience"] = "xyz_value"
-			}
-		}
-	}
-
-}
-----
-=====
-
-[TIP]
-====
-Notice that we don't need to customize the `SecurityFilterChain` bean in this case, and can stick with the defaults.
-If using Spring Boot with no additional customizations, we can actually omit the `SecurityFilterChain` bean entirely.
-====
-
-Prior to Spring Security 6.2, we had to ensure that this customization was applied for both OAuth2 Login (if we are using this feature) and OAuth2 Client components using the Spring Security DSL.
-To understand what is being configured behind the scenes, here's what the configuration might have looked like:
-
-.Customize Token Request Parameters for Authorization Code Grant (prior to 6.2)
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-@Configuration
-@EnableWebSecurity
-public class SecurityConfig {
-
-	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		OAuth2AuthorizationCodeGrantRequestEntityConverter requestEntityConverter =
-			new OAuth2AuthorizationCodeGrantRequestEntityConverter();
-		requestEntityConverter.addParametersConverter(parametersConverter());
-
-		DefaultAuthorizationCodeTokenResponseClient accessTokenResponseClient =
-			new DefaultAuthorizationCodeTokenResponseClient();
-		accessTokenResponseClient.setRequestEntityConverter(requestEntityConverter);
-
-		http
-			.authorizeHttpRequests((authorize) -> authorize
-				.anyRequest().authenticated()
-			)
-			.oauth2Login((oauth2Login) -> oauth2Login
-				.tokenEndpoint((tokenEndpoint) -> tokenEndpoint
-					.accessTokenResponseClient(accessTokenResponseClient)
-				)
-			)
-			.oauth2Client((oauth2Client) -> oauth2Client
-				.authorizationCodeGrant((authorizationCode) -> authorizationCode
-					.accessTokenResponseClient(accessTokenResponseClient)
-				)
-			);
-
-		return http.build();
-	}
-
-	private static Converter<OAuth2AuthorizationCodeGrantRequest, MultiValueMap<String, String>> parametersConverter() {
-		// ...
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-import org.springframework.security.config.annotation.web.invoke
-
-@Configuration
-@EnableWebSecurity
-class SecurityConfig {
-
-	@Bean
-	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-		val requestEntityConverter = OAuth2AuthorizationCodeGrantRequestEntityConverter()
-		requestEntityConverter.addParametersConverter(parametersConverter())
-
-		val tokenResponseClient = DefaultAuthorizationCodeTokenResponseClient()
-		tokenResponseClient.setRequestEntityConverter(requestEntityConverter)
-
-		http {
-			authorizeHttpRequests {
-				authorize(anyRequest, authenticated)
-			}
-			oauth2Login {
-				tokenEndpoint {
-					accessTokenResponseClient = tokenResponseClient
-				}
-			}
-			oauth2Client {
-				authorizationCodeGrant {
-					accessTokenResponseClient = tokenResponseClient
-				}
-			}
-		}
-
-		return http.build()
-	}
-
-	private fun parametersConverter(): Converter<OAuth2AuthorizationCodeGrantRequest, MultiValueMap<String, String>> {
-		// ...
-	}
-
-}
-----
-=====
-
-For other grant types we can publish additional `OAuth2AccessTokenResponseClient` beans to override the defaults.
-For example, to customize token requests for the `client_credentials` grant we can publish the following bean:
-
-.Customize Token Request Parameters for Client Credentials Grant
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-@Configuration
-public class SecurityConfig {
-
-	@Bean
-	public OAuth2AccessTokenResponseClient<OAuth2ClientCredentialsGrantRequest> clientCredentialsAccessTokenResponseClient() {
-		OAuth2ClientCredentialsGrantRequestEntityConverter requestEntityConverter =
-			new OAuth2ClientCredentialsGrantRequestEntityConverter();
-		requestEntityConverter.addParametersConverter(parametersConverter());
-
-		DefaultClientCredentialsTokenResponseClient accessTokenResponseClient =
-				new DefaultClientCredentialsTokenResponseClient();
-		accessTokenResponseClient.setRequestEntityConverter(requestEntityConverter);
-
-		return accessTokenResponseClient;
-	}
-
-	private static Converter<OAuth2ClientCredentialsGrantRequest, MultiValueMap<String, String>> parametersConverter() {
-		// ...
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Configuration
-class SecurityConfig {
-
-	@Bean
-	fun clientCredentialsAccessTokenResponseClient(): OAuth2AccessTokenResponseClient<OAuth2ClientCredentialsGrantRequest> {
-		val requestEntityConverter = OAuth2ClientCredentialsGrantRequestEntityConverter()
-		requestEntityConverter.addParametersConverter(parametersConverter())
-
-		val accessTokenResponseClient = DefaultClientCredentialsTokenResponseClient()
-		accessTokenResponseClient.setRequestEntityConverter(requestEntityConverter)
-
-		return accessTokenResponseClient
-	}
-
-	private fun parametersConverter(): Converter<OAuth2ClientCredentialsGrantRequest, MultiValueMap<String, String>> {
-		// ...
-	}
-
-}
-----
-=====
-
-Spring Security automatically resolves the following generic types of `OAuth2AccessTokenResponseClient` beans:
-
-* `OAuth2AuthorizationCodeGrantRequest` (see `DefaultAuthorizationCodeTokenResponseClient`)
-* `OAuth2RefreshTokenGrantRequest` (see `DefaultRefreshTokenTokenResponseClient`)
-* `OAuth2ClientCredentialsGrantRequest` (see `DefaultClientCredentialsTokenResponseClient`)
-* `OAuth2PasswordGrantRequest` (see `DefaultPasswordTokenResponseClient`)
-* `JwtBearerGrantRequest` (see `DefaultJwtBearerTokenResponseClient`)
-* `TokenExchangeGrantRequest` (see `DefaultTokenExchangeTokenResponseClient`)
-
-[TIP]
-====
-Publishing a bean of type `OAuth2AccessTokenResponseClient<JwtBearerGrantRequest>` will automatically enable the `jwt-bearer` grant type without the need to <<oauth2-client-enable-extension-grant-type,configure it separately>>.
-====
-
-[TIP]
-====
-Publishing a bean of type `OAuth2AccessTokenResponseClient<TokenExchangeGrantRequest>` will automatically enable the `token-exchange` grant type without the need to <<oauth2-client-enable-extension-grant-type,configure it separately>>.
-====
-
-[[oauth2-client-customize-rest-operations]]
-=== Customize the `RestOperations` used by OAuth2 Client Components
-
-Another common use case is the need to customize the `RestOperations` used when obtaining an access token.
-We might need to do this to customize processing of the response (via a custom `HttpMessageConverter`) or to apply proxy settings for a corporate network (via a customized `ClientHttpRequestFactory`).
-
-With Spring Security 6.2 and later, we can simply publish beans of type `OAuth2AccessTokenResponseClient` and Spring Security will configure and publish an `OAuth2AuthorizedClientManager` bean for us.
-
-The following example customizes the `RestOperations` for all of the supported grant types:
-
-.Customize `RestOperations` for OAuth2 Client
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-@Configuration
-public class SecurityConfig {
-
-	@Bean
-	public OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> authorizationCodeAccessTokenResponseClient() {
-		DefaultAuthorizationCodeTokenResponseClient accessTokenResponseClient =
-			new DefaultAuthorizationCodeTokenResponseClient();
-		accessTokenResponseClient.setRestOperations(restTemplate());
-
-		return accessTokenResponseClient;
-	}
-
-	@Bean
-	public OAuth2AccessTokenResponseClient<OAuth2RefreshTokenGrantRequest> refreshTokenAccessTokenResponseClient() {
-		DefaultRefreshTokenTokenResponseClient accessTokenResponseClient =
-			new DefaultRefreshTokenTokenResponseClient();
-		accessTokenResponseClient.setRestOperations(restTemplate());
-
-		return accessTokenResponseClient;
-	}
-
-	@Bean
-	public OAuth2AccessTokenResponseClient<OAuth2ClientCredentialsGrantRequest> clientCredentialsAccessTokenResponseClient() {
-		DefaultClientCredentialsTokenResponseClient accessTokenResponseClient =
-			new DefaultClientCredentialsTokenResponseClient();
-		accessTokenResponseClient.setRestOperations(restTemplate());
-
-		return accessTokenResponseClient;
-	}
-
-	@Bean
-	public OAuth2AccessTokenResponseClient<OAuth2PasswordGrantRequest> passwordAccessTokenResponseClient() {
-		DefaultPasswordTokenResponseClient accessTokenResponseClient =
-			new DefaultPasswordTokenResponseClient();
-		accessTokenResponseClient.setRestOperations(restTemplate());
-
-		return accessTokenResponseClient;
-	}
-
-	@Bean
-	public OAuth2AccessTokenResponseClient<JwtBearerGrantRequest> jwtBearerAccessTokenResponseClient() {
-		DefaultJwtBearerTokenResponseClient accessTokenResponseClient =
-			new DefaultJwtBearerTokenResponseClient();
-		accessTokenResponseClient.setRestOperations(restTemplate());
-
-		return accessTokenResponseClient;
-	}
-
-	@Bean
-	public OAuth2AccessTokenResponseClient<TokenExchangeGrantRequest> tokenExchangeAccessTokenResponseClient() {
-		DefaultTokenExchangeTokenResponseClient accessTokenResponseClient =
-			new DefaultTokenExchangeTokenResponseClient();
-		accessTokenResponseClient.setRestOperations(restTemplate());
-
-		return accessTokenResponseClient;
-	}
-
-	@Bean
-	public RestTemplate restTemplate() {
-		// ...
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Configuration
-class SecurityConfig {
-
-	@Bean
-	fun authorizationCodeAccessTokenResponseClient(): OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> {
-		val accessTokenResponseClient = DefaultAuthorizationCodeTokenResponseClient()
-		accessTokenResponseClient.setRestOperations(restTemplate())
-
-		return accessTokenResponseClient
-	}
-
-	@Bean
-	fun refreshTokenAccessTokenResponseClient(): OAuth2AccessTokenResponseClient<OAuth2RefreshTokenGrantRequest> {
-		val accessTokenResponseClient = DefaultRefreshTokenTokenResponseClient()
-		accessTokenResponseClient.setRestOperations(restTemplate())
-
-		return accessTokenResponseClient
-	}
-
-	@Bean
-	fun clientCredentialsAccessTokenResponseClient(): OAuth2AccessTokenResponseClient<OAuth2ClientCredentialsGrantRequest> {
-		val accessTokenResponseClient = DefaultClientCredentialsTokenResponseClient()
-		accessTokenResponseClient.setRestOperations(restTemplate())
-
-		return accessTokenResponseClient
-	}
-
-	@Bean
-	fun passwordAccessTokenResponseClient(): OAuth2AccessTokenResponseClient<OAuth2PasswordGrantRequest> {
-		val accessTokenResponseClient = DefaultPasswordTokenResponseClient()
-		accessTokenResponseClient.setRestOperations(restTemplate())
-
-		return accessTokenResponseClient
-	}
-
-	@Bean
-	fun jwtBearerAccessTokenResponseClient(): OAuth2AccessTokenResponseClient<JwtBearerGrantRequest> {
-		val accessTokenResponseClient = DefaultJwtBearerTokenResponseClient()
-		accessTokenResponseClient.setRestOperations(restTemplate())
-
-		return accessTokenResponseClient
-	}
-
-	@Bean
-	fun tokenExchangeAccessTokenResponseClient(): OAuth2AccessTokenResponseClient<TokenExchangeGrantRequest> {
-		val accessTokenResponseClient = DefaultTokenExchangeTokenResponseClient()
-		accessTokenResponseClient.setRestOperations(restTemplate())
-
-		return accessTokenResponseClient
-	}
-
-	@Bean
-	fun restTemplate(): RestTemplate {
-		// ...
-	}
-
-}
-----
-=====
-
-A default `OAuth2AuthorizedClientManager` will be published automatically by Spring Security when one is not already provided.
-
-[TIP]
-====
-Notice that we don't need to customize the `SecurityFilterChain` bean in this case, and can stick with the defaults.
-If using Spring Boot with no additional customizations, we can actually omit the `SecurityFilterChain` bean entirely.
-====
-
-Prior to Spring Security 6.2, we had to ensure this customization was applied to both OAuth2 Login (if we are using this feature) and OAuth2 Client components.
-We had to use both the Spring Security DSL (for the `authorization_code` grant) and publish a bean of type `OAuth2AuthorizedClientManager` for other grant types.
-To understand what is being configured behind the scenes, here's what the configuration might have looked like:
-
-.Customize `RestOperations` for OAuth2 Client (prior to 6.2)
-[tabs]
-=====
-Java::
-+
-[source,java,role="primary"]
-----
-@Configuration
-@EnableWebSecurity
-public class SecurityConfig {
-
-	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		DefaultAuthorizationCodeTokenResponseClient accessTokenResponseClient =
-			new DefaultAuthorizationCodeTokenResponseClient();
-		accessTokenResponseClient.setRestOperations(restTemplate());
-
-		http
-			// ...
-			.oauth2Login((oauth2Login) -> oauth2Login
-				.tokenEndpoint((tokenEndpoint) -> tokenEndpoint
-					.accessTokenResponseClient(accessTokenResponseClient)
-				)
-			)
-			.oauth2Client((oauth2Client) -> oauth2Client
-				.authorizationCodeGrant((authorizationCode) -> authorizationCode
-					.accessTokenResponseClient(accessTokenResponseClient)
-				)
-			);
-
-		return http.build();
-	}
-
-	@Bean
-	public OAuth2AuthorizedClientManager authorizedClientManager(
-			ClientRegistrationRepository clientRegistrationRepository,
-			OAuth2AuthorizedClientRepository authorizedClientRepository) {
-
-		DefaultRefreshTokenTokenResponseClient refreshTokenAccessTokenResponseClient =
-			new DefaultRefreshTokenTokenResponseClient();
-		refreshTokenAccessTokenResponseClient.setRestOperations(restTemplate());
-
-		DefaultClientCredentialsTokenResponseClient clientCredentialsAccessTokenResponseClient =
-			new DefaultClientCredentialsTokenResponseClient();
-		clientCredentialsAccessTokenResponseClient.setRestOperations(restTemplate());
-
-		DefaultPasswordTokenResponseClient passwordAccessTokenResponseClient =
-			new DefaultPasswordTokenResponseClient();
-		passwordAccessTokenResponseClient.setRestOperations(restTemplate());
-
-		DefaultJwtBearerTokenResponseClient jwtBearerAccessTokenResponseClient =
-			new DefaultJwtBearerTokenResponseClient();
-		jwtBearerAccessTokenResponseClient.setRestOperations(restTemplate());
-
-		JwtBearerOAuth2AuthorizedClientProvider jwtBearerAuthorizedClientProvider =
-			new JwtBearerOAuth2AuthorizedClientProvider();
-		jwtBearerAuthorizedClientProvider.setAccessTokenResponseClient(jwtBearerAccessTokenResponseClient);
-
-		DefaultTokenExchangeTokenResponseClient tokenExchangeAccessTokenResponseClient =
-			new DefaultTokenExchangeTokenResponseClient();
-		tokenExchangeAccessTokenResponseClient.setRestOperations(restTemplate());
-
-		TokenExchangeOAuth2AuthorizedClientProvider tokenExchangeAuthorizedClientProvider =
-			new TokenExchangeOAuth2AuthorizedClientProvider();
-		tokenExchangeAuthorizedClientProvider.setAccessTokenResponseClient(tokenExchangeAccessTokenResponseClient);
-
-		OAuth2AuthorizedClientProvider authorizedClientProvider =
-			OAuth2AuthorizedClientProviderBuilder.builder()
-				.authorizationCode()
-				.refreshToken((refreshToken) -> refreshToken
-					.accessTokenResponseClient(refreshTokenAccessTokenResponseClient)
-				)
-				.clientCredentials((clientCredentials) -> clientCredentials
-					.accessTokenResponseClient(clientCredentialsAccessTokenResponseClient)
-				)
-				.password((password) -> password
-					.accessTokenResponseClient(passwordAccessTokenResponseClient)
-				)
-				.provider(jwtBearerAuthorizedClientProvider)
-				.provider(tokenExchangeAuthorizedClientProvider)
-				.build();
-
-		DefaultOAuth2AuthorizedClientManager authorizedClientManager =
-			new DefaultOAuth2AuthorizedClientManager(
-				clientRegistrationRepository, authorizedClientRepository);
-		authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider);
-
-		return authorizedClientManager;
-	}
-
-	@Bean
-	public RestTemplate restTemplate() {
-		// ...
-	}
-
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-import org.springframework.security.config.annotation.web.invoke
-
-@Configuration
-@EnableWebSecurity
-class SecurityConfig {
-
-	@Bean
-	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-		val tokenResponseClient = DefaultAuthorizationCodeTokenResponseClient()
-		tokenResponseClient.setRestOperations(restTemplate())
-
-		http {
-			// ...
-			oauth2Login {
-				tokenEndpoint {
-					accessTokenResponseClient = tokenResponseClient
-				}
-			}
-			oauth2Client {
-				authorizationCodeGrant {
-					accessTokenResponseClient = tokenResponseClient
-				}
-			}
-		}
-
-		return http.build()
-	}
-
-	@Bean
-	fun authorizedClientManager(
-		clientRegistrationRepository: ClientRegistrationRepository?,
-		authorizedClientRepository: OAuth2AuthorizedClientRepository?
-	): OAuth2AuthorizedClientManager {
-		val refreshTokenAccessTokenResponseClient = DefaultRefreshTokenTokenResponseClient()
-		refreshTokenAccessTokenResponseClient.setRestOperations(restTemplate())
-
-		val clientCredentialsAccessTokenResponseClient = DefaultClientCredentialsTokenResponseClient()
-		clientCredentialsAccessTokenResponseClient.setRestOperations(restTemplate())
-
-		val passwordAccessTokenResponseClient = DefaultPasswordTokenResponseClient()
-		passwordAccessTokenResponseClient.setRestOperations(restTemplate())
-
-		val jwtBearerAccessTokenResponseClient = DefaultJwtBearerTokenResponseClient()
-		jwtBearerAccessTokenResponseClient.setRestOperations(restTemplate())
-
-		val jwtBearerAuthorizedClientProvider = JwtBearerOAuth2AuthorizedClientProvider()
-		jwtBearerAuthorizedClientProvider.setAccessTokenResponseClient(jwtBearerAccessTokenResponseClient)
-
-		val tokenExchangeAccessTokenResponseClient = DefaultTokenExchangeTokenResponseClient()
-		tokenExchangeAccessTokenResponseClient.setRestOperations(restTemplate())
-
-		val tokenExchangeAuthorizedClientProvider = TokenExchangeOAuth2AuthorizedClientProvider()
-		tokenExchangeAuthorizedClientProvider.setAccessTokenResponseClient(tokenExchangeAccessTokenResponseClient)
-
-		val authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder()
-			.authorizationCode()
-			.refreshToken { refreshToken ->
-				refreshToken.accessTokenResponseClient(refreshTokenAccessTokenResponseClient)
-			}
-			.clientCredentials { clientCredentials ->
-				clientCredentials.accessTokenResponseClient(clientCredentialsAccessTokenResponseClient)
-			}
-			.password { password ->
-				password.accessTokenResponseClient(passwordAccessTokenResponseClient)
-			}
-			.provider(jwtBearerAuthorizedClientProvider)
-			.provider(tokenExchangeAuthorizedClientProvider)
-			.build()
-
-		val authorizedClientManager = DefaultOAuth2AuthorizedClientManager(
-			clientRegistrationRepository, authorizedClientRepository
-		)
-		authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider)
-
-		return authorizedClientManager
-	}
-
-	@Bean
-	fun restTemplate(): RestTemplate {
-		// ...
-	}
-
-}
-----
-=====
-
-
-[[further-reading]]
-== Further Reading
-
-The preceding sections introduced Spring Security's support for OAuth2 with examples for common scenarios.
-You can read more about OAuth2 Client and Resource Server in the following sections of the reference documentation:
-
-* xref:servlet/oauth2/login/index.adoc[]
-* xref:servlet/oauth2/client/index.adoc[]
-* xref:servlet/oauth2/resource-server/index.adoc[]
+= OAuth2Spring Security provides comprehensive OAuth 2.0 support.This section discusses how to integrate OAuth 2.0 into your servlet based application.[[oauth2-overview]]== OverviewSpring Security's OAuth 2.0 support consists of two primary feature sets:* <<oauth2-resource-server>>* <<oauth2-client>>[NOTE]====<<oauth2-client-log-users-in,OAuth2 Login>> is a very powerful OAuth2 Client feature that deserves its own section in the reference documentation.However, it does not exist as a standalone feature and requires OAuth2 Client in order to function.====These feature sets cover the _resource server_ and _client_ roles defined in the https://tools.ietf.org/html/rfc6749#section-1.1[OAuth 2.0 Authorization Framework], while the _authorization server_ role is covered by https://docs.spring.io/spring-authorization-server/reference/index.html[Spring Authorization Server], which is a separate project built on xref:index.adoc[Spring Security].The _resource server_ and _client_ roles in OAuth2 are typically represented by one or more server-side applications.Additionally, the _authorization server_ role can be represented by one or more third parties (as is the case when centralizing identity management and/or authentication within an organization) *-or-* it can be represented by an application (as is the case with Spring Authorization Server).For example, a typical OAuth2-based microservices architecture might consist of a single user-facing client application, several backend resource servers providing REST APIs and a third party authorization server for managing users and authentication concerns.It is also common to have a single application representing only one of these roles with the need to integrate with one or more third parties that are providing the other roles.Spring Security handles these scenarios and more.The following sections cover the roles provided by Spring Security and contain examples for common scenarios.[[oauth2-resource-server]]== OAuth2 Resource Server[NOTE]====This section contains a summary of OAuth2 Resource Server features with examples.See xref:servlet/oauth2/resource-server/index.adoc[OAuth 2.0 Resource Server] for complete reference documentation.====To get started, add the `spring-security-oauth2-resource-server` dependency to your project.When using Spring Boot, add the following starter:.OAuth2 Client with Spring Boot[tabs]======Gradle::+[source,gradle,role="primary"]----implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'----Maven::+[source,maven,role="secondary"]----<dependency>	<groupId>org.springframework.boot</groupId>	<artifactId>spring-boot-starter-oauth2-resource-server</artifactId></dependency>----======[TIP]====See xref:getting-spring-security.adoc[] for additional options when not using Spring Boot.====Consider the following use cases for OAuth2 Resource Server:* I want to <<oauth2-resource-server-access-token,protect access to the API using OAuth2>> (authorization server provides JWT or opaque access token)* I want to <<oauth2-resource-server-custom-jwt,protect access to the API using a JWT>> (custom token)[[oauth2-resource-server-access-token]]=== Protect Access with an OAuth2 Access TokenIt is very common to protect access to an API using OAuth2 access tokens.In most cases, Spring Security requires only minimal configuration to secure an application with OAuth2.There are two types of `Bearer` tokens supported by Spring Security which each use a different component for validation:* <<oauth2-resource-server-access-token-jwt,JWT support>> uses a `JwtDecoder` bean to validate signatures and decode tokens* <<oauth2-resource-server-access-token-opaque,Opaque token support>> uses an `OpaqueTokenIntrospector` bean to introspect tokens[[oauth2-resource-server-access-token-jwt]]==== JWT SupportThe following example configures a `JwtDecoder` bean using Spring Boot configuration properties:[source,yaml]----spring:  security:    oauth2:      resourceserver:        jwt:          issuer-uri: https://my-auth-server.com----When using Spring Boot, this is all that is required.The default arrangement provided by Spring Boot is equivalent to the following:.Configure Resource Server with JWTs[tabs]=====Java::+[source,java,role="primary"]----@Configuration@EnableWebSecuritypublic class SecurityConfig {	@Bean	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {		http			.authorizeHttpRequests((authorize) -> authorize				.anyRequest().authenticated()			)			.oauth2ResourceServer((oauth2) -> oauth2				.jwt(Customizer.withDefaults())			);		return http.build();	}	@Bean	public JwtDecoder jwtDecoder() {		return JwtDecoders.fromIssuerLocation("https://my-auth-server.com");	}}----Kotlin::+[source,kotlin,role="secondary"]----import org.springframework.security.config.annotation.web.invoke@Configuration@EnableWebSecurityclass SecurityConfig {	@Bean	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {		http {			authorizeHttpRequests {				authorize(anyRequest, authenticated)			}			oauth2ResourceServer {				jwt { }			}		}		return http.build()	}	@Bean	fun jwtDecoder(): JwtDecoder {		return JwtDecoders.fromIssuerLocation("https://my-auth-server.com")	}}----=====[[oauth2-resource-server-access-token-opaque]]==== Opaque Token SupportThe following example configures an `OpaqueTokenIntrospector` bean using Spring Boot configuration properties:[source,yaml]----spring:  security:    oauth2:      resourceserver:        opaquetoken:          introspection-uri: https://my-auth-server.com/oauth2/introspect          client-id: my-client-id          client-secret: my-client-secret----When using Spring Boot, this is all that is required.The default arrangement provided by Spring Boot is equivalent to the following:.Configure Resource Server with Opaque Tokens[tabs]=====Java::+[source,java,role="primary"]----@Configuration@EnableWebSecuritypublic class SecurityConfig {	@Bean	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {		http			.authorizeHttpRequests((authorize) -> authorize				.anyRequest().authenticated()			)			.oauth2ResourceServer((oauth2) -> oauth2				.opaqueToken(Customizer.withDefaults())			);		return http.build();	}	@Bean	public OpaqueTokenIntrospector opaqueTokenIntrospector() {		return new SpringOpaqueTokenIntrospector(			"https://my-auth-server.com/oauth2/introspect", "my-client-id", "my-client-secret");	}}----Kotlin::+[source,kotlin,role="secondary"]----import org.springframework.security.config.annotation.web.invoke@Configuration@EnableWebSecurityclass SecurityConfig {	@Bean	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {		http {			authorizeHttpRequests {				authorize(anyRequest, authenticated)			}			oauth2ResourceServer {				opaqueToken { }			}		}		return http.build()	}	@Bean	fun opaqueTokenIntrospector(): OpaqueTokenIntrospector {		return SpringOpaqueTokenIntrospector(			"https://my-auth-server.com/oauth2/introspect", "my-client-id", "my-client-secret"		)	}}----=====[[oauth2-resource-server-custom-jwt]]=== Protect Access with a custom JWTIt is a fairly common goal to protect access to an API using JWTs, particularly when the frontend is developed as a single-page application.The OAuth2 Resource Server support in Spring Security can be used for any type of `Bearer` token, including a custom JWT.All that is required to protect an API using JWTs is a `JwtDecoder` bean, which is used to validate signatures and decode tokens.Spring Security will automatically use the provided bean to configure protection within the `SecurityFilterChain`.The following example configures a `JwtDecoder` bean using Spring Boot configuration properties:[source,yaml]----spring:  security:    oauth2:      resourceserver:        jwt:          public-key-location: classpath:my-public-key.pub----[NOTE]====You can provide the public key as a classpath resource (called `my-public-key.pub` in this example).====When using Spring Boot, this is all that is required.The default arrangement provided by Spring Boot is equivalent to the following:.Configure Resource Server with Custom JWTs[tabs]=====Java::+[source,java,role="primary"]----@Configuration@EnableWebSecuritypublic class SecurityConfig {	@Bean	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {		http			.authorizeHttpRequests((authorize) -> authorize				.anyRequest().authenticated()			)			.oauth2ResourceServer((oauth2) -> oauth2				.jwt(Customizer.withDefaults())			);		return http.build();	}	@Bean	public JwtDecoder jwtDecoder() {		return NimbusJwtDecoder.withPublicKey(publicKey()).build();	}	private RSAPublicKey publicKey() {		// ...	}}----Kotlin::+[source,kotlin,role="secondary"]----import org.springframework.security.config.annotation.web.invoke@Configuration@EnableWebSecurityclass SecurityConfig {	@Bean	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {		http {			authorizeHttpRequests {				authorize(anyRequest, authenticated)			}			oauth2ResourceServer {				jwt { }			}		}		return http.build()	}	@Bean	fun jwtDecoder(): JwtDecoder {		return NimbusJwtDecoder.withPublicKey(publicKey()).build()	}	private fun publicKey(): RSAPublicKey {		// ...	}}----=====[NOTE]====Spring Security does not provide an endpoint for minting tokens.However, Spring Security does provide the `JwtEncoder` interface along with one implementation, which is `NimbusJwtEncoder`.====[[oauth2-client]]== OAuth2 Client[NOTE]====This section contains a summary of OAuth2 Client features with examples.See xref:servlet/oauth2/client/index.adoc[OAuth 2.0 Client] and xref:servlet/oauth2/login/index.adoc[OAuth 2.0 Login] for complete reference documentation.====To get started, add the `spring-security-oauth2-client` dependency to your project.When using Spring Boot, add the following starter:.OAuth2 Client with Spring Boot[tabs]======Gradle::+[source,gradle,role="primary"]----implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'----Maven::+[source,maven,role="secondary"]----<dependency>	<groupId>org.springframework.boot</groupId>	<artifactId>spring-boot-starter-oauth2-client</artifactId></dependency>----======[TIP]====See xref:getting-spring-security.adoc[] for additional options when not using Spring Boot.====Consider the following use cases for OAuth2 Client:* I want to <<oauth2-client-log-users-in,log users in using OAuth 2.0 or OpenID Connect 1.0>>* I want to <<oauth2-client-access-protected-resources,use `RestClient` to obtain an access token for users>> in order to access a third-party API* I want to <<oauth2-client-access-protected-resources-webclient,use `WebClient` to obtain an access token for users>> in order to access a third-party API* I want to <<oauth2-client-access-protected-resources-current-user,do both>> (log users in _and_ access a third-party API)* I want to <<oauth2-client-client-credentials,use the `client_credentials` grant type>> to obtain a single token per application* I want to <<oauth2-client-enable-extension-grant-type,enable an extension grant type>>* I want to <<oauth2-client-customize-existing-grant-type,customize an existing grant type>>* I want to <<oauth2-client-customize-request-parameters,customize token request parameters>>* I want to <<oauth2-client-customize-rest-operations,customize the `RestOperations` used by OAuth2 Client components>>[[oauth2-client-log-users-in]]=== Log Users In with OAuth2It is very common to require users to log in via OAuth2.https://openid.net/specs/openid-connect-core-1_0.html[OpenID Connect 1.0] provides a special token called the `id_token` which is designed to provide an OAuth2 Client with the ability to perform user identity verification and log users in.In certain cases, OAuth2 can be used directly to log users in (as is the case with popular social login providers that do not implement OpenID Connect such as GitHub and Facebook).The following example configures the application to act as an OAuth2 Client capable of logging users in with OAuth2 or OpenID Connect:.Configure OAuth2 Login[tabs]=====Java::+[source,java,role="primary"]----@Configuration@EnableWebSecuritypublic class SecurityConfig {	@Bean	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {		http			// ...			.oauth2Login(Customizer.withDefaults());		return http.build();	}}----Kotlin::+[source,kotlin,role="secondary"]----import org.springframework.security.config.annotation.web.invoke@Configuration@EnableWebSecurityclass SecurityConfig {	@Bean	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {		http {			// ...			oauth2Login { }		}		return http.build()	}}----=====In addition to the above configuration, the application requires at least one `ClientRegistration` to be configured through the use of a `ClientRegistrationRepository` bean.The following example configures an `InMemoryClientRegistrationRepository` bean using Spring Boot configuration properties:[source,yaml]----spring:  security:    oauth2:      client:        registration:          my-oidc-client:            provider: my-oidc-provider            client-id: my-client-id            client-secret: my-client-secret            authorization-grant-type: authorization_code            scope: openid,profile        provider:          my-oidc-provider:            issuer-uri: https://my-oidc-provider.com----With the above configuration, the application now supports two additional endpoints:1. The login endpoint (e.g. `/oauth2/authorization/my-oidc-client`) is used to initiate login and perform a redirect to the third party authorization server.2. The redirection endpoint (e.g. `/login/oauth2/code/my-oidc-client`) is used by the authorization server to redirect back to the client application, and will contain a `code` parameter used to obtain an `id_token` and/or `access_token` via the access token request.[NOTE]====The presence of the `openid` scope in the above configuration indicates that OpenID Connect 1.0 should be used.This instructs Spring Security to use OIDC-specific components (such as `OidcUserService`) during request processing.Without this scope, Spring Security will use OAuth2-specific components (such as `DefaultOAuth2UserService`) instead.====[[oauth2-client-access-protected-resources]]=== Access Protected ResourcesMaking requests to a third party API that is protected by OAuth2 is a core use case of OAuth2 Client.This is accomplished by authorizing a client (represented by the `OAuth2AuthorizedClient` class in Spring Security) and accessing protected resources by placing a `Bearer` token in the `Authorization` header of an outbound request.The following example configures the application to act as an OAuth2 Client capable of requesting protected resources from a third party API:.Configure OAuth2 Client[tabs]=====Java::+[source,java,role="primary"]----@Configuration@EnableWebSecuritypublic class SecurityConfig {	@Bean	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {		http			// ...			.oauth2Client(Customizer.withDefaults());		return http.build();	}}----Kotlin::+[source,kotlin,role="secondary"]----import org.springframework.security.config.annotation.web.invoke@Configuration@EnableWebSecurityclass SecurityConfig {	@Bean	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {		http {			// ...			oauth2Client { }		}		return http.build()	}}----=====[NOTE]====The above example does not provide a way to log users in.You can use any other login mechanism (such as `formLogin()`).See the <<oauth2-client-access-protected-resources-current-user,next section>> for an example combining `oauth2Client()` with `oauth2Login()`.====In addition to the above configuration, the application requires at least one `ClientRegistration` to be configured through the use of a `ClientRegistrationRepository` bean.The following example configures an `InMemoryClientRegistrationRepository` bean using Spring Boot configuration properties:[source,yaml]----spring:  security:    oauth2:      client:        registration:          my-oauth2-client:            provider: my-auth-server            client-id: my-client-id            client-secret: my-client-secret            authorization-grant-type: authorization_code            scope: message.read,message.write        provider:          my-auth-server:            issuer-uri: https://my-auth-server.com----In addition to configuring Spring Security to support OAuth2 Client features, you will also need to decide how you will be accessing protected resources and configure your application accordingly.Spring Security provides implementations of `OAuth2AuthorizedClientManager` for obtaining access tokens that can be used to access protected resources.[TIP]====Spring Security registers a default `OAuth2AuthorizedClientManager` bean for you when one does not exist.====The easiest way to use an `OAuth2AuthorizedClientManager` is via a `ClientHttpRequestInterceptor` that intercepts requests through a `RestClient`, which is already available when `spring-web` is on the classpath.The following example uses the default `OAuth2AuthorizedClientManager` to configure a `RestClient` capable of accessing protected resources by placing `Bearer` tokens in the `Authorization` header of each request:.Configure `RestClient` with `ClientHttpRequestInterceptor`[tabs]=====Java::+[source,java,role="primary"]----@Configurationpublic class RestClientConfig {	@Bean	public RestClient restClient(OAuth2AuthorizedClientManager authorizedClientManager) {		OAuth2ClientHttpRequestInterceptor requestInterceptor =				new OAuth2ClientHttpRequestInterceptor(authorizedClientManager);		return RestClient.builder()				.requestInterceptor(requestInterceptor)				.build();	}}----Kotlin::+[source,kotlin,role="secondary"]----@Configurationclass RestClientConfig {	@Bean	fun restClient(authorizedClientManager: OAuth2AuthorizedClientManager): RestClient {		val requestInterceptor = OAuth2ClientHttpRequestInterceptor(authorizedClientManager)		return RestClient.builder()			.requestInterceptor(requestInterceptor)			.build()	}}----=====This configured `RestClient` can be used as in the following example:[[oauth2-client-accessing-protected-resources-example]].Use `RestClient` to Access Protected Resources[tabs]=====Java::+[source,java,role="primary"]----import static org.springframework.security.oauth2.client.web.client.RequestAttributeClientRegistrationIdResolver.clientRegistrationId;@RestControllerpublic class MessagesController {	private final RestClient restClient;	public MessagesController(RestClient restClient) {		this.restClient = restClient;	}	@GetMapping("/messages")	public ResponseEntity<List<Message>> messages() {		Message[] messages = this.restClient.get()				.uri("http://localhost:8090/messages")				.attributes(clientRegistrationId("my-oauth2-client"))				.retrieve()				.body(Message[].class);		return ResponseEntity.ok(Arrays.asList(messages));	}	public record Message(String message) {	}}----Kotlin::+[source,kotlin,role="secondary"]----import org.springframework.security.oauth2.client.web.client.RequestAttributeClientRegistrationIdResolver.clientRegistrationIdimport org.springframework.web.client.body@RestControllerclass MessagesController(private val restClient: RestClient) {	@GetMapping("/messages")	fun messages(): ResponseEntity<List<Message>> {		val messages = restClient.get()			.uri("http://localhost:8090/messages")			.attributes(clientRegistrationId("my-oauth2-client"))			.retrieve()			.body<Array<Message>>()!!			.toList()		return ResponseEntity.ok(messages)	}	data class Message(val message: String)}----=====[[oauth2-client-access-protected-resources-webclient]]=== Access Protected Resources with `WebClient`Making requests to a third party API that is protected by OAuth2 is a core use case of OAuth2 Client.This is accomplished by authorizing a client (represented by the `OAuth2AuthorizedClient` class in Spring Security) and accessing protected resources by placing a `Bearer` token in the `Authorization` header of an outbound request.The following example configures the application to act as an OAuth2 Client capable of requesting protected resources from a third party API:.Configure OAuth2 Client[tabs]=====Java::+[source,java,role="primary"]----@Configuration@EnableWebSecuritypublic class SecurityConfig {	@Bean	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {		http			// ...			.oauth2Client(Customizer.withDefaults());		return http.build();	}}----Kotlin::+[source,kotlin,role="secondary"]----import org.springframework.security.config.annotation.web.invoke@Configuration@EnableWebSecurityclass SecurityConfig {	@Bean	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {		http {			// ...			oauth2Client { }		}		return http.build()	}}----=====[NOTE]====The above example does not provide a way to log users in.You can use any other login mechanism (such as `formLogin()`).See the <<oauth2-client-access-protected-resources-current-user,previous section>> for an example combining `oauth2Client()` with `oauth2Login()`.====In addition to the above configuration, the application requires at least one `ClientRegistration` to be configured through the use of a `ClientRegistrationRepository` bean.The following example configures an `InMemoryClientRegistrationRepository` bean using Spring Boot configuration properties:[source,yaml]----spring:  security:    oauth2:      client:        registration:          my-oauth2-client:            provider: my-auth-server            client-id: my-client-id            client-secret: my-client-secret            authorization-grant-type: authorization_code            scope: message.read,message.write        provider:          my-auth-server:            issuer-uri: https://my-auth-server.com----In addition to configuring Spring Security to support OAuth2 Client features, you will also need to decide how you will be accessing protected resources and configure your application accordingly.Spring Security provides implementations of `OAuth2AuthorizedClientManager` for obtaining access tokens that can be used to access protected resources.[TIP]====Spring Security registers a default `OAuth2AuthorizedClientManager` bean for you when one does not exist.====<<oauth2-client-access-protected-resources,Instead of configuring a `RestClient`>>, another way to use an `OAuth2AuthorizedClientManager` is via an `ExchangeFilterFunction` that intercepts requests through a `WebClient`.To use `WebClient`, you will need to add the `spring-webflux` dependency along with a reactive client implementation:.Add Spring WebFlux Dependency[tabs]======Gradle::+[source,gradle,role="primary"]----implementation 'org.springframework:spring-webflux'implementation 'io.projectreactor.netty:reactor-netty'----Maven::+[source,maven,role="secondary"]----<dependency>	<groupId>org.springframework</groupId>	<artifactId>spring-webflux</artifactId></dependency><dependency>	<groupId>io.projectreactor.netty</groupId>	<artifactId>reactor-netty</artifactId></dependency>----======The following example uses the default `OAuth2AuthorizedClientManager` to configure a `WebClient` capable of accessing protected resources by placing `Bearer` tokens in the `Authorization` header of each request:.Configure `WebClient` with `ExchangeFilterFunction`[tabs]=====Java::+[source,java,role="primary"]----@Configurationpublic class WebClientConfig {	@Bean	public WebClient webClient(OAuth2AuthorizedClientManager authorizedClientManager) {		ServletOAuth2AuthorizedClientExchangeFilterFunction filter =				new ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager);		return WebClient.builder()				.apply(filter.oauth2Configuration())				.build();	}}----Kotlin::+[source,kotlin,role="secondary"]----@Configurationclass WebClientConfig {	@Bean	fun webClient(authorizedClientManager: OAuth2AuthorizedClientManager): WebClient {		val filter = ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)		return WebClient.builder()			.apply(filter.oauth2Configuration())			.build()	}}----=====This configured `WebClient` can be used as in the following example:.Use `WebClient` to Access Protected Resources[tabs]=====Java::+[source,java,role="primary"]----import static org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction.clientRegistrationId;@RestControllerpublic class MessagesController {	private final WebClient webClient;	public MessagesController(WebClient webClient) {		this.webClient = webClient;	}	@GetMapping("/messages")	public ResponseEntity<List<Message>> messages() {		return this.webClient.get()				.uri("http://localhost:8090/messages")				.attributes(clientRegistrationId("my-oauth2-client"))				.retrieve()				.toEntityList(Message.class)				.block();	}	public record Message(String message) {	}}----Kotlin::+[source,kotlin,role="secondary"]----import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction.clientRegistrationId@RestControllerclass MessagesController(private val webClient: WebClient) {	@GetMapping("/messages")	fun messages(): ResponseEntity<List<Message>> {		return webClient.get()			.uri("http://localhost:8090/messages")			.attributes(clientRegistrationId("my-oauth2-client"))			.retrieve()			.toEntityList<Message>()			.block()!!	}	data class Message(val message: String)}----=====[[oauth2-client-access-protected-resources-current-user]]=== Access Protected Resources for the Current UserWhen a user is logged in via OAuth2 or OpenID Connect, the authorization server may provide an access token that can be used directly to access protected resources.This is convenient because it only requires a single `ClientRegistration` to be configured for both use cases simultaneously.[NOTE]====This section combines <<oauth2-client-log-users-in>> and <<oauth2-client-access-protected-resources>> into a single configuration.Other advanced scenarios exist, such as configuring one `ClientRegistration` for login and another for accessing protected resources.All such scenarios would use the same basic configuration.====The following example configures the application to act as an OAuth2 Client capable of logging the user in _and_ requesting protected resources from a third party API:.Configure OAuth2 Login and OAuth2 Client[tabs]=====Java::+[source,java,role="primary"]----@Configuration@EnableWebSecuritypublic class SecurityConfig {	@Bean	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {		http			// ...			.oauth2Login(Customizer.withDefaults())			.oauth2Client(Customizer.withDefaults());		return http.build();	}}----Kotlin::+[source,kotlin,role="secondary"]----import org.springframework.security.config.annotation.web.invoke@Configuration@EnableWebSecurityclass SecurityConfig {	@Bean	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {		http {			// ...			oauth2Login { }			oauth2Client { }		}		return http.build()	}}----=====In addition to the above configuration, the application requires at least one `ClientRegistration` to be configured through the use of a `ClientRegistrationRepository` bean.The following example configures an `InMemoryClientRegistrationRepository` bean using Spring Boot configuration properties:[source,yaml]----spring:  security:    oauth2:      client:        registration:          my-combined-client:            provider: my-auth-server            client-id: my-client-id            client-secret: my-client-secret            authorization-grant-type: authorization_code            scope: openid,profile,message.read,message.write        provider:          my-auth-server:            issuer-uri: https://my-auth-server.com----[NOTE]====The main difference between the previous examples (<<oauth2-client-log-users-in>>,  <<oauth2-client-access-protected-resources>>) and this one is what is configured via the `scope` property, which combines the standard scopes `openid` and `profile` with the custom scopes `message.read` and `message.write`.====In addition to configuring Spring Security to support OAuth2 Client features, you will also need to decide how you will be accessing protected resources and configure your application accordingly.Spring Security provides implementations of `OAuth2AuthorizedClientManager` for obtaining access tokens that can be used to access protected resources.[TIP]====Spring Security registers a default `OAuth2AuthorizedClientManager` bean for you when one does not exist.====The easiest way to use an `OAuth2AuthorizedClientManager` is via a `ClientHttpRequestInterceptor` that intercepts requests through a `RestClient`, which is already available when `spring-web` is on the classpath.The following example uses the default `OAuth2AuthorizedClientManager` to configure a `RestClient` capable of accessing protected resources by placing `Bearer` tokens in the `Authorization` header of each request:.Configure `RestClient` with `ClientHttpRequestInterceptor`[tabs]=====Java::+[source,java,role="primary"]----@Configurationpublic class RestClientConfig {	@Bean	public RestClient restClient(OAuth2AuthorizedClientManager authorizedClientManager) {		OAuth2ClientHttpRequestInterceptor requestInterceptor =				new OAuth2ClientHttpRequestInterceptor(authorizedClientManager);		requestInterceptor.setClientRegistrationIdResolver(clientRegistrationIdResolver());		return RestClient.builder()				.requestInterceptor(requestInterceptor)				.build();	}	private static ClientRegistrationIdResolver clientRegistrationIdResolver() {		return (request) -> {			Authentication authentication = SecurityContextHolder.getContext().getAuthentication();			return (authentication instanceof OAuth2AuthenticationToken principal)				? principal.getAuthorizedClientRegistrationId()				: null;		};	}}----Kotlin::+[source,kotlin,role="secondary"]----@Configurationclass RestClientConfig {	@Bean	fun restClient(authorizedClientManager: OAuth2AuthorizedClientManager): RestClient {		val requestInterceptor = OAuth2ClientHttpRequestInterceptor(authorizedClientManager, clientRegistrationIdResolver())		return RestClient.builder()			.requestInterceptor(requestInterceptor)			.build()	}	private fun clientRegistrationIdResolver(): OAuth2ClientHttpRequestInterceptor.ClientRegistrationIdResolver {		return OAuth2ClientHttpRequestInterceptor.ClientRegistrationIdResolver { request ->			val authentication = SecurityContextHolder.getContext().authentication			if (authentication is OAuth2AuthenticationToken) {				authentication.authorizedClientRegistrationId			} else {				null			}		}	}}----=====This configured `RestClient` can be used as in the following example:[[oauth2-client-accessing-protected-resources-current-user-example]].Use `RestClient` to Access Protected Resources (Current User)[tabs]=====Java::+[source,java,role="primary"]----@RestControllerpublic class MessagesController {	private final RestClient restClient;	public MessagesController(RestClient restClient) {		this.restClient = restClient;	}	@GetMapping("/messages")	public ResponseEntity<List<Message>> messages() {		Message[] messages = this.restClient.get()				.uri("http://localhost:8090/messages")				.retrieve()				.body(Message[].class);		return ResponseEntity.ok(Arrays.asList(messages));	}	public record Message(String message) {	}}----Kotlin::+[source,kotlin,role="secondary"]----import org.springframework.web.client.body@RestControllerclass MessagesController(private val restClient: RestClient) {	@GetMapping("/messages")	fun messages(): ResponseEntity<List<Message>> {		val messages = restClient.get()			.uri("http://localhost:8090/messages")			.retrieve()			.body<Array<Message>>()!!			.toList()		return ResponseEntity.ok(messages)	}	data class Message(val message: String)}----=====[NOTE]====Unlike the <<oauth2-client-accessing-protected-resources-example,previous example>>, notice that we do not need to tell Spring Security about the `clientRegistrationId` we'd like to use.This is because it can be derived from the currently logged in user.====[[oauth2-client-client-credentials]]=== Use the Client Credentials Grant[NOTE]====This section focuses on additional considerations for the client credentials grant type.See <<oauth2-client-access-protected-resources>> for general setup and usage with all grant types.====The https://tools.ietf.org/html/rfc6749#section-1.3.4[client credentials grant] allows a client to obtain an `access_token` on behalf of itself.The client credentials grant is a simple flow that does not involve a resource owner (i.e. a user).[WARNING]====It is important to note that typical use of the client credentials grant implies that any request (or user) can potentially obtain an access token and make protected resources requests to a resource server.Exercise caution when designing applications to ensure that users cannot make unauthorized requests since every request will be able to obtain an access token.====When obtaining access tokens within a web application where users can log in, the default behavior of Spring Security is to obtain an access token per user.[NOTE]====By default, access tokens are scoped to the principal name of the current user which means every user will receive a unique access token.====Clients using the client credentials grant typically require access tokens to be scoped to the application instead of to individual users so there is only one access token per application.In order to scope access tokens to the application, you will need to set a strategy for resolving a custom principal name.The following example does this by configuring a `RestClient` with the `RequestAttributePrincipalResolver`:.Configure `RestClient` for `client_credentials`[tabs]=====Java::+[source,java,role="primary"]----@Configurationpublic class RestClientConfig {	@Bean	public RestClient restClient(OAuth2AuthorizedClientManager authorizedClientManager) {		OAuth2ClientHttpRequestInterceptor requestInterceptor =				new OAuth2ClientHttpRequestInterceptor(authorizedClientManager);		requestInterceptor.setPrincipalResolver(new RequestAttributePrincipalResolver());		return RestClient.builder()				.requestInterceptor(requestInterceptor)				.build();	}}----Kotlin::+[source,kotlin,role="secondary"]----@Configurationclass RestClientConfig {	@Bean	fun restClient(authorizedClientManager: OAuth2AuthorizedClientManager): RestClient {		val requestInterceptor = OAuth2ClientHttpRequestInterceptor(authorizedClientManager)		requestInterceptor.setPrincipalResolver(RequestAttributePrincipalResolver())		return RestClient.builder()			.requestInterceptor(requestInterceptor)			.build()	}}----=====With the above configuration in place, a principal name can be specified for each request.The following example demonstrates how to scope access tokens to the application by specifying a principal name:.Scope Access Tokens to the Application[tabs]=====Java::+[source,java,role="primary"]----import static org.springframework.security.oauth2.client.web.client.RequestAttributeClientRegistrationIdResolver.clientRegistrationId;import static org.springframework.security.oauth2.client.web.client.RequestAttributePrincipalResolver.principal;@RestControllerpublic class MessagesController {	private final RestClient restClient;	public MessagesController(RestClient restClient) {		this.restClient = restClient;	}	@GetMapping("/messages")	public ResponseEntity<List<Message>> messages() {		Message[] messages = this.restClient.get()				.uri("http://localhost:8090/messages")				.attributes(clientRegistrationId("my-oauth2-client"))				.attributes(principal("my-application"))				.retrieve()				.body(Message[].class);		return ResponseEntity.ok(Arrays.asList(messages));	}	public record Message(String message) {	}}----Kotlin::+[source,kotlin,role="secondary"]----import org.springframework.security.oauth2.client.web.client.RequestAttributeClientRegistrationIdResolver.clientRegistrationIdimport org.springframework.security.oauth2.client.web.client.RequestAttributePrincipalResolver.principalimport org.springframework.web.client.body@RestControllerclass MessagesController(private val restClient: RestClient) {	@GetMapping("/messages")	fun messages(): ResponseEntity<List<Message>> {		val messages = restClient.get()			.uri("http://localhost:8090/messages")			.attributes(clientRegistrationId("my-oauth2-client"))			.attributes(principal("my-application"))			.retrieve()			.body<Array<Message>>()!!			.toList()		return ResponseEntity.ok(messages)	}	data class Message(val message: String)}----=====[NOTE]====When specifying a principal name via attributes as in the above example, there will only be a single access token and it will be used for all requests.====[[oauth2-client-enable-extension-grant-type]]=== Enable an Extension Grant TypeA common use case involves enabling and/or configuring an extension grant type.For example, Spring Security provides support for the `jwt-bearer` and `token-exchange` grant types, but does not enable them by default because they are not part of the core OAuth 2.0 specification.With Spring Security 6.2 and later, we can simply publish a bean for one or more `OAuth2AuthorizedClientProvider` and they will be picked up automatically.The following example simply enables the `jwt-bearer` grant type:.Enable `jwt-bearer` Grant Type[tabs]=====Java::+[source,java,role="primary"]----@Configurationpublic class SecurityConfig {	@Bean	public OAuth2AuthorizedClientProvider jwtBearer() {		return new JwtBearerOAuth2AuthorizedClientProvider();	}}----Kotlin::+[source,kotlin,role="secondary"]----@Configurationclass SecurityConfig {	@Bean	fun jwtBearer(): OAuth2AuthorizedClientProvider {		return JwtBearerOAuth2AuthorizedClientProvider()	}}----=====A default `OAuth2AuthorizedClientManager` will be published automatically by Spring Security when one is not already provided.[TIP]====Any custom `OAuth2AuthorizedClientProvider` bean will also be picked up and applied to the provided `OAuth2AuthorizedClientManager` after the default grant types.====In order to achieve the above configuration prior to Spring Security 6.2, we had to publish this bean ourselves and ensure we re-enabled default grant types as well.To understand what is being configured behind the scenes, here's what the configuration might have looked like:.Enable `jwt-bearer` Grant Type (prior to 6.2)[tabs]=====Java::+[source,java,role="primary"]----@Configurationpublic class SecurityConfig {	@Bean	public OAuth2AuthorizedClientManager authorizedClientManager(			ClientRegistrationRepository clientRegistrationRepository,			OAuth2AuthorizedClientRepository authorizedClientRepository) {		OAuth2AuthorizedClientProvider authorizedClientProvider =			OAuth2AuthorizedClientProviderBuilder.builder()				.authorizationCode()				.refreshToken()				.clientCredentials()				.password()				.provider(new JwtBearerOAuth2AuthorizedClientProvider())				.build();		DefaultOAuth2AuthorizedClientManager authorizedClientManager =			new DefaultOAuth2AuthorizedClientManager(				clientRegistrationRepository, authorizedClientRepository);		authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider);		return authorizedClientManager;	}}----Kotlin::+[source,kotlin,role="secondary"]----@Configurationclass SecurityConfig {	@Bean	fun authorizedClientManager(		clientRegistrationRepository: ClientRegistrationRepository,		authorizedClientRepository: OAuth2AuthorizedClientRepository	): OAuth2AuthorizedClientManager {		val authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder()			.authorizationCode()			.refreshToken()			.clientCredentials()			.password()			.provider(JwtBearerOAuth2AuthorizedClientProvider())			.build()		val authorizedClientManager = DefaultOAuth2AuthorizedClientManager(			clientRegistrationRepository, authorizedClientRepository		)		authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider)		return authorizedClientManager	}}----=====[[oauth2-client-customize-existing-grant-type]]=== Customize an Existing Grant TypeThe ability to <<oauth2-client-enable-extension-grant-type,enable extension grant types>> by publishing a bean also provides the opportunity for customizing an existing grant type without the need to re-define the defaults.For example, if we want to customize the clock skew of the `OAuth2AuthorizedClientProvider` for the `client_credentials` grant, we can simply publish a bean like so:.Customize Client Credentials Grant Type[tabs]=====Java::+[source,java,role="primary"]----@Configurationpublic class SecurityConfig {	@Bean	public OAuth2AuthorizedClientProvider clientCredentials() {		ClientCredentialsOAuth2AuthorizedClientProvider authorizedClientProvider =				new ClientCredentialsOAuth2AuthorizedClientProvider();		authorizedClientProvider.setClockSkew(Duration.ofMinutes(5));		return authorizedClientProvider;	}}----Kotlin::+[source,kotlin,role="secondary"]----@Configurationclass SecurityConfig {	@Bean	fun clientCredentials(): OAuth2AuthorizedClientProvider {		val authorizedClientProvider = ClientCredentialsOAuth2AuthorizedClientProvider()		authorizedClientProvider.setClockSkew(Duration.ofMinutes(5))		return authorizedClientProvider	}}----=====[[oauth2-client-customize-request-parameters]]=== Customize Token Request ParametersThe need to customize request parameters when obtaining an access token is fairly common.For example, let's say we want to add a custom `audience` parameter to the token request because the provider requires this parameter for the `authorization_code` grant.With Spring Security 6.2 and later, we can simply publish a bean of type `OAuth2AccessTokenResponseClient` with the generic type `OAuth2AuthorizationCodeGrantRequest` and it will be used by Spring Security to configure OAuth2 Client components.The following example customizes token request parameters for the `authorization_code` grant without the DSL:.Customize Token Request Parameters for Authorization Code Grant[tabs]=====Java::+[source,java,role="primary"]----@Configurationpublic class SecurityConfig {	@Bean	public OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> authorizationCodeAccessTokenResponseClient() {		OAuth2AuthorizationCodeGrantRequestEntityConverter requestEntityConverter =			new OAuth2AuthorizationCodeGrantRequestEntityConverter();		requestEntityConverter.addParametersConverter(parametersConverter());		DefaultAuthorizationCodeTokenResponseClient accessTokenResponseClient =			new DefaultAuthorizationCodeTokenResponseClient();		accessTokenResponseClient.setRequestEntityConverter(requestEntityConverter);		return accessTokenResponseClient;	}	private static Converter<OAuth2AuthorizationCodeGrantRequest, MultiValueMap<String, String>> parametersConverter() {		return (grantRequest) -> {			MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();			parameters.set("audience", "xyz_value");			return parameters;		};	}}----Kotlin::+[source,kotlin,role="secondary"]----@Configurationclass SecurityConfig {	@Bean	fun authorizationCodeAccessTokenResponseClient(): OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> {		val requestEntityConverter = OAuth2AuthorizationCodeGrantRequestEntityConverter()		requestEntityConverter.addParametersConverter(parametersConverter())		val accessTokenResponseClient = DefaultAuthorizationCodeTokenResponseClient()		accessTokenResponseClient.setRequestEntityConverter(requestEntityConverter)		return accessTokenResponseClient	}	private fun parametersConverter(): Converter<OAuth2AuthorizationCodeGrantRequest, MultiValueMap<String, String>> {		return Converter<OAuth2AuthorizationCodeGrantRequest, MultiValueMap<String, String>> { grantRequest ->			LinkedMultiValueMap<String, String>().also { parameters ->				parameters["audience"] = "xyz_value"			}		}	}}----=====[TIP]====Notice that we don't need to customize the `SecurityFilterChain` bean in this case, and can stick with the defaults.If using Spring Boot with no additional customizations, we can actually omit the `SecurityFilterChain` bean entirely.====Prior to Spring Security 6.2, we had to ensure that this customization was applied for both OAuth2 Login (if we are using this feature) and OAuth2 Client components using the Spring Security DSL.To understand what is being configured behind the scenes, here's what the configuration might have looked like:.Customize Token Request Parameters for Authorization Code Grant (prior to 6.2)[tabs]=====Java::+[source,java,role="primary"]----@Configuration@EnableWebSecuritypublic class SecurityConfig {	@Bean	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {		OAuth2AuthorizationCodeGrantRequestEntityConverter requestEntityConverter =			new OAuth2AuthorizationCodeGrantRequestEntityConverter();		requestEntityConverter.addParametersConverter(parametersConverter());		DefaultAuthorizationCodeTokenResponseClient accessTokenResponseClient =			new DefaultAuthorizationCodeTokenResponseClient();		accessTokenResponseClient.setRequestEntityConverter(requestEntityConverter);		http			.authorizeHttpRequests((authorize) -> authorize				.anyRequest().authenticated()			)			.oauth2Login((oauth2Login) -> oauth2Login				.tokenEndpoint((tokenEndpoint) -> tokenEndpoint					.accessTokenResponseClient(accessTokenResponseClient)				)			)			.oauth2Client((oauth2Client) -> oauth2Client				.authorizationCodeGrant((authorizationCode) -> authorizationCode					.accessTokenResponseClient(accessTokenResponseClient)				)			);		return http.build();	}	private static Converter<OAuth2AuthorizationCodeGrantRequest, MultiValueMap<String, String>> parametersConverter() {		// ...	}}----Kotlin::+[source,kotlin,role="secondary"]----import org.springframework.security.config.annotation.web.invoke@Configuration@EnableWebSecurityclass SecurityConfig {	@Bean	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {		val requestEntityConverter = OAuth2AuthorizationCodeGrantRequestEntityConverter()		requestEntityConverter.addParametersConverter(parametersConverter())		val tokenResponseClient = DefaultAuthorizationCodeTokenResponseClient()		tokenResponseClient.setRequestEntityConverter(requestEntityConverter)		http {			authorizeHttpRequests {				authorize(anyRequest, authenticated)			}			oauth2Login {				tokenEndpoint {					accessTokenResponseClient = tokenResponseClient				}			}			oauth2Client {				authorizationCodeGrant {					accessTokenResponseClient = tokenResponseClient				}			}		}		return http.build()	}	private fun parametersConverter(): Converter<OAuth2AuthorizationCodeGrantRequest, MultiValueMap<String, String>> {		// ...	}}----=====For other grant types we can publish additional `OAuth2AccessTokenResponseClient` beans to override the defaults.For example, to customize token requests for the `client_credentials` grant we can publish the following bean:.Customize Token Request Parameters for Client Credentials Grant[tabs]=====Java::+[source,java,role="primary"]----@Configurationpublic class SecurityConfig {	@Bean	public OAuth2AccessTokenResponseClient<OAuth2ClientCredentialsGrantRequest> clientCredentialsAccessTokenResponseClient() {		OAuth2ClientCredentialsGrantRequestEntityConverter requestEntityConverter =			new OAuth2ClientCredentialsGrantRequestEntityConverter();		requestEntityConverter.addParametersConverter(parametersConverter());		DefaultClientCredentialsTokenResponseClient accessTokenResponseClient =				new DefaultClientCredentialsTokenResponseClient();		accessTokenResponseClient.setRequestEntityConverter(requestEntityConverter);		return accessTokenResponseClient;	}	private static Converter<OAuth2ClientCredentialsGrantRequest, MultiValueMap<String, String>> parametersConverter() {		// ...	}}----Kotlin::+[source,kotlin,role="secondary"]----@Configurationclass SecurityConfig {	@Bean	fun clientCredentialsAccessTokenResponseClient(): OAuth2AccessTokenResponseClient<OAuth2ClientCredentialsGrantRequest> {		val requestEntityConverter = OAuth2ClientCredentialsGrantRequestEntityConverter()		requestEntityConverter.addParametersConverter(parametersConverter())		val accessTokenResponseClient = DefaultClientCredentialsTokenResponseClient()		accessTokenResponseClient.setRequestEntityConverter(requestEntityConverter)		return accessTokenResponseClient	}	private fun parametersConverter(): Converter<OAuth2ClientCredentialsGrantRequest, MultiValueMap<String, String>> {		// ...	}}----=====Spring Security automatically resolves the following generic types of `OAuth2AccessTokenResponseClient` beans:* `OAuth2AuthorizationCodeGrantRequest` (see `DefaultAuthorizationCodeTokenResponseClient`)* `OAuth2RefreshTokenGrantRequest` (see `DefaultRefreshTokenTokenResponseClient`)* `OAuth2ClientCredentialsGrantRequest` (see `DefaultClientCredentialsTokenResponseClient`)* `OAuth2PasswordGrantRequest` (see `DefaultPasswordTokenResponseClient`)* `JwtBearerGrantRequest` (see `DefaultJwtBearerTokenResponseClient`)* `TokenExchangeGrantRequest` (see `DefaultTokenExchangeTokenResponseClient`)[TIP]====Publishing a bean of type `OAuth2AccessTokenResponseClient<JwtBearerGrantRequest>` will automatically enable the `jwt-bearer` grant type without the need to <<oauth2-client-enable-extension-grant-type,configure it separately>>.====[TIP]====Publishing a bean of type `OAuth2AccessTokenResponseClient<TokenExchangeGrantRequest>` will automatically enable the `token-exchange` grant type without the need to <<oauth2-client-enable-extension-grant-type,configure it separately>>.====[[oauth2-client-customize-rest-operations]]=== Customize the `RestOperations` used by OAuth2 Client ComponentsAnother common use case is the need to customize the `RestOperations` used when obtaining an access token.We might need to do this to customize processing of the response (via a custom `HttpMessageConverter`) or to apply proxy settings for a corporate network (via a customized `ClientHttpRequestFactory`).With Spring Security 6.2 and later, we can simply publish beans of type `OAuth2AccessTokenResponseClient` and Spring Security will configure and publish an `OAuth2AuthorizedClientManager` bean for us.The following example customizes the `RestOperations` for all of the supported grant types:.Customize `RestOperations` for OAuth2 Client[tabs]=====Java::+[source,java,role="primary"]----@Configurationpublic class SecurityConfig {	@Bean	public OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> authorizationCodeAccessTokenResponseClient() {		DefaultAuthorizationCodeTokenResponseClient accessTokenResponseClient =			new DefaultAuthorizationCodeTokenResponseClient();		accessTokenResponseClient.setRestOperations(restTemplate());		return accessTokenResponseClient;	}	@Bean	public OAuth2AccessTokenResponseClient<OAuth2RefreshTokenGrantRequest> refreshTokenAccessTokenResponseClient() {		DefaultRefreshTokenTokenResponseClient accessTokenResponseClient =			new DefaultRefreshTokenTokenResponseClient();		accessTokenResponseClient.setRestOperations(restTemplate());		return accessTokenResponseClient;	}	@Bean	public OAuth2AccessTokenResponseClient<OAuth2ClientCredentialsGrantRequest> clientCredentialsAccessTokenResponseClient() {		DefaultClientCredentialsTokenResponseClient accessTokenResponseClient =			new DefaultClientCredentialsTokenResponseClient();		accessTokenResponseClient.setRestOperations(restTemplate());		return accessTokenResponseClient;	}	@Bean	public OAuth2AccessTokenResponseClient<OAuth2PasswordGrantRequest> passwordAccessTokenResponseClient() {		DefaultPasswordTokenResponseClient accessTokenResponseClient =			new DefaultPasswordTokenResponseClient();		accessTokenResponseClient.setRestOperations(restTemplate());		return accessTokenResponseClient;	}	@Bean	public OAuth2AccessTokenResponseClient<JwtBearerGrantRequest> jwtBearerAccessTokenResponseClient() {		DefaultJwtBearerTokenResponseClient accessTokenResponseClient =			new DefaultJwtBearerTokenResponseClient();		accessTokenResponseClient.setRestOperations(restTemplate());		return accessTokenResponseClient;	}	@Bean	public OAuth2AccessTokenResponseClient<TokenExchangeGrantRequest> tokenExchangeAccessTokenResponseClient() {		DefaultTokenExchangeTokenResponseClient accessTokenResponseClient =			new DefaultTokenExchangeTokenResponseClient();		accessTokenResponseClient.setRestOperations(restTemplate());		return accessTokenResponseClient;	}	@Bean	public RestTemplate restTemplate() {		// ...	}}----Kotlin::+[source,kotlin,role="secondary"]----@Configurationclass SecurityConfig {	@Bean	fun authorizationCodeAccessTokenResponseClient(): OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> {		val accessTokenResponseClient = DefaultAuthorizationCodeTokenResponseClient()		accessTokenResponseClient.setRestOperations(restTemplate())		return accessTokenResponseClient	}	@Bean	fun refreshTokenAccessTokenResponseClient(): OAuth2AccessTokenResponseClient<OAuth2RefreshTokenGrantRequest> {		val accessTokenResponseClient = DefaultRefreshTokenTokenResponseClient()		accessTokenResponseClient.setRestOperations(restTemplate())		return accessTokenResponseClient	}	@Bean	fun clientCredentialsAccessTokenResponseClient(): OAuth2AccessTokenResponseClient<OAuth2ClientCredentialsGrantRequest> {		val accessTokenResponseClient = DefaultClientCredentialsTokenResponseClient()		accessTokenResponseClient.setRestOperations(restTemplate())		return accessTokenResponseClient	}	@Bean	fun passwordAccessTokenResponseClient(): OAuth2AccessTokenResponseClient<OAuth2PasswordGrantRequest> {		val accessTokenResponseClient = DefaultPasswordTokenResponseClient()		accessTokenResponseClient.setRestOperations(restTemplate())		return accessTokenResponseClient	}	@Bean	fun jwtBearerAccessTokenResponseClient(): OAuth2AccessTokenResponseClient<JwtBearerGrantRequest> {		val accessTokenResponseClient = DefaultJwtBearerTokenResponseClient()		accessTokenResponseClient.setRestOperations(restTemplate())		return accessTokenResponseClient	}	@Bean	fun tokenExchangeAccessTokenResponseClient(): OAuth2AccessTokenResponseClient<TokenExchangeGrantRequest> {		val accessTokenResponseClient = DefaultTokenExchangeTokenResponseClient()		accessTokenResponseClient.setRestOperations(restTemplate())		return accessTokenResponseClient	}	@Bean	fun restTemplate(): RestTemplate {		// ...	}}----=====A default `OAuth2AuthorizedClientManager` will be published automatically by Spring Security when one is not already provided.[TIP]====Notice that we don't need to customize the `SecurityFilterChain` bean in this case, and can stick with the defaults.If using Spring Boot with no additional customizations, we can actually omit the `SecurityFilterChain` bean entirely.====Prior to Spring Security 6.2, we had to ensure this customization was applied to both OAuth2 Login (if we are using this feature) and OAuth2 Client components.We had to use both the Spring Security DSL (for the `authorization_code` grant) and publish a bean of type `OAuth2AuthorizedClientManager` for other grant types.To understand what is being configured behind the scenes, here's what the configuration might have looked like:.Customize `RestOperations` for OAuth2 Client (prior to 6.2)[tabs]=====Java::+[source,java,role="primary"]----@Configuration@EnableWebSecuritypublic class SecurityConfig {	@Bean	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {		DefaultAuthorizationCodeTokenResponseClient accessTokenResponseClient =			new DefaultAuthorizationCodeTokenResponseClient();		accessTokenResponseClient.setRestOperations(restTemplate());		http			// ...			.oauth2Login((oauth2Login) -> oauth2Login				.tokenEndpoint((tokenEndpoint) -> tokenEndpoint					.accessTokenResponseClient(accessTokenResponseClient)				)			)			.oauth2Client((oauth2Client) -> oauth2Client				.authorizationCodeGrant((authorizationCode) -> authorizationCode					.accessTokenResponseClient(accessTokenResponseClient)				)			);		return http.build();	}	@Bean	public OAuth2AuthorizedClientManager authorizedClientManager(			ClientRegistrationRepository clientRegistrationRepository,			OAuth2AuthorizedClientRepository authorizedClientRepository) {		DefaultRefreshTokenTokenResponseClient refreshTokenAccessTokenResponseClient =			new DefaultRefreshTokenTokenResponseClient();		refreshTokenAccessTokenResponseClient.setRestOperations(restTemplate());		DefaultClientCredentialsTokenResponseClient clientCredentialsAccessTokenResponseClient =			new DefaultClientCredentialsTokenResponseClient();		clientCredentialsAccessTokenResponseClient.setRestOperations(restTemplate());		DefaultPasswordTokenResponseClient passwordAccessTokenResponseClient =			new DefaultPasswordTokenResponseClient();		passwordAccessTokenResponseClient.setRestOperations(restTemplate());		DefaultJwtBearerTokenResponseClient jwtBearerAccessTokenResponseClient =			new DefaultJwtBearerTokenResponseClient();		jwtBearerAccessTokenResponseClient.setRestOperations(restTemplate());		JwtBearerOAuth2AuthorizedClientProvider jwtBearerAuthorizedClientProvider =			new JwtBearerOAuth2AuthorizedClientProvider();		jwtBearerAuthorizedClientProvider.setAccessTokenResponseClient(jwtBearerAccessTokenResponseClient);		DefaultTokenExchangeTokenResponseClient tokenExchangeAccessTokenResponseClient =			new DefaultTokenExchangeTokenResponseClient();		tokenExchangeAccessTokenResponseClient.setRestOperations(restTemplate());		TokenExchangeOAuth2AuthorizedClientProvider tokenExchangeAuthorizedClientProvider =			new TokenExchangeOAuth2AuthorizedClientProvider();		tokenExchangeAuthorizedClientProvider.setAccessTokenResponseClient(tokenExchangeAccessTokenResponseClient);		OAuth2AuthorizedClientProvider authorizedClientProvider =			OAuth2AuthorizedClientProviderBuilder.builder()				.authorizationCode()				.refreshToken((refreshToken) -> refreshToken					.accessTokenResponseClient(refreshTokenAccessTokenResponseClient)				)				.clientCredentials((clientCredentials) -> clientCredentials					.accessTokenResponseClient(clientCredentialsAccessTokenResponseClient)				)				.password((password) -> password					.accessTokenResponseClient(passwordAccessTokenResponseClient)				)				.provider(jwtBearerAuthorizedClientProvider)				.provider(tokenExchangeAuthorizedClientProvider)				.build();		DefaultOAuth2AuthorizedClientManager authorizedClientManager =			new DefaultOAuth2AuthorizedClientManager(				clientRegistrationRepository, authorizedClientRepository);		authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider);		return authorizedClientManager;	}	@Bean	public RestTemplate restTemplate() {		// ...	}}----Kotlin::+[source,kotlin,role="secondary"]----import org.springframework.security.config.annotation.web.invoke@Configuration@EnableWebSecurityclass SecurityConfig {	@Bean	fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {		val tokenResponseClient = DefaultAuthorizationCodeTokenResponseClient()		tokenResponseClient.setRestOperations(restTemplate())		http {			// ...			oauth2Login {				tokenEndpoint {					accessTokenResponseClient = tokenResponseClient				}			}			oauth2Client {				authorizationCodeGrant {					accessTokenResponseClient = tokenResponseClient				}			}		}		return http.build()	}	@Bean	fun authorizedClientManager(		clientRegistrationRepository: ClientRegistrationRepository?,		authorizedClientRepository: OAuth2AuthorizedClientRepository?	): OAuth2AuthorizedClientManager {		val refreshTokenAccessTokenResponseClient = DefaultRefreshTokenTokenResponseClient()		refreshTokenAccessTokenResponseClient.setRestOperations(restTemplate())		val clientCredentialsAccessTokenResponseClient = DefaultClientCredentialsTokenResponseClient()		clientCredentialsAccessTokenResponseClient.setRestOperations(restTemplate())		val passwordAccessTokenResponseClient = DefaultPasswordTokenResponseClient()		passwordAccessTokenResponseClient.setRestOperations(restTemplate())		val jwtBearerAccessTokenResponseClient = DefaultJwtBearerTokenResponseClient()		jwtBearerAccessTokenResponseClient.setRestOperations(restTemplate())		val jwtBearerAuthorizedClientProvider = JwtBearerOAuth2AuthorizedClientProvider()		jwtBearerAuthorizedClientProvider.setAccessTokenResponseClient(jwtBearerAccessTokenResponseClient)		val tokenExchangeAccessTokenResponseClient = DefaultTokenExchangeTokenResponseClient()		tokenExchangeAccessTokenResponseClient.setRestOperations(restTemplate())		val tokenExchangeAuthorizedClientProvider = TokenExchangeOAuth2AuthorizedClientProvider()		tokenExchangeAuthorizedClientProvider.setAccessTokenResponseClient(tokenExchangeAccessTokenResponseClient)		val authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder()			.authorizationCode()			.refreshToken { refreshToken ->				refreshToken.accessTokenResponseClient(refreshTokenAccessTokenResponseClient)			}			.clientCredentials { clientCredentials ->				clientCredentials.accessTokenResponseClient(clientCredentialsAccessTokenResponseClient)			}			.password { password ->				password.accessTokenResponseClient(passwordAccessTokenResponseClient)			}			.provider(jwtBearerAuthorizedClientProvider)			.provider(tokenExchangeAuthorizedClientProvider)			.build()		val authorizedClientManager = DefaultOAuth2AuthorizedClientManager(			clientRegistrationRepository, authorizedClientRepository		)		authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider)		return authorizedClientManager	}	@Bean	fun restTemplate(): RestTemplate {		// ...	}}----=====[[further-reading]]== Further ReadingThe preceding sections introduced Spring Security's support for OAuth2 with examples for common scenarios.You can read more about OAuth2 Client and Resource Server in the following sections of the reference documentation:* xref:servlet/oauth2/login/index.adoc[]* xref:servlet/oauth2/client/index.adoc[]* xref:servlet/oauth2/resource-server/index.adoc[]


### PR DESCRIPTION
The code example in the "**Access Protected Resources for the Current User**" -> "**Configure RestClient with ClientHttpRequestInterceptor**" section was incorrect. Updated the example to use the correct `OAuth2ClientHttpRequestInterceptor ` constructor and added a call to `setClientRegistrationIdResolver`. This ensures accurate usage of the API.

Closes gh-16165