### PR TITLE
Fix OAuth2 documentation: Correct OAuth2ClientHttpRequestInterceptor usage

### DIFF
--- a/docs/modules/ROOT/pages/servlet/oauth2/index.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/index.adoc
@@ -1032,7 +1032,9 @@ public class RestClientConfig {
 	@Bean
 	public RestClient restClient(OAuth2AuthorizedClientManager authorizedClientManager) {
 		OAuth2ClientHttpRequestInterceptor requestInterceptor =
-				new OAuth2ClientHttpRequestInterceptor(authorizedClientManager, clientRegistrationIdResolver());
+				new OAuth2ClientHttpRequestInterceptor(authorizedClientManager);
+		requestInterceptor.setClientRegistrationIdResolver(clientRegistrationIdResolver());
+
 		return RestClient.builder()
 				.requestInterceptor(requestInterceptor)
 				.build();
@@ -1059,7 +1061,9 @@ class RestClientConfig {
 
 	@Bean
 	fun restClient(authorizedClientManager: OAuth2AuthorizedClientManager): RestClient {
-		val requestInterceptor = OAuth2ClientHttpRequestInterceptor(authorizedClientManager, clientRegistrationIdResolver())
+		val requestInterceptor = OAuth2ClientHttpRequestInterceptor(authorizedClientManager)
+		requestInterceptor.setClientRegistrationIdResolver(clientRegistrationIdResolver())
+
 		return RestClient.builder()
 			.requestInterceptor(requestInterceptor)
 			.build()


### PR DESCRIPTION
The code example in the "Access Protected Resources for the Current User" -> "Configure RestClient with ClientHttpRequestInterceptor" section was incorrect. Updated the example to use the correct `OAuth2ClientHttpRequestInterceptor ` constructor and added a call to `setClientRegistrationIdResolver`. This ensures accurate usage of the API.

Closes gh-16165.
