### PR TITLE
Fix Typo in 'What's New' Documentation

### DIFF
--- a/docs/modules/ROOT/pages/whats-new.adoc
+++ b/docs/modules/ROOT/pages/whats-new.adoc
@@ -223,7 +223,7 @@ class SecurityConfig {
 == SAML 2.0
 
 * Added xref:servlet/saml2/opensaml.adoc[OpenSAML 5 Support].
-Now you can use either OpenSAML 4 or OpenSAML 5; by default, Spring Security will select the write implementations based on what's on your classpath.
+Now you can use either OpenSAML 4 or OpenSAML 5; by default, Spring Security will select the right implementations based on what's on your classpath.
 * Using EntityIDs for the `registrationId` is simplified.
 +
 A common pattern is to identify asserting parties by their `entityID`.


### PR DESCRIPTION
This PR fixes a typo in the 'What's New' documentation. The phrase `'select the write' `has been corrected to `'select the right'` for clarity and accuracy.

The change ensures better readability and aligns with the intended meaning in the context of the documentation.

Closes gh-16178
