### PR TITLE
Only set httpOnly and secure flags to Csrf cookie if the values are true

### DIFF
--- a/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CookieCsrfTokenRepository.java
@@ -189,10 +189,14 @@ public final class CookieCsrfTokenRepository implements CsrfTokenRepository {
 
 	private Cookie mapToCookie(ResponseCookie responseCookie) {
 		Cookie cookie = new Cookie(responseCookie.getName(), responseCookie.getValue());
-		cookie.setSecure(responseCookie.isSecure());
+		if (responseCookie.isSecure()) {
+			cookie.setSecure(true);
+		}
 		cookie.setPath(responseCookie.getPath());
 		cookie.setMaxAge((int) responseCookie.getMaxAge().getSeconds());
-		cookie.setHttpOnly(responseCookie.isHttpOnly());
+		if (responseCookie.isHttpOnly()) {
+			cookie.setHttpOnly(true);
+		}
 		if (StringUtils.hasLength(responseCookie.getDomain())) {
 			cookie.setDomain(responseCookie.getDomain());
 		}


### PR DESCRIPTION
### Description of the Issue
The HttpOnly and Secure flags for a CSRF cookie should only be set if their respective properties are explicitly true.

This is because HttpOnly and Secure are boolean flags, and even assigning them an empty string can cause these flags to be applied. An example of this behavior can be observed in Tomcat 11. According to the [Tomcat 11 changelog](https://tomcat.apache.org/tomcat-11.0-doc/changelog.html):

> Refactor the internal representation of the HttpOnly and Secure attributes to use the empty string as the value for consistency with the recent changes to Set-Cookie header generation.

In Tomcat 11, this change results in the HttpOnly and Secure flags being added to cookies even if Spring Security does not intend to set these properties. This creates unexpected behavior where these flags are applied by default, potentially breaking existing configurations or assumptions.

### Proposed Solution
Modify the behavior of the CSRF cookie generation to only include the HttpOnly and Secure flags when their properties are explicitly set to true. This ensures compatibility with Tomcat 11 and other servlet containers following a similar approach.