### PR TITLE
Improve AuthorizationManager configuration error messages

### DIFF
--- a/config/src/main/java/org/springframework/security/config/http/AuthorizationFilterParser.java
+++ b/config/src/main/java/org/springframework/security/config/http/AuthorizationFilterParser.java
@@ -76,12 +76,12 @@ class AuthorizationFilterParser implements BeanDefinitionParser {
 	public BeanDefinition parse(Element element, ParserContext parserContext) {
 		if (!isUseExpressions(element)) {
 			parserContext.getReaderContext()
-				.error("AuthorizationManager must be used with `use-expressions=\"true\"", element);
+				.error("AuthorizationManager must be used with `use-expressions=\"true\"; Add `use-authorization-manager=\"false\"` or enable use of expressions in `<http>` block", element);
 			return null;
 		}
 		if (StringUtils.hasText(element.getAttribute(ATT_ACCESS_DECISION_MANAGER_REF))) {
 			parserContext.getReaderContext()
-				.error("AuthorizationManager cannot be used in conjunction with `access-decision-manager-ref`",
+				.error("AuthorizationManager cannot be used in conjunction with `access-decision-manager-ref`; either remove the reference to AccessDecisionManager or add `use-authorization-manager=\"false\"` to `<http>` block",
 						element);
 			return null;
 		}

--- a/config/src/main/java/org/springframework/security/config/http/AuthorizationFilterParser.java
+++ b/config/src/main/java/org/springframework/security/config/http/AuthorizationFilterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,12 +76,13 @@ class AuthorizationFilterParser implements BeanDefinitionParser {
 	public BeanDefinition parse(Element element, ParserContext parserContext) {
 		if (!isUseExpressions(element)) {
 			parserContext.getReaderContext()
-				.error("AuthorizationManager must be used with `use-expressions=\"true\"; Add `use-authorization-manager=\"false\"` or enable use of expressions in `<http>` block", element);
+				.error("AuthorizationManager must be used with `use-expressions=\"true\"; either add `use-authorization-manager=\"false\"` or `use-expressions=`\"false\"` in your `<http>` block",
+						element);
 			return null;
 		}
 		if (StringUtils.hasText(element.getAttribute(ATT_ACCESS_DECISION_MANAGER_REF))) {
 			parserContext.getReaderContext()
-				.error("AuthorizationManager cannot be used in conjunction with `access-decision-manager-ref`; either remove the reference to AccessDecisionManager or add `use-authorization-manager=\"false\"` to `<http>` block",
+				.error("AuthorizationManager cannot be used in conjunction with `access-decision-manager-ref`; either remove the reference to AccessDecisionManager or add `use-authorization-manager=\"false\"` to your `<http>` block",
 						element);
 			return null;
 		}


### PR DESCRIPTION
Users that are migrating from Spring 5.x don't know that the AuthorizationManager is turned on by default in 6.x and incompatible with their existing Access Decision Manager configuration.
This improvement to the error message with help to bring their attention to the relevant option that is true by default. It will also prevent them from wasting time and looking at where they implement or wire an AuthorizationManager instance.

Closes #16193
