### PR TITLE
Fix: Correct OpenSAML 5.x Documentation

### DIFF
--- a/docs/modules/ROOT/pages/servlet/saml2/opensaml.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/opensaml.adoc
@@ -25,33 +25,6 @@ Maven::
 +
 [source,maven,role="primary"]
 ----
-<dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>org.opensaml</groupId>
-            <artifactId>opensaml-core-api</artifactId>
-            <version>5.1.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.opensaml</groupId>
-            <artifactId>opensaml-core-impl</artifactId>
-            <version>5.1.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.opensaml</groupId>
-            <artifactId>opensaml-saml-api</artifactId>
-            <version>5.1.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.opensaml</groupId>
-            <artifactId>opensaml-saml-impl</artifactId>
-            <version>5.1.2</version>
-        </dependency>
-    </dependencies>
-</dependencyManagement>
-
-// ...
-
 <dependencies>
     <dependency>
         <groupId>org.springframework.security</groupId>
@@ -59,9 +32,19 @@ Maven::
         <exclusions>
             <exclusion>
                 <groupId>org.opensaml</groupId>
-                <artifactId>opensaml-core</artifactId>
+                <artifactId>*</artifactId>
             </exclusion>
         </exclusions>
+    </dependency>
+    <dependency>
+        <groupId>org.opensaml</groupId>
+        <artifactId>opensaml-saml-api</artifactId>
+        <version>5.1.2</version>
+    </dependency>
+    <dependency>
+        <groupId>org.opensaml</groupId>
+        <artifactId>opensaml-saml-impl</artifactId>
+        <version>5.1.2</version>
     </dependency>
 </dependencies>
 ----


### PR DESCRIPTION
- Corrected a typo in the closing dependency XML tag.
- Corrected typo in `<artifactId>` (`opensaml-saml-imple `-> `opensaml-saml-impl`).
- Excluded all `OpenSAML 4.x` dependencies.
- Removed redundant dependencies (`opensaml-core-api` and `opensaml-core-impl`) as they are transitively included in `opensaml-saml-api` and `opensaml-saml-impl`.

Closes gh-16191

