### PR TITLE
Remove duplicate cache in AuthenticationPrincipalArgumentResolver、and CurrentSecurityContextArgumentResolver

### DIFF
--- a/messaging/src/main/java/org/springframework/security/messaging/context/AuthenticationPrincipalArgumentResolver.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/context/AuthenticationPrincipalArgumentResolver.java
@@ -17,8 +17,6 @@
 package org.springframework.security.messaging.context;
 
 import java.lang.annotation.Annotation;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.expression.Expression;
@@ -95,8 +93,6 @@ public final class AuthenticationPrincipalArgumentResolver implements HandlerMet
 	private SecurityContextHolderStrategy securityContextHolderStrategy = SecurityContextHolder
 		.getContextHolderStrategy();
 
-	private final Map<MethodParameter, Annotation> cachedAttributes = new ConcurrentHashMap<>();
-
 	private ExpressionParser parser = new SpelExpressionParser();
 
 	private SecurityAnnotationScanner<AuthenticationPrincipal> scanner = SecurityAnnotationScanners
@@ -164,8 +160,7 @@ public final class AuthenticationPrincipalArgumentResolver implements HandlerMet
 	 */
 	@SuppressWarnings("unchecked")
 	private <T extends Annotation> T findMethodAnnotation(MethodParameter parameter) {
-		return (T) this.cachedAttributes.computeIfAbsent(parameter,
-				(methodParameter) -> this.scanner.scan(methodParameter.getParameter()));
+		return (T) this.scanner.scan(parameter.getParameter());
 	}
 
 }

--- a/messaging/src/main/java/org/springframework/security/messaging/handler/invocation/reactive/AuthenticationPrincipalArgumentResolver.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/handler/invocation/reactive/AuthenticationPrincipalArgumentResolver.java
@@ -17,8 +17,6 @@
 package org.springframework.security.messaging.handler.invocation.reactive;
 
 import java.lang.annotation.Annotation;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
@@ -98,8 +96,6 @@ import org.springframework.util.StringUtils;
  * @since 5.2
  */
 public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
-
-	private final Map<MethodParameter, Annotation> cachedAttributes = new ConcurrentHashMap<>();
 
 	private ExpressionParser parser = new SpelExpressionParser();
 
@@ -205,8 +201,7 @@ public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArg
 	 */
 	@SuppressWarnings("unchecked")
 	private <T extends Annotation> T findMethodAnnotation(MethodParameter parameter) {
-		return (T) this.cachedAttributes.computeIfAbsent(parameter,
-				(methodParameter) -> this.scanner.scan(methodParameter.getParameter()));
+		return (T) this.scanner.scan(parameter.getParameter());
 	}
 
 }

--- a/messaging/src/main/java/org/springframework/security/messaging/handler/invocation/reactive/CurrentSecurityContextArgumentResolver.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/handler/invocation/reactive/CurrentSecurityContextArgumentResolver.java
@@ -17,8 +17,6 @@
 package org.springframework.security.messaging.handler.invocation.reactive;
 
 import java.lang.annotation.Annotation;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
@@ -96,8 +94,6 @@ import org.springframework.util.StringUtils;
  * @since 5.2
  */
 public class CurrentSecurityContextArgumentResolver implements HandlerMethodArgumentResolver {
-
-	private final Map<MethodParameter, Annotation> cachedAttributes = new ConcurrentHashMap<>();
 
 	private ExpressionParser parser = new SpelExpressionParser();
 
@@ -222,8 +218,7 @@ public class CurrentSecurityContextArgumentResolver implements HandlerMethodArgu
 	 */
 	@SuppressWarnings("unchecked")
 	private <T extends Annotation> T findMethodAnnotation(MethodParameter parameter) {
-		return (T) this.cachedAttributes.computeIfAbsent(parameter,
-				(methodParameter) -> this.scanner.scan(methodParameter.getParameter()));
+		return (T) this.scanner.scan(parameter.getParameter());
 	}
 
 }

--- a/web/src/main/java/org/springframework/security/web/method/annotation/AuthenticationPrincipalArgumentResolver.java
+++ b/web/src/main/java/org/springframework/security/web/method/annotation/AuthenticationPrincipalArgumentResolver.java
@@ -17,8 +17,6 @@
 package org.springframework.security.web.method.annotation;
 
 import java.lang.annotation.Annotation;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.expression.BeanResolver;
@@ -97,8 +95,6 @@ public final class AuthenticationPrincipalArgumentResolver implements HandlerMet
 
 	private SecurityContextHolderStrategy securityContextHolderStrategy = SecurityContextHolder
 		.getContextHolderStrategy();
-
-	private final Map<MethodParameter, Annotation> cachedAttributes = new ConcurrentHashMap<>();
 
 	private ExpressionParser parser = new SpelExpressionParser();
 
@@ -179,8 +175,7 @@ public final class AuthenticationPrincipalArgumentResolver implements HandlerMet
 	 */
 	@SuppressWarnings("unchecked")
 	private <T extends Annotation> T findMethodAnnotation(MethodParameter parameter) {
-		return (T) this.cachedAttributes.computeIfAbsent(parameter,
-				(methodParameter) -> this.scanner.scan(methodParameter.getParameter()));
+		return (T) this.scanner.scan(parameter.getParameter());
 	}
 
 }

--- a/web/src/main/java/org/springframework/security/web/method/annotation/CurrentSecurityContextArgumentResolver.java
+++ b/web/src/main/java/org/springframework/security/web/method/annotation/CurrentSecurityContextArgumentResolver.java
@@ -17,8 +17,6 @@
 package org.springframework.security.web.method.annotation;
 
 import java.lang.annotation.Annotation;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.expression.BeanResolver;
@@ -83,8 +81,6 @@ public final class CurrentSecurityContextArgumentResolver implements HandlerMeth
 
 	private SecurityContextHolderStrategy securityContextHolderStrategy = SecurityContextHolder
 		.getContextHolderStrategy();
-
-	private final Map<MethodParameter, Annotation> cachedAttributes = new ConcurrentHashMap<>();
 
 	private ExpressionParser parser = new SpelExpressionParser();
 
@@ -177,8 +173,7 @@ public final class CurrentSecurityContextArgumentResolver implements HandlerMeth
 	 */
 	@SuppressWarnings("unchecked")
 	private <T extends Annotation> T findMethodAnnotation(MethodParameter parameter) {
-		return (T) this.cachedAttributes.computeIfAbsent(parameter,
-				(methodParameter) -> this.scanner.scan(methodParameter.getParameter()));
+		return (T) this.scanner.scan(parameter.getParameter());
 	}
 
 }

--- a/web/src/main/java/org/springframework/security/web/reactive/result/method/annotation/AuthenticationPrincipalArgumentResolver.java
+++ b/web/src/main/java/org/springframework/security/web/reactive/result/method/annotation/AuthenticationPrincipalArgumentResolver.java
@@ -17,8 +17,6 @@
 package org.springframework.security.web.reactive.result.method.annotation;
 
 import java.lang.annotation.Annotation;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
@@ -52,8 +50,6 @@ import org.springframework.web.server.ServerWebExchange;
  * @since 5.0
  */
 public class AuthenticationPrincipalArgumentResolver extends HandlerMethodArgumentResolverSupport {
-
-	private final Map<MethodParameter, Annotation> cachedAttributes = new ConcurrentHashMap<>();
 
 	private ExpressionParser parser = new SpelExpressionParser();
 
@@ -149,8 +145,7 @@ public class AuthenticationPrincipalArgumentResolver extends HandlerMethodArgume
 	 */
 	@SuppressWarnings("unchecked")
 	private <T extends Annotation> T findMethodAnnotation(MethodParameter parameter) {
-		return (T) this.cachedAttributes.computeIfAbsent(parameter,
-				(methodParameter) -> this.scanner.scan(methodParameter.getParameter()));
+		return (T) this.scanner.scan(parameter.getParameter());
 	}
 
 }

--- a/web/src/main/java/org/springframework/security/web/reactive/result/method/annotation/CurrentSecurityContextArgumentResolver.java
+++ b/web/src/main/java/org/springframework/security/web/reactive/result/method/annotation/CurrentSecurityContextArgumentResolver.java
@@ -17,8 +17,6 @@
 package org.springframework.security.web.reactive.result.method.annotation;
 
 import java.lang.annotation.Annotation;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
@@ -52,8 +50,6 @@ import org.springframework.web.server.ServerWebExchange;
  * @since 5.2
  */
 public class CurrentSecurityContextArgumentResolver extends HandlerMethodArgumentResolverSupport {
-
-	private final Map<MethodParameter, Annotation> cachedAttributes = new ConcurrentHashMap<>();
 
 	private ExpressionParser parser = new SpelExpressionParser();
 
@@ -189,8 +185,7 @@ public class CurrentSecurityContextArgumentResolver extends HandlerMethodArgumen
 	 */
 	@SuppressWarnings("unchecked")
 	private <T extends Annotation> T findMethodAnnotation(MethodParameter parameter) {
-		return (T) this.cachedAttributes.computeIfAbsent(parameter,
-				(methodParameter) -> this.scanner.scan(methodParameter.getParameter()));
+		return (T) this.scanner.scan(parameter.getParameter());
 	}
 
 }


### PR DESCRIPTION
Since UniqueSecurityAnnotationScanner has cached annotations internally