### PR TITLE
A RequestMatcherFactory API

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configuration/WebMvcSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configuration/WebMvcSecurityConfiguration.java
@@ -38,6 +38,7 @@ import org.springframework.beans.factory.support.ManagedList;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Scope;
 import org.springframework.context.expression.BeanFactoryResolver;
 import org.springframework.expression.BeanResolver;
 import org.springframework.security.core.annotation.AnnotationTemplateExpressionDefaults;
@@ -54,6 +55,7 @@ import org.springframework.security.web.method.annotation.AuthenticationPrincipa
 import org.springframework.security.web.method.annotation.CsrfTokenArgumentResolver;
 import org.springframework.security.web.method.annotation.CurrentSecurityContextArgumentResolver;
 import org.springframework.security.web.servlet.support.csrf.CsrfRequestDataValueProcessor;
+import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcherFactory;
 import org.springframework.web.filter.CompositeFilter;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -173,6 +175,12 @@ class WebMvcSecurityConfiguration implements WebMvcConfigurer, ApplicationContex
 				}
 			}
 		};
+	}
+
+	@Bean
+	@Scope("prototype")
+	MvcRequestMatcherFactory.Builder mvcRequestMatcherFactoryBuilder(HandlerMappingIntrospector introspector) {
+		return MvcRequestMatcherFactory.builder(introspector);
 	}
 
 	/**

--- a/config/src/test/java/org/springframework/security/config/annotation/web/AbstractRequestMatcherRegistryTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/AbstractRequestMatcherRegistryTests.java
@@ -24,6 +24,7 @@ import jakarta.servlet.Servlet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.ApplicationContext;
@@ -42,6 +43,7 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.DispatcherTypeRequestMatcher;
 import org.springframework.security.web.util.matcher.RegexRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcherFactory;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -87,6 +89,13 @@ public class AbstractRequestMatcherRegistryTests {
 		given(given).willReturn(postProcessors);
 		given(postProcessors.getObject()).willReturn(NO_OP_OBJECT_POST_PROCESSOR);
 		given(this.context.getServletContext()).willReturn(MockServletContext.mvc());
+		ObjectProvider<RequestMatcherFactory> requestMatcherFactories = new ObjectProvider<>() {
+			@Override
+			public RequestMatcherFactory getObject() throws BeansException {
+				return AbstractRequestMatcherRegistryTests.this.matcherRegistry.new DefaultRequestMatcherFactory();
+			}
+		};
+		given(this.context.getBeanProvider(RequestMatcherFactory.class)).willReturn(requestMatcherFactories);
 		this.matcherRegistry.setApplicationContext(this.context);
 		mockMvcIntrospector(true);
 	}

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/AuthorizeHttpRequestsConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/AuthorizeHttpRequestsConfigurerTests.java
@@ -64,6 +64,8 @@ import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import org.springframework.security.web.access.intercept.RequestMatcherDelegatingAuthorizationManager;
 import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcherFactory;
+import org.springframework.security.web.util.matcher.RequestMatcherFactory;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
@@ -72,6 +74,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
@@ -665,6 +668,19 @@ public class AuthorizeHttpRequestsConfigurerTests {
 		this.mvc.perform(get("/").with(user("user").roles("USER"))).andExpect(status().isOk());
 		this.mvc.perform(get("/").with(user("user").roles("WRONG"))).andExpect(status().isForbidden());
 		verifyNoInteractions(handler);
+	}
+
+	@Test
+	public void requestMatchersWhenMultipleDispatcherServletsAndPathBeanThenAllows() throws Exception {
+		this.spring.register(MvcRequestMatcherFactoryConfig.class, BasicController.class)
+			.postProcessor((context) -> context.getServletContext()
+				.addServlet("otherDispatcherServlet", DispatcherServlet.class)
+				.addMapping("/mvc"))
+			.autowire();
+		this.mvc.perform(get("/mvc/path").servletPath("/mvc").with(user("user"))).andExpect(status().isOk());
+		this.mvc.perform(get("/mvc/path").servletPath("/mvc").with(user("user").roles("DENIED")))
+			.andExpect(status().isForbidden());
+		this.mvc.perform(get("/path").with(user("user"))).andExpect(status().isForbidden());
 	}
 
 	@Configuration
@@ -1262,6 +1278,10 @@ public class AuthorizeHttpRequestsConfigurerTests {
 		void rootPost() {
 		}
 
+		@GetMapping("/path")
+		void path() {
+		}
+
 	}
 
 	@Configuration
@@ -1313,6 +1333,25 @@ public class AuthorizeHttpRequestsConfigurerTests {
 		@Bean
 		SecurityObservationSettings observabilityDefaults() {
 			return SecurityObservationSettings.withDefaults().shouldObserveAuthorizations(false).build();
+		}
+
+	}
+
+	@Configuration
+	@EnableWebSecurity
+	@EnableWebMvc
+	static class MvcRequestMatcherFactoryConfig {
+
+		@Bean
+		RequestMatcherFactory servletPath(MvcRequestMatcherFactory.Builder builder) {
+			return builder.servletPath("/mvc").build();
+		}
+
+		@Bean
+		SecurityFilterChain security(HttpSecurity http) throws Exception {
+			http.authorizeHttpRequests((authorize) -> authorize.requestMatchers("/path").hasRole("USER"))
+				.httpBasic(withDefaults());
+			return http.build();
 		}
 
 	}

--- a/docs/modules/ROOT/pages/servlet/authorization/authorize-http-requests.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/authorize-http-requests.adoc
@@ -640,10 +640,119 @@ Xml::
 ----
 ======
 
+[[conditions-for-servlet-path-matching]]
 This need can arise in at least two different ways:
 
 * If you use the `spring.mvc.servlet.path` Boot property to change the default path (`/`) to something else
 * If you register more than one Spring MVC `DispatcherServlet` (thus requiring that one of them not be the default path)
+
+=== Using a `RequestMatcherFactory`
+
+You can reduce the boilerplate of constructing several `MvcRequestMatcher` instances by providing a single instance of `RequestMatcherFactory`.
+
+For example, if all of your requests in `requestMatcher(String)` are MVC requests, then you can do:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Bean
+RequestMatcherFactory allRequestsAreMvc(HandlerMappingIntrospector introspector) {
+	MvcRequestMatcher.Builder mvc = new MvcRequestMatcher.Builder(introspector).servletPath("/my-servlet-path");
+	return mvc::pattern;
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@Bean fun allRequestsAreMvc(introspector: HandlerMappingIntrospector?): RequestMatcherFactory {
+    var mvc = MvcRequestMatcher.Builder(introspector).servletPath("/my-servlet-path")
+    return mvc::pattern
+}
+----
+======
+
+Spring Security will use this builder for all request matchers specified as a `String`.
+
+[TIP]
+====
+Often the only non-MVC requests that there are in a Spring Boot application are those to static resources like `/css", '/js', and 'favicon.ico`.
+====
+
+You can permit these by using Spring Boot's `RequestMatchers` static factory like so:
+
+[tabs]
+======
+Java::
++
+[source,java]
+----
+@Bean
+SecurityFilterChain security(HttpSecurity http) throws Exception {
+	http
+        .authorizeHttpRequests((authorize) -> authorize
+            .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+            .requestMatchers("/my", "/mvc", "/requests").hasAuthority("app")
+        )
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+http {
+    authorizeHttpRequests {
+        authorize(PathRequest.toStaticResources().atCommonLocations(), permitAll)
+        authorize("/my", hasAuthority("app"))
+        authorize("/mvc", hasAuthority("app"))
+        authorize("/requests", hasAuthority("app"))
+    }
+}
+----
+======
+
+Since `atCommonLocations` returns instances of `RequestMatcher`, this technique allows you to publish an MVC-based `RequestMatcherFactory` for the rest.
+
+In the event that <<conditions-for-servlet-path-matching, the absolute path would be ambiguous>>, you can publish an `MvcDelegatingRequestMatcherFactory` instance instead:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Bean
+RequestMatcherFactory allRequestsAreMvc(MvcRequestMatcherFactory.Builder builder) {
+	return builder.servletPath("/my-mvc-servlet-path").build();
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@Bean
+fun allRequestsAreMvc(builder: MvcRequestMatcherFactory.Builder?): RequestMatcherBuilder {
+    return builder.servletPath("/my-mvc-servlet-path").build()
+}
+----
+======
+
+This produces matchers that check first if the request is an MVC request; if it is, use an `MvcRequestMatcher` and otherwise use an `AntPathRequestMatcher`.
+
+[NOTE]
+====
+The reason this `RequestMatcherFactory` is not used by default is because of potential ambiguities in the meaning of given `String` patterns.
+For example, consider a servlet mapped to `/example` and a Spring MVC endpoint mapped to `/mvc-servlet-path/example` where `/mvc-servlet-path` is the servlet path for MVC endpoints.
+In this case, it's unclear whether by `requestMatchers("/example")` you mean to secure `/example`` or `/mvc-servlet-path/example`.
+
+Publishing any `RequestMatcherFactory` indicates that you will handle these ambiguous situations, should they arise.
+====
 
 [[match-by-custom]]
 === Using a Custom Matcher

--- a/web/src/main/java/org/springframework/security/web/servlet/util/matcher/MvcRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/servlet/util/matcher/MvcRequestMatcher.java
@@ -49,7 +49,7 @@ import org.springframework.web.util.UrlPathHelper;
  */
 public class MvcRequestMatcher implements RequestMatcher, RequestVariablesExtractor {
 
-	private final DefaultMatcher defaultMatcher = new DefaultMatcher();
+	private RequestMatcher defaultMatcher = new DefaultMatcher();
 
 	private final HandlerMappingIntrospector introspector;
 
@@ -128,6 +128,16 @@ public class MvcRequestMatcher implements RequestMatcher, RequestVariablesExtrac
 
 	protected final String getServletPath() {
 		return this.servletPath;
+	}
+
+	/**
+	 * The matcher that this should fall back on in the event that the request isn't
+	 * recognized by Spring MVC
+	 * @param defaultMatcher the default matcher to use
+	 * @since 6.4
+	 */
+	public void setDefaultMatcher(RequestMatcher defaultMatcher) {
+		this.defaultMatcher = defaultMatcher;
 	}
 
 	@Override

--- a/web/src/main/java/org/springframework/security/web/servlet/util/matcher/MvcRequestMatcherFactory.java
+++ b/web/src/main/java/org/springframework/security/web/servlet/util/matcher/MvcRequestMatcherFactory.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.servlet.util.matcher;
+
+import jakarta.servlet.ServletRegistration;
+import jakarta.servlet.http.HttpServletMapping;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.MappingMatch;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcherFactory;
+import org.springframework.util.Assert;
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
+
+/**
+ * A {@link RequestMatcherFactory} that builder {@link RequestMatcher} instances that
+ * first check to see if the request is a Spring MVC request. If so, it matches using
+ * {@link HandlerMappingIntrospector}. If it's not an MVC request, it falls back to ant
+ * path request matching.
+ *
+ * <p>
+ * Note that this implementation is stricter than {@link MvcRequestMatcher} in that it
+ * requires {@link MvcRequestMatcher#setServletPath} be configured if Spring MVC has a
+ * custom servlet path.
+ * </p>
+ *
+ * @author Josh Cummings
+ * @since 6.4
+ */
+public final class MvcRequestMatcherFactory implements RequestMatcherFactory {
+
+	private final HandlerMappingIntrospector introspector;
+
+	private final RequestMatcher isMvcRequest;
+
+	private String servletPath;
+
+	MvcRequestMatcherFactory(HandlerMappingIntrospector introspector) {
+		this(introspector, null);
+	}
+
+	MvcRequestMatcherFactory(HandlerMappingIntrospector introspector, String servletPath) {
+		this.introspector = introspector;
+		if (servletPath != null) {
+			Assert.isTrue(servletPath.startsWith("/") && !servletPath.endsWith("/*"),
+					"Please sure the each servlet path is of the format /path");
+		}
+		this.servletPath = servletPath;
+		this.isMvcRequest = new OrRequestMatcher(new MockMvcRequestMatcher(),
+				new DispatcherServletRequestMatcher(this.introspector));
+	}
+
+	/**
+	 * Use the following {@link HandlerMappingIntrospector}.
+	 * @param introspector
+	 * @return
+	 */
+	public static Builder builder(HandlerMappingIntrospector introspector) {
+		return new Builder(introspector);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	@Override
+	public RequestMatcher requestMatcher(HttpMethod method, String pattern) {
+		Assert.isTrue(pattern.startsWith("/"), "Please ensure that all patterns start with a /");
+		AntPathRequestMatcher ant = new AntPathRequestMatcher(pattern, (method != null) ? method.name() : null);
+		MvcRequestMatcher mvc = new StrictMvcRequestMatcher(this.introspector, pattern);
+		mvc.setMethod(method);
+		mvc.setServletPath(this.servletPath);
+		mvc.setDefaultMatcher((request) -> false);
+		return new MvcDelegatingRequestMatcher(ant, mvc, this.isMvcRequest);
+	}
+
+	public static final class Builder {
+
+		private HandlerMappingIntrospector introspector;
+
+		private String servletPath;
+
+		private Builder(HandlerMappingIntrospector introspector) {
+			this.introspector = introspector;
+		}
+
+		public Builder servletPath(String servletPath) {
+			this.servletPath = servletPath;
+			return this;
+		}
+
+		public MvcRequestMatcherFactory build() {
+			return new MvcRequestMatcherFactory(this.introspector, this.servletPath);
+		}
+
+	}
+
+	/**
+	 * MockMvc does not populate the entire servlet registration. However, it's reasonable
+	 * to assume that if a request is using MockMvc, then it is targeting MVC endpoints.
+	 */
+	static class MockMvcRequestMatcher implements RequestMatcher {
+
+		@Override
+		public boolean matches(HttpServletRequest request) {
+			return request.getAttribute("org.springframework.test.web.servlet.MockMvc.MVC_RESULT_ATTRIBUTE") != null;
+		}
+
+	}
+
+	static class DispatcherServletRequestMatcher implements RequestMatcher {
+
+		private final HandlerMappingIntrospector introspector;
+
+		DispatcherServletRequestMatcher(HandlerMappingIntrospector introspector) {
+			this.introspector = introspector;
+		}
+
+		@Override
+		public boolean matches(HttpServletRequest request) {
+			String name = request.getHttpServletMapping().getServletName();
+			ServletRegistration registration = request.getServletContext().getServletRegistration(name);
+			if (registration != null) {
+				return isDispatcherServlet(registration);
+			}
+			// in some testing scenarios, the servlet context is not configured, so fall
+			// back to introspection
+			return foundMapping(request);
+		}
+
+		private boolean isDispatcherServlet(ServletRegistration registration) {
+			try {
+				Class<?> clazz = Class.forName(registration.getClassName());
+				return DispatcherServlet.class.isAssignableFrom(clazz);
+			}
+			catch (ClassNotFoundException ex) {
+				throw new IllegalStateException(ex);
+			}
+		}
+
+		private boolean foundMapping(HttpServletRequest request) {
+			try {
+				return this.introspector.getMatchableHandlerMapping(request) != null;
+			}
+			catch (Exception ex) {
+				throw new IllegalStateException(ex);
+			}
+		}
+
+	}
+
+	static class MvcDelegatingRequestMatcher implements RequestMatcher {
+
+		private final RequestMatcher ant;
+
+		private final RequestMatcher mvc;
+
+		private final RequestMatcher isMvcRequest;
+
+		MvcDelegatingRequestMatcher(RequestMatcher ant, RequestMatcher mvc, RequestMatcher isMvcRequest) {
+			this.ant = ant;
+			this.mvc = mvc;
+			this.isMvcRequest = isMvcRequest;
+		}
+
+		RequestMatcher requestMatcher(HttpServletRequest request) {
+			return (this.isMvcRequest.matches(request)) ? this.mvc : this.ant;
+		}
+
+		@Override
+		public boolean matches(HttpServletRequest request) {
+			return requestMatcher(request).matches(request);
+		}
+
+		@Override
+		public MatchResult matcher(HttpServletRequest request) {
+			return requestMatcher(request).matcher(request);
+		}
+
+		@Override
+		public String toString() {
+			return "MvcDelegating [ant = " + this.ant + ", mvc = " + this.mvc + "]";
+		}
+
+	}
+
+	/**
+	 * A matcher implementation that errors if {@link DispatcherServlet} is mapped to a
+	 * path and this matcher does not have a servlet path specified.
+	 */
+	static final class StrictMvcRequestMatcher extends MvcRequestMatcher {
+
+		StrictMvcRequestMatcher(HandlerMappingIntrospector introspector, String pattern) {
+			super(introspector, pattern);
+		}
+
+		private void validateConfiguration(HttpServletRequest request) {
+			String requestServletPath = getRequestServletPath(request);
+			String configuredServletPath = getServletPath();
+			Assert.state(requestServletPath == null || configuredServletPath != null,
+					String.format(
+							"It appears the Spring MVC servlet path is not root. "
+									+ "Please provide the servlet path %s when constructing MvcRequestMatcherFactory",
+							requestServletPath));
+		}
+
+		@Override
+		public boolean matches(HttpServletRequest request) {
+			validateConfiguration(request);
+			return super.matches(request);
+		}
+
+		@Override
+		public MatchResult matcher(HttpServletRequest request) {
+			validateConfiguration(request);
+			return super.matcher(request);
+		}
+
+		private String getRequestServletPath(HttpServletRequest request) {
+			HttpServletMapping mapping = request.getHttpServletMapping();
+			if (mapping == null) {
+				// some testing scenarios do not configure a servlet mapping, so we cannot
+				// validate
+				return null;
+			}
+			if (mapping.getMappingMatch() != MappingMatch.PATH) {
+				return null;
+			}
+			String servletMapping = mapping.getPattern();
+			if (servletMapping.length() <= 2) {
+				// this is either an EXACT or a CONTEXT_ROOT match so we'll ignore
+				return null;
+			}
+			if (!servletMapping.endsWith("/*")) {
+				// this is an EXACT match so we'll ignore
+				return null;
+			}
+			return servletMapping.substring(0, servletMapping.length() - 2);
+		}
+
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/util/matcher/RequestMatcherFactory.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/RequestMatcherFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.util.matcher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.http.HttpMethod;
+
+public interface RequestMatcherFactory {
+
+	default RequestMatcher[] requestMatchers(HttpMethod method, String... patterns) {
+		List<RequestMatcher> requestMatchers = new ArrayList<>();
+		for (String pattern : patterns) {
+			requestMatchers.add(requestMatcher(method, pattern));
+		}
+		return requestMatchers.toArray(RequestMatcher[]::new);
+	}
+
+	default RequestMatcher[] requestMatchers(String... patterns) {
+		return requestMatchers(null, patterns);
+	}
+
+	RequestMatcher requestMatcher(HttpMethod method, String pattern);
+
+}

--- a/web/src/test/java/org/springframework/security/web/servlet/MockServletContext.java
+++ b/web/src/test/java/org/springframework/security/web/servlet/MockServletContext.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2002-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.servlet;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.servlet.MultipartConfigElement;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletRegistration;
+import jakarta.servlet.ServletSecurityElement;
+
+import org.springframework.lang.NonNull;
+import org.springframework.web.servlet.DispatcherServlet;
+
+public class MockServletContext extends org.springframework.mock.web.MockServletContext {
+
+	private final Map<String, ServletRegistration> registrations = new LinkedHashMap<>();
+
+	public static MockServletContext mvc() {
+		MockServletContext servletContext = new MockServletContext();
+		servletContext.addServlet("dispatcherServlet", DispatcherServlet.class).addMapping("/");
+		return servletContext;
+	}
+
+	@NonNull
+	@Override
+	public ServletRegistration.Dynamic addServlet(@NonNull String servletName, Class<? extends Servlet> clazz) {
+		ServletRegistration.Dynamic dynamic = new MockServletRegistration(servletName, clazz);
+		this.registrations.put(servletName, dynamic);
+		return dynamic;
+	}
+
+	@NonNull
+	@Override
+	public Map<String, ? extends ServletRegistration> getServletRegistrations() {
+		return this.registrations;
+	}
+
+	@Override
+	public ServletRegistration getServletRegistration(String servletName) {
+		return this.registrations.get(servletName);
+	}
+
+	private static class MockServletRegistration implements ServletRegistration.Dynamic {
+
+		private final String name;
+
+		private final Class<?> clazz;
+
+		private final Set<String> mappings = new LinkedHashSet<>();
+
+		MockServletRegistration(String name, Class<?> clazz) {
+			this.name = name;
+			this.clazz = clazz;
+		}
+
+		@Override
+		public void setLoadOnStartup(int loadOnStartup) {
+
+		}
+
+		@Override
+		public Set<String> setServletSecurity(ServletSecurityElement constraint) {
+			return null;
+		}
+
+		@Override
+		public void setMultipartConfig(MultipartConfigElement multipartConfig) {
+
+		}
+
+		@Override
+		public void setRunAsRole(String roleName) {
+
+		}
+
+		@Override
+		public void setAsyncSupported(boolean isAsyncSupported) {
+
+		}
+
+		@Override
+		public Set<String> addMapping(String... urlPatterns) {
+			this.mappings.addAll(Arrays.asList(urlPatterns));
+			return this.mappings;
+		}
+
+		@Override
+		public Collection<String> getMappings() {
+			return this.mappings;
+		}
+
+		@Override
+		public String getRunAsRole() {
+			return null;
+		}
+
+		@Override
+		public String getName() {
+			return this.name;
+		}
+
+		@Override
+		public String getClassName() {
+			return this.clazz.getName();
+		}
+
+		@Override
+		public boolean setInitParameter(String name, String value) {
+			return false;
+		}
+
+		@Override
+		public String getInitParameter(String name) {
+			return null;
+		}
+
+		@Override
+		public Set<String> setInitParameters(Map<String, String> initParameters) {
+			return null;
+		}
+
+		@Override
+		public Map<String, String> getInitParameters() {
+			return null;
+		}
+
+	}
+
+}

--- a/web/src/test/java/org/springframework/security/web/servlet/util/matcher/MvcRequestMatcherFactoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/servlet/util/matcher/MvcRequestMatcherFactoryTests.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.servlet.util.matcher;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.MappingMatch;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockHttpServletMapping;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.web.servlet.MockServletContext;
+import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcherFactory.MvcDelegatingRequestMatcher;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.GenericWebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
+import org.springframework.web.servlet.handler.MatchableHandlerMapping;
+import org.springframework.web.servlet.handler.RequestMatchResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@ExtendWith(MockitoExtension.class)
+class MvcRequestMatcherFactoryTests {
+
+	@Mock
+	HandlerMappingIntrospector introspector;
+
+	@Mock
+	MatchableHandlerMapping handlerMapping;
+
+	MvcRequestMatcherFactory builder;
+
+	@BeforeEach
+	void mocks() {
+		this.builder = new MvcRequestMatcherFactory(this.introspector, "/servlet/path");
+	}
+
+	@Test
+	void requestWhenNotDispatcherServletThenUsesAntPath() {
+		ServletContext servletContext = MockServletContext.mvc();
+		servletContext.addServlet("dispatcherServlet", DispatcherServlet.class).addMapping("/servlet/path");
+		MockHttpServletRequest request = new MockHttpServletRequest(servletContext, "GET", "/endpoint");
+		MvcDelegatingRequestMatcher matcher = (MvcDelegatingRequestMatcher) this.builder.requestMatcher(HttpMethod.GET,
+				"/endpoint");
+		RequestMatcher delegateMatcher = matcher.requestMatcher(request);
+		assertThat(delegateMatcher).isInstanceOf(AntPathRequestMatcher.class);
+	}
+
+	@Test
+	void requestWhenDispatcherServletThenUsesMvc() {
+		MockHttpServletRequest request = mvcRequest();
+		MvcDelegatingRequestMatcher matcher = (MvcDelegatingRequestMatcher) this.builder.requestMatcher(HttpMethod.GET,
+				"/endpoint");
+		RequestMatcher delegateMatcher = matcher.requestMatcher(request);
+		assertThat(delegateMatcher).isInstanceOf(MvcRequestMatcher.class);
+	}
+
+	@Test
+	void mvcRequestWhenNoMvcMappingThenDoesNotMatch() {
+		MockHttpServletRequest request = mvcRequest();
+		MvcDelegatingRequestMatcher matcher = (MvcDelegatingRequestMatcher) this.builder.requestMatcher(HttpMethod.GET,
+				"/endpoint");
+		RequestMatcher delegateMatcher = matcher.requestMatcher(request);
+		assertThat(delegateMatcher.matches(request)).isFalse();
+	}
+
+	@Test
+	void mvcRequestWhenMvcMappingThenMatches() throws Exception {
+		given(this.introspector.getMatchableHandlerMapping(any())).willReturn(this.handlerMapping);
+		given(this.handlerMapping.match(any(), any())).willReturn(mock(RequestMatchResult.class));
+		MockHttpServletRequest request = mvcRequest();
+		MvcDelegatingRequestMatcher matcher = (MvcDelegatingRequestMatcher) this.builder.requestMatcher(HttpMethod.GET,
+				"/endpoint");
+		RequestMatcher delegateMatcher = matcher.requestMatcher(request);
+		assertThat(delegateMatcher.matcher(request).isMatch()).isTrue();
+	}
+
+	@Test
+	void mvcRequestWhenDispatcherServletPathThenRequiresServletPath() {
+		MvcRequestMatcherFactory builder = new MvcRequestMatcherFactory(this.introspector);
+		MockHttpServletRequest request = mvcRequest();
+		MvcDelegatingRequestMatcher matcher = (MvcDelegatingRequestMatcher) builder.requestMatcher(HttpMethod.GET,
+				"/endpoint");
+		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> matcher.matcher(request));
+	}
+
+	@Test
+	void mvcReqwestWhenMockMvcThenUsesMvc() throws Exception {
+		WebApplicationContext wac = new GenericWebApplicationContext();
+		MockMvc mvc = MockMvcBuilders.standaloneSetup(wac).build();
+		MockHttpServletRequest request = mvc.perform(get("/endpoint")).andReturn().getRequest();
+		MvcDelegatingRequestMatcher matcher = (MvcDelegatingRequestMatcher) this.builder.requestMatcher(HttpMethod.GET,
+				"/endpoint");
+		RequestMatcher delegateMatcher = matcher.requestMatcher(request);
+		assertThat(delegateMatcher).isInstanceOf(MvcRequestMatcher.class);
+	}
+
+	private MockServletContext mvcWithServletPath() {
+		MockServletContext servletContext = MockServletContext.mvc();
+		servletContext.addServlet("dispatcherServlet", DispatcherServlet.class).addMapping("/servlet/path");
+		return servletContext;
+	}
+
+	private MockHttpServletRequest mvcRequest() {
+		ServletContext servletContext = mvcWithServletPath();
+		MockHttpServletRequest request = new MockHttpServletRequest(servletContext, "GET", "/servlet/path/endpoint");
+		request.setServletPath("/servlet/path");
+		request.setHttpServletMapping(
+				new MockHttpServletMapping("/servlet/path", "/servlet/path/*", "dispatcherServlet", MappingMatch.PATH));
+		return request;
+	}
+
+}


### PR DESCRIPTION
Closes gh-13562

This allows an application to directly configure how `requestMatchers(String)` works, thereby delegating the responsibility of disambiguating request patterns.

For example, in an application where Spring MVC is on `/servlet/path` and there are other servlets, there might exist two endpoints, one at `/example` and one at `/servlet/path/example`. Because Spring MVC patterns exclude the `/servlet/path` prefix, a declaration like this one:

```java
.requestMatchers("/example").permitAll()
```

becomes ambiguous.

With this PR, an application can alleviate this in one of three ways:

First, they can state that all their `String`-based request matcher endpoints are MVC endpoints, a common scenario:

```java
@Bean
RequestMatcherFactory useMvc(HandlerMappingIntrospector introspector) {
    MvcRequestMatcher.Builder builder = new MvcRequestMatcher.Builder(introspector).servletPath("/servlet/path");
    return mvc:pattern;
}
```

Spring Security will consult this bean instead of using the default behavior in `requestMatchers(String)` , `securityMatchers(String)` or `ignoringRequestMatchers(String)` methods and interpret each one as a Spring MVC request.

Second, they can construct a `MvcRequestMatcherFactory` which will check the destination of the request and use MVC matching rules if the request is targeting `DispatcherServlet` or Ant matching rules otherwise:

```java
@Bean
RequestMatcherFactory delegating(MvcRequestMatcherFactory.Builder builder) {
    return builder.servletPath("/servlet/path").build();
}
```

Or third, they can introduce logic of their own like so:

```java
@Bean
RequestMatcherFactory custom(HandlerMappingIntrospector introspector) {
    MvcRequestMatcher.Builder mvc = new MvcRequestMatcher.Builder(introspector).servletPath("/servlet/path");
    return (method, pattern) -> ("/graphql".equals(pattern)) ? 
            new AntPathRequestMatcher("/graphql") : mvc.requestMatcher(method, pattern);
}
```

Though in the third case, it will likely be less work to do the first or second option and then do:

```java
@Bean 
SecurityFilterChain security(HttpSecurity http) throws Exception {
    http
        .authorizeHttpRequests((authorize) -> authorize
            .requestMatchers(new AntPathRequestMatcher("/graphql")).hasAuthority("graphql")
            .requestMatchers("/my", "/mvc", "/endpoints').hasAuthority("app")
        )
}
```