### PR TITLE
Fix: Combine XML and Gradle Code Snippets into Joint Tabs for getting-spring-security page

### DIFF
--- a/docs/modules/ROOT/pages/getting-spring-security.adoc
+++ b/docs/modules/ROOT/pages/getting-spring-security.adoc
@@ -15,19 +15,22 @@ Typically, these are done to provide improved security to match modern security 
 
 
 [[maven]]
-== Usage with Maven
+== Usage with Maven and Gradle
 
-As most open source projects, Spring Security deploys its dependencies as Maven artifacts.
-The topics in this section describe how to consume Spring Security when using Maven.
+As most open source projects, Spring Security deploys its dependencies as Maven artifacts, which makes them compatible with both Maven and Gradle. The following sections demonstrate how to integrate Spring Security with these build tools, with examples for Spring Boot and standalone usage.
 
 [[getting-maven-boot]]
-=== Spring Boot with Maven
+[[getting-gradle-boot]]
+=== Spring Boot with Maven and Gradle
 
 Spring Boot provides a `spring-boot-starter-security` starter that aggregates Spring Security-related dependencies.
 The simplest and preferred way to use the starter is to use https://docs.spring.io/initializr/docs/current/reference/html/[Spring Initializr] by using an IDE integration in (https://joshlong.com/jl/blogPost/tech_tip_geting_started_with_spring_boot.html[Eclipse] or https://www.jetbrains.com/help/idea/spring-boot.html#d1489567e2[IntelliJ], https://github.com/AlexFalappa/nb-springboot/wiki/Quick-Tour[NetBeans]) or through https://start.spring.io.
 Alternatively, you can manually add the starter, as the following example shows:
 
-
+[tabs]
+======
+Maven::
++
 .pom.xml
 [source,xml,subs="verbatim,attributes"]
 ----
@@ -40,9 +43,25 @@ Alternatively, you can manually add the starter, as the following example shows:
 </dependencies>
 ----
 
-Since Spring Boot provides a Maven BOM to manage dependency versions, you do not need to specify a version.
-If you wish to override the Spring Security version, you can do so by providing a Maven property:
+Gradle::
++
+.build.gradle
+[source,groovy]
+[subs="verbatim,attributes"]
+----
+dependencies {
+	implementation "org.springframework.boot:spring-boot-starter-security"
+}
+----
+======
 
+Since Spring Boot provides a Maven BOM to manage dependency versions, you do not need to specify a version.
+If you wish to override the Spring Security version, you can do so by providing a Maven property or declaring it as a Gradle property, as shown below:
+
+[tabs]
+======
+Maven::
++
 .pom.xml
 [source,xml,subs="verbatim,attributes"]
 ----
@@ -52,10 +71,24 @@ If you wish to override the Spring Security version, you can do so by providing 
 </properties>
 ----
 
+Gradle::
++
+.build.gradle
+[source,groovy]
+[subs="verbatim,attributes"]
+----
+ext['spring-security.version']='{spring-security-version}'
+----
+======
+
 Since Spring Security makes breaking changes only in major releases, you can safely use a newer version of Spring Security with Spring Boot.
 However, at times, you may need to update the version of Spring Framework as well.
-You can do so by adding a Maven property:
+You can do so by adding a Maven or Gradle property:
 
+[tabs]
+======
+Maven::
++
 .pom.xml
 [source,xml,subs="verbatim,attributes"]
 ----
@@ -65,13 +98,27 @@ You can do so by adding a Maven property:
 </properties>
 ----
 
+Gradle::
++
+.build.gradle
+[source,groovy]
+[subs="verbatim,attributes"]
+----
+ext['spring.version']='{spring-core-version}'
+----
+======
+
 If you use additional features (such as LDAP, OAuth 2, and others), you need to also include the appropriate xref:modules.adoc#modules[Project Modules and Dependencies].
 
 [[getting-maven-no-boot]]
-=== Maven Without Spring Boot
+=== Standalone Usage (Without Spring Boot)
 
-When you use Spring Security without Spring Boot, the preferred way is to use Spring Security's BOM to ensure that a consistent version of Spring Security is used throughout the entire project. The following example shows how to do so:
+When you use Spring Security without Spring Boot, the preferred way is to use Spring Security's BOM to ensure that a consistent version of Spring Security is used throughout the entire project.  For Gradle, you can do so by using the https://github.com/spring-gradle-plugins/dependency-management-plugin[Dependency Management Plugin]:
 
+[tabs]
+======
+Maven::
++
 .pom.xml
 [source,xml,ubs="verbatim,attributes"]
 ----
@@ -89,8 +136,31 @@ When you use Spring Security without Spring Boot, the preferred way is to use Sp
 </dependencyManagement>
 ----
 
+Gradle::
++
+.build.gradle
+[source,groovy]
+[subs="verbatim,attributes"]
+----
+plugins {
+	id "io.spring.dependency-management" version "1.0.6.RELEASE"
+}
+
+dependencyManagement {
+	imports {
+		mavenBom 'org.springframework.security:spring-security-bom:{spring-security-version}'
+	}
+}
+----
+======
+
+
 A minimal Spring Security Maven set of dependencies typically looks like the following example:
 
+[tabs]
+======
+Maven::
++
 .pom.xml
 [source,xml,subs="verbatim,attributes"]
 ----
@@ -107,12 +177,29 @@ A minimal Spring Security Maven set of dependencies typically looks like the fol
 </dependencies>
 ----
 
+Gradle::
++
+.build.gradle
+[source,groovy]
+[subs="verbatim,attributes"]
+----
+dependencies {
+	implementation "org.springframework.security:spring-security-web"
+	implementation "org.springframework.security:spring-security-config"
+}
+----
+======
+
 If you use additional features (such as LDAP, OAuth 2, and others), you need to also include the appropriate xref:modules.adoc#modules[Project Modules and Dependencies].
 
 Spring Security builds against Spring Framework {spring-core-version} but should generally work with any newer version of Spring Framework 5.x.
 Many users are likely to run afoul of the fact that Spring Security's transitive dependencies resolve Spring Framework {spring-core-version}, which can cause strange classpath problems.
-The easiest way to resolve this is to use the `spring-framework-bom` within the `<dependencyManagement>` section of your `pom.xml`:
+The easiest way to resolve this is to use the `spring-framework-bom` within the `<dependencyManagement>` section of your `pom.xml` or your `dependencyManagement` section of your `build.gradle`. For Gradle, you can do so by using the https://github.com/spring-gradle-plugins/dependency-management-plugin[Dependency Management Plugin]:
 
+[tabs]
+======
+Maven::
++
 .pom.xml
 [source,xml,subs="verbatim,attributes"]
 ----
@@ -130,133 +217,8 @@ The easiest way to resolve this is to use the `spring-framework-bom` within the 
 </dependencyManagement>
 ----
 
-The preceding example ensures that all the transitive dependencies of Spring Security use the Spring {spring-core-version} modules.
-
-[NOTE]
-====
-This approach uses Maven's "`bill of materials`" (BOM) concept and is only available in Maven 2.0.9+.
-For additional details about how dependencies are resolved, see https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html[Maven's Introduction to the Dependency Mechanism documentation].
-====
-
-[[maven-repositories]]
-=== Maven Repositories
-All GA releases (that is, versions ending in .RELEASE) are deployed to Maven Central, so you need not declare additional Maven repositories in your pom.
-
-If you use a SNAPSHOT version, you need to ensure that you have the Spring Snapshot repository defined:
-
-.pom.xml
-[source,xml]
-----
-<repositories>
-	<!-- ... possibly other repository elements ... -->
-	<repository>
-		<id>spring-snapshot</id>
-		<name>Spring Snapshot Repository</name>
-		<url>https://repo.spring.io/snapshot</url>
-	</repository>
-</repositories>
-----
-
-If you use a milestone or release candidate version, you need to ensure that you have the Spring Milestone repository defined, as the following example shows:
-
-.pom.xml
-[source,xml]
-----
-<repositories>
-	<!-- ... possibly other repository elements ... -->
-	<repository>
-		<id>spring-milestone</id>
-		<name>Spring Milestone Repository</name>
-		<url>https://repo.spring.io/milestone</url>
-	</repository>
-</repositories>
-----
-
-[[getting-gradle]]
-== Gradle
-
-As most open source projects, Spring Security deploys its dependencies as Maven artifacts, which allows for first-class Gradle support.
-The following topics describe how to consume Spring Security when using Gradle.
-
-[[getting-gradle-boot]]
-=== Spring Boot with Gradle
-
-Spring Boot provides a `spring-boot-starter-security` starter that aggregates Spring Security related dependencies.
-The simplest and preferred method to use the starter is to use https://docs.spring.io/initializr/docs/current/reference/html/[Spring Initializr] by using an IDE integration in (https://joshlong.com/jl/blogPost/tech_tip_geting_started_with_spring_boot.html[Eclipse] or https://www.jetbrains.com/help/idea/spring-boot.html#d1489567e2[IntelliJ], https://github.com/AlexFalappa/nb-springboot/wiki/Quick-Tour[NetBeans]) or through https://start.spring.io.
-
-Alternatively, you can manually add the starter:
-
-.build.gradle
-[source,groovy]
-[subs="verbatim,attributes"]
-----
-dependencies {
-	implementation "org.springframework.boot:spring-boot-starter-security"
-}
-----
-
-Since Spring Boot provides a Maven BOM to manage dependency versions, you need not specify a version.
-If you wish to override the Spring Security version, you can do so by providing a Gradle property:
-
-.build.gradle
-[source,groovy]
-[subs="verbatim,attributes"]
-----
-ext['spring-security.version']='{spring-security-version}'
-----
-
-Since Spring Security makes breaking changes only in major releases, you can safely use a newer version of Spring Security with Spring Boot.
-However, at times, you may need to update the version of Spring Framework as well.
-You can do so by adding a Gradle property:
-
-.build.gradle
-[source,groovy]
-[subs="verbatim,attributes"]
-----
-ext['spring.version']='{spring-core-version}'
-----
-
-If you use additional features (such as LDAP, OAuth 2, and others), you need to also include the appropriate xref:modules.adoc#modules[Project Modules and Dependencies].
-
-=== Gradle Without Spring Boot
-
-When you use Spring Security without Spring Boot, the preferred way is to use Spring Security's BOM to ensure a consistent version of Spring Security is used throughout the entire project.
-You can do so by using the https://github.com/spring-gradle-plugins/dependency-management-plugin[Dependency Management Plugin]:
-
-.build.gradle
-[source,groovy]
-[subs="verbatim,attributes"]
-----
-plugins {
-	id "io.spring.dependency-management" version "1.0.6.RELEASE"
-}
-
-dependencyManagement {
-	imports {
-		mavenBom 'org.springframework.security:spring-security-bom:{spring-security-version}'
-	}
-}
-----
-
-A minimal Spring Security Maven set of dependencies typically looks like the following:
-
-.build.gradle
-[source,groovy]
-[subs="verbatim,attributes"]
-----
-dependencies {
-	implementation "org.springframework.security:spring-security-web"
-	implementation "org.springframework.security:spring-security-config"
-}
-----
-
-If you use additional features (such as LDAP, OAuth 2, and others), you need to also include the appropriate xref:modules.adoc#modules[Project Modules and Dependencies].
-
-Spring Security builds against Spring Framework {spring-core-version} but should generally work with any newer version of Spring Framework 5.x.
-Many users are likely to run afoul of the fact that Spring Security's transitive dependencies resolve Spring Framework {spring-core-version}, which can cause strange classpath problems.
-The easiest way to resolve this is to use the `spring-framework-bom` within your `dependencyManagement` section of your `build.gradle`.
-You can do so by using the https://github.com/spring-gradle-plugins/dependency-management-plugin[Dependency Management Plugin]:
-
+Gradle::
++
 .build.gradle
 [source,groovy]
 [subs="verbatim,attributes"]
@@ -271,12 +233,19 @@ dependencyManagement {
 	}
 }
 ----
+======
 
 The preceding example ensures that all the transitive dependencies of Spring Security use the Spring {spring-core-version} modules.
 
-[[gradle-repositories]]
-=== Gradle Repositories
-All GA releases (that is, versions ending in .RELEASE) are deployed to Maven Central, so using the `mavenCentral()` repository is sufficient for GA releases. The following example shows how to do so:
+[NOTE]
+====
+This approach uses Maven's "`bill of materials`" (BOM) concept and is only available in Maven 2.0.9+.
+For additional details about how dependencies are resolved, see https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html[Maven's Introduction to the Dependency Mechanism documentation].
+====
+
+[[maven-gradle-gearepositories]]
+=== Maven and Gradle Repositories
+All GA releases (that is, versions ending in .RELEASE) are deployed to Maven Central, so you need not declare additional Maven repositories in your `pom.xml` or, for Gradle, using the `mavenCentral()` repository is sufficient for GA releases.
 
 .build.gradle
 [source,groovy]
@@ -288,6 +257,25 @@ repositories {
 
 If you use a SNAPSHOT version, you need to ensure that you have the Spring Snapshot repository defined:
 
+[tabs]
+======
+Maven::
++
+.pom.xml
+[source,xml]
+----
+<repositories>
+	<!-- ... possibly other repository elements ... -->
+	<repository>
+		<id>spring-snapshot</id>
+		<name>Spring Snapshot Repository</name>
+		<url>https://repo.spring.io/snapshot</url>
+	</repository>
+</repositories>
+----
+
+Gradle::
++
 .build.gradle
 [source,groovy]
 ----
@@ -295,9 +283,29 @@ repositories {
 	maven { url 'https://repo.spring.io/snapshot' }
 }
 ----
+======
 
-If you use a milestone or release candidate version, you need to ensure that you have the Spring Milestone repository defined:
+If you use a milestone or release candidate version, you need to ensure that you have the Spring Milestone repository defined, as the following example shows:
 
+[tabs]
+======
+Maven::
++
+.pom.xml
+[source,xml]
+----
+<repositories>
+	<!-- ... possibly other repository elements ... -->
+	<repository>
+		<id>spring-milestone</id>
+		<name>Spring Milestone Repository</name>
+		<url>https://repo.spring.io/milestone</url>
+	</repository>
+</repositories>
+----
+
+Gradle::
++
 .build.gradle
 [source,groovy]
 ----
@@ -305,3 +313,5 @@ repositories {
 	maven { url 'https://repo.spring.io/milestone' }
 }
 ----
+======
+


### PR DESCRIPTION
This PR consolidates the separate XML and Gradle code snippets into joint tabs within the `getting-spring-security.adoc` file 
Closes gh-16228.

