### PR TITLE
Avoid requesting an unnecessary attestation statement when creating a webauthn credential

### DIFF
--- a/web/src/main/java/org/springframework/security/web/webauthn/management/Webauthn4JRelyingPartyOperations.java
+++ b/web/src/main/java/org/springframework/security/web/webauthn/management/Webauthn4JRelyingPartyOperations.java
@@ -183,7 +183,7 @@ public class Webauthn4JRelyingPartyOperations implements WebAuthnRelyingPartyOpe
 		List<CredentialRecord> credentialRecords = this.userCredentials.findByUserId(userEntity.getId());
 
 		PublicKeyCredentialCreationOptions options = PublicKeyCredentialCreationOptions.builder()
-			.attestation(AttestationConveyancePreference.DIRECT)
+			.attestation(AttestationConveyancePreference.NONE)
 			.pubKeyCredParams(PublicKeyCredentialParameters.EdDSA, PublicKeyCredentialParameters.ES256,
 					PublicKeyCredentialParameters.RS256)
 			.authenticatorSelection(authenticatorSelection)

--- a/web/src/test/java/org/springframework/security/web/webauthn/api/TestPublicKeyCredentialCreationOptions.java
+++ b/web/src/test/java/org/springframework/security/web/webauthn/api/TestPublicKeyCredentialCreationOptions.java
@@ -40,7 +40,7 @@ public final class TestPublicKeyCredentialCreationOptions {
 		ImmutableAuthenticationExtensionsClientInputs clientInputs = new ImmutableAuthenticationExtensionsClientInputs(
 				ImmutableAuthenticationExtensionsClientInput.credProps);
 		return PublicKeyCredentialCreationOptions.builder()
-			.attestation(AttestationConveyancePreference.DIRECT)
+			.attestation(AttestationConveyancePreference.NONE)
 			.user(userEntity)
 			.pubKeyCredParams(PublicKeyCredentialParameters.EdDSA, PublicKeyCredentialParameters.ES256,
 					PublicKeyCredentialParameters.RS256)

--- a/web/src/test/java/org/springframework/security/web/webauthn/jackson/JacksonTests.java
+++ b/web/src/test/java/org/springframework/security/web/webauthn/jackson/JacksonTests.java
@@ -149,7 +149,7 @@ class JacksonTests {
 	void writePublicKeyCredentialCreationOptions() throws Exception {
 		String expected = """
 				{
-				    "attestation": "direct",
+				    "attestation": "none",
 				    "authenticatorSelection": {
 				        "residentKey": "required"
 				    },

--- a/web/src/test/java/org/springframework/security/web/webauthn/registration/PublicKeyCredentialCreationOptionsFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/webauthn/registration/PublicKeyCredentialCreationOptionsFilterTests.java
@@ -153,7 +153,7 @@ class PublicKeyCredentialCreationOptionsFilterTests {
 									"residentKey": "required",
 									"userVerification": "preferred"
 								},
-								"attestation": "direct",
+								"attestation": "none",
 								"extensions": {
 									"credProps": true
 								}


### PR DESCRIPTION
[The attestation option in PublicKeyCredentialCreationOptions](https://www.w3.org/TR/webauthn-3/#dom-publickeycredentialcreationoptions-attestation) is a parameter that controls whether to request attestation statement from the security key. Currently, Spring Security Passkeys requests attestation statement by specifiy `direct` value to `attestation` option, but Spring Security Passkeys doesn't implement attestation statement verification[1]. Therefore, the requested attestation statement is not used at all.
Specifying `direct` to request attestation may trigger browsers to display additional privacy related dialog to users, so it is best to avoid specifying `direct` unnecessarily.

![image](https://github.com/user-attachments/assets/f010634c-b1bf-4505-92cc-c2dcaea619b6)


[1] Spring Security Passkeys uses [WebAuthnManager.createNonStrictWebAuthnManager()](https://github.com/spring-projects/spring-security/blob/main/web/src/main/java/org/springframework/security/web/webauthn/management/Webauthn4JRelyingPartyOperations.java#L99) to [setup a `WebAuthnManager` instance configured not to verify attestation statements.](https://webauthn4j.github.io/webauthn4j/en/#configuration)