### PR TITLE
Adds OneTimeTokenSettings

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/ott/OneTimeTokenSettings.java
+++ b/core/src/main/java/org/springframework/security/authentication/ott/OneTimeTokenSettings.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authentication.ott;
+
+import java.time.Duration;
+
+/**
+ * A facility for {@link OneTimeToken} configuration settings.
+ *
+ * @author Micah Moore (Zetetic LLC)
+ * @since 6.4.2
+ */
+public final class OneTimeTokenSettings {
+
+	private static final Duration DEFAULT_TIME_TO_LIVE = Duration.ofMinutes(5L);
+
+	private final Duration timeToLive;
+
+	private OneTimeTokenSettings(Duration timeToLive) {
+		this.timeToLive = timeToLive;
+	}
+
+	public Duration getTimeToLive() {
+		return this.timeToLive;
+	}
+
+	public static Builder withDefaults() {
+		return new Builder(DEFAULT_TIME_TO_LIVE);
+	}
+
+	public static final class Builder {
+
+		private Duration timeToLive;
+
+		Builder(Duration timeToLive) {
+			this.timeToLive = timeToLive;
+		}
+
+		public Builder timeToLive(Duration timeToLive) {
+			this.timeToLive = timeToLive;
+			return this;
+		}
+
+		public OneTimeTokenSettings build() {
+			return new OneTimeTokenSettings(this.timeToLive);
+		}
+
+	}
+
+}


### PR DESCRIPTION
Provided to OneTimeTokenService constructors to customize expire time when generating OneTimeToken

We've started implementing OneTimeTokenLogin after it's recent inclusion in Spring Security and appreciate this great feature addition.

During testing, the default expiration time (5 minutes) seems to be sufficient. As we move towards production usage we've started considering more scenarios which we think may warrant increasing it: delayed mail delivery, user doesn't check the email right away, etc. Because of this, we're planning on increasing the expiration time slightly (to 10 or 15 minutes).

We've switched over to using JdbcOneTimeTokenService for production, but when looking for a spot to modify the expiration time, we saw that there wasn't an option present to do so.

After consulting the documentation, there is mention of [modifying the one-time token expire time](https://github.com/spring-projects/spring-security/blob/4cbaabb23985800b3589f9c0cb21ac2646fdd6dc/docs/modules/ROOT/pages/reactive/authentication/onetimetoken.adoc#customize-how-to-generate-and-consume-one-time-tokens) by creating a Custom OneTimeTokenService.

A full custom implementation to only override the expire time is potentially risky as it requires implementing/duplicating the majority of the logic (in JdbcOneTimeTokenService) which doesn't need to change in order to fulfill this type of behavior.

This PR includes:

* A new class: `OneTimeTokenSettings` which has a property for the OneTimeToken timeToLive Duration
* Overloaded Constructors for InMemoryOneTimeTokenService and JdbcOneTimeTokenService which take OneTimeTokenSettings as a parameter to set as a private field. If OneTimeTokenSettings isn't provided to the constructors, the default one is used (5 minutes timeToLive)
* Both classes' `generate` implementations now use the OneTimeTokenSettings timeToLive Duration value when establishing the expire time
* Tests in InMemoryOneTimeTokenServiceTests + JdbcOneTimeTokenServiecTests using oneTimeTokenServices with non-default OneTimeTokenSettings to confirm generation, consumption, expiration of OneTimeTokens with custom expirations based on OneTimeTokenSettings

Submitted on behalf of Zetetic, LLC
