### PR TITLE
Fix WebAuthnWebdriverTests

### DIFF
--- a/config/src/integration-test/java/org/springframework/security/config/annotation/configurers/WebAuthnWebDriverTests.java
+++ b/config/src/integration-test/java/org/springframework/security/config/annotation/configurers/WebAuthnWebDriverTests.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -67,7 +66,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Daniel Garnier-Moiroux
  */
-@Disabled
 class WebAuthnWebDriverTests {
 
 	private String baseUrl;
@@ -194,6 +192,11 @@ class WebAuthnWebDriverTests {
 		this.driver.findElement(passkeyLabel()).sendKeys("Virtual authenticator");
 		this.driver.findElement(registerPasskeyButton()).click();
 
+		// Ensure the page location has changed before performing further assertions.
+		// This is required because the location change is asynchronously performed in
+		// javascript, and performing assertions based on this.driver.findElement(...)
+		// may result in a StaleElementReferenceException.
+		await(() -> assertThat(this.driver.getCurrentUrl()).endsWith("/webauthn/register?success"));
 		await(() -> assertHasAlertStartingWith("success", "Success!"));
 
 		List<WebElement> passkeyRows = this.driver.findElements(passkeyTableRows());


### PR DESCRIPTION
`WebAuthnWebdriverTests.loginWhenAuthenticatorRegisteredThenSuccess` was flakey, and failed with `StaleElementReferenceException`.

This is a race condition between:
- asynchronously changing the page location through javascript on registration success, using `window.location.href`
- asserting that there is a success message displayed, by calling `WebElement alert = this.driver.findElement(...)` and then calling `alert.isDisplayed()`, where the `alert` could reference an element on the page BEFORE the redirect

Fix: ensure the page change is complete before asserting on elements in the page, with an additional assertion.


reviewer: @rwinch 