### PR TITLE
Fixed the issue where the annotation parameter scan skipped first-level conflicts

### DIFF
--- a/core/src/test/java/org/springframework/security/core/annotation/UniqueSecurityAnnotationScannerTests.java
+++ b/core/src/test/java/org/springframework/security/core/annotation/UniqueSecurityAnnotationScannerTests.java
@@ -319,6 +319,13 @@ public class UniqueSecurityAnnotationScannerTests {
 		assertThat(pre).isNotNull();
 	}
 
+	@Test
+	void scanParameterAnnotationWhenPresentInParentAndInterfaceThenException() throws Exception {
+		Parameter parameter = DefaultUserService.class.getDeclaredMethod("batch", String[].class).getParameters()[0];
+		assertThatExceptionOfType(AnnotationConfigurationException.class)
+			.isThrownBy(() -> this.parameterScanner.scan(parameter));
+	}
+
 	interface UserService {
 
 		void add(@CustomParameterAnnotation("one") String user);
@@ -345,6 +352,8 @@ public class UniqueSecurityAnnotationScannerTests {
 
 	interface RemoteUserService extends ThirdPartyUserService {
 
+		void batch(@CustomParameterAnnotation("six") String... user);
+
 	}
 
 	static class UserServiceImpl implements UserService, OtherUserService, RemoteUserService {
@@ -366,6 +375,20 @@ public class UniqueSecurityAnnotationScannerTests {
 
 		@Override
 		public void delete(String user) {
+
+		}
+
+		@Override
+		public void batch(@CustomParameterAnnotation("seven") String... user) {
+
+		}
+
+	}
+
+	static class DefaultUserService extends UserServiceImpl implements RemoteUserService {
+
+		@Override
+		public void batch(String... user) {
 
 		}
 


### PR DESCRIPTION
When searching for parameter annotations, I overlooked a scenario as below:

```java
interface RemoteUserService {

    void batch(@CustomParameterAnnotation("six") String... user);

}

class UserServiceImpl implements RemoteUserService {

    @Override
    public void batch(@CustomParameterAnnotation("seven") String... user) {
      
    }

}

class DefaultUserService extends UserServiceImpl implements RemoteUserService {

    @Override
    public void batch(String... user) {
      
    }

}
```

When I run test should be throw exception :

```java
Parameter parameter = DefaultUserService.class.getDeclaredMethod("batch", String[].class).getParameters()[0];
this.parameterScanner.scan(parameter);
```
