### PR TITLE
Remove Autowire annotation on the unique constructor in ReactiveAuthorizationManagerMethodSecurityConfiguration

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/ReactiveAuthorizationManagerMethodSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/ReactiveAuthorizationManagerMethodSecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ import org.springframework.security.core.annotation.AnnotationTemplateExpression
  * Configuration for a {@link ReactiveAuthenticationManager} based Method Security.
  *
  * @author Evgeniy Cheban
+ * @author Ding Hao
  * @since 5.8
  */
 @Configuration(value = "_reactiveMethodSecurityConfiguration", proxyBeanMethods = false)
@@ -83,7 +84,6 @@ final class ReactiveAuthorizationManagerMethodSecurityConfiguration
 
 	private final AuthorizationManagerAfterReactiveMethodInterceptor postAuthorizeMethodInterceptor;
 
-	@Autowired(required = false)
 	ReactiveAuthorizationManagerMethodSecurityConfiguration(MethodSecurityExpressionHandler expressionHandler,
 			ObjectProvider<ObjectPostProcessor<ReactiveAuthorizationManager<MethodInvocation>>> preAuthorizePostProcessor,
 			ObjectProvider<ObjectPostProcessor<ReactiveAuthorizationManager<MethodInvocationResult>>> postAuthorizePostProcessor) {


### PR DESCRIPTION
Closes gh-16325

There is a `methodSecurityExpressionHandler `bean with @Fallback in the `ReactiveAuthorizationManagerMethodSecurityConfiguration`.
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
