### PR TITLE
Fix logout code snippet for Kotlin

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/logout.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/logout.adoc
@@ -226,7 +226,7 @@ Kotlin::
 ----
 http {
     logout {
-        deleteCookies = "our-custom-cookie"
+        deleteCookies("our-custom-cookie")
     }
 }
 ----


### PR DESCRIPTION
### Contents

- Fix logout code snippet for Kotlin: Corrected deleteCookies syntax

### Reason

- The deleteCookies property of org.springframework.security.config.annotation.web.LogoutDsl has a private access modifier, so it cannot be used in the format deleteCookies = ""