### PR TITLE
Fix incorrect rendering of SpEL expression example tabs

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
@@ -216,13 +216,15 @@ Java::
 ----
 @PreAuthorize("hasAuthority('permission:read') || hasRole('ADMIN')")
 ----
-======
 
-.Kotlin
-[source,kotlin,role="kotlin"]
+Kotlin::
++
+[source,kotlin,role="secondary"]
 ----
 @PreAuthorize("hasAuthority('permission:read') || hasRole('ADMIN')")
 ----
+======
+
 
 However, you could instead grant `permission:read` to those with `ROLE_ADMIN`.
 One way to do this is with a `RoleHierarchy` like so:


### PR DESCRIPTION
Related to [gh-16342](https://github.com/spring-projects/spring-security/issues/16342).
This corrects the rendering issue in the SpEL expression example tabs 
within the documentation.
It updates the adoc syntax for this tab components.
