### PR TITLE
Fix OAuth reference documentation typo

### DIFF
--- a/docs/modules/ROOT/pages/servlet/oauth2/client/index.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/client/index.adoc
@@ -1,5 +1,5 @@
 [[oauth2-client]]
-= [[oauth2client]]OAuth 2.0 Client
+= OAuth 2.0 Client
 :page-section-summary-toc: 1
 
 The OAuth 2.0 Client features provide support for the Client role as defined in the https://tools.ietf.org/html/rfc6749#section-1.1[OAuth 2.0 Authorization Framework].


### PR DESCRIPTION
Text `OAuth 2.0 Client` does not link to page `OAuth 2.0 Client`


Reference
https://docs.spring.io/spring-security/reference/6.5-SNAPSHOT/servlet/oauth2/index.html#further-reading

![image](https://github.com/user-attachments/assets/f8d86df1-0240-4e32-b2bd-f7cb721b75d5)
