### PR TITLE
Update docs to link to AuthorizationFilter instead of deprecated FilterSecurityInterceptor

### DIFF
--- a/docs/modules/ROOT/pages/servlet/architecture.adoc
+++ b/docs/modules/ROOT/pages/servlet/architecture.adoc
@@ -609,7 +609,7 @@ try {
 }
 ----
 <1> As described in <<servlet-filters-review>>, invoking `FilterChain.doFilter(request, response)` is the equivalent of invoking the rest of the application.
-This means that if another part of the application, (<<servlet-authorization-filtersecurityinterceptor,`FilterSecurityInterceptor`>> or method security) throws an `AuthenticationException` or `AccessDeniedException` it is caught and handled here.
+This means that if another part of the application, (xref:servlet/authorization/authorize-http-requests.adoc[`AuthorizationFilter`] or method security) throws an `AuthenticationException` or `AccessDeniedException` it is caught and handled here.
 <2> If the user is not authenticated or it is an `AuthenticationException`, __Start Authentication__.
 <3> Otherwise, __Access Denied__
 


### PR DESCRIPTION
Change deprecated FilterSecurityInterceptor to AuthorizationFilter with a link to authorization page.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
