### PR TITLE
add the ability to store additional grant request parameters for the OIDC token exchange grant request

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/InMemoryOAuth2AuthorizedClientService.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/InMemoryOAuth2AuthorizedClientService.java
@@ -86,7 +86,8 @@ public final class InMemoryOAuth2AuthorizedClientService implements OAuth2Author
 			return null;
 		}
 		return (T) new OAuth2AuthorizedClient(registration, cachedAuthorizedClient.getPrincipalName(),
-				cachedAuthorizedClient.getAccessToken(), cachedAuthorizedClient.getRefreshToken());
+				cachedAuthorizedClient.getAccessToken(), cachedAuthorizedClient.getRefreshToken(),
+				cachedAuthorizedClient.getAttributes());
 	}
 
 	@Override

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/OAuth2AuthorizationContext.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/OAuth2AuthorizationContext.java
@@ -60,6 +60,8 @@ public final class OAuth2AuthorizationContext {
 	 */
 	public static final String PASSWORD_ATTRIBUTE_NAME = OAuth2AuthorizationContext.class.getName().concat(".PASSWORD");
 
+	public static final String ADDITIONAL_GRANT_REQUEST_PARAMETERS_ATTRIBUTE_NAME = OAuth2AuthorizationContext.class.getName().concat(".ADDITIONAL_GRANT_REQUEST_PARAMETERS");
+
 	private ClientRegistration clientRegistration;
 
 	private OAuth2AuthorizedClient authorizedClient;

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/OAuth2AuthorizedClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/OAuth2AuthorizedClient.java
@@ -17,6 +17,7 @@
 package org.springframework.security.oauth2.client;
 
 import java.io.Serializable;
+import java.util.Map;
 
 import org.springframework.lang.Nullable;
 import org.springframework.security.core.SpringSecurityCoreVersion;
@@ -53,6 +54,8 @@ public class OAuth2AuthorizedClient implements Serializable {
 
 	private final OAuth2RefreshToken refreshToken;
 
+	private final Map<String, Object> attributes;
+
 	/**
 	 * Constructs an {@code OAuth2AuthorizedClient} using the provided parameters.
 	 * @param clientRegistration the authorized client's registration
@@ -73,6 +76,20 @@ public class OAuth2AuthorizedClient implements Serializable {
 	 */
 	public OAuth2AuthorizedClient(ClientRegistration clientRegistration, String principalName,
 			OAuth2AccessToken accessToken, @Nullable OAuth2RefreshToken refreshToken) {
+		this(clientRegistration, principalName, accessToken, refreshToken, null);
+	}
+
+	/**
+	 * Constructs an {@code OAuth2AuthorizedClient} using the provided parameters.
+	 * @param clientRegistration the authorized client's registration
+	 * @param principalName the name of the End-User {@code Principal} (Resource Owner)
+	 * @param accessToken the access token credential granted
+	 * @param refreshToken the refresh token credential granted
+	 * @param attributes associated with the client
+	 */
+	public OAuth2AuthorizedClient(ClientRegistration clientRegistration, String principalName,
+			OAuth2AccessToken accessToken, @Nullable OAuth2RefreshToken refreshToken,
+			@Nullable Map<String, Object> attributes) {
 		Assert.notNull(clientRegistration, "clientRegistration cannot be null");
 		Assert.hasText(principalName, "principalName cannot be empty");
 		Assert.notNull(accessToken, "accessToken cannot be null");
@@ -80,6 +97,7 @@ public class OAuth2AuthorizedClient implements Serializable {
 		this.principalName = principalName;
 		this.accessToken = accessToken;
 		this.refreshToken = refreshToken;
+		this.attributes = attributes;
 	}
 
 	/**
@@ -115,4 +133,21 @@ public class OAuth2AuthorizedClient implements Serializable {
 		return this.refreshToken;
 	}
 
+	/**
+	 * Returns the {@link Map} attributes.
+	 * @return the {@link Map}
+	 * @since 6.5
+	 */
+	public @Nullable Map<String, Object> getAttributes() {
+		return this.attributes;
+	}
+
+	@Nullable
+	@SuppressWarnings("unchecked")
+	public <T> T getAttribute(String name) {
+		if (this.getAttributes() == null) {
+			return null;
+		}
+		return (T) this.getAttributes().get(name);
+	}
 }

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/TokenExchangeGrantRequest.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/TokenExchangeGrantRequest.java
@@ -27,6 +27,8 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 
+import java.util.Map;
+
 /**
  * A Token Exchange Grant request that holds the {@link OAuth2Token subject token} and
  * optional {@link OAuth2Token actor token}.
@@ -53,6 +55,8 @@ public class TokenExchangeGrantRequest extends AbstractOAuth2AuthorizationGrantR
 
 	private final OAuth2Token actorToken;
 
+	private final Map<String, Object> additionalParameters;
+
 	/**
 	 * Constructs a {@code TokenExchangeGrantRequest} using the provided parameters.
 	 * @param clientRegistration the client registration
@@ -61,12 +65,24 @@ public class TokenExchangeGrantRequest extends AbstractOAuth2AuthorizationGrantR
 	 */
 	public TokenExchangeGrantRequest(ClientRegistration clientRegistration, OAuth2Token subjectToken,
 			OAuth2Token actorToken) {
+		this(clientRegistration,subjectToken,actorToken,null);
+	}
+
+	/**
+	 * Constructs a {@code TokenExchangeGrantRequest} using the provided parameters.
+	 * @param clientRegistration the client registration
+	 * @param subjectToken the subject token
+	 * @param actorToken the actor token
+	 */
+	public TokenExchangeGrantRequest(ClientRegistration clientRegistration, OAuth2Token subjectToken,
+			OAuth2Token actorToken, Map<String, Object> additionalParameters) {
 		super(AuthorizationGrantType.TOKEN_EXCHANGE, clientRegistration);
 		Assert.isTrue(AuthorizationGrantType.TOKEN_EXCHANGE.equals(clientRegistration.getAuthorizationGrantType()),
 				"clientRegistration.authorizationGrantType must be AuthorizationGrantType.TOKEN_EXCHANGE");
 		Assert.notNull(subjectToken, "subjectToken cannot be null");
 		this.subjectToken = subjectToken;
 		this.actorToken = actorToken;
+		this.additionalParameters = additionalParameters;
 	}
 
 	/**
@@ -83,6 +99,14 @@ public class TokenExchangeGrantRequest extends AbstractOAuth2AuthorizationGrantR
 	 */
 	public OAuth2Token getActorToken() {
 		return this.actorToken;
+	}
+
+	/**
+	 * Returns the {@link Map additional parameters}.
+	 * @return the {@link Map additional parameters}
+	 */
+	public Map<String, Object> getAdditionalParameters() {
+		return this.additionalParameters;
 	}
 
 	/**


### PR DESCRIPTION


This is an attempt at implementing the issue gh-#16373. Check the issue for detailed explanation of what this tries to achieve.
