### PR TITLE
Favor PathPatternParser Over HandlerMappingIntrospector

### DIFF
--- a/config/src/test/java/org/springframework/security/config/FilterChainProxyConfigTests.java
+++ b/config/src/test/java/org/springframework/security/config/FilterChainProxyConfigTests.java
@@ -39,6 +39,7 @@ import org.springframework.security.web.servletapi.SecurityContextHolderAwareReq
 import org.springframework.security.web.util.matcher.AnyRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.util.pattern.PathPattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -120,7 +121,8 @@ public class FilterChainProxyConfigTests {
 
 	private String getPattern(SecurityFilterChain chain) {
 		RequestMatcher requestMatcher = ((DefaultSecurityFilterChain) chain).getRequestMatcher();
-		return (String) ReflectionTestUtils.getField(requestMatcher, "pattern");
+		Object pattern = ReflectionTestUtils.getField(requestMatcher, "pattern");
+		return (pattern instanceof PathPattern) ? pattern.toString() : (String) pattern;
 	}
 
 	private void checkPathAndFilterOrder(FilterChainProxy filterChainProxy) {

--- a/config/src/test/java/org/springframework/security/config/annotation/web/AbstractRequestMatcherRegistryTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/AbstractRequestMatcherRegistryTests.java
@@ -24,6 +24,7 @@ import jakarta.servlet.Servlet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.ApplicationContext;
@@ -42,6 +43,7 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.DispatcherTypeRequestMatcher;
 import org.springframework.security.web.util.matcher.RegexRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcherBuilder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -87,6 +89,13 @@ public class AbstractRequestMatcherRegistryTests {
 		given(given).willReturn(postProcessors);
 		given(postProcessors.getObject()).willReturn(NO_OP_OBJECT_POST_PROCESSOR);
 		given(this.context.getServletContext()).willReturn(MockServletContext.mvc());
+		ObjectProvider<RequestMatcherBuilder> requestMatcherFactories = new ObjectProvider<>() {
+			@Override
+			public RequestMatcherBuilder getObject() throws BeansException {
+				return AbstractRequestMatcherRegistryTests.this.matcherRegistry.new DefaultRequestMatcherBuilder();
+			}
+		};
+		given(this.context.getBeanProvider(RequestMatcherBuilder.class)).willReturn(requestMatcherFactories);
 		this.matcherRegistry.setApplicationContext(this.context);
 		mockMvcIntrospector(true);
 	}

--- a/docs/modules/ROOT/pages/migration-7/web.adoc
+++ b/docs/modules/ROOT/pages/migration-7/web.adoc
@@ -102,3 +102,23 @@ Xml::
 </b:bean>
 ----
 ======
+
+== Favor PathPatternRequestMatcher
+
+`MvcRequestMatcher` is deprecated in 6.5.
+XML, Kotlin, and Java will all favor `PathPatternRequestMatcher` by default in 7.0.
+
+If you aren't already publishing a `RequestMatcherBuilder` bean, you can prepare for this change in defaults by publishing the following bean:
+
+[source,java]
+----
+@Bean
+RequestMatcherBuilder favorPathPattern() {
+	return ServletRequestMatcherBuilders.deducePath();
+}
+----
+
+This static factory aligns with the Spring Security defaults for request matchers except that it uses `PathPatternRequestMatcher` instead.
+It reflects what the default will be in Spring Security 7.
+
+If this creates problems for you and you cannot use this bean at the moment, then change each of your `String` URI authorization rules to xref:servlet/authorization/authorize-http-requests.adoc#security-matchers[use a `RequestMatcher`].

--- a/docs/modules/ROOT/pages/servlet/appendix/namespace/http.adoc
+++ b/docs/modules/ROOT/pages/servlet/appendix/namespace/http.adoc
@@ -124,7 +124,7 @@ Corresponds to the `realmName` property on `BasicAuthenticationEntryPoint`.
 Defines the `RequestMatcher` strategy used in the `FilterChainProxy` and the beans created by the `intercept-url` to match incoming requests.
 Options are currently `mvc`, `ant`, `regex` and `ciRegex`, for Spring MVC, ant, regular-expression and case-insensitive regular-expression respectively.
 A separate instance is created for each <<nsa-intercept-url,intercept-url>> element using its <<nsa-intercept-url-pattern,pattern>>, <<nsa-intercept-url-method,method>> and <<nsa-intercept-url-servlet-path,servlet-path>> attributes.
-Ant paths are matched using an `AntPathRequestMatcher`, regular expressions are matched using a `RegexRequestMatcher` and for Spring MVC path matching the `MvcRequestMatcher` is used.
+Ant paths are matched using an `AntPathRequestMatcher`, regular expressions are matched using a `RegexRequestMatcher` and for Spring MVC path matching the `PathPatternRequestMatcher` is used.
 See the Javadoc for these classes for more details on exactly how the matching is performed.
 MVC is the default strategy if Spring MVC is present in the classpath, if not, Ant paths are used.
 

--- a/docs/modules/ROOT/pages/servlet/authorization/authorize-http-requests.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/authorize-http-requests.adoc
@@ -577,15 +577,11 @@ http {
 ======
 
 [[match-by-mvc]]
-=== Using an MvcRequestMatcher
+=== Matching by Servlet Path
 
 Generally speaking, you can use `requestMatchers(String)` as demonstrated above.
 
-However, if you map Spring MVC to a different servlet path, then you need to account for that in your security configuration.
-
-For example, if Spring MVC is mapped to `/spring-mvc` instead of `/` (the default), then you may have an endpoint like `/spring-mvc/my/controller` that you want to authorize.
-
-You need to use `MvcRequestMatcher` to split the servlet path and the controller path in your configuration like so:
+However, if you have authorization rules from multiple servlets, you need to specify those:
 
 .Match by MvcRequestMatcher
 [tabs]
@@ -594,16 +590,14 @@ Java::
 +
 [source,java,role="primary"]
 ----
-@Bean
-MvcRequestMatcher.Builder mvc(HandlerMappingIntrospector introspector) {
-	return new MvcRequestMatcher.Builder(introspector).servletPath("/spring-mvc");
-}
+import static org.springframework.security.web.servlet.util.matcher.ServletRequestMatcherBuilders.servletPath;
 
 @Bean
-SecurityFilterChain appEndpoints(HttpSecurity http, MvcRequestMatcher.Builder mvc) {
+SecurityFilterChain appEndpoints(HttpSecurity http) {
 	http
         .authorizeHttpRequests((authorize) -> authorize
-            .requestMatchers(mvc.pattern("/my/controller/**")).hasAuthority("controller")
+            .requestMatchers(servletPath("/spring-mvc").pattern("/admin/**")).hasAuthority("admin")
+            .requestMatchers(servletPath("/spring-mvc").pattern("/my/controller/**")).hasAuthority("controller")
             .anyRequest().authenticated()
         );
 
@@ -616,17 +610,15 @@ Kotlin::
 [source,kotlin,role="secondary"]
 ----
 @Bean
-fun mvc(introspector: HandlerMappingIntrospector): MvcRequestMatcher.Builder =
-    MvcRequestMatcher.Builder(introspector).servletPath("/spring-mvc");
-
-@Bean
-fun appEndpoints(http: HttpSecurity, mvc: MvcRequestMatcher.Builder): SecurityFilterChain =
+fun appEndpoints(http: HttpSecurity): SecurityFilterChain {
     http {
         authorizeHttpRequests {
-            authorize(mvc.pattern("/my/controller/**"), hasAuthority("controller"))
+            authorize("/spring-mvc", "/admin/**", hasAuthority("admin"))
+            authorize("/spring-mvc", "/my/controller/**", hasAuthority("controller"))
             authorize(anyRequest, authenticated)
         }
     }
+}
 ----
 
 Xml::
@@ -634,16 +626,91 @@ Xml::
 [source,xml,role="secondary"]
 ----
 <http>
+    <intercept-url servlet-path="/spring-mvc" pattern="/admin/**" access="hasAuthority('admin')"/>
     <intercept-url servlet-path="/spring-mvc" pattern="/my/controller/**" access="hasAuthority('controller')"/>
     <intercept-url pattern="/**" access="authenticated"/>
 </http>
 ----
 ======
 
-This need can arise in at least two different ways:
+The primary reason for this is that Spring MVC URIs are relative to the servlet.
+In other words, an authorization rule usually doesn't include the servlet path.
 
-* If you use the `spring.mvc.servlet.path` Boot property to change the default path (`/`) to something else
-* If you register more than one Spring MVC `DispatcherServlet` (thus requiring that one of them not be the default path)
+Other URIs may include the servlet path.
+Because of that, the best practice is to always supply the servlet path when your application has more than one servlet.
+
+==== But I do only have one servlet, why is Spring Security complaining?
+
+Sometimes, application containers include additional servlets.
+This can cause some confusion when you know as the developer that the only authorization rules you are writing are for your one servlet (Spring MVC, for example)
+
+In this case, in the Java DSL you can publish a `ServletRequestMatcherBuilders#servletPath` as a `@Bean` and Spring Security will use it for all URIs.
+
+For example, the above Java sample can be rewritten as:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Bean
+RequestMatcherBuilder mvc() {
+	return ServeltRequestMatcherBuilders.servletPath("/spring-mvc");
+}
+
+@Bean
+SecurityFilterChain security(HttpSecurity http) throws Exception {
+	http
+		.authorizeHttpRequests((authorize) -> authorize
+			.requestMatchers("/admin/**").hasAuthority("admin")
+			.requestMatchers("/my/controller/**").hasAuthority("controller")
+			.anyRequest().authenticated()
+		);
+	return http.build();
+}
+----
+======
+
+[TIP]
+====
+If you are a Spring Boot application, you may be able to publish the above bean like so:
+
+[source,java]
+----
+@Bean
+RequestMatcherBuilder mvc(WebMvcProperties properties) {
+	return ServletRequestMatcherBuilders.servletPath(proeprties.getServlet().getPath());
+}
+----
+====
+
+This same strategy is useful when it comes to static resources.
+You can permit these by using Spring Boot's `RequestMatchers` static factory like so:
+
+[tabs]
+======
+Java::
++
+[source,java]
+----
+@Bean
+RequestMatcherBuilder mvc() {
+	return ServletRequestMatcherBuilders.servletPath("/mvc");
+}
+
+@Bean
+SecurityFilterChain security(HttpSecurity http) throws Exception {
+	http
+        .authorizeHttpRequests((authorize) -> authorize
+            .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+            .requestMatchers("/my/**", "/app/**", "/requests/**").hasAuthority("app")
+        )
+}
+----
+======
+
+Since `atCommonLocations` returns instances of `RequestMatcher`, this technique allows you to have all your `String`-based authorizations relative to the globally-configured `ServletRequestMatcherBuilders#servletPath`.
 
 [[match-by-custom]]
 === Using a Custom Matcher

--- a/docs/modules/ROOT/pages/servlet/integrations/mvc.adoc
+++ b/docs/modules/ROOT/pages/servlet/integrations/mvc.adoc
@@ -22,13 +22,13 @@ This means that, if you use more advanced options, such as integrating with `Web
 ====
 
 [[mvc-requestmatcher]]
-== MvcRequestMatcher
+== PathPatternRequestMatcher
 
-Spring Security provides deep integration with how Spring MVC matches on URLs with `MvcRequestMatcher`.
+Spring Security provides deep integration with how Spring MVC matches on URLs with `PahtPatternRequestMatcher`.
 This is helpful to ensure that your Security rules match the logic used to handle your requests.
 
-To use `MvcRequestMatcher`, you must place the Spring Security Configuration in the same `ApplicationContext` as your `DispatcherServlet`.
-This is necessary because Spring Security's `MvcRequestMatcher` expects a `HandlerMappingIntrospector` bean with the name of `mvcHandlerMappingIntrospector` to be registered by your Spring MVC configuration that is used to perform the matching.
+To use `PathPatternRequestMatcher`, you may need to place the Spring Security Configuration in the same `ApplicationContext` as your `DispatcherServlet`.
+This is necessary when using a custom `PathPatternParser` `@Bean`. In this case, both Spring MVC and  Spring Security needs to be able to see this bean.
 
 For a `web.xml` file, this means that you should place your configuration in the `DispatcherServlet.xml`:
 
@@ -196,18 +196,18 @@ Additionally, depending on our Spring MVC configuration, the `/admin` URL also m
 The problem is that our security rule protects only  `/admin`.
 We could add additional rules for all the permutations of Spring MVC, but this would be quite verbose and tedious.
 
-Fortunately, when using the `requestMatchers` DSL method, Spring Security automatically creates a `MvcRequestMatcher` if it detects that Spring MVC is available in the classpath.
+Fortunately, when using the `requestMatchers` DSL method, Spring Security automatically creates a `PathPatternRequestMatcher` if it detects that Spring MVC is available in the classpath.
 Therefore, it will protect the same URLs that Spring MVC will match on by using Spring MVC to match on the URL.
 
 One common requirement when using Spring MVC is to specify the servlet path property.
 
-For Java-based Configuration, you can use the `MvcRequestMatcher.Builder` to create multiple `MvcRequestMatcher` instances that share the same servlet path:
+For Java-based Configuration, you can use the `PathPatternRequestMatcher.Builder` to create multiple `PathPatternRequestMatcher` instances that share the same servlet path:
 
 [source,java,role="primary"]
 ----
 @Bean
-public SecurityFilterChain filterChain(HttpSecurity http, HandlerMappingIntrospector introspector) throws Exception {
-	MvcRequestMatcher.Builder mvcMatcherBuilder = new MvcRequestMatcher.Builder(introspector).servletPath("/path");
+public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+	PathPatternRequestMatcher.Builder mvcMatcherBuilder = new PathPatternRequestMatcher.Builder().servletPath("/path");
 	http
 		.authorizeHttpRequests((authorize) -> authorize
 			.requestMatchers(mvcMatcherBuilder.pattern("/admin")).hasRole("ADMIN")
@@ -216,6 +216,11 @@ public SecurityFilterChain filterChain(HttpSecurity http, HandlerMappingIntrospe
 	return http.build();
 }
 ----
+
+[NOTE]
+=====
+For your convenience, you also can use `ServletRequestMatcherBuilders` which exposes an API that more directly reflects the Servlet spec.
+=====
 
 For Kotlin and XML, this happens when you specify the servlet path for each path like so:
 

--- a/etc/checkstyle/checkstyle-suppressions.xml
+++ b/etc/checkstyle/checkstyle-suppressions.xml
@@ -38,6 +38,8 @@
 	<suppress files="AbstractOAuth2AuthorizationGrantRequestEntityConverter\.java" checks="SpringMethodVisibility"/>
 	<suppress files="JoseHeader\.java" checks="SpringMethodVisibility"/>
 	<suppress files="DefaultLoginPageGeneratingFilterTests\.java" checks="SpringLeadingWhitespace"/>
+	<suppress files="MatcherType\.java" checks="SpringMethodVisibility"/>
+	<suppress files="MatcherType\.java" checks="RedundantModifier"/>
 
 	<!-- Lambdas that we can't replace with a method reference because a closure is required -->
 	<suppress files="BearerTokenAuthenticationFilter\.java" checks="SpringLambda"/>

--- a/web/src/main/java/org/springframework/security/web/FilterInvocation.java
+++ b/web/src/main/java/org/springframework/security/web/FilterInvocation.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -178,6 +179,8 @@ public class FilterInvocation {
 
 		private final Map<String, String[]> parameters = new LinkedHashMap<>();
 
+		private final Map<String, Object> attributes = new HashMap<>();
+
 		DummyRequest() {
 			super(UNSUPPORTED_REQUEST);
 		}
@@ -189,7 +192,12 @@ public class FilterInvocation {
 
 		@Override
 		public Object getAttribute(String attributeName) {
-			return null;
+			return this.attributes.get(attributeName);
+		}
+
+		@Override
+		public void setAttribute(String name, Object value) {
+			this.attributes.put(name, value);
 		}
 
 		void setRequestURI(String requestURI) {

--- a/web/src/main/java/org/springframework/security/web/servlet/util/matcher/MvcRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/servlet/util/matcher/MvcRequestMatcher.java
@@ -23,6 +23,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import org.springframework.http.HttpMethod;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcherBuilder;
 import org.springframework.security.web.util.matcher.RequestVariablesExtractor;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
@@ -46,7 +47,9 @@ import org.springframework.web.util.UrlPathHelper;
  * @author Eddú Meléndez
  * @author Evgeniy Cheban
  * @since 4.1.1
+ * @deprecated Use {@link PathPatternRequestMatcher} instead.
  */
+@Deprecated
 public class MvcRequestMatcher implements RequestMatcher, RequestVariablesExtractor {
 
 	private final DefaultMatcher defaultMatcher = new DefaultMatcher();
@@ -197,7 +200,7 @@ public class MvcRequestMatcher implements RequestMatcher, RequestVariablesExtrac
 	 * @author Marcus Da Coregio
 	 * @since 5.8
 	 */
-	public static final class Builder {
+	public static final class Builder implements RequestMatcherBuilder {
 
 		private final HandlerMappingIntrospector introspector;
 
@@ -237,6 +240,7 @@ public class MvcRequestMatcher implements RequestMatcher, RequestVariablesExtrac
 		 * @param pattern the patterns used to match
 		 * @return the generated {@link MvcRequestMatcher}
 		 */
+		@Override
 		public MvcRequestMatcher pattern(HttpMethod method, String pattern) {
 			MvcRequestMatcher mvcRequestMatcher = new MvcRequestMatcher(this.introspector, pattern);
 			mvcRequestMatcher.setServletPath(this.servletPath);

--- a/web/src/main/java/org/springframework/security/web/servlet/util/matcher/PathPatternRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/servlet/util/matcher/PathPatternRequestMatcher.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.servlet.util.matcher;
+
+import java.util.Objects;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.http.server.PathContainer;
+import org.springframework.http.server.RequestPath;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcherBuilder;
+import org.springframework.util.Assert;
+import org.springframework.web.util.ServletRequestPathUtils;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPatternParser;
+
+/**
+ * A {@link RequestMatcher} that uses {@link PathPattern}s to match against each
+ * {@link HttpServletRequest}. Specifically, this means that the class anticipates that
+ * the provided pattern does not include the servlet path in order to align with Spring
+ * MVC.
+ *
+ * <p>
+ * Note that the {@link org.springframework.web.servlet.HandlerMapping} that contains the
+ * related URI patterns must be using the same
+ * {@link org.springframework.web.util.pattern.PathPatternParser} configured in this
+ * class.
+ * </p>
+ *
+ * @author Josh Cummings
+ * @since 6.5
+ */
+public final class PathPatternRequestMatcher implements RequestMatcher {
+
+	private static final String PATH_ATTRIBUTE = PathPatternRequestMatcher.class + ".PATH";
+
+	static final String ANY_SERVLET = new String();
+
+	private final PathPattern pattern;
+
+	private String servletPath;
+
+	private HttpMethod method;
+
+	PathPatternRequestMatcher(PathPattern pattern) {
+		this.pattern = pattern;
+	}
+
+	/**
+	 * Create a {@link Builder} for creating {@link PathPattern}-based request matchers.
+	 * That is, matchers that anticipate patterns do not specify the servlet path.
+	 * @return the {@link Builder}
+	 */
+	public static Builder builder() {
+		return new Builder(PathPatternParser.defaultInstance);
+	}
+
+	/**
+	 * Create a {@link Builder} for creating {@link PathPattern}-based request matchers.
+	 * That is, matchers that anticipate patterns do not specify the servlet path.
+	 * @param parser the {@link PathPatternParser}; only needed when different from
+	 * {@link PathPatternParser#defaultInstance}
+	 * @return the {@link Builder}
+	 */
+	public static Builder withPathPatternParser(PathPatternParser parser) {
+		return new Builder(parser);
+	}
+
+	@Override
+	public boolean matches(HttpServletRequest request) {
+		return matcher(request).isMatch();
+	}
+
+	@Override
+	public MatchResult matcher(HttpServletRequest request) {
+		if (this.method != null && !this.method.name().equals(request.getMethod())) {
+			return MatchResult.notMatch();
+		}
+		if (this.servletPath != null && !this.servletPath.equals(request.getServletPath())
+				&& !ANY_SERVLET.equals(this.servletPath)) {
+			return MatchResult.notMatch();
+		}
+		PathContainer path = getPathContainer(request);
+		PathPattern.PathMatchInfo info = this.pattern.matchAndExtract(path);
+		return (info != null) ? MatchResult.match(info.getUriVariables()) : MatchResult.notMatch();
+	}
+
+	PathContainer getPathContainer(HttpServletRequest request) {
+		if (this.servletPath != null) {
+			return ServletRequestPathUtils.parseAndCache(request).pathWithinApplication();
+		}
+		else {
+			return parseAndCache(request);
+		}
+	}
+
+	PathContainer parseAndCache(HttpServletRequest request) {
+		PathContainer path = (PathContainer) request.getAttribute(PATH_ATTRIBUTE);
+		if (path != null) {
+			return path;
+		}
+		path = RequestPath.parse(request.getRequestURI(), request.getContextPath()).pathWithinApplication();
+		request.setAttribute(PATH_ATTRIBUTE, path);
+		return path;
+	}
+
+	void setServletPath(String servletPath) {
+		this.servletPath = servletPath;
+	}
+
+	void setMethod(HttpMethod method) {
+		this.method = method;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (!(o instanceof PathPatternRequestMatcher that)) {
+			return false;
+		}
+		return Objects.equals(this.pattern, that.pattern) && Objects.equals(this.servletPath, that.servletPath)
+				&& Objects.equals(this.method, that.method);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.pattern, this.servletPath, this.method);
+	}
+
+	@Override
+	public String toString() {
+		return "PathPatternRequestMatcher [pattern=" + this.pattern + ", servletPath=" + this.servletPath + ", method="
+				+ this.method + ']';
+	}
+
+	/**
+	 * A builder for {@link MvcRequestMatcher}
+	 *
+	 * @author Marcus Da Coregio
+	 * @since 6.5
+	 */
+	public static final class Builder implements RequestMatcherBuilder {
+
+		private final PathPatternParser parser;
+
+		private HttpMethod method;
+
+		private String servletPath;
+
+		/**
+		 * Construct a new instance of this builder
+		 */
+		public Builder(PathPatternParser parser) {
+			Assert.notNull(parser, "pathPatternParser cannot be null");
+			this.parser = parser;
+		}
+
+		public Builder method(HttpMethod method) {
+			this.method = method;
+			return this;
+		}
+
+		/**
+		 * Sets the servlet path to be used by the {@link MvcRequestMatcher} generated by
+		 * this builder
+		 * @param servletPath the servlet path to use
+		 * @return the {@link MvcRequestMatcher.Builder} for further configuration
+		 */
+		public Builder servletPath(String servletPath) {
+			this.servletPath = servletPath;
+			return this;
+		}
+
+		/**
+		 * Creates an {@link MvcRequestMatcher} that uses the provided pattern and HTTP
+		 * method to match
+		 * @param method the {@link HttpMethod}, can be null
+		 * @param pattern the patterns used to match
+		 * @return the generated {@link MvcRequestMatcher}
+		 */
+		public PathPatternRequestMatcher pattern(HttpMethod method, String pattern) {
+			String parsed = this.parser.initFullPathPattern(pattern);
+			PathPattern pathPattern = this.parser.parse(parsed);
+			PathPatternRequestMatcher requestMatcher = new PathPatternRequestMatcher(pathPattern);
+			requestMatcher.setServletPath(this.servletPath);
+			requestMatcher.setMethod(method);
+			return requestMatcher;
+		}
+
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/servlet/util/matcher/ServletRegistrationsSupport.java
+++ b/web/src/main/java/org/springframework/security/web/servlet/util/matcher/ServletRegistrationsSupport.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.servlet.util.matcher;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletRegistration;
+
+import org.springframework.util.ClassUtils;
+
+class ServletRegistrationsSupport {
+
+	private final Collection<RegistrationMapping> registrations;
+
+	ServletRegistrationsSupport(ServletContext servletContext) {
+		Map<String, ? extends ServletRegistration> registrations = servletContext.getServletRegistrations();
+		Collection<RegistrationMapping> mappings = new ArrayList<>();
+		for (Map.Entry<String, ? extends ServletRegistration> entry : registrations.entrySet()) {
+			if (!entry.getValue().getMappings().isEmpty()) {
+				for (String mapping : entry.getValue().getMappings()) {
+					mappings.add(new RegistrationMapping(entry.getValue(), mapping));
+				}
+			}
+		}
+		this.registrations = mappings;
+	}
+
+	Collection<RegistrationMapping> dispatcherServletMappings() {
+		Collection<RegistrationMapping> mappings = new ArrayList<>();
+		for (RegistrationMapping registration : this.registrations) {
+			if (registration.isDispatcherServlet()) {
+				mappings.add(registration);
+			}
+		}
+		return mappings;
+	}
+
+	Collection<RegistrationMapping> mappings() {
+		return this.registrations;
+	}
+
+	record RegistrationMapping(ServletRegistration registration, String mapping) {
+		boolean isDispatcherServlet() {
+			Class<?> dispatcherServlet = ClassUtils
+				.resolveClassName("org.springframework.web.servlet.DispatcherServlet", null);
+			try {
+				Class<?> clazz = Class.forName(this.registration.getClassName());
+				return dispatcherServlet.isAssignableFrom(clazz);
+			}
+			catch (ClassNotFoundException ex) {
+				return false;
+			}
+		}
+
+		boolean isDefault() {
+			return "/".equals(this.mapping);
+		}
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/servlet/util/matcher/ServletRequestMatcherBuilders.java
+++ b/web/src/main/java/org/springframework/security/web/servlet/util/matcher/ServletRequestMatcherBuilders.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.servlet.util.matcher;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletRegistration;
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.security.web.servlet.util.matcher.ServletRegistrationsSupport.RegistrationMapping;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcherBuilder;
+import org.springframework.util.Assert;
+import org.springframework.web.servlet.DispatcherServlet;
+
+/**
+ * A {@link RequestMatcherBuilder} for specifying the servlet path separately from the
+ * rest of the URI. This is helpful when you have more than one servlet.
+ *
+ * <p>
+ * For example, if Spring MVC is deployed to `/mvc` and another servlet to `/other`, then
+ * you can do
+ * </p>
+ *
+ * <code>
+ *     http
+ *         .authorizeHttpRequests((authorize) -> authorize
+ *         		.requestMatchers(servletPath("/mvc").pattern("/my/**", "/controller/**", "/endpoints/**")).hasAuthority(...
+ *         		.requestMatchers(servletPath("/other").pattern("/my/**", "/non-mvc/**", "/endpoints/**")).hasAuthority(...
+ *         	}
+ *         	...
+ * </code>
+ *
+ * @author Josh Cummings
+ * @since 6.5
+ */
+public final class ServletRequestMatcherBuilders {
+
+	private ServletRequestMatcherBuilders() {
+	}
+
+	/**
+	 * Create {@link RequestMatcher}s that will only match URIs against the default
+	 * servlet.
+	 * @return a {@link ServletRequestMatcherBuilders} that matches URIs mapped to the
+	 * default servlet
+	 */
+	public static RequestMatcherBuilder defaultServlet() {
+		return servletPathInternal("");
+	}
+
+	/**
+	 * Create {@link RequestMatcher}s that will only match URIs against the given servlet
+	 * path
+	 *
+	 * <p>
+	 * The path must be of the format {@code /path}. It should not end in `/` or `/*`, nor
+	 * should it be a file extension. To specify the default servlet, use
+	 * {@link #defaultServlet()}.
+	 * </p>
+	 * @return a {@link ServletRequestMatcherBuilders} that matches URIs mapped to the
+	 * given servlet path
+	 */
+	public static RequestMatcherBuilder servletPath(String servletPath) {
+		Assert.notNull(servletPath, "servletPath cannot be null");
+		Assert.isTrue(servletPath.startsWith("/"), "servletPath must start with '/'");
+		Assert.isTrue(!servletPath.endsWith("/"), "servletPath must not end with '/'");
+		Assert.isTrue(!servletPath.endsWith("/*"), "servletPath must not end with '/*'");
+		return servletPathInternal(servletPath);
+	}
+
+	private static RequestMatcherBuilder servletPathInternal(String servletPath) {
+		return (method, pattern) -> {
+			Assert.notNull(pattern, "pattern cannot be null");
+			Assert.isTrue(pattern.startsWith("/"), "pattern must start with '/'");
+			return PathPatternRequestMatcher.builder().servletPath(servletPath).pattern(method, pattern);
+		};
+	}
+
+	/**
+	 * Create {@link RequestMatcher}s that will deduce the servlet path by testing the
+	 * given patterns as relative and absolute. If the target servlet is
+	 * {@link DispatcherServlet}, then it tests the pattern as relative to the servlet
+	 * path; otherwise, it tests the pattern as absolute
+	 * @return a {@link ServletRequestMatcherBuilders} that deduces the servlet path at
+	 * request time
+	 */
+	public static RequestMatcherBuilder servletPathDeducing() {
+		return (method, pattern) -> {
+			Assert.notNull(pattern, "pattern cannot be null");
+			Assert.isTrue(pattern.startsWith("/"), "pattern must start with '/'");
+			return new PathDeducingRequestMatcher(method, pattern);
+		};
+	}
+
+	static final class PathDeducingRequestMatcher implements RequestMatcher {
+
+		private static final RequestMatcher isMockMvc = (request) -> request
+			.getAttribute("org.springframework.test.web.servlet.MockMvc.MVC_RESULT_ATTRIBUTE") != null;
+
+		private static final RequestMatcher isDispatcherServlet = (request) -> {
+			String name = request.getHttpServletMapping().getServletName();
+			ServletContext servletContext = request.getServletContext();
+			ServletRegistration registration = servletContext.getServletRegistration(name);
+			Assert.notNull(registration, () -> computeErrorMessage(servletContext.getServletRegistrations().values()));
+			String mapping = request.getHttpServletMapping().getPattern();
+			return new RegistrationMapping(registration, mapping).isDispatcherServlet();
+		};
+
+		private final Map<ServletContext, RequestMatcher> delegates = new ConcurrentHashMap<>();
+
+		private HttpMethod method;
+
+		private String pattern;
+
+		PathDeducingRequestMatcher(HttpMethod method, String pattern) {
+			this.method = method;
+			this.pattern = pattern;
+		}
+
+		RequestMatcher requestMatcher(HttpServletRequest request) {
+			return this.delegates.computeIfAbsent(request.getServletContext(), (servletContext) -> {
+				PathPatternRequestMatcher absolute = PathPatternRequestMatcher.builder()
+					.pattern(this.method, this.pattern);
+				PathPatternRequestMatcher relative = PathPatternRequestMatcher.builder()
+					.pattern(this.method, this.pattern);
+				ServletRegistrationsSupport registrations = new ServletRegistrationsSupport(servletContext);
+				Collection<RegistrationMapping> mappings = registrations.mappings();
+				if (mappings.isEmpty()) {
+					relative.setServletPath(PathPatternRequestMatcher.ANY_SERVLET);
+					return new EitherRequestMatcher(relative, absolute, isMockMvc);
+				}
+				Collection<RegistrationMapping> dispatcherServletMappings = registrations.dispatcherServletMappings();
+				if (dispatcherServletMappings.isEmpty()) {
+					relative.setServletPath(PathPatternRequestMatcher.ANY_SERVLET);
+					return new EitherRequestMatcher(relative, absolute, isMockMvc);
+				}
+				if (dispatcherServletMappings.size() > 1) {
+					String errorMessage = computeErrorMessage(servletContext.getServletRegistrations().values());
+					throw new IllegalArgumentException(errorMessage);
+				}
+				RegistrationMapping dispatcherServlet = dispatcherServletMappings.iterator().next();
+				if (mappings.size() > 1 && !dispatcherServlet.isDefault()) {
+					String errorMessage = computeErrorMessage(servletContext.getServletRegistrations().values());
+					throw new IllegalArgumentException(errorMessage);
+				}
+				if (dispatcherServlet.isDefault()) {
+					relative.setServletPath("");
+					if (mappings.size() == 1) {
+						return relative;
+					}
+					return new EitherRequestMatcher(relative, absolute,
+							new OrRequestMatcher(isMockMvc, isDispatcherServlet));
+				}
+				String mapping = dispatcherServlet.mapping();
+				relative.setServletPath(mapping.substring(0, mapping.length() - 2));
+				return relative;
+			});
+		}
+
+		@Override
+		public boolean matches(HttpServletRequest request) {
+			return matcher(request).isMatch();
+		}
+
+		@Override
+		public MatchResult matcher(HttpServletRequest request) {
+			return requestMatcher(request).matcher(request);
+		}
+
+		private static String computeErrorMessage(Collection<? extends ServletRegistration> registrations) {
+			String template = """
+					This method cannot decide whether these patterns are Spring MVC patterns or not. \
+					This is because there is more than one mappable servlet in your servlet context: %s.
+
+					To address this, please create one ServletRequestMatcherBuilder#servletPath for each servlet that has \
+					authorized endpoints and use them to construct request matchers manually. \
+					If all your URIs are unambiguous, then you can simply publish one ServletRequestMatcherBuilders#servletPath as \
+					a @Bean and Spring Security will use it for all URIs""";
+			Map<String, Collection<String>> mappings = new LinkedHashMap<>();
+			for (ServletRegistration registration : registrations) {
+				mappings.put(registration.getClassName(), registration.getMappings());
+			}
+			return String.format(template, mappings);
+		}
+
+		@Override
+		public String toString() {
+			return "PathDeducingRequestMatcher [delegates = " + this.delegates + "]";
+		}
+
+	}
+
+	static class EitherRequestMatcher implements RequestMatcher {
+
+		final RequestMatcher right;
+
+		final RequestMatcher left;
+
+		final RequestMatcher test;
+
+		EitherRequestMatcher(RequestMatcher right, RequestMatcher left, RequestMatcher test) {
+			this.left = left;
+			this.right = right;
+			this.test = test;
+		}
+
+		RequestMatcher requestMatcher(HttpServletRequest request) {
+			return this.test.matches(request) ? this.right : this.left;
+		}
+
+		@Override
+		public boolean matches(HttpServletRequest request) {
+			return requestMatcher(request).matches(request);
+		}
+
+		@Override
+		public MatchResult matcher(HttpServletRequest request) {
+			return requestMatcher(request).matcher(request);
+		}
+
+		@Override
+		public String toString() {
+			return "Either [" + "left = " + this.left + ", right = " + this.right + "]";
+		}
+
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/util/matcher/RequestMatcherBuilder.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/RequestMatcherBuilder.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.util.matcher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.http.HttpMethod;
+
+public interface RequestMatcherBuilder {
+
+	default RequestMatcher[] pattern(HttpMethod method, String... patterns) {
+		List<RequestMatcher> requestMatchers = new ArrayList<>();
+		for (String pattern : patterns) {
+			requestMatchers.add(pattern(method, pattern));
+		}
+		return requestMatchers.toArray(RequestMatcher[]::new);
+	}
+
+	default RequestMatcher[] pattern(String... patterns) {
+		return pattern(null, patterns);
+	}
+
+	default RequestMatcher pattern(String pattern) {
+		return pattern(null, pattern);
+	}
+
+	default RequestMatcher anyRequest() {
+		return pattern(null, "/**");
+	}
+
+	RequestMatcher pattern(HttpMethod method, String pattern);
+
+}

--- a/web/src/test/java/org/springframework/security/web/servlet/util/matcher/PathPatternRequestMatcherTests.java
+++ b/web/src/test/java/org/springframework/security/web/servlet/util/matcher/PathPatternRequestMatcherTests.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.servlet.util.matcher;
+
+import jakarta.servlet.http.MappingMatch;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockHttpServletMapping;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link PathPatternRequestMatcher}
+ */
+public class PathPatternRequestMatcherTests {
+
+	@Test
+	void matcherWhenPatternMatchesRequestThenMatchResult() {
+		RequestMatcher matcher = PathPatternRequestMatcher.builder().pattern("/uri");
+		assertThat(matcher.matches(request("GET", "/uri"))).isTrue();
+	}
+
+	@Test
+	void matcherWhenPatternContainsPlaceholdersThenMatchResult() {
+		RequestMatcher matcher = PathPatternRequestMatcher.builder().pattern("/uri/{username}");
+		assertThat(matcher.matcher(request("GET", "/uri/bob")).getVariables()).containsEntry("username", "bob");
+	}
+
+	@Test
+	void matcherWhenSameServletPathThenMatchResult() {
+		RequestMatcher matcher = PathPatternRequestMatcher.builder().servletPath("/mvc").pattern("/uri");
+		assertThat(matcher.matches(request("GET", "/mvc/uri", "/mvc"))).isTrue();
+	}
+
+	@Test
+	void matcherWhenSameMethodThenMatchResult() {
+		RequestMatcher matcher = PathPatternRequestMatcher.builder().pattern(HttpMethod.GET, "/uri");
+		assertThat(matcher.matches(request("GET", "/uri"))).isTrue();
+	}
+
+	@Test
+	void matcherWhenDifferentPathThenNotMatchResult() {
+		RequestMatcher matcher = PathPatternRequestMatcher.builder()
+			.servletPath("/mvc")
+			.pattern(HttpMethod.GET, "/uri");
+		assertThat(matcher.matches(request("GET", "/uri", ""))).isFalse();
+	}
+
+	@Test
+	void matcherWhenDifferentMethodThenNotMatchResult() {
+		RequestMatcher matcher = PathPatternRequestMatcher.builder()
+			.servletPath("/mvc")
+			.pattern(HttpMethod.GET, "/uri");
+		assertThat(matcher.matches(request("POST", "/mvc/uri", "/mvc"))).isFalse();
+	}
+
+	@Test
+	void matcherWhenNoServletPathThenMatchAbsolute() {
+		RequestMatcher matcher = PathPatternRequestMatcher.builder().pattern(HttpMethod.GET, "/uri");
+		assertThat(matcher.matches(request("GET", "/mvc/uri", "/mvc"))).isFalse();
+		assertThat(matcher.matches(request("GET", "/uri", ""))).isTrue();
+	}
+
+	MockHttpServletRequest request(String method, String uri) {
+		return new MockHttpServletRequest(method, uri);
+	}
+
+	MockHttpServletRequest request(String method, String uri, String servletPath) {
+		MockHttpServletRequest request = new MockHttpServletRequest(method, uri);
+		request.setServletPath(servletPath);
+		request
+			.setHttpServletMapping(new MockHttpServletMapping(uri, servletPath + "/*", "servlet", MappingMatch.PATH));
+		return request;
+	}
+
+}

--- a/web/src/test/java/org/springframework/security/web/servlet/util/matcher/ServletRequestMatcherBuildersTests.java
+++ b/web/src/test/java/org/springframework/security/web/servlet/util/matcher/ServletRequestMatcherBuildersTests.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.servlet.util.matcher;
+
+import jakarta.servlet.Servlet;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.web.servlet.MockServletContext;
+import org.springframework.security.web.servlet.TestMockHttpServletMappings;
+import org.springframework.security.web.servlet.util.matcher.ServletRequestMatcherBuilders.EitherRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.ServletRequestMatcherBuilders.PathDeducingRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcherBuilder;
+import org.springframework.web.servlet.DispatcherServlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class ServletRequestMatcherBuildersTests {
+
+	@Test
+	void patternWhenServletPathThenUsesPathPattern() {
+		RequestMatcherBuilder builder = ServletRequestMatcherBuilders.servletPath("/servlet/path");
+		RequestMatcher requestMatcher = builder.pattern(HttpMethod.GET, "/endpoint");
+		assertThat(requestMatcher).isInstanceOf(PathPatternRequestMatcher.class);
+	}
+
+	@Test
+	void patternWhenDefaultServletThenUsesPathPattern() {
+		RequestMatcherBuilder builder = ServletRequestMatcherBuilders.defaultServlet();
+		RequestMatcher requestMatcher = builder.pattern(HttpMethod.GET, "/endpoint");
+		assertThat(requestMatcher).isInstanceOf(PathPatternRequestMatcher.class);
+	}
+
+	@Test
+	void patternWhenServletPathDeducingThenUsesComposite() {
+		RequestMatcherBuilder builder = ServletRequestMatcherBuilders.servletPathDeducing();
+		RequestMatcher requestMatcher = builder.pattern(HttpMethod.GET, "/endpoint");
+		assertThat(requestMatcher).isInstanceOf(PathDeducingRequestMatcher.class);
+	}
+
+	@Test
+	void requestMatchersWhenAmbiguousServletsThenException() {
+		MockServletContext servletContext = new MockServletContext();
+		servletContext.addServlet("dispatcherServlet", DispatcherServlet.class).addMapping("/");
+		servletContext.addServlet("servletTwo", DispatcherServlet.class).addMapping("/servlet/*");
+		RequestMatcher requestMatcher = ServletRequestMatcherBuilders.servletPathDeducing().pattern("/**");
+		assertThatExceptionOfType(IllegalArgumentException.class)
+			.isThrownBy(() -> requestMatcher.matches(new MockHttpServletRequest(servletContext)));
+	}
+
+	@Test
+	void requestMatchersWhenMultipleDispatcherServletMappingsThenException() {
+		MockServletContext servletContext = new MockServletContext();
+		servletContext.addServlet("dispatcherServlet", DispatcherServlet.class).addMapping("/", "/mvc/*");
+		RequestMatcher requestMatcher = ServletRequestMatcherBuilders.servletPathDeducing().pattern("/**");
+		assertThatExceptionOfType(IllegalArgumentException.class)
+			.isThrownBy(() -> requestMatcher.matcher(new MockHttpServletRequest(servletContext)));
+	}
+
+	@Test
+	void requestMatchersWhenPathDispatcherServletAndOtherServletsThenException() {
+		MockServletContext servletContext = new MockServletContext();
+		servletContext.addServlet("dispatcherServlet", DispatcherServlet.class).addMapping("/mvc/*");
+		servletContext.addServlet("default", Servlet.class).addMapping("/");
+		RequestMatcher requestMatcher = ServletRequestMatcherBuilders.servletPathDeducing().pattern("/**");
+		assertThatExceptionOfType(IllegalArgumentException.class)
+			.isThrownBy(() -> requestMatcher.matcher(new MockHttpServletRequest(servletContext)));
+	}
+
+	@Test
+	void requestMatchersWhenUnmappableServletsThenSkips() {
+		MockServletContext servletContext = new MockServletContext();
+		servletContext.addServlet("dispatcherServlet", DispatcherServlet.class).addMapping("/");
+		servletContext.addServlet("servletTwo", Servlet.class);
+		PathDeducingRequestMatcher requestMatcher = (PathDeducingRequestMatcher) ServletRequestMatcherBuilders
+			.servletPathDeducing()
+			.pattern("/**");
+		RequestMatcher deduced = requestMatcher.requestMatcher(new MockHttpServletRequest(servletContext));
+		assertThat(deduced).isInstanceOf(PathPatternRequestMatcher.class);
+	}
+
+	@Test
+	void requestMatchersWhenOnlyDispatcherServletThenAllows() {
+		MockServletContext servletContext = new MockServletContext();
+		servletContext.addServlet("dispatcherServlet", DispatcherServlet.class).addMapping("/mvc/*");
+		PathDeducingRequestMatcher requestMatcher = (PathDeducingRequestMatcher) ServletRequestMatcherBuilders
+			.servletPathDeducing()
+			.pattern("/**");
+		RequestMatcher deduced = requestMatcher.requestMatcher(new MockHttpServletRequest(servletContext));
+		assertThat(deduced).isInstanceOf(PathPatternRequestMatcher.class);
+	}
+
+	@Test
+	void requestMatchersWhenImplicitServletsThenAllows() {
+		MockServletContext servletContext = new MockServletContext();
+		servletContext.addServlet("defaultServlet", Servlet.class);
+		servletContext.addServlet("jspServlet", Servlet.class).addMapping("*.jsp", "*.jspx");
+		servletContext.addServlet("dispatcherServlet", DispatcherServlet.class).addMapping("/");
+		PathDeducingRequestMatcher requestMatcher = (PathDeducingRequestMatcher) ServletRequestMatcherBuilders
+			.servletPathDeducing()
+			.pattern("/**");
+		RequestMatcher deduced = requestMatcher.requestMatcher(new MockHttpServletRequest(servletContext));
+		assertThat(deduced).isInstanceOf(EitherRequestMatcher.class);
+	}
+
+	@Test
+	void requestMatchersWhenPathBasedNonDispatcherServletThenAllows() {
+		MockServletContext servletContext = new MockServletContext();
+		servletContext.addServlet("path", Servlet.class).addMapping("/services/*");
+		servletContext.addServlet("default", DispatcherServlet.class).addMapping("/");
+		PathDeducingRequestMatcher requestMatcher = (PathDeducingRequestMatcher) ServletRequestMatcherBuilders
+			.servletPathDeducing()
+			.pattern("/services/*");
+		RequestMatcher deduced = requestMatcher.requestMatcher(new MockHttpServletRequest(servletContext));
+		assertThat(deduced).isInstanceOf(EitherRequestMatcher.class);
+		MockHttpServletRequest request = new MockHttpServletRequest(servletContext, "GET", "/services/endpoint");
+		request.setHttpServletMapping(TestMockHttpServletMappings.defaultMapping());
+		request.setServletPath("");
+		assertThat(deduced.matcher(request).isMatch()).isTrue();
+		request.setHttpServletMapping(TestMockHttpServletMappings.path(request, "/services"));
+		request.setServletPath("/services");
+		request.setPathInfo("/endpoint");
+		assertThat(deduced.matcher(request).isMatch()).isTrue();
+	}
+
+	@Test
+	void matchesWhenDispatcherServletThenMvc() {
+		MockServletContext servletContext = new MockServletContext();
+		servletContext.addServlet("default", DispatcherServlet.class).addMapping("/");
+		servletContext.addServlet("path", Servlet.class).addMapping("/services/*");
+		PathDeducingRequestMatcher requestMatcher = (PathDeducingRequestMatcher) ServletRequestMatcherBuilders
+			.servletPathDeducing()
+			.pattern("/services/*");
+		MockHttpServletRequest request = new MockHttpServletRequest(servletContext, "GET", "/services/endpoint");
+		request.setHttpServletMapping(TestMockHttpServletMappings.defaultMapping());
+		EitherRequestMatcher either = (EitherRequestMatcher) requestMatcher.requestMatcher(request);
+		RequestMatcher deduced = either.requestMatcher(request);
+		assertThat(deduced).isEqualTo(either.right);
+		request.setHttpServletMapping(TestMockHttpServletMappings.path(request, "/services"));
+		deduced = either.requestMatcher(request);
+		assertThat(deduced).isEqualTo(either.left);
+	}
+
+	@Test
+	void matchesWhenNoMappingThenException() {
+		MockServletContext servletContext = new MockServletContext();
+		servletContext.addServlet("default", DispatcherServlet.class).addMapping("/");
+		servletContext.addServlet("path", Servlet.class).addMapping("/services/*");
+		MockHttpServletRequest request = new MockHttpServletRequest(servletContext, "GET", "/services/endpoint");
+		RequestMatcher requestMatcher = ServletRequestMatcherBuilders.servletPathDeducing().pattern("/services/*");
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> requestMatcher.matcher(request));
+	}
+
+}


### PR DESCRIPTION
Closes https://github.com/spring-projects/spring-security/issues/13562

Instead of needing a `HandlerMappingIntrospector` instance, applications can now do the following to simplify specifying the servlet path in the Java DSL:

```java
import static org.springframework.security.web.util.matcher.ServletRequestMatcherBuilders.servletPath;

@Bean 
SecurityFilterChain webSecurity(HttpSecurity http) throws Exception {
    http
        .authorizeHttpRequests((authorize) -> authorize
            .requestMatchers(servletPath("/graphql").anyRequest()).hasRole("GRAPHQL")
            .requestMatchers(servletPath("/mvc").pattern("/these/**", "/endpoints/**")).hasRole("USER")
            .requestMatchers(servletPath("/mvc").pattern("/admin/**")).hasRole("ADMIN")
        // ....

    return http.build();
}
```

To apply one across all DSL instances, do:

```java
@Bean 
RequestMatcherBuilder mvcOnly() {
    return ServletRequestMatcherBuilders.servletPath("/mvc");
}

@Bean 
SecurityFilterChain webSecurity(HttpSecurity http) throws Exception {
    http
        .authorizeHttpRequests((authorize) -> authorize
            .requestMatchers(antPattern("/graphql/**")).hasRole("GRAPHQL")
            .requestMatchers("/these/**", "/endpoints/**").hasRole("USER")
            .requestMatchers("/admin/**").hasRole("ADMIN")
        // ....

    return http.build();
}
```

This second one is quite handy for when Spring MVC has a non-root servlet path. For example, there may be an option for Spring Boot to publish this bean since it knows when a servlet path has been specified in Boot properties

This PR also produces `PathPatternRequestMatcher`, which allows for specifying a `PathPatternParser`.

Questions:

* Can we favor `PathPatternRequestMatcher` in a minor release? `MvcRequestMatcher` post-processors added to the `ObjectPostProcessor<Object>` would not have an effect in that case, meaning that the change isn't passive.
