### PR TITLE
Fix broken link to MockMvc documentation

### DIFF
--- a/docs/modules/ROOT/pages/servlet/test/mockmvc/index.adoc
+++ b/docs/modules/ROOT/pages/servlet/test/mockmvc/index.adoc
@@ -2,4 +2,4 @@
 = Spring MVC Test Integration
 :page-section-summary-toc: 1
 
-Spring Security provides comprehensive integration with https://docs.spring.io/spring/docs/current/spring-framework-reference/html/testing.html#spring-mvc-test-framework[Spring MVC Test]
+Spring Security provides comprehensive integration with https://docs.spring.io/spring-framework/reference/testing/mockmvc.html[Spring Testing MockMVC]


### PR DESCRIPTION
Link to Test chapter of Spring Framework documentation is broken, this commit fixes it.

No GitHub issue created for this.
