### PR TITLE
Use spring.security prefix instead of security.security

### DIFF
--- a/web/src/main/java/org/springframework/security/web/ObservationFilterChainDecorator.java
+++ b/web/src/main/java/org/springframework/security/web/ObservationFilterChainDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -554,7 +554,7 @@ public final class ObservationFilterChainDecorator implements FilterChainProxy.F
 
 		private static final String CHAIN_SIZE_NAME = "spring.security.filterchain.size";
 
-		private static final String FILTER_SECTION_NAME = "security.security.reached.filter.section";
+		private static final String FILTER_SECTION_NAME = "spring.security.reached.filter.section";
 
 		private static final String FILTER_NAME = "spring.security.reached.filter.name";
 


### PR DESCRIPTION
Closes gh-16422

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
