### PR TITLE
Suggest replacing size() == 0 with isEmpty() for collection check

### DIFF
--- a/core/src/main/java/org/springframework/security/core/ComparableVersion.java
+++ b/core/src/main/java/org/springframework/security/core/ComparableVersion.java
@@ -414,7 +414,7 @@ class ComparableVersion implements Comparable<ComparableVersion> {
 
 		@Override
 		public boolean isNull() {
-			return (size() == 0);
+			return isEmpty();
 		}
 
 		void normalize() {
@@ -434,7 +434,7 @@ class ComparableVersion implements Comparable<ComparableVersion> {
 		@Override
 		public int compareTo(Item item) {
 			if (item == null) {
-				if (size() == 0) {
+				if (isEmpty()) {
 					return 0; // 1-0 = 1- (normalize) = 1
 				}
 				Item first = get(0);


### PR DESCRIPTION
Suggestion: Consider using isEmpty() instead of size() == 0

I hope this doesn’t cause any inconvenience, but I was wondering if there’s a specific reason why size() == 0 is used instead of isEmpty(). Using isEmpty() can make the code more readable and aligns with modern Java practices. It conveys the intent more clearly, improving overall clarity.

I apologize for taking your time and appreciate your consideration.