### PR TITLE
Fix loader has changed while resolving nodes in WebAuthnWebDriverTests

### DIFF
--- a/config/src/integration-test/java/org/springframework/security/config/annotation/configurers/WebAuthnWebDriverTests.java
+++ b/config/src/integration-test/java/org/springframework/security/config/annotation/configurers/WebAuthnWebDriverTests.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -273,12 +274,14 @@ class WebAuthnWebDriverTests {
 
 	/**
 	 * Await until the assertion passes. If the assertion fails, it will display the
-	 * assertion error in stdout.
+	 * assertion error in stdout. WebDriver-related exceptions are ignored, so that
+	 * {@code assertion}s can interact with the page and be retried on error, e.g.
+	 * {@code assertThat(this.driver.findElement(By.Id("some-id")).isNotNull()}.
 	 */
 	private void await(Supplier<AbstractAssert<?, ?>> assertion) {
 		new FluentWait<>(this.driver).withTimeout(Duration.ofSeconds(2))
 			.pollingEvery(Duration.ofMillis(100))
-			.ignoring(AssertionError.class)
+			.ignoring(AssertionError.class, WebDriverException.class)
 			.until((d) -> {
 				assertion.get();
 				return true;


### PR DESCRIPTION
reviewer: @rwinch 

## Context

Test `WebAuthnWebDriverTests.loginWhenNoValidAuthenticatorCredentialsThenRejects` has been flakey ; throwing:

```
org.openqa.selenium.WebDriverException: aborted by navigation: loader has changed while resolving nodes
[... redacted ...]
    at java.base@17.0.3/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at java.base@17.0.3/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
    at java.base@17.0.3/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at java.base@17.0.3/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
    at java.base@17.0.3/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
    at app//org.openqa.selenium.remote.ErrorCodec.decode(ErrorCodec.java:167)
    at app//org.openqa.selenium.remote.codec.w3c.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:138)
    at app//org.openqa.selenium.remote.codec.w3c.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:50)
    at app//org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:190)
    at app//org.openqa.selenium.remote.TracedCommandExecutor.execute(TracedCommandExecutor.java:53)
    at app//org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:545)
    at app//org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:618)
    at app//org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:622)
    at app//org.openqa.selenium.remote.RemoteWebDriver.getCurrentUrl(RemoteWebDriver.java:325)
    at app//org.springframework.security.config.annotation.configurers.WebAuthnWebDriverTests.lambda$loginWhenNoValidAuthenticatorCredentialsThenRejects$0(WebAuthnWebDriverTests.java:147)
    at app//org.springframework.security.config.annotation.configurers.WebAuthnWebDriverTests.lambda$await$8(WebAuthnWebDriverTests.java:283)
    at app//org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:203)
    at app//org.springframework.security.config.annotation.configurers.WebAuthnWebDriverTests.await(WebAuthnWebDriverTests.java:282)
    at app//org.springframework.security.config.annotation.configurers.WebAuthnWebDriverTests.loginWhenNoValidAuthenticatorCredentialsThenRejects(WebAuthnWebDriverTests.java:147)
```

The cause as a navigation by the browser during the `getCurrentUrl` call.

Fix: allow `await` to retry when encountering `WebDriverException`.
