### PR TITLE
Add `HttpStatusAccessDeniedHandler`

### DIFF
--- a/web/src/main/java/org/springframework/security/web/access/HttpStatusAccessDeniedHandler.java
+++ b/web/src/main/java/org/springframework/security/web/access/HttpStatusAccessDeniedHandler.java
@@ -1,0 +1,34 @@
+package org.springframework.security.web.access;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.core.log.LogMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.util.Assert;
+
+import java.io.IOException;
+
+public class HttpStatusAccessDeniedHandler implements AccessDeniedHandler {
+
+	protected static final Log logger = LogFactory.getLog(HttpStatusAccessDeniedHandler.class);
+
+	private final HttpStatus httpStatus;
+
+	public HttpStatusAccessDeniedHandler(HttpStatus httpStatus) {
+		Assert.notNull(httpStatus, "httpStatus cannot be null");
+		this.httpStatus = httpStatus;
+	}
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+			AccessDeniedException accessDeniedException) throws IOException, ServletException {
+		logger.debug(LogMessage.format("Access denied with status code %d", this.httpStatus.value()));
+
+		response.sendError(this.httpStatus.value(),  "Access Denied");
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/access/HttpStatusAccessDeniedHandler.java
+++ b/web/src/main/java/org/springframework/security/web/access/HttpStatusAccessDeniedHandler.java
@@ -1,23 +1,50 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.security.web.access;
+
+import java.io.IOException;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.core.log.LogMessage;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.util.Assert;
 
-import java.io.IOException;
+/**
+ * An {@link AccessDeniedHandler} that sends an {@link HttpStatus} as a response.
+ *
+ * @author Sangyoon Jeong
+ * @since 6.5
+ */
+public final class HttpStatusAccessDeniedHandler implements AccessDeniedHandler {
 
-public class HttpStatusAccessDeniedHandler implements AccessDeniedHandler {
-
-	protected static final Log logger = LogFactory.getLog(HttpStatusAccessDeniedHandler.class);
+	private static final Log logger = LogFactory.getLog(HttpStatusAccessDeniedHandler.class);
 
 	private final HttpStatus httpStatus;
 
+	/**
+	 * Creates a new instance.
+	 * @param httpStatus the HttpStatus to set
+	 */
 	public HttpStatusAccessDeniedHandler(HttpStatus httpStatus) {
 		Assert.notNull(httpStatus, "httpStatus cannot be null");
 		this.httpStatus = httpStatus;
@@ -28,7 +55,7 @@ public class HttpStatusAccessDeniedHandler implements AccessDeniedHandler {
 			AccessDeniedException accessDeniedException) throws IOException, ServletException {
 		logger.debug(LogMessage.format("Access denied with status code %d", this.httpStatus.value()));
 
-		response.sendError(this.httpStatus.value(),  "Access Denied");
+		response.sendError(this.httpStatus.value(), "Access Denied");
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/access/HttpStatusAccessDeniedHandlerTests.java
+++ b/web/src/test/java/org/springframework/security/web/access/HttpStatusAccessDeniedHandlerTests.java
@@ -1,4 +1,22 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.security.web.access;
+
+import java.io.IOException;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -7,11 +25,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.access.AccessDeniedException;
-
-import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;

--- a/web/src/test/java/org/springframework/security/web/access/HttpStatusAccessDeniedHandlerTests.java
+++ b/web/src/test/java/org/springframework/security/web/access/HttpStatusAccessDeniedHandlerTests.java
@@ -1,0 +1,46 @@
+package org.springframework.security.web.access;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+@ExtendWith(MockitoExtension.class)
+public class HttpStatusAccessDeniedHandlerTests {
+
+	@Mock
+	private HttpServletRequest request;
+
+	@Mock
+	private HttpServletResponse response;
+
+	private HttpStatus httpStatus = HttpStatus.FORBIDDEN;
+
+	private HttpStatusAccessDeniedHandler handler = new HttpStatusAccessDeniedHandler(this.httpStatus);
+
+	private AccessDeniedException exception = new AccessDeniedException("Forbidden");
+
+	@Test
+	public void constructorHttpStatusWhenNullThenException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> new HttpStatusAccessDeniedHandler(null));
+	}
+
+	@Test
+	public void commenceThenStatusSet() throws IOException, ServletException {
+		this.response = new MockHttpServletResponse();
+		this.handler.handle(this.request, this.response, this.exception);
+		assertThat(this.response.getStatus()).isEqualTo(this.httpStatus.value());
+	}
+
+}


### PR DESCRIPTION
Add `HttpStatusAccessDeniedHandler`, **`AccessDeniedHandler` that sets the HTTP status code** like `HttpStatusEntryPoint`. This feature is already supported by Spring WebFlux as `HttpStatusServerAccessDeniedHandler`, but is not supported by Spring Web MVC.