### PR TITLE
Include AuthenticationRequest in AuthenticationException

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/DelegatingReactiveAuthenticationManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/DelegatingReactiveAuthenticationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.util.Assert;
 
 /**
@@ -58,6 +59,7 @@ public class DelegatingReactiveAuthenticationManager implements ReactiveAuthenti
 	public Mono<Authentication> authenticate(Authentication authentication) {
 		Flux<ReactiveAuthenticationManager> result = Flux.fromIterable(this.delegates);
 		Function<ReactiveAuthenticationManager, Mono<Authentication>> logging = (m) -> m.authenticate(authentication)
+			.doOnError(AuthenticationException.class, (ex) -> ex.setAuthenticationRequest(authentication))
 			.doOnError(this.logger::debug);
 
 		return ((this.continueOnError) ? result.concatMapDelayError(logging) : result.concatMap(logging)).next();

--- a/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -202,6 +202,7 @@ public class ProviderManager implements AuthenticationManager, MessageSourceAwar
 				throw ex;
 			}
 			catch (AuthenticationException ex) {
+				ex.setAuthenticationRequest(authentication);
 				logger.debug(LogMessage.format("Authentication failed with provider %s since %s",
 						provider.getClass().getSimpleName(), ex.getMessage()));
 				lastException = ex;
@@ -265,6 +266,7 @@ public class ProviderManager implements AuthenticationManager, MessageSourceAwar
 
 	@SuppressWarnings("deprecation")
 	private void prepareException(AuthenticationException ex, Authentication auth) {
+		ex.setAuthenticationRequest(auth);
 		this.eventPublisher.publishAuthenticationFailure(ex, auth);
 	}
 

--- a/core/src/main/java/org/springframework/security/core/AuthenticationException.java
+++ b/core/src/main/java/org/springframework/security/core/AuthenticationException.java
@@ -18,6 +18,8 @@ package org.springframework.security.core;
 
 import java.io.Serial;
 
+import org.springframework.util.Assert;
+
 /**
  * Abstract superclass for all exceptions related to an {@link Authentication} object
  * being invalid for whatever reason.
@@ -30,6 +32,16 @@ public abstract class AuthenticationException extends RuntimeException {
 	private static final long serialVersionUID = 2018827803361503060L;
 
 	/**
+	 * The {@link Authentication} object representing the failed authentication attempt.
+	 * <p>
+	 * This field captures the authentication request that was attempted but ultimately
+	 * failed, providing critical information for diagnosing the failure and facilitating
+	 * debugging. If set, the value must not be null.
+	 * </p>
+	 */
+	private Authentication authRequest;
+
+	/**
 	 * Constructs an {@code AuthenticationException} with the specified message and root
 	 * cause.
 	 * @param msg the detail message
@@ -37,6 +49,7 @@ public abstract class AuthenticationException extends RuntimeException {
 	 */
 	public AuthenticationException(String msg, Throwable cause) {
 		super(msg, cause);
+		this.authRequest = null;
 	}
 
 	/**
@@ -46,6 +59,23 @@ public abstract class AuthenticationException extends RuntimeException {
 	 */
 	public AuthenticationException(String msg) {
 		super(msg);
+		this.authRequest = null;
+	}
+
+
+	/**
+	 * Sets the {@link Authentication} object representing the failed authentication
+	 * attempt.
+	 * <p>
+	 * This method allows the injection of the authentication request that resulted in a
+	 * failure. The provided {@code authRequest} should not be null if set.
+	 * </p>
+	 * @param authRequest the authentication request associated with the failed
+	 * authentication attempt.
+	 */
+	public void setAuthRequest(Authentication authRequest) {
+		Assert.notNull(authRequest, "AuthRequest cannot be null");
+		this.authRequest = authRequest;
 	}
 
 }

--- a/core/src/main/java/org/springframework/security/core/AuthenticationException.java
+++ b/core/src/main/java/org/springframework/security/core/AuthenticationException.java
@@ -31,15 +31,7 @@ public abstract class AuthenticationException extends RuntimeException {
 	@Serial
 	private static final long serialVersionUID = 2018827803361503060L;
 
-	/**
-	 * The {@link Authentication} object representing the failed authentication attempt.
-	 * <p>
-	 * This field captures the authentication request that was attempted but ultimately
-	 * failed, providing critical information for diagnosing the failure and facilitating
-	 * debugging. If set, the value must not be null.
-	 * </p>
-	 */
-	private Authentication authRequest;
+	private Authentication authenticationRequest;
 
 	/**
 	 * Constructs an {@code AuthenticationException} with the specified message and root
@@ -49,7 +41,6 @@ public abstract class AuthenticationException extends RuntimeException {
 	 */
 	public AuthenticationException(String msg, Throwable cause) {
 		super(msg, cause);
-		this.authRequest = null;
 	}
 
 	/**
@@ -59,23 +50,33 @@ public abstract class AuthenticationException extends RuntimeException {
 	 */
 	public AuthenticationException(String msg) {
 		super(msg);
-		this.authRequest = null;
 	}
 
-
 	/**
-	 * Sets the {@link Authentication} object representing the failed authentication
+	 * Get the {@link Authentication} object representing the failed authentication
 	 * attempt.
 	 * <p>
-	 * This method allows the injection of the authentication request that resulted in a
-	 * failure. The provided {@code authRequest} should not be null if set.
-	 * </p>
-	 * @param authRequest the authentication request associated with the failed
-	 * authentication attempt.
+	 * This field captures the authentication request that was attempted but ultimately
+	 * failed, providing critical information for diagnosing the failure and facilitating
+	 * debugging
+	 * @since 6.5
 	 */
-	public void setAuthRequest(Authentication authRequest) {
-		Assert.notNull(authRequest, "AuthRequest cannot be null");
-		this.authRequest = authRequest;
+	public Authentication getAuthenticationRequest() {
+		return this.authenticationRequest;
+	}
+
+	/**
+	 * Set the {@link Authentication} object representing the failed authentication
+	 * attempt.
+	 * <p>
+	 * The provided {@code authenticationRequest} should not be null
+	 * @param authenticationRequest the authentication request associated with the failed
+	 * authentication attempt
+	 * @since 6.5
+	 */
+	public void setAuthenticationRequest(Authentication authenticationRequest) {
+		Assert.notNull(authenticationRequest, "authenticationRequest cannot be null");
+		this.authenticationRequest = authenticationRequest;
 	}
 
 }

--- a/core/src/main/java/org/springframework/security/jackson2/BadCredentialsExceptionMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson2/BadCredentialsExceptionMixin.java
@@ -40,7 +40,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  * @see CoreJackson2Module
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
-@JsonIgnoreProperties(ignoreUnknown = true, value = { "cause", "stackTrace" })
+@JsonIgnoreProperties(ignoreUnknown = true, value = { "cause", "stackTrace", "authenticationRequest" })
 class BadCredentialsExceptionMixin {
 
 	/**

--- a/core/src/test/java/org/springframework/security/authentication/ProviderManagerTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/ProviderManagerTests.java
@@ -253,6 +253,34 @@ public class ProviderManagerTests {
 		verify(publisher).publishAuthenticationFailure(expected, authReq);
 	}
 
+	@Test
+	void whenAccountStatusExceptionThenAuthenticationRequestIsIncluded() {
+		AuthenticationException expected = new LockedException("");
+		ProviderManager mgr = new ProviderManager(createProviderWhichThrows(expected));
+		Authentication authReq = mock(Authentication.class);
+		assertThatExceptionOfType(LockedException.class).isThrownBy(() -> mgr.authenticate(authReq));
+		assertThat(expected.getAuthenticationRequest()).isEqualTo(authReq);
+	}
+
+	@Test
+	void whenInternalServiceAuthenticationExceptionThenAuthenticationRequestIsIncluded() {
+		AuthenticationException expected = new InternalAuthenticationServiceException("");
+		ProviderManager mgr = new ProviderManager(createProviderWhichThrows(expected));
+		Authentication authReq = mock(Authentication.class);
+		assertThatExceptionOfType(InternalAuthenticationServiceException.class)
+			.isThrownBy(() -> mgr.authenticate(authReq));
+		assertThat(expected.getAuthenticationRequest()).isEqualTo(authReq);
+	}
+
+	@Test
+	void whenAuthenticationExceptionThenAuthenticationRequestIsIncluded() {
+		AuthenticationException expected = new BadCredentialsException("");
+		ProviderManager mgr = new ProviderManager(createProviderWhichThrows(expected));
+		Authentication authReq = mock(Authentication.class);
+		assertThatExceptionOfType(BadCredentialsException.class).isThrownBy(() -> mgr.authenticate(authReq));
+		assertThat(expected.getAuthenticationRequest()).isEqualTo(authReq);
+	}
+
 	// SEC-2367
 	@Test
 	void providerThrowsInternalAuthenticationServiceException() {

--- a/core/src/test/java/org/springframework/security/authentication/ProviderManagerTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/ProviderManagerTests.java
@@ -18,7 +18,6 @@ package org.springframework.security.authentication;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -47,7 +46,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 public class ProviderManagerTests {
 
 	@Test
-	public void authenticationFailsWithUnsupportedToken() {
+	void authenticationFailsWithUnsupportedToken() {
 		Authentication token = new AbstractAuthenticationToken(null) {
 			@Override
 			public Object getCredentials() {
@@ -65,7 +64,7 @@ public class ProviderManagerTests {
 	}
 
 	@Test
-	public void credentialsAreClearedByDefault() {
+	void credentialsAreClearedByDefault() {
 		UsernamePasswordAuthenticationToken token = UsernamePasswordAuthenticationToken.unauthenticated("Test",
 				"Password");
 		ProviderManager mgr = makeProviderManager();
@@ -78,8 +77,8 @@ public class ProviderManagerTests {
 	}
 
 	@Test
-	public void authenticationSucceedsWithSupportedTokenAndReturnsExpectedObject() {
-		final Authentication a = mock(Authentication.class);
+	void authenticationSucceedsWithSupportedTokenAndReturnsExpectedObject() {
+		Authentication a = mock(Authentication.class);
 		ProviderManager mgr = new ProviderManager(createProviderWhichReturns(a));
 		AuthenticationEventPublisher publisher = mock(AuthenticationEventPublisher.class);
 		mgr.setAuthenticationEventPublisher(publisher);
@@ -89,8 +88,8 @@ public class ProviderManagerTests {
 	}
 
 	@Test
-	public void authenticationSucceedsWhenFirstProviderReturnsNullButSecondAuthenticates() {
-		final Authentication a = mock(Authentication.class);
+	void authenticationSucceedsWhenFirstProviderReturnsNullButSecondAuthenticates() {
+		Authentication a = mock(Authentication.class);
 		ProviderManager mgr = new ProviderManager(
 				Arrays.asList(createProviderWhichReturns(null), createProviderWhichReturns(a)));
 		AuthenticationEventPublisher publisher = mock(AuthenticationEventPublisher.class);
@@ -101,24 +100,24 @@ public class ProviderManagerTests {
 	}
 
 	@Test
-	public void testStartupFailsIfProvidersNotSetAsList() {
+	void testStartupFailsIfProvidersNotSetAsList() {
 		assertThatIllegalArgumentException().isThrownBy(() -> new ProviderManager((List<AuthenticationProvider>) null));
 	}
 
 	@Test
-	public void testStartupFailsIfProvidersNotSetAsVarargs() {
+	void testStartupFailsIfProvidersNotSetAsVarargs() {
 		assertThatIllegalArgumentException().isThrownBy(() -> new ProviderManager((AuthenticationProvider) null));
 	}
 
 	@Test
-	public void testStartupFailsIfProvidersContainNullElement() {
+	void testStartupFailsIfProvidersContainNullElement() {
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> new ProviderManager(Arrays.asList(mock(AuthenticationProvider.class), null)));
 	}
 
 	// gh-8689
 	@Test
-	public void constructorWhenUsingListOfThenNoException() {
+	void constructorWhenUsingListOfThenNoException() {
 		List<AuthenticationProvider> providers = spy(ArrayList.class);
 		// List.of(null) in JDK 9 throws a NullPointerException
 		given(providers.contains(eq(null))).willThrow(NullPointerException.class);
@@ -127,7 +126,7 @@ public class ProviderManagerTests {
 	}
 
 	@Test
-	public void detailsAreNotSetOnAuthenticationTokenIfAlreadySetByProvider() {
+	void detailsAreNotSetOnAuthenticationTokenIfAlreadySetByProvider() {
 		Object requestDetails = "(Request Details)";
 		final Object resultDetails = "(Result Details)";
 		// A provider which sets the details object
@@ -151,7 +150,7 @@ public class ProviderManagerTests {
 	}
 
 	@Test
-	public void detailsAreSetOnAuthenticationTokenIfNotAlreadySetByProvider() {
+	void detailsAreSetOnAuthenticationTokenIfNotAlreadySetByProvider() {
 		Object details = new Object();
 		ProviderManager authMgr = makeProviderManager();
 		TestingAuthenticationToken request = createAuthenticationToken();
@@ -162,8 +161,8 @@ public class ProviderManagerTests {
 	}
 
 	@Test
-	public void authenticationExceptionIsIgnoredIfLaterProviderAuthenticates() {
-		final Authentication authReq = mock(Authentication.class);
+	void authenticationExceptionIsIgnoredIfLaterProviderAuthenticates() {
+		Authentication authReq = mock(Authentication.class);
 		ProviderManager mgr = new ProviderManager(
 				createProviderWhichThrows(new BadCredentialsException("", new Throwable())),
 				createProviderWhichReturns(authReq));
@@ -171,7 +170,7 @@ public class ProviderManagerTests {
 	}
 
 	@Test
-	public void authenticationExceptionIsRethrownIfNoLaterProviderAuthenticates() {
+	void authenticationExceptionIsRethrownIfNoLaterProviderAuthenticates() {
 		ProviderManager mgr = new ProviderManager(Arrays
 			.asList(createProviderWhichThrows(new BadCredentialsException("")), createProviderWhichReturns(null)));
 		assertThatExceptionOfType(BadCredentialsException.class)
@@ -180,7 +179,7 @@ public class ProviderManagerTests {
 
 	// SEC-546
 	@Test
-	public void accountStatusExceptionPreventsCallsToSubsequentProviders() {
+	void accountStatusExceptionPreventsCallsToSubsequentProviders() {
 		AuthenticationProvider iThrowAccountStatusException = createProviderWhichThrows(new AccountStatusException("") {
 		});
 		AuthenticationProvider otherProvider = mock(AuthenticationProvider.class);
@@ -191,48 +190,47 @@ public class ProviderManagerTests {
 	}
 
 	@Test
-	public void parentAuthenticationIsUsedIfProvidersDontAuthenticate() {
+	void parentAuthenticationIsUsedIfProvidersDontAuthenticate() {
 		AuthenticationManager parent = mock(AuthenticationManager.class);
 		Authentication authReq = mock(Authentication.class);
 		given(parent.authenticate(authReq)).willReturn(authReq);
-		ProviderManager mgr = new ProviderManager(Collections.singletonList(mock(AuthenticationProvider.class)),
-				parent);
+		ProviderManager mgr = new ProviderManager(List.of(mock(AuthenticationProvider.class)), parent);
 		assertThat(mgr.authenticate(authReq)).isSameAs(authReq);
 	}
 
 	@Test
-	public void parentIsNotCalledIfAccountStatusExceptionIsThrown() {
+	void parentIsNotCalledIfAccountStatusExceptionIsThrown() {
 		AuthenticationProvider iThrowAccountStatusException = createProviderWhichThrows(
 				new AccountStatusException("", new Throwable()) {
 				});
 		AuthenticationManager parent = mock(AuthenticationManager.class);
-		ProviderManager mgr = new ProviderManager(Collections.singletonList(iThrowAccountStatusException), parent);
+		ProviderManager mgr = new ProviderManager(List.of(iThrowAccountStatusException), parent);
 		assertThatExceptionOfType(AccountStatusException.class)
 			.isThrownBy(() -> mgr.authenticate(mock(Authentication.class)));
 		verifyNoInteractions(parent);
 	}
 
 	@Test
-	public void providerNotFoundFromParentIsIgnored() {
+	void providerNotFoundFromParentIsIgnored() {
 		final Authentication authReq = mock(Authentication.class);
 		AuthenticationEventPublisher publisher = mock(AuthenticationEventPublisher.class);
 		AuthenticationManager parent = mock(AuthenticationManager.class);
 		given(parent.authenticate(authReq)).willThrow(new ProviderNotFoundException(""));
 		// Set a provider that throws an exception - this is the exception we expect to be
 		// propagated
-		ProviderManager mgr = new ProviderManager(
-				Collections.singletonList(createProviderWhichThrows(new BadCredentialsException(""))), parent);
+		ProviderManager mgr = new ProviderManager(List.of(createProviderWhichThrows(new BadCredentialsException(""))),
+				parent);
 		mgr.setAuthenticationEventPublisher(publisher);
 		assertThatExceptionOfType(BadCredentialsException.class).isThrownBy(() -> mgr.authenticate(authReq))
 			.satisfies((ex) -> verify(publisher).publishAuthenticationFailure(ex, authReq));
 	}
 
 	@Test
-	public void authenticationExceptionFromParentOverridesPreviousOnes() {
+	void authenticationExceptionFromParentOverridesPreviousOnes() {
 		AuthenticationManager parent = mock(AuthenticationManager.class);
-		ProviderManager mgr = new ProviderManager(
-				Collections.singletonList(createProviderWhichThrows(new BadCredentialsException(""))), parent);
-		final Authentication authReq = mock(Authentication.class);
+		ProviderManager mgr = new ProviderManager(List.of(createProviderWhichThrows(new BadCredentialsException(""))),
+				parent);
+		Authentication authReq = mock(Authentication.class);
 		AuthenticationEventPublisher publisher = mock(AuthenticationEventPublisher.class);
 		mgr.setAuthenticationEventPublisher(publisher);
 		// Set a provider that throws an exception - this is the exception we expect to be
@@ -244,12 +242,11 @@ public class ProviderManagerTests {
 	}
 
 	@Test
-	public void statusExceptionIsPublished() {
+	void statusExceptionIsPublished() {
 		AuthenticationManager parent = mock(AuthenticationManager.class);
-		final LockedException expected = new LockedException("");
-		ProviderManager mgr = new ProviderManager(Collections.singletonList(createProviderWhichThrows(expected)),
-				parent);
-		final Authentication authReq = mock(Authentication.class);
+		LockedException expected = new LockedException("");
+		ProviderManager mgr = new ProviderManager(List.of(createProviderWhichThrows(expected)), parent);
+		Authentication authReq = mock(Authentication.class);
 		AuthenticationEventPublisher publisher = mock(AuthenticationEventPublisher.class);
 		mgr.setAuthenticationEventPublisher(publisher);
 		assertThatExceptionOfType(LockedException.class).isThrownBy(() -> mgr.authenticate(authReq));
@@ -258,7 +255,7 @@ public class ProviderManagerTests {
 
 	// SEC-2367
 	@Test
-	public void providerThrowsInternalAuthenticationServiceException() {
+	void providerThrowsInternalAuthenticationServiceException() {
 		InternalAuthenticationServiceException expected = new InternalAuthenticationServiceException("Expected");
 		ProviderManager mgr = new ProviderManager(Arrays.asList(createProviderWhichThrows(expected),
 				createProviderWhichThrows(new BadCredentialsException("Oops"))), null);
@@ -269,15 +266,15 @@ public class ProviderManagerTests {
 
 	// gh-6281
 	@Test
-	public void authenticateWhenFailsInParentAndPublishesThenChildDoesNotPublish() {
+	void authenticateWhenFailsInParentAndPublishesThenChildDoesNotPublish() {
 		BadCredentialsException badCredentialsExParent = new BadCredentialsException("Bad Credentials in parent");
 		ProviderManager parentMgr = new ProviderManager(createProviderWhichThrows(badCredentialsExParent));
-		ProviderManager childMgr = new ProviderManager(Collections.singletonList(
-				createProviderWhichThrows(new BadCredentialsException("Bad Credentials in child"))), parentMgr);
+		ProviderManager childMgr = new ProviderManager(
+				List.of(createProviderWhichThrows(new BadCredentialsException("Bad Credentials in child"))), parentMgr);
 		AuthenticationEventPublisher publisher = mock(AuthenticationEventPublisher.class);
 		parentMgr.setAuthenticationEventPublisher(publisher);
 		childMgr.setAuthenticationEventPublisher(publisher);
-		final Authentication authReq = mock(Authentication.class);
+		Authentication authReq = mock(Authentication.class);
 		assertThatExceptionOfType(BadCredentialsException.class).isThrownBy(() -> childMgr.authenticate(authReq))
 			.isSameAs(badCredentialsExParent);
 		verify(publisher).publishAuthenticationFailure(badCredentialsExParent, authReq); // Parent

--- a/etc/checkstyle/checkstyle-suppressions.xml
+++ b/etc/checkstyle/checkstyle-suppressions.xml
@@ -38,6 +38,7 @@
 	<suppress files="AbstractOAuth2AuthorizationGrantRequestEntityConverter\.java" checks="SpringMethodVisibility"/>
 	<suppress files="JoseHeader\.java" checks="SpringMethodVisibility"/>
 	<suppress files="DefaultLoginPageGeneratingFilterTests\.java" checks="SpringLeadingWhitespace"/>
+	<suppress files="AuthenticationException\.java" checks="MutableException"/>
 
 	<!-- Lambdas that we can't replace with a method reference because a closure is required -->
 	<suppress files="BearerTokenAuthenticationFilter\.java" checks="SpringLambda"/>

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerAuthenticationManagerResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -176,9 +176,17 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 			String issuer = this.issuerConverter.convert(token);
 			AuthenticationManager authenticationManager = this.issuerAuthenticationManagerResolver.resolve(issuer);
 			if (authenticationManager == null) {
-				throw new InvalidBearerTokenException("Invalid issuer");
+				AuthenticationException ex = new InvalidBearerTokenException("Invalid issuer");
+				ex.setAuthenticationRequest(authentication);
+				throw ex;
 			}
-			return authenticationManager.authenticate(authentication);
+			try {
+				return authenticationManager.authenticate(authentication);
+			}
+			catch (AuthenticationException ex) {
+				ex.setAuthenticationRequest(authentication);
+				throw ex;
+			}
 		}
 
 	}
@@ -194,10 +202,14 @@ public final class JwtIssuerAuthenticationManagerResolver implements Authenticat
 					return issuer;
 				}
 			}
-			catch (Exception ex) {
-				throw new InvalidBearerTokenException(ex.getMessage(), ex);
+			catch (Exception cause) {
+				AuthenticationException ex = new InvalidBearerTokenException(cause.getMessage(), cause);
+				ex.setAuthenticationRequest(authentication);
+				throw ex;
 			}
-			throw new InvalidBearerTokenException("Missing issuer");
+			AuthenticationException ex = new InvalidBearerTokenException("Missing issuer");
+			ex.setAuthenticationRequest(authentication);
+			throw ex;
 		}
 
 	}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolverTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtIssuerReactiveAuthenticationManagerResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,13 +34,16 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import org.springframework.security.authentication.ReactiveAuthenticationManager;
 import org.springframework.security.authentication.ReactiveAuthenticationManagerResolver;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.jose.TestKeys;
 import org.springframework.security.oauth2.jwt.JwtClaimNames;
+import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
 import org.springframework.security.oauth2.server.resource.authentication.JwtIssuerReactiveAuthenticationManagerResolver.TrustedIssuerJwtAuthenticationManagerResolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -260,6 +263,20 @@ public class JwtIssuerReactiveAuthenticationManagerResolverTests {
 						.block())
 				.withMessage("Invalid token");
 		// @formatter:on
+	}
+
+	@Test
+	public void resolveWhenAuthenticationExceptionThenAuthenticationRequestIsIncluded() {
+		Authentication authentication = new BearerTokenAuthenticationToken(this.jwt);
+		AuthenticationException ex = new InvalidBearerTokenException("");
+		ReactiveAuthenticationManager manager = mock(ReactiveAuthenticationManager.class);
+		given(manager.authenticate(any())).willReturn(Mono.error(ex));
+		JwtIssuerReactiveAuthenticationManagerResolver resolver = new JwtIssuerReactiveAuthenticationManagerResolver(
+				(issuer) -> Mono.just(manager));
+		StepVerifier.create(resolver.resolve(null).block().authenticate(authentication))
+			.expectError(InvalidBearerTokenException.class)
+			.verify();
+		assertThat(ex.getAuthenticationRequest()).isEqualTo(authentication);
 	}
 
 	@Test

--- a/web/src/main/java/org/springframework/security/web/access/ExceptionTranslationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/access/ExceptionTranslationFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2022 the original author or authors.
+ * Copyright 2004-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -194,10 +194,11 @@ public class ExceptionTranslationFilter extends GenericFilterBean implements Mes
 				logger.trace(LogMessage.format("Sending %s to authentication entry point since access is denied",
 						authentication), exception);
 			}
-			sendStartAuthentication(request, response, chain,
-					new InsufficientAuthenticationException(
-							this.messages.getMessage("ExceptionTranslationFilter.insufficientAuthentication",
-									"Full authentication is required to access this resource")));
+			AuthenticationException ex = new InsufficientAuthenticationException(
+					this.messages.getMessage("ExceptionTranslationFilter.insufficientAuthentication",
+							"Full authentication is required to access this resource"));
+			ex.setAuthenticationRequest(authentication);
+			sendStartAuthentication(request, response, chain, ex);
 		}
 		else {
 			if (logger.isTraceEnabled()) {

--- a/web/src/main/java/org/springframework/security/web/authentication/RequestMatcherDelegatingAuthenticationManagerResolver.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/RequestMatcherDelegatingAuthenticationManagerResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationManagerResolver;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.access.intercept.RequestMatcherDelegatingAuthorizationManager;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcherEntry;
@@ -46,7 +47,9 @@ public final class RequestMatcherDelegatingAuthenticationManagerResolver
 	private final List<RequestMatcherEntry<AuthenticationManager>> authenticationManagers;
 
 	private AuthenticationManager defaultAuthenticationManager = (authentication) -> {
-		throw new AuthenticationServiceException("Cannot authenticate " + authentication);
+		AuthenticationException ex = new AuthenticationServiceException("Cannot authenticate " + authentication);
+		ex.setAuthenticationRequest(authentication);
+		throw ex;
 	};
 
 	/**

--- a/web/src/main/java/org/springframework/security/web/server/authentication/ServerWebExchangeDelegatingReactiveAuthenticationManagerResolver.java
+++ b/web/src/main/java/org/springframework/security/web/server/authentication/ServerWebExchangeDelegatingReactiveAuthenticationManagerResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import reactor.core.publisher.Mono;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.ReactiveAuthenticationManager;
 import org.springframework.security.authentication.ReactiveAuthenticationManagerResolver;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.access.intercept.RequestMatcherDelegatingAuthorizationManager;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcherEntry;
@@ -46,8 +47,11 @@ public final class ServerWebExchangeDelegatingReactiveAuthenticationManagerResol
 
 	private final List<ServerWebExchangeMatcherEntry<ReactiveAuthenticationManager>> authenticationManagers;
 
-	private ReactiveAuthenticationManager defaultAuthenticationManager = (authentication) -> Mono
-		.error(new AuthenticationServiceException("Cannot authenticate " + authentication));
+	private ReactiveAuthenticationManager defaultAuthenticationManager = (authentication) -> {
+		AuthenticationException ex = new AuthenticationServiceException("Cannot authenticate " + authentication);
+		ex.setAuthenticationRequest(authentication);
+		return Mono.error(ex);
+	};
 
 	/**
 	 * Construct an

--- a/web/src/main/java/org/springframework/security/web/server/authorization/ExceptionTranslationWebFilter.java
+++ b/web/src/main/java/org/springframework/security/web/server/authorization/ExceptionTranslationWebFilter.java
@@ -101,6 +101,9 @@ public class ExceptionTranslationWebFilter implements WebFilter {
 		AuthenticationException cause = new InsufficientAuthenticationException(
 				"Full authentication is required to access this resource");
 		AuthenticationException ex = new AuthenticationCredentialsNotFoundException("Not Authenticated", cause);
+		if (authentication != null) {
+			ex.setAuthenticationRequest(authentication);
+		}
 		return this.authenticationEntryPoint.commence(exchange, ex).then(Mono.empty());
 	}
 

--- a/web/src/main/java/org/springframework/security/web/server/authorization/ExceptionTranslationWebFilter.java
+++ b/web/src/main/java/org/springframework/security/web/server/authorization/ExceptionTranslationWebFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,14 +50,19 @@ public class ExceptionTranslationWebFilter implements WebFilter {
 	@Override
 	public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
 		return chain.filter(exchange)
-			.onErrorResume(AccessDeniedException.class, (denied) -> exchange.getPrincipal()
-				.filter((principal) -> (!(principal instanceof Authentication) || (principal instanceof Authentication
-						&& (this.authenticationTrustResolver.isAuthenticated((Authentication) principal)))))
-				.switchIfEmpty(commenceAuthentication(exchange,
-						new InsufficientAuthenticationException(
-								"Full authentication is required to access this resource")))
-				.flatMap((principal) -> this.accessDeniedHandler.handle(exchange, denied))
-				.then());
+			.onErrorResume(AccessDeniedException.class,
+					(denied) -> exchange.getPrincipal()
+						.switchIfEmpty(Mono.defer(() -> commenceAuthentication(exchange, null)))
+						.flatMap((principal) -> {
+							if (!(principal instanceof Authentication authentication)) {
+								return this.accessDeniedHandler.handle(exchange, denied);
+							}
+							if (this.authenticationTrustResolver.isAuthenticated(authentication)) {
+								return this.accessDeniedHandler.handle(exchange, denied);
+							}
+							return commenceAuthentication(exchange, authentication);
+						})
+						.then());
 	}
 
 	/**
@@ -92,10 +97,11 @@ public class ExceptionTranslationWebFilter implements WebFilter {
 		this.authenticationTrustResolver = authenticationTrustResolver;
 	}
 
-	private <T> Mono<T> commenceAuthentication(ServerWebExchange exchange, AuthenticationException denied) {
-		return this.authenticationEntryPoint
-			.commence(exchange, new AuthenticationCredentialsNotFoundException("Not Authenticated", denied))
-			.then(Mono.empty());
+	private <T> Mono<T> commenceAuthentication(ServerWebExchange exchange, Authentication authentication) {
+		AuthenticationException cause = new InsufficientAuthenticationException(
+				"Full authentication is required to access this resource");
+		AuthenticationException ex = new AuthenticationCredentialsNotFoundException("Not Authenticated", cause);
+		return this.authenticationEntryPoint.commence(exchange, ex).then(Mono.empty());
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/server/authorization/ExceptionTranslationWebFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/authorization/ExceptionTranslationWebFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,7 +129,6 @@ public class ExceptionTranslationWebFilterTests {
 	@Test
 	public void filterWhenAccessDeniedExceptionAndAuthenticatedThenHandled() {
 		given(this.deniedHandler.handle(any(), any())).willReturn(this.deniedPublisher.mono());
-		given(this.entryPoint.commence(any(), any())).willReturn(this.entryPointPublisher.mono());
 		given(this.exchange.getPrincipal()).willReturn(Mono.just(this.principal));
 		given(this.chain.filter(this.exchange)).willReturn(Mono.error(new AccessDeniedException("Not Authorized")));
 		StepVerifier.create(this.filter.filter(this.exchange, this.chain)).expectComplete().verify();


### PR DESCRIPTION
- #16444 
- Store the authentication request details in the `authRequest` field of `AuthenticationException` when an authentication exception occurs.
@rwinch 
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
