### PR TITLE
Replace dynamic error message with static "Access Denied"

### DIFF
--- a/test/src/test/java/org/springframework/security/test/web/reactive/server/SecurityMockServerConfigurersTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/reactive/server/SecurityMockServerConfigurersTests.java
@@ -136,7 +136,7 @@ public class SecurityMockServerConfigurersTests extends AbstractMockServerConfig
 			.expectStatus()
 			.isEqualTo(HttpStatus.FORBIDDEN)
 			.expectBody()
-			.consumeWith((b) -> assertThat(new String(b.getResponseBody())).contains("CSRF"));
+			.consumeWith((b) -> assertThat(new String(b.getResponseBody())).contains("Access Denied"));
 		this.client.mutateWith(SecurityMockServerConfigurers.csrf()).post().exchange().expectStatus().isOk();
 	}
 

--- a/web/src/main/java/org/springframework/security/web/server/authorization/HttpStatusServerAccessDeniedHandler.java
+++ b/web/src/main/java/org/springframework/security/web/server/authorization/HttpStatusServerAccessDeniedHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ public class HttpStatusServerAccessDeniedHandler implements ServerAccessDeniedHa
 			response.setStatusCode(this.httpStatus);
 			response.getHeaders().setContentType(MediaType.TEXT_PLAIN);
 			DataBufferFactory dataBufferFactory = response.bufferFactory();
-			DataBuffer buffer = dataBufferFactory.wrap(ex.getMessage().getBytes(Charset.defaultCharset()));
+			DataBuffer buffer = dataBufferFactory.wrap("Access Denied".getBytes(Charset.defaultCharset()));
 			return response.writeWith(Mono.just(buffer)).doOnError((error) -> DataBufferUtils.release(buffer));
 		});
 	}

--- a/web/src/test/java/org/springframework/security/web/server/authorization/HttpStatusServerAccessDeniedHandlerTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/authorization/HttpStatusServerAccessDeniedHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +23,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpResponse;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.web.server.ServerWebExchange;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 public class HttpStatusServerAccessDeniedHandlerTests {
 
 	@Mock
-	private ServerWebExchange exchange;
+	private MockServerWebExchange exchange;
 
 	private HttpStatus httpStatus = HttpStatus.FORBIDDEN;
 
@@ -62,7 +62,9 @@ public class HttpStatusServerAccessDeniedHandlerTests {
 	public void commenceWhenSubscribeThenStatusSet() {
 		this.exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
 		this.handler.handle(this.exchange, this.exception).block();
-		assertThat(this.exchange.getResponse().getStatusCode()).isEqualTo(this.httpStatus);
+		MockServerHttpResponse response = this.exchange.getResponse();
+		assertThat(response.getStatusCode()).isEqualTo(this.httpStatus);
+		assertThat(response.getBodyAsString().block()).isEqualTo("Access Denied");
 	}
 
 	@Test
@@ -71,7 +73,9 @@ public class HttpStatusServerAccessDeniedHandlerTests {
 		this.handler = new HttpStatusServerAccessDeniedHandler(this.httpStatus);
 		this.exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
 		this.handler.handle(this.exchange, this.exception).block();
-		assertThat(this.exchange.getResponse().getStatusCode()).isEqualTo(this.httpStatus);
+		MockServerHttpResponse response = this.exchange.getResponse();
+		assertThat(response.getStatusCode()).isEqualTo(this.httpStatus);
+		assertThat(response.getBodyAsString().block()).isEqualTo("Access Denied");
 	}
 
 }


### PR DESCRIPTION
### Motivation
- HttpStatusServerAccessDeniedHandler previously returned the exception message,
  which could expose sensitive information.
- This PR ensures that the handler always returns a static "Access Denied" message.

### Modification
- Updated HttpStatusServerAccessDeniedHandler to return a static message.
- Updated tests to verify the response body.

### Result
Closes gh-16514

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
