### PR TITLE
Bug #16340: check username attribute when calling user.getName() (instead of checking in constructor)

### DIFF
--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/user/DefaultOAuth2User.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/user/DefaultOAuth2User.java
@@ -69,8 +69,6 @@ public class DefaultOAuth2User implements OAuth2User, Serializable {
 			String nameAttributeKey) {
 		Assert.notEmpty(attributes, "attributes cannot be empty");
 		Assert.hasText(nameAttributeKey, "nameAttributeKey cannot be empty");
-		Assert.notNull(attributes.get(nameAttributeKey),
-				"Attribute value for '" + nameAttributeKey + "' cannot be null");
 
 		this.authorities = (authorities != null)
 				? Collections.unmodifiableSet(new LinkedHashSet<>(this.sortAuthorities(authorities)))
@@ -81,7 +79,9 @@ public class DefaultOAuth2User implements OAuth2User, Serializable {
 
 	@Override
 	public String getName() {
-		return this.getAttribute(this.nameAttributeKey).toString();
+		final Object name = attributes.get(nameAttributeKey);
+		Assert.notNull(name, "Attribute value for '" + nameAttributeKey + "' cannot be null");
+		return name.toString();
 	}
 
 	@Override

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/user/DefaultOAuth2UserTests.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/user/DefaultOAuth2UserTests.java
@@ -61,9 +61,10 @@ public class DefaultOAuth2UserTests {
 	}
 
 	@Test
-	public void constructorWhenAttributeValueIsNullThenThrowIllegalArgumentException() {
-		assertThatIllegalArgumentException().isThrownBy(() -> new DefaultOAuth2User(AUTHORITIES,
-				Collections.singletonMap(ATTRIBUTE_NAME_KEY, null), ATTRIBUTE_NAME_KEY));
+	public void getNameWhenAttributeValueIsNullThenThrowIllegalArgumentException() {
+		final DefaultOAuth2User user = new DefaultOAuth2User(AUTHORITIES,
+				Collections.singletonMap(ATTRIBUTE_NAME_KEY, null), ATTRIBUTE_NAME_KEY);
+		assertThatIllegalArgumentException().isThrownBy(user::getName);
 	}
 
 	@Test
@@ -72,9 +73,10 @@ public class DefaultOAuth2UserTests {
 	}
 
 	@Test
-	public void constructorWhenNameAttributeKeyIsInvalidThenThrowIllegalArgumentException() {
+	public void getNameWhenNameAttributeKeyIsInvalidThenThrowIllegalArgumentException() {
+		final DefaultOAuth2User user = new DefaultOAuth2User(AUTHORITIES, ATTRIBUTES, "invalid");
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> new DefaultOAuth2User(AUTHORITIES, ATTRIBUTES, "invalid"));
+			.isThrownBy(user::getName);
 	}
 
 	@Test


### PR DESCRIPTION
See: https://github.com/spring-projects/spring-security/issues/16340

When first loaded, the oauth2 user has not the username attribute in his claims. For this reason, checking for the presence of this attribute in the constructor is too early. Once loaded from the userinfo endpoint, the oauth2 user has the username attribute.

I moved the check from constructor to `getName()` call to prevent this issue. Junits have been rewritten accordingly.