### PR TITLE
Allow to set an authentication manager for back-channel logout in ServerHttpSecurity

### DIFF
--- a/config/src/main/java/org/springframework/security/config/web/server/OidcBackChannelLogoutReactiveAuthenticationManager.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/OidcBackChannelLogoutReactiveAuthenticationManager.java
@@ -64,14 +64,14 @@ import org.springframework.util.StringUtils;
  * "https://openid.net/specs/openid-connect-backchannel-1_0.html">OIDC Back-Channel
  * Logout</a>
  */
-final class OidcBackChannelLogoutReactiveAuthenticationManager implements ReactiveAuthenticationManager {
+public final class OidcBackChannelLogoutReactiveAuthenticationManager implements ReactiveAuthenticationManager {
 
 	private ReactiveJwtDecoderFactory<ClientRegistration> logoutTokenDecoderFactory;
 
 	/**
 	 * Construct an {@link OidcBackChannelLogoutReactiveAuthenticationManager}
 	 */
-	OidcBackChannelLogoutReactiveAuthenticationManager() {
+	public OidcBackChannelLogoutReactiveAuthenticationManager() {
 		Function<ClientRegistration, OAuth2TokenValidator<Jwt>> jwtValidator = (clientRegistration) -> JwtValidators
 			.createDefaultWithValidators(new OidcBackChannelLogoutTokenValidator(clientRegistration));
 		this.logoutTokenDecoderFactory = (clientRegistration) -> {
@@ -130,7 +130,7 @@ final class OidcBackChannelLogoutReactiveAuthenticationManager implements Reacti
 	 * correspond to the {@link ClientRegistration} associated with the OIDC logout token.
 	 * @param logoutTokenDecoderFactory the {@link JwtDecoderFactory} to use
 	 */
-	void setLogoutTokenDecoderFactory(ReactiveJwtDecoderFactory<ClientRegistration> logoutTokenDecoderFactory) {
+	public void setLogoutTokenDecoderFactory(ReactiveJwtDecoderFactory<ClientRegistration> logoutTokenDecoderFactory) {
 		Assert.notNull(logoutTokenDecoderFactory, "logoutTokenDecoderFactory cannot be null");
 		this.logoutTokenDecoderFactory = logoutTokenDecoderFactory;
 	}

--- a/config/src/main/java/org/springframework/security/config/web/server/OidcBackChannelLogoutTokenValidator.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/OidcBackChannelLogoutTokenValidator.java
@@ -46,7 +46,7 @@ import org.springframework.util.Assert;
  * "https://openid.net/specs/openid-connect-backchannel-1_0.html#Validation">the OIDC
  * Back-Channel Logout spec</a>
  */
-final class OidcBackChannelLogoutTokenValidator implements OAuth2TokenValidator<Jwt> {
+public final class OidcBackChannelLogoutTokenValidator implements OAuth2TokenValidator<Jwt> {
 
 	private static final String LOGOUT_VALIDATION_URL = "https://openid.net/specs/openid-connect-backchannel-1_0.html#Validation";
 
@@ -56,7 +56,7 @@ final class OidcBackChannelLogoutTokenValidator implements OAuth2TokenValidator<
 
 	private final String issuer;
 
-	OidcBackChannelLogoutTokenValidator(ClientRegistration clientRegistration) {
+	public OidcBackChannelLogoutTokenValidator(ClientRegistration clientRegistration) {
 		this.audience = clientRegistration.getClientId();
 		String issuer = clientRegistration.getProviderDetails().getIssuerUri();
 		Assert.hasText(issuer, "Provider issuer cannot be null");

--- a/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
@@ -5600,7 +5600,7 @@ public class ServerHttpSecurity {
 
 			private ServerAuthenticationConverter authenticationConverter;
 
-			private final ReactiveAuthenticationManager authenticationManager = new OidcBackChannelLogoutReactiveAuthenticationManager();
+			private ReactiveAuthenticationManager authenticationManager;
 
 			private Supplier<ServerLogoutHandler> logoutHandler = this::logoutHandler;
 
@@ -5613,6 +5613,9 @@ public class ServerHttpSecurity {
 			}
 
 			private ReactiveAuthenticationManager authenticationManager() {
+				if (this.authenticationManager == null) {
+					this.authenticationManager = new OidcBackChannelLogoutReactiveAuthenticationManager();
+				}
 				return this.authenticationManager;
 			}
 
@@ -5743,6 +5746,41 @@ public class ServerHttpSecurity {
 			public BackChannelLogoutConfigurer logoutHandler(ServerLogoutHandler logoutHandler) {
 				this.logoutHandler = () -> logoutHandler;
 				return this;
+			}
+
+			/**
+			 * Configure a custom instance of the authentication manager used for
+			 * back-channel logout.
+			 *
+			 * <p>
+			 * By default, a new instance of
+			 * {@link OidcBackChannelLogoutReactiveAuthenticationManager} will be created.
+			 * If you want to customize the authentication manager, you can use this
+			 * method.
+			 *
+			 * <p>
+			 * For example, if you want to customize the WebClient instance for fetching
+			 * the JWKS keys in the logout process, you can configure Back-Channel Logout
+			 * in the following way:
+			 *
+			 * <pre>
+			 * 	http
+			 *     	.oidcLogout((oidc) -&gt; oidc
+			 *     		.backChannel(config -> {
+			 *     			var logoutTokenDecoderFactory = new CustomOidcLogoutTokenDecoderFactory();
+			 * 				var manager = new OidcBackChannelLogoutReactiveAuthenticationManager();
+			 * 				manager.setLogoutTokenDecoderFactory(logoutTokenDecoderFactory);
+			 * 				config.authenticationManager(manager);
+			 *			}))
+			 *     	);
+			 * </pre>
+			 * @param authenticationManager the {@link ReactiveAuthenticationManager} to
+			 * use as replacement of the default used authentication manager
+			 * @return {@link BackChannelLogoutConfigurer} for further customizations
+			 * @since 6.5
+			 */
+			public void setAuthenticationManager(ReactiveAuthenticationManager authenticationManager) {
+				this.authenticationManager = authenticationManager;
 			}
 
 			void configure(ServerHttpSecurity http) {


### PR DESCRIPTION
Allow to set custom OidcBackChannelLogoutReactiveAuthenticationManager instance so you can override the logout token decoder factory with for setting a custom WebClient instance. 

Issue: https://github.com/spring-projects/spring-security/issues/16545

Usage:

```java
http
		.oauth2Login(Customizer.withDefaults())
		.oidcLogout(customizer -> customizer
				.backChannel(config -> {
					var manager = new OidcBackChannelLogoutReactiveAuthenticationManager();
					manager.setLogoutTokenDecoderFactory(logoutTokenDecoderFactory);
					config.authenticationManager(manager);
				}));

```