### PR TITLE
Polish AbstractAuthenticationTargetUrlRequestHandler

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationTargetUrlRequestHandler.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationTargetUrlRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -195,8 +195,10 @@ public abstract class AbstractAuthenticationTargetUrlRequestHandler {
 
 	/**
 	 * Allows overriding of the behaviour when redirecting to a target URL.
+	 * @param redirectStrategy {@link RedirectStrategy} to use
 	 */
 	public void setRedirectStrategy(RedirectStrategy redirectStrategy) {
+		Assert.notNull(redirectStrategy, "redirectStrategy cannot be null");
 		this.redirectStrategy = redirectStrategy;
 	}
 

--- a/web/src/test/java/org/springframework/security/web/authentication/AbstractAuthenticationTargetUrlRequestHandlerTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/AbstractAuthenticationTargetUrlRequestHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 /**
  * @author Dayan Kodippily
@@ -106,6 +107,11 @@ public class AbstractAuthenticationTargetUrlRequestHandlerTests {
 		this.handler.setUseReferer(false);
 		this.request.addHeader("Referer", REFERER_URL);
 		assertThat(this.handler.determineTargetUrl(this.request, this.response)).isEqualTo(DEFAULT_TARGET_URL);
+	}
+
+	@Test
+	void setRedirectStrategyWhenGivenNullThenThrowsException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.handler.setRedirectStrategy(null));
 	}
 
 }


### PR DESCRIPTION
This is small polish add assertion to `setRedirectStrategy` of `AbstractAuthenticationTargetUrlRequestHandler` to prevent `NullPointnerException`.
