### PR TITLE
Add customizable RowMappers for user details and authorities in JdbcUserDetailsManager

### DIFF
--- a/core/src/main/java/org/springframework/security/provisioning/JdbcUserDetailsManager.java
+++ b/core/src/main/java/org/springframework/security/provisioning/JdbcUserDetailsManager.java
@@ -181,7 +181,7 @@ public class JdbcUserDetailsManager extends JdbcDaoImpl implements UserDetailsMa
 		return getJdbcTemplate().query(getUsersByUsernameQuery(), this::mapToUser, username);
 	}
 
-	private UserDetails mapToUser(ResultSet rs, int rowNum) throws SQLException {
+	protected UserDetails mapToUser(ResultSet rs, int rowNum) throws SQLException {
 		String userName = rs.getString(1);
 		String password = rs.getString(2);
 		boolean enabled = rs.getBoolean(3);
@@ -390,7 +390,7 @@ public class JdbcUserDetailsManager extends JdbcDaoImpl implements UserDetailsMa
 				this::mapToGrantedAuthority);
 	}
 
-	private GrantedAuthority mapToGrantedAuthority(ResultSet rs, int rowNum) throws SQLException {
+	protected GrantedAuthority mapToGrantedAuthority(ResultSet rs, int rowNum) throws SQLException {
 		String roleName = getRolePrefix() + rs.getString(3);
 		return new SimpleGrantedAuthority(roleName);
 	}

--- a/core/src/main/java/org/springframework/security/provisioning/JdbcUserDetailsManager.java
+++ b/core/src/main/java/org/springframework/security/provisioning/JdbcUserDetailsManager.java
@@ -30,6 +30,7 @@ import org.springframework.context.ApplicationContextException;
 import org.springframework.core.log.LogMessage;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.jdbc.core.PreparedStatementSetter;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -156,11 +157,18 @@ public class JdbcUserDetailsManager extends JdbcDaoImpl implements UserDetailsMa
 
 	private UserCache userCache = new NullUserCache();
 
+	private RowMapper<UserDetails> userDetailsMapper = this::mapToUser;
+
 	public JdbcUserDetailsManager() {
 	}
 
 	public JdbcUserDetailsManager(DataSource dataSource) {
 		setDataSource(dataSource);
+	}
+
+	public void setUserDetailsMapper(RowMapper<UserDetails> mapper) {
+		Assert.notNull(mapper, "userDetailsMapper cannot be null");
+		this.userDetailsMapper = mapper;
 	}
 
 	@Override
@@ -178,7 +186,7 @@ public class JdbcUserDetailsManager extends JdbcDaoImpl implements UserDetailsMa
 	 */
 	@Override
 	protected List<UserDetails> loadUsersByUsername(String username) {
-		return getJdbcTemplate().query(getUsersByUsernameQuery(), this::mapToUser, username);
+		return getJdbcTemplate().query(getUsersByUsernameQuery(), userDetailsMapper, username);
 	}
 
 	protected UserDetails mapToUser(ResultSet rs, int rowNum) throws SQLException {

--- a/core/src/main/java/org/springframework/security/provisioning/JdbcUserDetailsManager.java
+++ b/core/src/main/java/org/springframework/security/provisioning/JdbcUserDetailsManager.java
@@ -189,7 +189,7 @@ public class JdbcUserDetailsManager extends JdbcDaoImpl implements UserDetailsMa
 		return getJdbcTemplate().query(getUsersByUsernameQuery(), userDetailsMapper, username);
 	}
 
-	protected UserDetails mapToUser(ResultSet rs, int rowNum) throws SQLException {
+	private UserDetails mapToUser(ResultSet rs, int rowNum) throws SQLException {
 		String userName = rs.getString(1);
 		String password = rs.getString(2);
 		boolean enabled = rs.getBoolean(3);

--- a/core/src/main/java/org/springframework/security/provisioning/JdbcUserDetailsManager.java
+++ b/core/src/main/java/org/springframework/security/provisioning/JdbcUserDetailsManager.java
@@ -166,6 +166,17 @@ public class JdbcUserDetailsManager extends JdbcDaoImpl implements UserDetailsMa
 		setDataSource(dataSource);
 	}
 
+	/**
+	 * Sets the {@code RowMapper} to convert each user result row into a
+	 * {@link UserDetails} object.
+	 *
+	 * The default mapper expects columns with names like 'username', 'password',
+	 * 'enabled', etc., and maps them directly to the corresponding UserDetails
+	 * properties.
+	 * @param mapper the {@code RowMapper} to use for mapping rows in the database, must
+	 * not be null
+	 * @since 6.5
+	 */
 	public void setUserDetailsMapper(RowMapper<UserDetails> mapper) {
 		Assert.notNull(mapper, "userDetailsMapper cannot be null");
 		this.userDetailsMapper = mapper;

--- a/core/src/test/java/org/springframework/security/provisioning/JdbcUserDetailsManagerTests.java
+++ b/core/src/test/java/org/springframework/security/provisioning/JdbcUserDetailsManagerTests.java
@@ -52,9 +52,8 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.verify;
 
 /**
  * Tests for {@link JdbcUserDetailsManager}
@@ -373,18 +372,36 @@ public class JdbcUserDetailsManagerTests {
 	@Test
 	public void setUserDetailsMapperWithNullMapperThrowsException() {
 		assertThatExceptionOfType(IllegalArgumentException.class)
-				.isThrownBy(() -> this.manager.setUserDetailsMapper(null))
-				.withMessage("userDetailsMapper cannot be null");
+			.isThrownBy(() -> this.manager.setUserDetailsMapper(null))
+			.withMessage("userDetailsMapper cannot be null");
 	}
 
 	@Test
 	public void setUserDetailsMapperWithMockMapper() throws SQLException {
 		RowMapper<UserDetails> mockMapper = mock(RowMapper.class);
-		when(mockMapper.mapRow(any(), anyInt())).thenReturn(joe);
+		given(mockMapper.mapRow(any(), anyInt())).willReturn(joe);
 		this.manager.setUserDetailsMapper(mockMapper);
 		insertJoe();
 		UserDetails newJoe = this.manager.loadUserByUsername("joe");
 		assertThat(joe).isEqualTo(newJoe);
+		verify(mockMapper).mapRow(any(), anyInt());
+	}
+
+	@Test
+	public void setGrantedAuthorityMapperWithNullMapperThrowsException() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+			.isThrownBy(() -> this.manager.setGrantedAuthorityMapper(null))
+			.withMessage("grantedAuthorityMapper cannot be null");
+	}
+
+	@Test
+	public void setGrantedAuthorityMapperWithMockMapper() throws SQLException {
+		RowMapper<GrantedAuthority> mockMapper = mock(RowMapper.class);
+		GrantedAuthority mockAuthority = new SimpleGrantedAuthority("ROLE_MOCK");
+		given(mockMapper.mapRow(any(), anyInt())).willReturn(mockAuthority);
+		this.manager.setGrantedAuthorityMapper(mockMapper);
+		List<GrantedAuthority> authGroup = this.manager.findGroupAuthorities("GROUP_0");
+		assertThat(authGroup.get(0)).isEqualTo(mockAuthority);
 		verify(mockMapper).mapRow(any(), anyInt());
 	}
 


### PR DESCRIPTION
# Overview
- added setUserDetailsMapper method to allow customization of UserDetails mapping using RowMapper
- added setGrantedAuthorityMapper method to allow customization of GrantedAuthority mapping using RowMapper
- unit tests for updated methods

# Related
- Closes gh-16540

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
