### PR TITLE
Fix RestClient Documentation Header

### DIFF
--- a/docs/modules/ROOT/partials/servlet/oauth2/client/rest-client-access-token-response-client.adoc
+++ b/docs/modules/ROOT/partials/servlet/oauth2/client/rest-client-access-token-response-client.adoc
@@ -257,7 +257,7 @@ accessTokenResponseClient.setParametersCustomizer { parameters ->
 `{class-name}` provides hooks for customizing response parameters and error handling of the OAuth 2.0 Access Token Response.
 
 [#oauth2-client-{section-id}-access-token-response-rest-client]
-=== Customizing the `WebClient`
+=== Customizing the `RestClient`
 
 You can customize the Token Response by providing a pre-configured `RestClient` to `setRestClient()`.
 The default `RestClient` is configured as follows:


### PR DESCRIPTION
In line 260, there is the mention of "=== Customizing the `WebClient`" while it should be "=== Customizing the `RestClient`"

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
<img width="1150" alt="Screenshot 2025-02-05 at 18 49 00" src="https://github.com/user-attachments/assets/7bbdc131-9d1d-4a62-88cf-31fd66b34f86" />

