### PR TITLE
Generic error message in Log In page and debug messages

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/DefaultLoginPageConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/DefaultLoginPageConfigurerTests.java
@@ -22,14 +22,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.config.ObjectPostProcessor;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.test.SpringTestContext;
 import org.springframework.security.config.test.SpringTestContextExtension;
-import org.springframework.security.core.SpringSecurityMessageSource;
 import org.springframework.security.core.userdetails.PasswordEncodedUser;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
@@ -76,8 +74,6 @@ public class DefaultLoginPageConfigurerTests {
 
 	@Autowired
 	MockMvc mvc;
-
-	MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
 
 	@Test
 	public void getWhenFormLoginEnabledThenRedirectsToLoginPage() throws Exception {
@@ -148,8 +144,7 @@ public class DefaultLoginPageConfigurerTests {
 		this.mvc.perform(get("/login?error").session((MockHttpSession) mvcResult.getRequest().getSession())
 				.sessionAttr(csrfAttributeName, csrfToken))
 				.andExpect((result) -> {
-					String badCredentialsLocalizedMessage = this.messages
-							.getMessage("AbstractUserDetailsAuthenticationProvider.badCredentials", "Bad credentials");
+					String defaultErrorMessage = "Invalid credentials";
 					CsrfToken token = (CsrfToken) result.getRequest().getAttribute(CsrfToken.class.getName());
 					assertThat(result.getResponse().getContentAsString()).isEqualTo("""
 						<!DOCTYPE html>
@@ -184,7 +179,7 @@ public class DefaultLoginPageConfigurerTests {
 
 						    </div>
 						  </body>
-						</html>""".formatted(badCredentialsLocalizedMessage, token.getToken()));
+						</html>""".formatted(defaultErrorMessage, token.getToken()));
 				});
 		// @formatter:on
 	}

--- a/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
@@ -185,13 +185,25 @@ public class ProviderManager implements AuthenticationManager, MessageSourceAwar
 					break;
 				}
 			}
-			catch (AccountStatusException | InternalAuthenticationServiceException ex) {
+			catch (AccountStatusException ex) {
 				prepareException(ex, authentication);
+				logger.debug(LogMessage.format("Authentication failed for user '%s' since account status is %s",
+						authentication.getName(), ex.getMessage()));
+				// SEC-546: Avoid polling additional providers if auth failure is due to
+				// invalid account status
+				throw ex;
+			}
+			catch (InternalAuthenticationServiceException ex) {
+				prepareException(ex, authentication);
+				logger.debug(LogMessage.format(
+						"Authentication failed due to an internal authentication service error: %s", ex.getMessage()));
 				// SEC-546: Avoid polling additional providers if auth failure is due to
 				// invalid account status
 				throw ex;
 			}
 			catch (AuthenticationException ex) {
+				logger.debug(LogMessage.format("Authentication failed with provider %s since %s",
+						provider.getClass().getSimpleName(), ex.getMessage()));
 				lastException = ex;
 			}
 		}
@@ -241,6 +253,13 @@ public class ProviderManager implements AuthenticationManager, MessageSourceAwar
 		if (parentException == null) {
 			prepareException(lastException, authentication);
 		}
+
+		// Ensure this message is not logged when authentication is attempted by
+		// the parent provider
+		if (this.parent != null) {
+			logger.debug("Denying authentication since all attempted providers failed");
+		}
+
 		throw lastException;
 	}
 

--- a/web/src/main/java/org/springframework/security/web/authentication/ui/DefaultLoginPageGeneratingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/ui/DefaultLoginPageGeneratingFilter.java
@@ -29,14 +29,10 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
 
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.WebAttributes;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.rememberme.AbstractRememberMeServices;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.GenericFilterBean;
 
 /**
@@ -221,7 +217,7 @@ public class DefaultLoginPageGeneratingFilter extends GenericFilterBean {
 	}
 
 	private String generateLoginPageHtml(HttpServletRequest request, boolean loginError, boolean logoutSuccess) {
-		String errorMsg = loginError ? getLoginErrorMessage(request) : "Invalid credentials";
+		String errorMsg = "Invalid credentials";
 		String contextPath = request.getContextPath();
 
 		return HtmlTemplates.fromTemplate(LOGIN_PAGE_TEMPLATE)
@@ -356,21 +352,6 @@ public class DefaultLoginPageGeneratingFilter extends GenericFilterBean {
 			.withValue("url", contextPath + url)
 			.withValue("clientName", clientName)
 			.render();
-	}
-
-	private String getLoginErrorMessage(HttpServletRequest request) {
-		HttpSession session = request.getSession(false);
-		if (session == null) {
-			return "Invalid credentials";
-		}
-		if (!(session
-			.getAttribute(WebAttributes.AUTHENTICATION_EXCEPTION) instanceof AuthenticationException exception)) {
-			return "Invalid credentials";
-		}
-		if (!StringUtils.hasText(exception.getMessage())) {
-			return "Invalid credentials";
-		}
-		return exception.getMessage();
 	}
 
 	private String renderHiddenInput(String name, String value) {

--- a/web/src/test/java/org/springframework/security/web/authentication/DefaultLoginPageGeneratingFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/DefaultLoginPageGeneratingFilterTests.java
@@ -18,17 +18,14 @@ package org.springframework.security.web.authentication;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Locale;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.core.SpringSecurityMessageSource;
 import org.springframework.security.web.WebAttributes;
 import org.springframework.security.web.authentication.ui.DefaultLoginPageGeneratingFilter;
 
@@ -126,22 +123,6 @@ public class DefaultLoginPageGeneratingFilterTests {
 		request.setQueryString("not");
 		filter.doFilter(request, response, this.chain);
 		assertThat(response.getContentAsString()).isEmpty();
-	}
-
-	/* SEC-1111 */
-	@Test
-	public void handlesNonIso8859CharsInErrorMessage() throws Exception {
-		DefaultLoginPageGeneratingFilter filter = new DefaultLoginPageGeneratingFilter(
-				new UsernamePasswordAuthenticationFilter());
-		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/login");
-		MockHttpServletResponse response = new MockHttpServletResponse();
-		request.setQueryString("error");
-		MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
-		String message = messages.getMessage("AbstractUserDetailsAuthenticationProvider.badCredentials",
-				"Bad credentials", Locale.KOREA);
-		request.getSession().setAttribute(WebAttributes.AUTHENTICATION_EXCEPTION, new BadCredentialsException(message));
-		filter.doFilter(request, response, this.chain);
-		assertThat(response.getContentAsString()).contains(message);
 	}
 
 	// gh-5394
@@ -244,7 +225,7 @@ public class DefaultLoginPageGeneratingFilterTests {
 				    <div class="content">
 				      <form class="login-form" method="post" action="null">
 				        <h2>Please sign in</h2>
-				<div class="alert alert-danger" role="alert">Bad credentials</div>
+				<div class="alert alert-danger" role="alert">Invalid credentials</div>
 				        <p>
 				          <label for="username" class="screenreader">Username</label>
 				          <input type="text" id="username" name="username" placeholder="Username" required autofocus>
@@ -259,12 +240,12 @@ public class DefaultLoginPageGeneratingFilterTests {
 				      </form>
 
 				<h2>Login with OAuth 2.0</h2>
-				<div class="alert alert-danger" role="alert">Bad credentials</div>
+				<div class="alert alert-danger" role="alert">Invalid credentials</div>
 				<table class="table table-striped">
 				  <tr><td><a href="/oauth2/authorization/google">Google &lt; &gt; &quot; &#39; &amp;</a></td></tr>
 				</table>
 				<h2>Login with SAML 2.0</h2>
-				<div class="alert alert-danger" role="alert">Bad credentials</div>
+				<div class="alert alert-danger" role="alert">Invalid credentials</div>
 				<table class="table table-striped">
 				  <tr><td><a href="/saml/sso/google">Google &lt; &gt; &quot; &#39; &amp;</a></td></tr>
 				</table>


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->

Overview,
1. Login page, now displays "Invalid Credentials" as a generic error message for any authentication failures.
2. Debug messages are provided at `ProviderManager` to check where and why the authentication has failed.

Closes [gh-16484](https://github.com/spring-projects/spring-security/issues/16473?issue=spring-projects%7Cspring-security%7C16484)
