### PR TITLE
Grammar Fixes in OAuth 2.0 JavaDoc

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/DelegatingOAuth2AuthorizedClientProvider.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/DelegatingOAuth2AuthorizedClientProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.springframework.util.Assert;
 
 /**
  * An implementation of an {@link OAuth2AuthorizedClientProvider} that simply delegates to
- * it's internal {@code List} of {@link OAuth2AuthorizedClientProvider}(s).
+ * its internal {@code List} of {@link OAuth2AuthorizedClientProvider}(s).
  * <p>
  * Each provider is given a chance to
  * {@link OAuth2AuthorizedClientProvider#authorize(OAuth2AuthorizationContext) authorize}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/DelegatingReactiveOAuth2AuthorizedClientProvider.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/DelegatingReactiveOAuth2AuthorizedClientProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.springframework.util.Assert;
 
 /**
  * An implementation of a {@link ReactiveOAuth2AuthorizedClientProvider} that simply
- * delegates to it's internal {@code List} of
+ * delegates to its internal {@code List} of
  * {@link ReactiveOAuth2AuthorizedClientProvider}(s).
  * <p>
  * Each provider is given a chance to

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/OAuth2AuthorizedClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/OAuth2AuthorizedClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.springframework.util.Assert;
  * A representation of an OAuth 2.0 &quot;Authorized Client&quot;.
  * <p>
  * A client is considered &quot;authorized&quot; when the End-User (Resource Owner) has
- * granted authorization to the client to access it's protected resources.
+ * granted authorization to the client to access its protected resources.
  * <p>
  * This class associates the {@link #getClientRegistration() Client} to the
  * {@link #getAccessToken() Access Token} granted/authorized by the

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/authentication/OAuth2AuthenticationToken.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/authentication/OAuth2AuthenticationToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import org.springframework.util.Assert;
  * <p>
  * The {@link Authentication} associates an {@link OAuth2User} {@code Principal} to the
  * identifier of the {@link #getAuthorizedClientRegistrationId() Authorized Client}, which
- * the End-User ({@code Principal}) granted authorization to so that it can access it's
+ * the End-User ({@code Principal}) granted authorization to so that it can access its
  * protected resources at the UserInfo Endpoint.
  *
  * @author Joe Grandja

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/userinfo/DelegatingOAuth2UserService.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/userinfo/DelegatingOAuth2UserService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.util.Assert;
 
 /**
- * An implementation of an {@link OAuth2UserService} that simply delegates to it's
- * internal {@code List} of {@link OAuth2UserService}(s).
+ * An implementation of an {@link OAuth2UserService} that simply delegates to its internal
+ * {@code List} of {@link OAuth2UserService}(s).
  * <p>
  * Each {@link OAuth2UserService} is given a chance to
  * {@link OAuth2UserService#loadUser(OAuth2UserRequest) load} an {@link OAuth2User} with

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/DefaultOAuth2AuthorizationRequestResolver.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/DefaultOAuth2AuthorizationRequestResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  *
  * <p>
  * <b>NOTE:</b> The default base {@code URI} {@code /oauth2/authorization} may be
- * overridden via it's constructor
+ * overridden via its constructor
  * {@link #DefaultOAuth2AuthorizationRequestResolver(ClientRegistrationRepository, String)}.
  *
  * @author Joe Grandja

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/AuthorizationGrantType.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/AuthorizationGrantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,13 +23,13 @@ import org.springframework.util.Assert;
 
 /**
  * An authorization grant is a credential representing the resource owner's authorization
- * (to access it's protected resources) to the client and used by the client to obtain an
+ * (to access its protected resources) to the client and used by the client to obtain an
  * access token.
  *
  * <p>
  * The OAuth 2.0 Authorization Framework defines four standard grant types: authorization
- * code, implicit, resource owner password credentials, and client credentials. It also provides an
- * extensibility mechanism for defining additional grant types.
+ * code, implicit, resource owner password credentials, and client credentials. It also
+ * provides an extensibility mechanism for defining additional grant types.
  *
  * @author Joe Grandja
  * @author Steve Riesenberg

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/AuthorizationGrantType.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/AuthorizationGrantType.java
@@ -28,7 +28,7 @@ import org.springframework.util.Assert;
  *
  * <p>
  * The OAuth 2.0 Authorization Framework defines four standard grant types: authorization
- * code, resource owner password credentials, and client credentials. It also provides an
+ * code, implicit, resource owner password credentials, and client credentials. It also provides an
  * extensibility mechanism for defining additional grant types.
  *
  * @author Joe Grandja

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ package org.springframework.security.oauth2.jwt;
 public interface JwtDecoder {
 
 	/**
-	 * Decodes the JWT from it's compact claims representation format and returns a
+	 * Decodes the JWT from its compact claims representation format and returns a
 	 * {@link Jwt}.
 	 * @param token the JWT value
 	 * @return a {@link Jwt}

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtEncoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.springframework.security.oauth2.jwt;
 
 /**
  * Implementations of this interface are responsible for encoding a JSON Web Token (JWT)
- * to it's compact claims representation format.
+ * to its compact claims representation format.
  *
  * <p>
  * JWTs may be represented using the JWS Compact Serialization format for a JSON Web
@@ -47,7 +47,7 @@ package org.springframework.security.oauth2.jwt;
 public interface JwtEncoder {
 
 	/**
-	 * Encode the JWT to it's compact claims representation format.
+	 * Encode the JWT to its compact claims representation format.
 	 * @param parameters the parameters containing the JOSE header and JWT Claims Set
 	 * @return a {@link Jwt}
 	 * @throws JwtEncodingException if an error occurs while attempting to encode the JWT

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 /**
  * An implementation of a {@link ReactiveJwtDecoder} that &quot;decodes&quot; a JSON Web
- * Token (JWT) and additionally verifies it's digital signature if the JWT is a JSON Web
+ * Token (JWT) and additionally verifies its digital signature if the JWT is a JSON Web
  * Signature (JWS).
  *
  * <p>

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/ReactiveJwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/ReactiveJwtDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import reactor.core.publisher.Mono;
 
 /**
  * Implementations of this interface are responsible for &quot;decoding&quot; a JSON Web
- * Token (JWT) from it's compact claims representation format to a {@link Jwt}.
+ * Token (JWT) from its compact claims representation format to a {@link Jwt}.
  *
  * <p>
  * JWTs may be represented using the JWS Compact Serialization format for a JSON Web
@@ -46,7 +46,7 @@ import reactor.core.publisher.Mono;
 public interface ReactiveJwtDecoder {
 
 	/**
-	 * Decodes the JWT from it's compact claims representation format and returns a
+	 * Decodes the JWT from its compact claims representation format and returns a
 	 * {@link Jwt}.
 	 * @param token the JWT value
 	 * @return a {@link Jwt}


### PR DESCRIPTION
Noticed one of the four oauth grant types was missing in this section of javadoc.  Included some minor grammar changes too.