### PR TITLE
Fix typo `security-api-url` attribute in `faq.adoc`

### DIFF
--- a/docs/modules/ROOT/pages/servlet/appendix/faq.adoc
+++ b/docs/modules/ROOT/pages/servlet/appendix/faq.adoc
@@ -649,7 +649,7 @@ class MyAuthoritiesPopulator : LdapAuthoritiesPopulator {
 
 You would then add a bean of this type to your application context and inject it into the `LdapAuthenticationProvider`. This is covered in the section on configuring LDAP by using explicit Spring beans in the LDAP chapter of the reference manual.
 Note that you cannot use the namespace for configuration in this case.
-You should also consult the security-api-url[Javadoc] for the relevant classes and interfaces.
+You should also consult the {security-api-url}[Javadoc] for the relevant classes and interfaces.
 
 
 [[appendix-faq-namespace-post-processor]]


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
