### PR TITLE
Remove dependency on oauth2-oidc-sdk inside NimbusOpaqueTokenIntrospector

### DIFF
--- a/config/src/main/java/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParser.java
@@ -40,7 +40,7 @@ import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
 import org.springframework.security.oauth2.server.resource.authentication.OpaqueTokenAuthenticationProvider;
-import org.springframework.security.oauth2.server.resource.introspection.NimbusOpaqueTokenIntrospector;
+import org.springframework.security.oauth2.server.resource.introspection.SpringOpaqueTokenIntrospector;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationEntryPoint;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
@@ -300,7 +300,7 @@ final class OAuth2ResourceServerBeanDefinitionParser implements BeanDefinitionPa
 			String clientId = element.getAttribute(CLIENT_ID);
 			String clientSecret = element.getAttribute(CLIENT_SECRET);
 			BeanDefinitionBuilder introspectorBuilder = BeanDefinitionBuilder
-				.rootBeanDefinition(NimbusOpaqueTokenIntrospector.class);
+				.rootBeanDefinition(SpringOpaqueTokenIntrospector.class);
 			introspectorBuilder.addConstructorArgValue(introspectionUri);
 			introspectorBuilder.addConstructorArgValue(clientId);
 			introspectorBuilder.addConstructorArgValue(clientSecret);

--- a/config/src/main/java/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
@@ -121,9 +121,9 @@ import org.springframework.security.oauth2.server.resource.authentication.Bearer
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.security.oauth2.server.resource.authentication.JwtIssuerAuthenticationManagerResolver;
-import org.springframework.security.oauth2.server.resource.introspection.NimbusOpaqueTokenIntrospector;
 import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
+import org.springframework.security.oauth2.server.resource.introspection.SpringOpaqueTokenIntrospector;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationEntryPoint;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
@@ -2594,8 +2594,8 @@ public class OAuth2ResourceServerConfigurerTests {
 		String introspectUri;
 
 		@Bean
-		NimbusOpaqueTokenIntrospector introspector() {
-			return new NimbusOpaqueTokenIntrospector(this.introspectUri, new RestTemplate());
+		SpringOpaqueTokenIntrospector introspector() {
+			return new SpringOpaqueTokenIntrospector(this.introspectUri, new RestTemplate());
 		}
 
 	}

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/src/test/java/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParserTests.java
+++ b/config/src/test/java/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParserTests.java
@@ -86,9 +86,9 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.TestJwts;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
-import org.springframework.security.oauth2.server.resource.introspection.NimbusOpaqueTokenIntrospector;
 import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
+import org.springframework.security.oauth2.server.resource.introspection.SpringOpaqueTokenIntrospector;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.test.context.annotation.SecurityTestExecutionListeners;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -1033,7 +1033,7 @@ public class OAuth2ResourceServerBeanDefinitionParserTests {
 
 		@Override
 		public OpaqueTokenIntrospector getObject() throws Exception {
-			return new NimbusOpaqueTokenIntrospector(this.introspectionUri, new RestTemplate());
+			return new SpringOpaqueTokenIntrospector(this.introspectionUri, new RestTemplate());
 		}
 
 		@Override

--- a/config/src/test/java/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParserTests.java
+++ b/config/src/test/java/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/resourceserver/OpaqueTokenDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/resourceserver/OpaqueTokenDslTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/resourceserver/OpaqueTokenDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/resourceserver/OpaqueTokenDslTests.kt
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -41,7 +42,6 @@ import org.springframework.security.oauth2.core.DefaultOAuth2AuthenticatedPrinci
 import org.springframework.security.oauth2.core.TestOAuth2AccessTokens
 import org.springframework.security.oauth2.jwt.JwtClaimNames
 import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication
-import org.springframework.security.oauth2.server.resource.introspection.NimbusOpaqueTokenIntrospector
 import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector
 import org.springframework.security.oauth2.server.resource.introspection.SpringOpaqueTokenIntrospector
 import org.springframework.security.web.SecurityFilterChain
@@ -84,14 +84,16 @@ class OpaqueTokenDslTests {
         val headers = HttpHeaders().apply {
             contentType = MediaType.APPLICATION_JSON
         }
-        val entity = ResponseEntity("{\n" +
-                "  \"active\" : true,\n" +
-                "  \"sub\": \"test-subject\",\n" +
-                "  \"scope\": \"message:read\",\n" +
-                "  \"exp\": 4683883211\n" +
-                "}", headers, HttpStatus.OK)
+        val entity = ResponseEntity(
+            mapOf<String, Any>(
+                "active" to true,
+                "sub" to "test-subject",
+                "scope" to "message:read",
+                "exp" to 4683883211
+            ), headers, HttpStatus.OK
+        )
         every {
-            DefaultOpaqueConfig.REST.exchange(any(), eq(String::class.java))
+            DefaultOpaqueConfig.REST.exchange(any(), any(ParameterizedTypeReference::class))
         } returns entity
 
         this.mockMvc.get("/authenticated") {
@@ -127,8 +129,8 @@ class OpaqueTokenDslTests {
         open fun rest(): RestOperations = REST
 
         @Bean
-        open fun tokenIntrospectionClient(): NimbusOpaqueTokenIntrospector {
-            return NimbusOpaqueTokenIntrospector("https://example.org/introspect", REST)
+        open fun tokenIntrospectionClient(): SpringOpaqueTokenIntrospector {
+            return SpringOpaqueTokenIntrospector("https://example.org/introspect", REST)
         }
     }
 

--- a/config/src/test/resources/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParserTests-OpaqueTokenWebServer.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParserTests-OpaqueTokenWebServer.xml
@@ -21,12 +21,10 @@
 		 xsi:schemaLocation="http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
 		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<b:bean name="rest" class="org.mockito.Mockito" factory-method="mock">
-		<b:constructor-arg value="org.springframework.web.client.RestOperations" type="java.lang.Class"/>
-	</b:bean>
-
 	<b:bean name="introspector"
 			class="org.springframework.security.config.http.OAuth2ResourceServerBeanDefinitionParserTests$OpaqueTokenIntrospectorFactoryBean">
-		<b:property name="rest" ref="rest"/>
+		<b:property name="introspectionUri" value="${introspection-uri}"/>
 	</b:bean>
+
+	<b:import resource="OAuth2ResourceServerBeanDefinitionParserTests-WebServer.xml"/>
 </b:beans>

--- a/config/src/test/resources/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParserTests-OpaqueTokenWebServer.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/OAuth2ResourceServerBeanDefinitionParserTests-OpaqueTokenWebServer.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2002-2020 the original author or authors.
+  ~ Copyright 2002-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/docs/modules/ROOT/pages/servlet/oauth2/resource-server/opaque-token.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/resource-server/opaque-token.adoc
@@ -4,9 +4,7 @@
 [[oauth2resourceserver-opaque-minimaldependencies]]
 == Minimal Dependencies for Introspection
 As described in xref:servlet/oauth2/resource-server/jwt.adoc#oauth2resourceserver-jwt-minimaldependencies[Minimal Dependencies for JWT] most of Resource Server support is collected in `spring-security-oauth2-resource-server`.
-However unless a custom <<oauth2resourceserver-opaque-introspector,`OpaqueTokenIntrospector`>> is provided, the Resource Server will fallback to NimbusOpaqueTokenIntrospector.
-Meaning that both `spring-security-oauth2-resource-server` and `oauth2-oidc-sdk` are necessary in order to have a working minimal Resource Server that supports opaque Bearer Tokens.
-Please refer to `spring-security-oauth2-resource-server` in order to determine the correct version for `oauth2-oidc-sdk`.
+However unless a custom <<oauth2resourceserver-opaque-introspector,`OpaqueTokenIntrospector`>> is provided, the Resource Server will fallback to SpringOpaqueTokenIntrospector.
 
 [[oauth2resourceserver-opaque-minimalconfiguration]]
 == Minimal Configuration for Introspection
@@ -361,7 +359,7 @@ Xml::
 [source,xml,role="primary"]
 ----
 <bean id="opaqueTokenIntrospector"
-        class="org.springframework.security.oauth2.server.resource.introspection.NimbusOpaqueTokenIntrospector">
+        class="org.springframework.security.oauth2.server.resource.introspection.SpringOpaqueTokenIntrospector">
     <constructor-arg value="${spring.security.oauth2.resourceserver.opaquetoken.introspection_uri}"/>
     <constructor-arg value="${spring.security.oauth2.resourceserver.opaquetoken.client_id}"/>
     <constructor-arg value="${spring.security.oauth2.resourceserver.opaquetoken.client_secret}"/>
@@ -445,7 +443,7 @@ Xml::
 [source,xml,role="secondary"]
 ----
 <bean id="opaqueTokenIntrospector"
-        class="org.springframework.security.oauth2.server.resource.introspection.NimbusOpaqueTokenIntrospector">
+        class="org.springframework.security.oauth2.server.resource.introspection.SpringOpaqueTokenIntrospector">
     <constructor-arg value="https://idp.example.com/introspect"/>
     <constructor-arg value="client"/>
     <constructor-arg value="secret"/>
@@ -740,7 +738,7 @@ By default, Resource Server uses connection and socket timeouts of 30 seconds ea
 This may be too short in some scenarios.
 Further, it doesn't take into account more sophisticated patterns like back-off and discovery.
 
-To adjust the way in which Resource Server connects to the authorization server, `NimbusOpaqueTokenIntrospector` accepts an instance of `RestOperations`:
+To adjust the way in which Resource Server connects to the authorization server, `SpringOpaqueTokenIntrospector` accepts an instance of `RestOperations`:
 
 [tabs]
 ======

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/NimbusOpaqueTokenIntrospector.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/NimbusOpaqueTokenIntrospector.java
@@ -16,38 +16,11 @@
 
 package org.springframework.security.oauth2.server.resource.introspection;
 
-import java.net.URI;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
-import com.nimbusds.oauth2.sdk.ErrorObject;
-import com.nimbusds.oauth2.sdk.TokenIntrospectionResponse;
-import com.nimbusds.oauth2.sdk.TokenIntrospectionSuccessResponse;
-import com.nimbusds.oauth2.sdk.http.HTTPResponse;
-import com.nimbusds.oauth2.sdk.id.Audience;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import org.springframework.core.convert.converter.Converter;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
-import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.support.BasicAuthenticationInterceptor;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
-import org.springframework.security.oauth2.core.OAuth2TokenIntrospectionClaimNames;
 import org.springframework.util.Assert;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestOperations;
-import org.springframework.web.client.RestTemplate;
 
 /**
  * A Nimbus implementation of {@link OpaqueTokenIntrospector} that verifies and
@@ -63,13 +36,7 @@ import org.springframework.web.client.RestTemplate;
 @Deprecated
 public class NimbusOpaqueTokenIntrospector implements OpaqueTokenIntrospector {
 
-	private static final String AUTHORITY_PREFIX = "SCOPE_";
-
-	private final Log logger = LogFactory.getLog(getClass());
-
-	private final RestOperations restOperations;
-
-	private Converter<String, RequestEntity<?>> requestEntityConverter;
+	private final SpringOpaqueTokenIntrospector delegate;
 
 	/**
 	 * Creates a {@code OpaqueTokenAuthenticationProvider} with the provided parameters
@@ -81,10 +48,7 @@ public class NimbusOpaqueTokenIntrospector implements OpaqueTokenIntrospector {
 		Assert.notNull(introspectionUri, "introspectionUri cannot be null");
 		Assert.notNull(clientId, "clientId cannot be null");
 		Assert.notNull(clientSecret, "clientSecret cannot be null");
-		this.requestEntityConverter = this.defaultRequestEntityConverter(URI.create(introspectionUri));
-		RestTemplate restTemplate = new RestTemplate();
-		restTemplate.getInterceptors().add(new BasicAuthenticationInterceptor(clientId, clientSecret));
-		this.restOperations = restTemplate;
+		this.delegate = new SpringOpaqueTokenIntrospector(introspectionUri, clientId, clientSecret);
 	}
 
 	/**
@@ -98,47 +62,12 @@ public class NimbusOpaqueTokenIntrospector implements OpaqueTokenIntrospector {
 	public NimbusOpaqueTokenIntrospector(String introspectionUri, RestOperations restOperations) {
 		Assert.notNull(introspectionUri, "introspectionUri cannot be null");
 		Assert.notNull(restOperations, "restOperations cannot be null");
-		this.requestEntityConverter = this.defaultRequestEntityConverter(URI.create(introspectionUri));
-		this.restOperations = restOperations;
-	}
-
-	private Converter<String, RequestEntity<?>> defaultRequestEntityConverter(URI introspectionUri) {
-		return (token) -> {
-			HttpHeaders headers = requestHeaders();
-			MultiValueMap<String, String> body = requestBody(token);
-			return new RequestEntity<>(body, headers, HttpMethod.POST, introspectionUri);
-		};
-	}
-
-	private HttpHeaders requestHeaders() {
-		HttpHeaders headers = new HttpHeaders();
-		headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
-		return headers;
-	}
-
-	private MultiValueMap<String, String> requestBody(String token) {
-		MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
-		body.add("token", token);
-		return body;
+		this.delegate = new SpringOpaqueTokenIntrospector(introspectionUri, restOperations);
 	}
 
 	@Override
 	public OAuth2AuthenticatedPrincipal introspect(String token) {
-		RequestEntity<?> requestEntity = this.requestEntityConverter.convert(token);
-		if (requestEntity == null) {
-			throw new OAuth2IntrospectionException("requestEntityConverter returned a null entity");
-		}
-		ResponseEntity<String> responseEntity = makeRequest(requestEntity);
-		HTTPResponse httpResponse = adaptToNimbusResponse(responseEntity);
-		TokenIntrospectionResponse introspectionResponse = parseNimbusResponse(httpResponse);
-		TokenIntrospectionSuccessResponse introspectionSuccessResponse = castToNimbusSuccess(introspectionResponse);
-		// relying solely on the authorization server to validate this token (not checking
-		// 'exp', for example)
-		if (!introspectionSuccessResponse.isActive()) {
-			this.logger.trace("Did not validate token since it is inactive");
-			throw new BadOpaqueTokenException("Provided token isn't active");
-		}
-		return convertClaimsSet(introspectionSuccessResponse);
+		return this.delegate.introspect(token);
 	}
 
 	/**
@@ -149,121 +78,7 @@ public class NimbusOpaqueTokenIntrospector implements OpaqueTokenIntrospector {
 	 */
 	public void setRequestEntityConverter(Converter<String, RequestEntity<?>> requestEntityConverter) {
 		Assert.notNull(requestEntityConverter, "requestEntityConverter cannot be null");
-		this.requestEntityConverter = requestEntityConverter;
-	}
-
-	private ResponseEntity<String> makeRequest(RequestEntity<?> requestEntity) {
-		try {
-			return this.restOperations.exchange(requestEntity, String.class);
-		}
-		catch (Exception ex) {
-			throw new OAuth2IntrospectionException(ex.getMessage(), ex);
-		}
-	}
-
-	private HTTPResponse adaptToNimbusResponse(ResponseEntity<String> responseEntity) {
-		MediaType contentType = responseEntity.getHeaders().getContentType();
-
-		if (contentType == null) {
-			this.logger.trace("Did not receive Content-Type from introspection endpoint in response");
-
-			throw new OAuth2IntrospectionException(
-					"Introspection endpoint response was invalid, as no Content-Type header was provided");
-		}
-
-		// Nimbus expects JSON, but does not appear to validate this header first.
-		if (!contentType.isCompatibleWith(MediaType.APPLICATION_JSON)) {
-			this.logger.trace("Did not receive JSON-compatible Content-Type from introspection endpoint in response");
-
-			throw new OAuth2IntrospectionException("Introspection endpoint response was invalid, as content type '"
-					+ contentType + "' is not compatible with JSON");
-		}
-
-		HTTPResponse response = new HTTPResponse(responseEntity.getStatusCode().value());
-		response.setHeader(HttpHeaders.CONTENT_TYPE, contentType.toString());
-		response.setContent(responseEntity.getBody());
-
-		if (response.getStatusCode() != HTTPResponse.SC_OK) {
-			this.logger.trace("Introspection endpoint returned non-OK status code");
-
-			throw new OAuth2IntrospectionException(
-					"Introspection endpoint responded with HTTP status code " + response.getStatusCode());
-		}
-		return response;
-	}
-
-	private TokenIntrospectionResponse parseNimbusResponse(HTTPResponse response) {
-		try {
-			return TokenIntrospectionResponse.parse(response);
-		}
-		catch (Exception ex) {
-			throw new OAuth2IntrospectionException(ex.getMessage(), ex);
-		}
-	}
-
-	private TokenIntrospectionSuccessResponse castToNimbusSuccess(TokenIntrospectionResponse introspectionResponse) {
-		if (!introspectionResponse.indicatesSuccess()) {
-			ErrorObject errorObject = introspectionResponse.toErrorResponse().getErrorObject();
-			String message = "Token introspection failed with response " + errorObject.toJSONObject().toJSONString();
-			this.logger.trace(message);
-			throw new OAuth2IntrospectionException(message);
-		}
-		return (TokenIntrospectionSuccessResponse) introspectionResponse;
-	}
-
-	private OAuth2AuthenticatedPrincipal convertClaimsSet(TokenIntrospectionSuccessResponse response) {
-		Collection<GrantedAuthority> authorities = new ArrayList<>();
-		Map<String, Object> claims = response.toJSONObject();
-		if (response.getAudience() != null) {
-			List<String> audiences = new ArrayList<>();
-			for (Audience audience : response.getAudience()) {
-				audiences.add(audience.getValue());
-			}
-			claims.put(OAuth2TokenIntrospectionClaimNames.AUD, Collections.unmodifiableList(audiences));
-		}
-		if (response.getClientID() != null) {
-			claims.put(OAuth2TokenIntrospectionClaimNames.CLIENT_ID, response.getClientID().getValue());
-		}
-		if (response.getExpirationTime() != null) {
-			Instant exp = response.getExpirationTime().toInstant();
-			claims.put(OAuth2TokenIntrospectionClaimNames.EXP, exp);
-		}
-		if (response.getIssueTime() != null) {
-			Instant iat = response.getIssueTime().toInstant();
-			claims.put(OAuth2TokenIntrospectionClaimNames.IAT, iat);
-		}
-		if (response.getIssuer() != null) {
-			// RFC-7662 page 7 directs users to RFC-7519 for defining the values of these
-			// issuer fields.
-			// https://datatracker.ietf.org/doc/html/rfc7662#page-7
-			//
-			// RFC-7519 page 9 defines issuer fields as being 'case-sensitive' strings
-			// containing
-			// a 'StringOrURI', which is defined on page 5 as being any string, but
-			// strings containing ':'
-			// should be treated as valid URIs.
-			// https://datatracker.ietf.org/doc/html/rfc7519#section-2
-			//
-			// It is not defined however as to whether-or-not normalized URIs should be
-			// treated as the same literal
-			// value. It only defines validation itself, so to avoid potential ambiguity
-			// or unwanted side effects that
-			// may be awkward to debug, we do not want to manipulate this value. Previous
-			// versions of Spring Security
-			// would *only* allow valid URLs, which is not what we wish to achieve here.
-			claims.put(OAuth2TokenIntrospectionClaimNames.ISS, response.getIssuer().getValue());
-		}
-		if (response.getNotBeforeTime() != null) {
-			claims.put(OAuth2TokenIntrospectionClaimNames.NBF, response.getNotBeforeTime().toInstant());
-		}
-		if (response.getScope() != null) {
-			List<String> scopes = Collections.unmodifiableList(response.getScope().toStringList());
-			claims.put(OAuth2TokenIntrospectionClaimNames.SCOPE, scopes);
-			for (String scope : scopes) {
-				authorities.add(new SimpleGrantedAuthority(AUTHORITY_PREFIX + scope));
-			}
-		}
-		return new OAuth2IntrospectionAuthenticatedPrincipal(claims, authorities);
+		this.delegate.setRequestEntityConverter(requestEntityConverter);
 	}
 
 }

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/NimbusOpaqueTokenIntrospector.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/NimbusOpaqueTokenIntrospector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/introspection/NimbusOpaqueTokenIntrospectorTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/introspection/NimbusOpaqueTokenIntrospectorTests.java
@@ -97,13 +97,6 @@ public class NimbusOpaqueTokenIntrospectorTests {
 	// @formatter:on
 
 	// @formatter:off
-	private static final String MALFORMED_ISSUER_RESPONSE = "{\n"
-			+ "     \"active\" : \"true\",\n"
-			+ "     \"iss\" : \"badissuer\"\n"
-			+ "    }";
-	// @formatter:on
-
-	// @formatter:off
 	private static final String MALFORMED_SCOPE_RESPONSE = "{\n"
 			+ "      \"active\": true,\n"
 			+ "      \"client_id\": \"l238j323ds-23ij4\",\n"
@@ -233,18 +226,6 @@ public class NimbusOpaqueTokenIntrospectorTests {
 	public void introspectWhenIntrospectionTokenReturnsInvalidResponseThenInvalidToken() throws IOException {
 		try (MockWebServer server = new MockWebServer()) {
 			server.setDispatcher(requiresAuth(CLIENT_ID, CLIENT_SECRET, INVALID_RESPONSE));
-			String introspectUri = server.url("/introspect").toString();
-			OpaqueTokenIntrospector introspectionClient = new NimbusOpaqueTokenIntrospector(introspectUri, CLIENT_ID,
-					CLIENT_SECRET);
-			assertThatExceptionOfType(OAuth2IntrospectionException.class)
-				.isThrownBy(() -> introspectionClient.introspect("token"));
-		}
-	}
-
-	@Test
-	public void introspectWhenIntrospectionTokenReturnsMalformedIssuerResponseThenInvalidToken() throws IOException {
-		try (MockWebServer server = new MockWebServer()) {
-			server.setDispatcher(requiresAuth(CLIENT_ID, CLIENT_SECRET, MALFORMED_ISSUER_RESPONSE));
 			String introspectUri = server.url("/introspect").toString();
 			OpaqueTokenIntrospector introspectionClient = new NimbusOpaqueTokenIntrospector(introspectUri, CLIENT_ID,
 					CLIENT_SECRET);

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/introspection/NimbusOpaqueTokenIntrospectorTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/introspection/NimbusOpaqueTokenIntrospectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
`NimbusOpaqueTokenIntrospector` now delegates to `SpringOpaqueTokenIntrospector`.

Required a lot of test changes since they are all mock-based relying on the implementation calling a specific method in the `RestOperations` interface and the two implementations differ in which method they call even though they are functionally the same. Tests were changed to use a `MockWebServer` and make real HTTP requests to enable the internals to be freely refactored.

One step of gh-14245