### PR TITLE
Update doc: disable CSRF protection when using REST API for login.

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/passwords/index.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/passwords/index.adoc
@@ -136,6 +136,7 @@ public class SecurityConfig {
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http
+			.csrf(AbstractHttpConfigurer::disable)
 			.authorizeHttpRequests((authorize) -> authorize
 				.requestMatchers("/login").permitAll()
 				.anyRequest().authenticated()


### PR DESCRIPTION
If CSRF protection is not disabled, Spring Security will return a 403 for the permitted `/login` API.