### PR TITLE
Provided uncached way to use (Reactive)OidcIdTokenDecoderFactory

### DIFF
--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/authentication/OidcIdTokenDecoderFactoryTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/authentication/OidcIdTokenDecoderFactoryTests.java
@@ -34,6 +34,7 @@ import org.springframework.security.oauth2.jose.jws.JwsAlgorithm;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -46,6 +47,7 @@ import static org.mockito.Mockito.verify;
 /**
  * @author Joe Grandja
  * @author Rafael Dominguez
+ * @author Ivan Golovko
  * @since 5.2
  */
 public class OidcIdTokenDecoderFactoryTests {
@@ -175,6 +177,23 @@ public class OidcIdTokenDecoderFactoryTests {
 			.willReturn(new ClaimTypeConverter(OidcIdTokenDecoderFactory.createDefaultClaimTypeConverters()));
 		this.idTokenDecoderFactory.createDecoder(clientRegistration);
 		verify(customClaimTypeConverterFactory).apply(same(clientRegistration));
+	}
+
+	@Test
+	public void createDecoderTwiceWithCaching() {
+		ClientRegistration clientRegistration = this.registration.build();
+		JwtDecoder decoder1 = this.idTokenDecoderFactory.createDecoder(clientRegistration);
+		JwtDecoder decoder2 = this.idTokenDecoderFactory.createDecoder(clientRegistration);
+		assertThat(decoder1).isSameAs(decoder2);
+	}
+
+	@Test
+	public void createDecoderTwiceWithoutCaching() {
+		this.idTokenDecoderFactory = new OidcIdTokenDecoderFactory(false);
+		ClientRegistration clientRegistration = this.registration.build();
+		JwtDecoder decoder1 = this.idTokenDecoderFactory.createDecoder(clientRegistration);
+		JwtDecoder decoder2 = this.idTokenDecoderFactory.createDecoder(clientRegistration);
+		assertThat(decoder1).isNotSameAs(decoder2);
 	}
 
 }

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/authentication/ReactiveOidcIdTokenDecoderFactoryTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/authentication/ReactiveOidcIdTokenDecoderFactoryTests.java
@@ -34,6 +34,7 @@ import org.springframework.security.oauth2.jose.jws.JwsAlgorithm;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -47,6 +48,7 @@ import static org.mockito.Mockito.verify;
  * @author Joe Grandja
  * @author Rafael Dominguez
  * @author Ubaid ur Rehman
+ * @author Ivan Golovko
  * @since 5.2
  */
 public class ReactiveOidcIdTokenDecoderFactoryTests {
@@ -175,6 +177,23 @@ public class ReactiveOidcIdTokenDecoderFactoryTests {
 			.willReturn(new ClaimTypeConverter(OidcIdTokenDecoderFactory.createDefaultClaimTypeConverters()));
 		this.idTokenDecoderFactory.createDecoder(clientRegistration);
 		verify(customClaimTypeConverterFactory).apply(same(clientRegistration));
+	}
+
+	@Test
+	public void createDecoderTwiceWithCaching() {
+		ClientRegistration clientRegistration = this.registration.build();
+		ReactiveJwtDecoder decoder1 = this.idTokenDecoderFactory.createDecoder(clientRegistration);
+		ReactiveJwtDecoder decoder2 = this.idTokenDecoderFactory.createDecoder(clientRegistration);
+		assertThat(decoder1).isSameAs(decoder2);
+	}
+
+	@Test
+	public void createDecoderTwiceWithoutCaching() {
+		this.idTokenDecoderFactory = new ReactiveOidcIdTokenDecoderFactory(false);
+		ClientRegistration clientRegistration = this.registration.build();
+		ReactiveJwtDecoder decoder1 = this.idTokenDecoderFactory.createDecoder(clientRegistration);
+		ReactiveJwtDecoder decoder2 = this.idTokenDecoderFactory.createDecoder(clientRegistration);
+		assertThat(decoder1).isNotSameAs(decoder2);
 	}
 
 }


### PR DESCRIPTION
Hello. 

Sorry for ignoring issue creating.

If ClientRegistration is managed by db, it's unreal to update jwsAlgorithm or jwksUri without restarting the app. 

So I added possibility not to use ConcurrentHashMap on decoderCreation to build new one everytime. It will be usefull in some multi-integration cases.
