### PR TITLE
Introduce JwtAudienceValidator

### DIFF
--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtAudienceValidator.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtAudienceValidator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.jwt;
+
+import java.util.Collection;
+
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.util.Assert;
+
+/**
+ * Validates that the "aud" claim in a {@link Jwt} matches a configured value.
+ *
+ * @author Vedran Pavic
+ * @since 6.5
+ */
+public final class JwtAudienceValidator implements OAuth2TokenValidator<Jwt> {
+
+	private final JwtClaimValidator<Collection<String>> validator;
+
+	/**
+	 * Constructs a {@link JwtAudienceValidator} using the provided parameters
+	 * @param audience - The audience that each {@link Jwt} should have.
+	 */
+	public JwtAudienceValidator(String audience) {
+		Assert.notNull(audience, "audience cannot be null");
+		this.validator = new JwtClaimValidator<>(JwtClaimNames.AUD,
+				(claimValue) -> (claimValue != null) && claimValue.contains(audience));
+	}
+
+	@Override
+	public OAuth2TokenValidatorResult validate(Jwt token) {
+		Assert.notNull(token, "token cannot be null");
+		return this.validator.validate(token);
+	}
+
+}

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtValidators.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtValidators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -182,8 +182,7 @@ public final class JwtValidators {
 		 * @return the {@link AtJwtBuilder} for further configuration
 		 */
 		public AtJwtBuilder audience(String audience) {
-			return validators((v) -> v.put(JwtClaimNames.AUD,
-					require(JwtClaimNames.AUD).satisfies((jwt) -> jwt.getAudience().contains(audience))));
+			return validators((v) -> v.put(JwtClaimNames.AUD, new JwtAudienceValidator(audience)));
 		}
 
 		/**

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtAudienceValidatorTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtAudienceValidatorTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.jwt;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link JwtAudienceValidator}.
+ *
+ * @author Vedran Pavic
+ */
+class JwtAudienceValidatorTests {
+
+	private final JwtAudienceValidator validator = new JwtAudienceValidator("audience");
+
+	@Test
+	void givenJwtWithMatchingAudienceThenShouldValidate() {
+		Jwt jwt = TestJwts.jwt().audience(List.of("audience")).build();
+		OAuth2TokenValidatorResult result = this.validator.validate(jwt);
+		assertThat(result).isEqualTo(OAuth2TokenValidatorResult.success());
+	}
+
+	@Test
+	void givenJwtWithoutMatchingAudienceThenShouldValidate() {
+		Jwt jwt = TestJwts.jwt().audience(List.of("other")).build();
+		OAuth2TokenValidatorResult result = this.validator.validate(jwt);
+		assertThat(result.hasErrors()).isTrue();
+	}
+
+	@Test
+	void givenJwtWithoutAudienceThenShouldValidate() {
+		Jwt jwt = TestJwts.jwt().audience(null).build();
+		OAuth2TokenValidatorResult result = this.validator.validate(jwt);
+		assertThat(result.hasErrors()).isTrue();
+	}
+
+}


### PR DESCRIPTION
Since audience is among claims that are often validated, this PR introduces `JwtAudienceValidator` to simplify such use case with `spring-security-oauth2-jose`. I've also plugged the new validator into recently introduced `at+jwt` support (thanks for that).