### PR TITLE
Update WebAuthn Test Objects Class Names

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/builders/TestHttpSecurities.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/builders/TestHttpSecurities.java
@@ -21,9 +21,9 @@ import java.util.List;
 import org.springframework.security.config.annotation.web.configurers.DefaultLoginPageConfigurer;
 import org.springframework.test.util.ReflectionTestUtils;
 
-public final class TestHttpSecurity {
+public final class TestHttpSecurities {
 
-	private TestHttpSecurity() {
+	private TestHttpSecurities() {
 
 	}
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/DefaultFiltersTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/DefaultFiltersTests.java
@@ -31,7 +31,7 @@ import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.TestHttpSecurity;
+import org.springframework.security.config.annotation.web.builders.TestHttpSecurities;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.test.SpringTestContext;
@@ -169,7 +169,7 @@ public class DefaultFiltersTests {
 
 		@Bean
 		SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-			TestHttpSecurity.disableDefaults(http);
+			TestHttpSecurities.disableDefaults(http);
 			http.formLogin();
 			return http.build();
 		}

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpCustomFilterTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/NamespaceHttpCustomFilterTests.java
@@ -32,7 +32,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.TestHttpSecurity;
+import org.springframework.security.config.annotation.web.builders.TestHttpSecurities;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.test.SpringTestContext;
 import org.springframework.security.config.test.SpringTestContextExtension;
@@ -140,7 +140,7 @@ public class NamespaceHttpCustomFilterTests {
 		@Bean
 		SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 			// @formatter:off
-			TestHttpSecurity.disableDefaults(http);
+			TestHttpSecurities.disableDefaults(http);
 			http
 				// this works so long as the CustomFilter extends one of the standard filters
 				// if not, use addFilterBefore or addFilterAfter
@@ -158,7 +158,7 @@ public class NamespaceHttpCustomFilterTests {
 		@Bean
 		SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 			// @formatter:off
-			TestHttpSecurity.disableDefaults(http);
+			TestHttpSecurities.disableDefaults(http);
 			http
 				.addFilterAt(new OtherCustomFilter(), UsernamePasswordAuthenticationFilter.class);
 			return http.build();
@@ -179,7 +179,7 @@ public class NamespaceHttpCustomFilterTests {
 		@Bean
 		SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 			// @formatter:off
-			TestHttpSecurity.disableDefaults(http);
+			TestHttpSecurities.disableDefaults(http);
 			http
 				.authorizeRequests()
 					.anyRequest().hasRole("USER")

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/SecurityContextConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/SecurityContextConfigurerTests.java
@@ -31,7 +31,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.ObjectPostProcessor;
 import org.springframework.security.config.TestDeferredSecurityContext;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.TestHttpSecurity;
+import org.springframework.security.config.annotation.web.builders.TestHttpSecurities;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.test.SpringTestContext;
 import org.springframework.security.config.test.SpringTestContextExtension;
@@ -199,7 +199,7 @@ public class SecurityContextConfigurerTests {
 
 		@Bean
 		SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-			TestHttpSecurity.disableDefaults(http);
+			TestHttpSecurities.disableDefaults(http);
 			// @formatter:off
 			http
 				.addFilter(new WebAsyncManagerIntegrationFilter())

--- a/web/src/test/java/org/springframework/security/web/access/RequestMatcherDelegatingWebInvocationPrivilegeEvaluatorTests.java
+++ b/web/src/test/java/org/springframework/security/web/access/RequestMatcherDelegatingWebInvocationPrivilegeEvaluatorTests.java
@@ -75,7 +75,7 @@ class RequestMatcherDelegatingWebInvocationPrivilegeEvaluatorTests {
 	@Test
 	void isAllowedWhenNotMatchThenAllowed() {
 		RequestMatcherEntry<List<WebInvocationPrivilegeEvaluator>> notMatch = entry(this.alwaysDeny,
-				TestWebInvocationPrivilegeEvaluator.alwaysAllow());
+				TestWebInvocationPrivilegeEvaluators.alwaysAllow());
 		WebInvocationPrivilegeEvaluator delegating = evaluator(notMatch);
 		assertThat(delegating.isAllowed(this.uri, this.authentication)).isTrue();
 		verify(notMatch.getRequestMatcher()).matches(any());
@@ -96,9 +96,9 @@ class RequestMatcherDelegatingWebInvocationPrivilegeEvaluatorTests {
 	@Test
 	void isAllowedWhenNotMatchThenMatchThenOnlySecondDelegateInvoked() {
 		RequestMatcherEntry<List<WebInvocationPrivilegeEvaluator>> notMatchDelegate = entry(this.alwaysDeny,
-				TestWebInvocationPrivilegeEvaluator.alwaysAllow());
+				TestWebInvocationPrivilegeEvaluators.alwaysAllow());
 		RequestMatcherEntry<List<WebInvocationPrivilegeEvaluator>> matchDelegate = entry(this.alwaysMatch,
-				TestWebInvocationPrivilegeEvaluator.alwaysAllow());
+				TestWebInvocationPrivilegeEvaluators.alwaysAllow());
 		RequestMatcherEntry<List<WebInvocationPrivilegeEvaluator>> spyNotMatchDelegate = spy(notMatchDelegate);
 		RequestMatcherEntry<List<WebInvocationPrivilegeEvaluator>> spyMatchDelegate = spy(matchDelegate);
 
@@ -120,8 +120,8 @@ class RequestMatcherDelegatingWebInvocationPrivilegeEvaluatorTests {
 
 	@Test
 	void isAllowedWhenFirstDelegateDenyThenDoNotInvokeOthers() {
-		WebInvocationPrivilegeEvaluator deny = TestWebInvocationPrivilegeEvaluator.alwaysDeny();
-		WebInvocationPrivilegeEvaluator allow = TestWebInvocationPrivilegeEvaluator.alwaysAllow();
+		WebInvocationPrivilegeEvaluator deny = TestWebInvocationPrivilegeEvaluators.alwaysDeny();
+		WebInvocationPrivilegeEvaluator allow = TestWebInvocationPrivilegeEvaluators.alwaysAllow();
 		WebInvocationPrivilegeEvaluator spyDeny = spy(deny);
 		WebInvocationPrivilegeEvaluator spyAllow = spy(allow);
 		RequestMatcherEntry<List<WebInvocationPrivilegeEvaluator>> delegate = entry(this.alwaysMatch, spyDeny,
@@ -136,7 +136,7 @@ class RequestMatcherDelegatingWebInvocationPrivilegeEvaluatorTests {
 
 	@Test
 	void isAllowedWhenDifferentArgumentsThenCallSpecificIsAllowedInDelegate() {
-		WebInvocationPrivilegeEvaluator deny = TestWebInvocationPrivilegeEvaluator.alwaysDeny();
+		WebInvocationPrivilegeEvaluator deny = TestWebInvocationPrivilegeEvaluators.alwaysDeny();
 		WebInvocationPrivilegeEvaluator spyDeny = spy(deny);
 		RequestMatcherEntry<List<WebInvocationPrivilegeEvaluator>> delegate = entry(this.alwaysMatch, spyDeny);
 
@@ -197,11 +197,11 @@ class RequestMatcherDelegatingWebInvocationPrivilegeEvaluatorTests {
 	}
 
 	private RequestMatcherEntry<List<WebInvocationPrivilegeEvaluator>> allow(RequestMatcher requestMatcher) {
-		return entry(requestMatcher, TestWebInvocationPrivilegeEvaluator.alwaysAllow());
+		return entry(requestMatcher, TestWebInvocationPrivilegeEvaluators.alwaysAllow());
 	}
 
 	private RequestMatcherEntry<List<WebInvocationPrivilegeEvaluator>> deny(RequestMatcher requestMatcher) {
-		return entry(requestMatcher, TestWebInvocationPrivilegeEvaluator.alwaysDeny());
+		return entry(requestMatcher, TestWebInvocationPrivilegeEvaluators.alwaysDeny());
 	}
 
 	private RequestMatcherEntry<List<WebInvocationPrivilegeEvaluator>> entry(RequestMatcher requestMatcher,

--- a/web/src/test/java/org/springframework/security/web/access/TestWebInvocationPrivilegeEvaluators.java
+++ b/web/src/test/java/org/springframework/security/web/access/TestWebInvocationPrivilegeEvaluators.java
@@ -18,13 +18,13 @@ package org.springframework.security.web.access;
 
 import org.springframework.security.core.Authentication;
 
-public final class TestWebInvocationPrivilegeEvaluator {
+public final class TestWebInvocationPrivilegeEvaluators {
 
 	private static final AlwaysAllowWebInvocationPrivilegeEvaluator ALWAYS_ALLOW = new AlwaysAllowWebInvocationPrivilegeEvaluator();
 
 	private static final AlwaysDenyWebInvocationPrivilegeEvaluator ALWAYS_DENY = new AlwaysDenyWebInvocationPrivilegeEvaluator();
 
-	private TestWebInvocationPrivilegeEvaluator() {
+	private TestWebInvocationPrivilegeEvaluators() {
 	}
 
 	public static WebInvocationPrivilegeEvaluator alwaysAllow() {


### PR DESCRIPTION
This PR addresses issue #16604 by renaming several WebAuthn test object classes to follow the established Spring Security convention of naming test objects as Test{Object}s (plural form).
Changes

Renamed TestAuthenticatorAttestationResponse → TestAuthenticatorAttestationResponses
Renamed TestCredentialRecord → TestCredentialRecords
Renamed TestPublicKeyCredential → TestPublicKeyCredentials
Renamed TestPublicKeyCredentialUserEntity → TestPublicKeyCredentialUserEntities
Renamed TestPublicKeyCredentialRpEntity → TestPublicKeyCredentialRpEntities