### PR TITLE
Make BearerTokenAccessDeniedHandler non-final

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/access/BearerTokenAccessDeniedHandler.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/access/BearerTokenAccessDeniedHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ import org.springframework.security.web.access.AccessDeniedHandler;
  * @author Josh Cummings
  * @since 5.1
  */
-public final class BearerTokenAccessDeniedHandler implements AccessDeniedHandler {
+public class BearerTokenAccessDeniedHandler implements AccessDeniedHandler {
 
 	private String realmName;
 


### PR DESCRIPTION
The reactor version of this class (BearerTokenServerAccessDeniedHandler) is already non-final, so I could not find a reason that it should stay like this.

___

In my specific case, I just wanted to add some debug/warn logs and I couldn't do it because the class is final*, that's what led me to this PR.

*As a workaround, I'll create a delegate class for this purpose, nevertheless I still propose this change.

Thanks