### PR TITLE
Simplify OIDC Back-Channel Logout DSL (Closes gh-15817)

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
@@ -16,18 +16,8 @@
 
 package org.springframework.security.config.annotation.web.builders;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import jakarta.servlet.Filter;
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
+import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
-
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.ApplicationContext;
@@ -48,29 +38,8 @@ import org.springframework.security.config.annotation.web.HttpSecurityBuilder;
 import org.springframework.security.config.annotation.web.RequestMatcherFactory;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
-import org.springframework.security.config.annotation.web.configurers.AnonymousConfigurer;
-import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
+import org.springframework.security.config.annotation.web.configurers.*;
 import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer.AuthorizationManagerRequestMatcherRegistry;
-import org.springframework.security.config.annotation.web.configurers.ChannelSecurityConfigurer;
-import org.springframework.security.config.annotation.web.configurers.CorsConfigurer;
-import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
-import org.springframework.security.config.annotation.web.configurers.ExceptionHandlingConfigurer;
-import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
-import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
-import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
-import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
-import org.springframework.security.config.annotation.web.configurers.HttpsRedirectConfigurer;
-import org.springframework.security.config.annotation.web.configurers.JeeConfigurer;
-import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
-import org.springframework.security.config.annotation.web.configurers.PasswordManagementConfigurer;
-import org.springframework.security.config.annotation.web.configurers.PortMapperConfigurer;
-import org.springframework.security.config.annotation.web.configurers.RememberMeConfigurer;
-import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
-import org.springframework.security.config.annotation.web.configurers.SecurityContextConfigurer;
-import org.springframework.security.config.annotation.web.configurers.ServletApiConfigurer;
-import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
-import org.springframework.security.config.annotation.web.configurers.WebAuthnConfigurer;
-import org.springframework.security.config.annotation.web.configurers.X509Configurer;
 import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2ClientConfigurer;
 import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
 import org.springframework.security.config.annotation.web.configurers.oauth2.client.OidcLogoutConfigurer;
@@ -102,6 +71,11 @@ import org.springframework.util.ClassUtils;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.filter.CorsFilter;
 import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * A {@link HttpSecurity} is similar to Spring Security's XML &lt;http&gt; element in the
@@ -2868,6 +2842,14 @@ public final class HttpSecurity extends AbstractConfiguredSecurityBuilder<Defaul
 			throws Exception {
 		oidcLogoutCustomizer.customize(getOrApply(new OidcLogoutConfigurer<>()));
 		return HttpSecurity.this;
+	}
+
+	public HttpSecurity oidcBackChannelLogout(Customizer<OidcLogoutConfigurer<HttpSecurity>> oidcBackChannelLogoutCustomizer)
+			throws Exception {
+		oidcBackChannelLogoutCustomizer.customize(
+				getOrApply(new OidcLogoutConfigurer<>()).backChannel(Customizer.withDefaults())
+		);
+		return this;
 	}
 
 	/**

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OidcLogoutConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OidcLogoutConfigurer.java
@@ -16,12 +16,8 @@
 
 package org.springframework.security.config.annotation.web.configurers.oauth2.client;
 
-import java.util.function.Consumer;
-import java.util.function.Function;
-
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
 import org.springframework.context.ApplicationContext;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
@@ -39,6 +35,9 @@ import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.util.Assert;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * An {@link AbstractHttpConfigurer} for OIDC Logout flows
@@ -102,7 +101,10 @@ public final class OidcLogoutConfigurer<B extends HttpSecurityBuilder<B>>
 	/**
 	 * Configure OIDC Back-Channel Logout using the provided {@link Consumer}
 	 * @return the {@link OidcLogoutConfigurer} for further configuration
+	 * @deprecated For removal in a future release. Use
+	 * {@link HttpSecurity#oidcBackChannelLogout(Customizer)} instead.
 	 */
+	@Deprecated(since = "6.2", forRemoval = true)
 	public OidcLogoutConfigurer<B> backChannel(Customizer<BackChannelLogoutConfigurer> backChannelLogoutConfigurer) {
 		if (this.backChannel == null) {
 			this.backChannel = new BackChannelLogoutConfigurer();
@@ -157,35 +159,6 @@ public final class OidcLogoutConfigurer<B extends HttpSecurityBuilder<B>>
 			return logoutHandler;
 		}
 
-		/**
-		 * Use this endpoint when invoking a back-channel logout.
-		 *
-		 * <p>
-		 * The resulting {@link LogoutHandler} will {@code POST} the session cookie and
-		 * CSRF token to this endpoint to invalidate the corresponding end-user session.
-		 *
-		 * <p>
-		 * Supports URI templates like {@code {baseUrl}}, {@code {baseScheme}}, and
-		 * {@code {basePort}}.
-		 *
-		 * <p>
-		 * By default, the URI is set to
-		 * {@code {baseScheme}://localhost{basePort}/logout}, meaning that the scheme and
-		 * port of the original back-channel request is preserved, while the host and
-		 * endpoint are changed.
-		 *
-		 * <p>
-		 * If you are using Spring Security for the logout endpoint, the path part of this
-		 * URI should match the value configured there.
-		 *
-		 * <p>
-		 * Otherwise, this is handy in the event that your server configuration means that
-		 * the scheme, server name, or port in the {@code Host} header are different from
-		 * how you would address the same server internally.
-		 * @param logoutUri the URI to request logout on the back-channel
-		 * @return the {@link BackChannelLogoutConfigurer} for further customizations
-		 * @since 6.2.4
-		 */
 		public BackChannelLogoutConfigurer logoutUri(String logoutUri) {
 			this.logoutHandler = (http) -> {
 				OidcBackChannelLogoutHandler logoutHandler = new OidcBackChannelLogoutHandler(


### PR DESCRIPTION
Currently, OIDC Back-Channel Logout is configured with a nested DSL:	This nested structure makes the DSL less navigable. To improve clarity and consistency with other logout DSLs (such as logout() and saml2Logout()), we introduce a new top-level DSL method:	

## Changes in this PR
- HttpSecurity Modification:
A new method oidcBackChannelLogout(Customizer<OidcLogoutConfigurer<HttpSecurity>>) has been added to HttpSecurity. This method internally creates an OidcLogoutConfigurer and applies the default back-channel configuration, thereby simplifying the DSL.
- OidcLogoutConfigurer Modification:
The existing backChannel(Customizer<BackChannelLogoutConfigurer>) method is now marked as deprecated with:	Its JavaDoc has been updated to recommend using the new DSL method oidcBackChannelLogout(Customizer.withDefaults()) instead.
- Testing:
A new test method, oidcBackChannelLogoutWhenDefaultsThenRemotelyInvalidatesSessions(), has been added to verify that when using the new DSL, the OIDC Back-Channel Logout filter is properly registered and that sessions are invalidated as expected.

## Related
Closes [gh-15817](https://github.com/spring-projects/spring-security/issues/15817)