### PR TITLE
Add not null validation for UserDetailsChecker in AbstractUserDetailsAuthenticationProvider

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/dao/AbstractUserDetailsAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/dao/AbstractUserDetailsAuthenticationProvider.java
@@ -117,6 +117,8 @@ public abstract class AbstractUserDetailsAuthenticationProvider
 	public final void afterPropertiesSet() throws Exception {
 		Assert.notNull(this.userCache, "A user cache must be set");
 		Assert.notNull(this.messages, "A message source must be set");
+		Assert.notNull(this.preAuthenticationChecks, "A pre authentication checks must be set");
+		Assert.notNull(this.postAuthenticationChecks, "A post authentication checks must be set");
 		doAfterPropertiesSet();
 	}
 


### PR DESCRIPTION
# Add early validation for authentication checks

## Details
This PR adds validation for `preAuthenticationChecks` and `postAuthenticationChecks` in 
`AbstractUserDetailsAuthenticationProvider`. The primary approach is to add assertions in
the `afterPropertiesSet()` method to detect null values early in the application lifecycle.

Currently, if these checks are set to null, a `NullPointerException` is thrown during the 
authentication process, which might be difficult to troubleshoot. The early validation approach
ensures errors are detected at initialization time with a clear error message.

## Alternative Approach Considered
As an alternative, we could add null checks before invoking the `check()` methods:
```java
if (this.preAuthenticationChecks != null) {
    this.preAuthenticationChecks.check(user);
}