### PR TITLE
Sets correct remote address in WebAuthenticationDetails

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/WebAuthenticationDetails.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/WebAuthenticationDetails.java
@@ -29,6 +29,7 @@ import org.springframework.security.core.SpringSecurityCoreVersion;
  *
  * @author Ben Alex
  * @author Luke Taylor
+ * @author Lazar Radinović
  */
 public class WebAuthenticationDetails implements Serializable {
 
@@ -44,7 +45,7 @@ public class WebAuthenticationDetails implements Serializable {
 	 * @param request that the authentication request was received from
 	 */
 	public WebAuthenticationDetails(HttpServletRequest request) {
-		this(request.getRemoteAddr(), extractSessionId(request));
+		this(getClientIp(request), extractSessionId(request));
 	}
 
 	/**
@@ -56,6 +57,20 @@ public class WebAuthenticationDetails implements Serializable {
 	public WebAuthenticationDetails(String remoteAddress, String sessionId) {
 		this.remoteAddress = remoteAddress;
 		this.sessionId = sessionId;
+	}
+
+	private static String getClientIp(HttpServletRequest request) {
+		String ip = request.getHeader("X-Forwarded-For");
+		if (ip != null && !ip.isBlank()) {
+			// Take the first IP (original client)
+			return ip.split(",")[0].trim();
+		}
+
+		// Alternative proxy header
+		ip = request.getHeader("X-Real-IP");
+
+		// Fallback to direct client ip
+		return (ip != null && !ip.isBlank()) ? ip : request.getRemoteAddr();
 	}
 
 	private static String extractSessionId(HttpServletRequest request) {


### PR DESCRIPTION
While I was going trough debug logs of my application on my test server I have noticed this line:

```
Set SecurityContextHolder to JwtAuthenticationToken [Principal=org.springframework.security.oauth2.jwt.Jwt@b2c2a23e, Credentials=[PROTECTED], Authenticated=true, Details=WebAuthenticationDetails [RemoteIpAddress=127.0.0.1, SessionId=null], Granted Authorities=[ROLE_offline_access, ROLE_default-roles-app, ROLE_uma_authorization, ROLE_consumer]]
```

Our application on test server is behind nginx, so because of that attribute `RemoteIpAddress` is set to 127.0.0.1 which is wrong...

So I have updated WebAuthenticationDetails to read remote address first from `X-Forwarded-For`, and then from `X-Real-IP` headers and then finally as fallback to use `request.getRemoteAddr()`. This sould cover almost all use cases I guess...