### PR TITLE
Fix typos Open SAML 5 Javadoc referencing Open SAML 4

### DIFF
--- a/saml2/saml2-service-provider/src/opensaml5Main/java/org/springframework/security/saml2/provider/service/authentication/OpenSaml5AuthenticationProvider.java
+++ b/saml2/saml2-service-provider/src/opensaml5Main/java/org/springframework/security/saml2/provider/service/authentication/OpenSaml5AuthenticationProvider.java
@@ -48,7 +48,7 @@ import org.springframework.util.StringUtils;
 /**
  * Implementation of {@link AuthenticationProvider} for SAML authentications when
  * receiving a {@code Response} object containing an {@code Assertion}. This
- * implementation uses the {@code OpenSAML 4} library.
+ * implementation uses the {@code OpenSAML 5} library.
  *
  * <p>
  * The {@link OpenSaml5AuthenticationProvider} supports {@link Saml2AuthenticationToken}
@@ -154,7 +154,7 @@ public final class OpenSaml5AuthenticationProvider implements AuthenticationProv
 	 * {@link #createDefaultResponseValidator()}, like so:
 	 *
 	 * <pre>
-	 * OpenSaml4AuthenticationProvider provider = new OpenSaml4AuthenticationProvider();
+	 * OpenSaml5AuthenticationProvider provider = new OpenSaml5AuthenticationProvider();
 	 * provider.setResponseValidator(responseToken -&gt; {
 	 * 		Saml2ResponseValidatorResult result = createDefaultResponseValidator()
 	 * 			.convert(responseToken)

--- a/saml2/saml2-service-provider/src/opensaml5Main/java/org/springframework/security/saml2/provider/service/authentication/logout/OpenSaml5LogoutRequestValidator.java
+++ b/saml2/saml2-service-provider/src/opensaml5Main/java/org/springframework/security/saml2/provider/service/authentication/logout/OpenSaml5LogoutRequestValidator.java
@@ -17,7 +17,7 @@
 package org.springframework.security.saml2.provider.service.authentication.logout;
 
 /**
- * An OpenSAML 4.x compatible implementation of {@link Saml2LogoutResponseValidator}
+ * An OpenSAML 5.x compatible implementation of {@link Saml2LogoutResponseValidator}
  *
  * @author Josh Cummings
  * @since 5.6

--- a/saml2/saml2-service-provider/src/opensaml5Main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/OpenSaml5LogoutRequestResolver.java
+++ b/saml2/saml2-service-provider/src/opensaml5Main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/OpenSaml5LogoutRequestResolver.java
@@ -33,7 +33,7 @@ import org.springframework.util.Assert;
 
 /**
  * A {@link Saml2LogoutRequestResolver} for resolving SAML 2.0 Logout Requests with
- * OpenSAML 4
+ * OpenSAML 5
  *
  * @author Josh Cummings
  * @author Gerhard Haege

--- a/saml2/saml2-service-provider/src/opensaml5Main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/OpenSaml5LogoutResponseResolver.java
+++ b/saml2/saml2-service-provider/src/opensaml5Main/java/org/springframework/security/saml2/provider/service/web/authentication/logout/OpenSaml5LogoutResponseResolver.java
@@ -32,7 +32,7 @@ import org.springframework.util.Assert;
 
 /**
  * A {@link Saml2LogoutResponseResolver} for resolving SAML 2.0 Logout Responses with
- * OpenSAML 4
+ * OpenSAML 5
  *
  * @author Josh Cummings
  * @since 5.6


### PR DESCRIPTION
Fixing some typos that I found while integrating with Open SAML 5