### PR TITLE
Fix javadocs on WebFlux CSRF classes

### DIFF
--- a/web/src/main/java/org/springframework/security/web/server/csrf/CsrfException.java
+++ b/web/src/main/java/org/springframework/security/web/server/csrf/CsrfException.java
@@ -19,13 +19,12 @@ package org.springframework.security.web.server.csrf;
 import java.io.Serial;
 
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.web.csrf.CsrfToken;
 
 /**
- * Thrown when an invalid or missing {@link CsrfToken} is found in the HttpServletRequest
+ * Thrown when an invalid or missing {@link CsrfToken} is found in the ServerWebExchange
  *
  * @author Rob Winch
- * @since 3.2
+ * @since 5.0
  */
 public class CsrfException extends AccessDeniedException {
 

--- a/web/src/main/java/org/springframework/security/web/server/csrf/WebSessionServerCsrfTokenRepository.java
+++ b/web/src/main/java/org/springframework/security/web/server/csrf/WebSessionServerCsrfTokenRepository.java
@@ -19,17 +19,16 @@ package org.springframework.security.web.server.csrf;
 import java.util.Map;
 import java.util.UUID;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import org.springframework.util.Assert;
 import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebSession;
 
 /**
  * A {@link ServerCsrfTokenRepository} that stores the {@link CsrfToken} in the
- * {@link HttpSession}.
+ * {@link WebSession}.
  *
  * @author Rob Winch
  * @since 5.0
@@ -78,7 +77,7 @@ public class WebSessionServerCsrfTokenRepository implements ServerCsrfTokenRepos
 	}
 
 	/**
-	 * Sets the {@link HttpServletRequest} parameter name that the {@link CsrfToken} is
+	 * Sets the {@link ServerWebExchange} parameter name that the {@link CsrfToken} is
 	 * expected to appear on
 	 * @param parameterName the new parameter name to use
 	 */
@@ -98,7 +97,7 @@ public class WebSessionServerCsrfTokenRepository implements ServerCsrfTokenRepos
 	}
 
 	/**
-	 * Sets the {@link HttpSession} attribute name that the {@link CsrfToken} is stored in
+	 * Sets the {@link WebSession} attribute name that the {@link CsrfToken} is stored in
 	 * @param sessionAttributeName the new attribute name to use
 	 */
 	public void setSessionAttributeName(String sessionAttributeName) {


### PR DESCRIPTION
I fixed javadocs on WebFlux CSRF protection classes.
They wrongly have Servlet API references since they were copied from Servlet equivalents.