### PR TITLE
Add getRequiredAddress() and getMaskBits() to IpAddressMatcher.java

### DIFF
--- a/web/src/main/java/org/springframework/security/web/util/matcher/IpAddressMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/IpAddressMatcher.java
@@ -130,4 +130,12 @@ public final class IpAddressMatcher implements RequestMatcher {
 		}
 	}
 
+	public InetAddress getRequiredAddress() {
+		return this.requiredAddress;
+	}
+
+	public int getMaskBits() {
+		return this.nMaskBits;
+	}
+
 }

--- a/web/src/test/java/org/springframework/security/web/util/matcher/IpAddressMatcherTests.java
+++ b/web/src/test/java/org/springframework/security/web/util/matcher/IpAddressMatcherTests.java
@@ -152,5 +152,18 @@ public class IpAddressMatcherTests {
 		assertThatIllegalArgumentException().isThrownBy(() -> new IpAddressMatcher(""))
 			.withMessage("ipAddress cannot be empty");
 	}
+	// gh-16693
+	@Test
+	public void getRequiredAddressWhenCidrIsValidThenReturnsHostAddress() {
+		IpAddressMatcher ipAddressMatcher = new IpAddressMatcher("192.168.1.0/24");
+		assertThat(ipAddressMatcher.getRequiredAddress().getHostAddress()).isEqualTo("192.168.1.0");
+	}
+
+	// gh-16693
+	@Test
+	public void getRequiredAddressWhenCidrIsValidThenReturnsMaskBits() {
+		IpAddressMatcher ipAddressMatcher = new IpAddressMatcher("192.168.1.0/24");
+		assertThat(ipAddressMatcher.getMaskBits()).isEqualTo(24);
+	}
 
 }


### PR DESCRIPTION
Closes gh-16693

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->


gh-16693

When reviewing the issue, the original request was to add a toString() method to IpAddressMatcher.
However, what the reporter actually needed was the hostAddress that had been set in the IpAddressMatcher.

I didn’t think it was appropriate to override toString() just to return the hostAddress, because toString() should ideally reflect the entire object state or be used for debugging purposes—not to expose a specific internal value. So I decided not to implement it that way.

As for getRequiredAddress(), I believed that it was sufficient to return the raw InetAddress directly without wrapping or transforming it to a hostAddress. This way, users can still access what they need without inconvenience.

On the other hand, since getMaskBits() is tightly coupled with the subnet concept and is inherently derived from the original hostAddress, I felt it was appropriate to expose that detail explicitly through this method.