### PR TITLE
Add toString() to IpAddressMatcher.java

### DIFF
--- a/web/src/main/java/org/springframework/security/web/util/matcher/IpAddressMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/IpAddressMatcher.java
@@ -130,4 +130,11 @@ public final class IpAddressMatcher implements RequestMatcher {
 		}
 	}
 
+	@Override
+	public String toString() {
+		String hostAddress = this.requiredAddress.getHostAddress();
+		return (this.nMaskBits < 0)
+				? "IpAddressMatcher[" + hostAddress + "]"
+				: "IpAddressMatcher[" + hostAddress + "/" + this.nMaskBits + "]";
+	}
 }

--- a/web/src/test/java/org/springframework/security/web/util/matcher/IpAddressMatcherTests.java
+++ b/web/src/test/java/org/springframework/security/web/util/matcher/IpAddressMatcherTests.java
@@ -152,5 +152,24 @@ public class IpAddressMatcherTests {
 		assertThatIllegalArgumentException().isThrownBy(() -> new IpAddressMatcher(""))
 			.withMessage("ipAddress cannot be empty");
 	}
+	// gh-16795
+	@Test
+	public void toStringWhenCidrIsProvidedThenReturnsIpAddressWithCidr() {
+		IpAddressMatcher matcher = new IpAddressMatcher("192.168.1.0/24");
+
+		String result = matcher.toString();
+
+		assertThat(result).isEqualTo("IpAddressMatcher[192.168.1.0/24]");
+	}
+
+	// gh-16795
+	@Test
+	public void toStringWhenOnlyIpIsProvidedThenReturnsIpAddressOnly() {
+		IpAddressMatcher matcher = new IpAddressMatcher("127.0.0.1");
+
+		String result = matcher.toString();
+
+		assertThat(result).isEqualTo("IpAddressMatcher[127.0.0.1]");
+	}
 
 }


### PR DESCRIPTION
Closes gh-16795

Implemented the toString method based on gh-16795.

In the future, if getHostAddress() or getMaskBits() methods are introduced, the internal logic of toString may be updated to use those methods.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
