### PR TITLE
Add mapping for DPoP in DefaultMapOAuth2AccessTokenResponseConverter

### DIFF
--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/DefaultMapOAuth2AccessTokenResponseConverter.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/DefaultMapOAuth2AccessTokenResponseConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,10 @@ public final class DefaultMapOAuth2AccessTokenResponseConverter
 		if (OAuth2AccessToken.TokenType.BEARER.getValue()
 			.equalsIgnoreCase(getParameterValue(tokenResponseParameters, OAuth2ParameterNames.TOKEN_TYPE))) {
 			return OAuth2AccessToken.TokenType.BEARER;
+		}
+		else if (OAuth2AccessToken.TokenType.DPOP.getValue()
+				.equalsIgnoreCase(getParameterValue(tokenResponseParameters, OAuth2ParameterNames.TOKEN_TYPE))) {
+			return OAuth2AccessToken.TokenType.DPOP;
 		}
 		return null;
 	}

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/DefaultMapOAuth2AccessTokenResponseConverterTests.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/endpoint/DefaultMapOAuth2AccessTokenResponseConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,6 +96,18 @@ public class DefaultMapOAuth2AccessTokenResponseConverterTests {
 		Map<String, Object> additionalParameters = converted.getAdditionalParameters();
 		assertThat(additionalParameters).isNotNull();
 		assertThat(additionalParameters).isEmpty();
+	}
+
+	@Test
+	public void shouldConvertDPoPToken() {
+		Map<String, Object> map = new HashMap<>();
+		map.put("access_token", "access-token-1234");
+		map.put("token_type", "dpop");
+		OAuth2AccessTokenResponse converted = this.messageConverter.convert(map);
+		OAuth2AccessToken accessToken = converted.getAccessToken();
+		assertThat(accessToken).isNotNull();
+		assertThat(accessToken.getTokenValue()).isEqualTo("access-token-1234");
+		assertThat(accessToken.getTokenType()).isEqualTo(OAuth2AccessToken.TokenType.DPOP);
 	}
 
 	@Test


### PR DESCRIPTION
This PR adds the missing mapping for the newly introduced  [TokenType.DPOP](https://github.com/spring-projects/spring-security/pull/16087) in [DefaultMapOAuth2AccessTokenResponseConverter](https://github.com/spring-projects/spring-security/blob/main/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/endpoint/DefaultMapOAuth2AccessTokenResponseConverter.java#L73). Without this mapping, deserializing an OAuth 2.0 Access Token Response containing a DPoP token type results in an error:
```An error occurred reading the OAuth 2.0 Access Token Response: tokenType cannot be null```

**Stacktrace** 
```
org.springframework.web.client.RestClientException: Error while extracting response for type [org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse] and content type [application/json;charset=UTF-8]
	at org.springframework.web.client.DefaultRestClient.readWithMessageConverters(DefaultRestClient.java:261) ~[spring-web-6.2.5.jar:6.2.5]
	at org.springframework.web.client.DefaultRestClient$DefaultResponseSpec.readBody(DefaultRestClient.java:814) ~[spring-web-6.2.5.jar:6.2.5]
	at org.springframework.web.client.DefaultRestClient$DefaultResponseSpec.lambda$body$0(DefaultRestClient.java:745) ~[spring-web-6.2.5.jar:6.2.5]
	at org.springframework.web.client.DefaultRestClient$DefaultRequestBodyUriSpec.exchangeInternal(DefaultRestClient.java:574) ~[spring-web-6.2.5.jar:6.2.5]
	at org.springframework.web.client.DefaultRestClient$DefaultRequestBodyUriSpec.exchange(DefaultRestClient.java:535) ~[spring-web-6.2.5.jar:6.2.5]
	at org.springframework.web.client.RestClient$RequestHeadersSpec.exchange(RestClient.java:677) ~[spring-web-6.2.5.jar:6.2.5]
	at org.springframework.web.client.DefaultRestClient$DefaultResponseSpec.executeAndExtract(DefaultRestClient.java:809) ~[spring-web-6.2.5.jar:6.2.5]
	at org.springframework.web.client.DefaultRestClient$DefaultResponseSpec.body(DefaultRestClient.java:745) ~[spring-web-6.2.5.jar:6.2.5]
	at org.springframework.security.oauth2.client.endpoint.AbstractRestClientOAuth2AccessTokenResponseClient.getTokenResponse(AbstractRestClientOAuth2AccessTokenResponseClient.java:94) ~[spring-security-oauth2-client-6.5.0-M3.jar:6.5.0-M3]
	... 25 common frames omitted
Caused by: org.springframework.http.converter.HttpMessageNotReadableException: An error occurred reading the OAuth 2.0 Access Token Response: tokenType cannot be null
	at org.springframework.security.oauth2.core.http.converter.OAuth2AccessTokenResponseHttpMessageConverter.readInternal(OAuth2AccessTokenResponseHttpMessageConverter.java:81) ~[spring-security-oauth2-core-6.5.0-M3.jar:6.5.0-M3]
	at org.springframework.security.oauth2.core.http.converter.OAuth2AccessTokenResponseHttpMessageConverter.readInternal(OAuth2AccessTokenResponseHttpMessageConverter.java:47) ~[spring-security-oauth2-core-6.5.0-M3.jar:6.5.0-M3]
	at org.springframework.http.converter.AbstractHttpMessageConverter.read(AbstractHttpMessageConverter.java:198) ~[spring-web-6.2.5.jar:6.2.5]
	at org.springframework.web.client.DefaultRestClient.readWithMessageConverters(DefaultRestClient.java:244) ~[spring-web-6.2.5.jar:6.2.5]
	... 33 common frames omitted
Caused by: java.lang.IllegalArgumentException: tokenType cannot be null
	at org.springframework.util.Assert.notNull(Assert.java:181) ~[spring-core-6.2.5.jar:6.2.5]
	at org.springframework.security.oauth2.core.OAuth2AccessToken.<init>(OAuth2AccessToken.java:76) ~[spring-security-oauth2-core-6.5.0-M3.jar:6.5.0-M3]
	at org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse$Builder.build(OAuth2AccessTokenResponse.java:191) ~[spring-security-oauth2-core-6.5.0-M3.jar:na]
	at org.springframework.security.oauth2.core.endpoint.DefaultMapOAuth2AccessTokenResponseConverter.convert(DefaultMapOAuth2AccessTokenResponseConverter.java:64) ~[classes/:na]
	at org.springframework.security.oauth2.core.endpoint.DefaultMapOAuth2AccessTokenResponseConverter.convert(DefaultMapOAuth2AccessTokenResponseConverter.java:37) ~[classes/:na]
	at org.springframework.security.oauth2.core.http.converter.OAuth2AccessTokenResponseHttpMessageConverter.readInternal(OAuth2AccessTokenResponseHttpMessageConverter.java:77) ~[spring-security-oauth2-core-6.5.0-M3.jar:6.5.0-M3]
	... 36 common frames omitted
```	

