### PR TITLE
Update WebAuthn Test Objects Class Names #16604

### DIFF
--- a/config/src/test/java/org/springframework/security/SpringSecurityCoreVersionSerializableTests.java
+++ b/config/src/test/java/org/springframework/security/SpringSecurityCoreVersionSerializableTests.java
@@ -239,9 +239,9 @@ import org.springframework.security.web.webauthn.api.PublicKeyCredentialType;
 import org.springframework.security.web.webauthn.api.PublicKeyCredentialUserEntity;
 import org.springframework.security.web.webauthn.api.TestAuthenticationAssertionResponses;
 import org.springframework.security.web.webauthn.api.TestBytes;
-import org.springframework.security.web.webauthn.api.TestPublicKeyCredential;
 import org.springframework.security.web.webauthn.api.TestPublicKeyCredentialRequestOptions;
-import org.springframework.security.web.webauthn.api.TestPublicKeyCredentialUserEntity;
+import org.springframework.security.web.webauthn.api.TestPublicKeyCredentialUserEntities;
+import org.springframework.security.web.webauthn.api.TestPublicKeyCredentials;
 import org.springframework.security.web.webauthn.api.UserVerificationRequirement;
 import org.springframework.security.web.webauthn.authentication.WebAuthnAuthentication;
 import org.springframework.security.web.webauthn.authentication.WebAuthnAuthenticationRequestToken;
@@ -640,7 +640,7 @@ class SpringSecurityCoreVersionSerializableTests {
 		AuthenticationExtensionsClientOutputs outputs = new ImmutableAuthenticationExtensionsClientOutputs(credentialOutput);
 		AuthenticatorAssertionResponse response = TestAuthenticationAssertionResponses.createAuthenticatorAssertionResponse()
 				.build();
-		PublicKeyCredential<AuthenticatorAssertionResponse> credential = TestPublicKeyCredential.createPublicKeyCredential(
+		PublicKeyCredential<AuthenticatorAssertionResponse> credential = TestPublicKeyCredentials.createPublicKeyCredential(
 				response, outputs)
 				.build();
 		RelyingPartyAuthenticationRequest authRequest = new RelyingPartyAuthenticationRequest(
@@ -658,9 +658,9 @@ class SpringSecurityCoreVersionSerializableTests {
 		generatorByClassName.put(AuthenticatorAttachment.class, (r) -> AuthenticatorAttachment.PLATFORM);
 		// @formatter:on
 		generatorByClassName.put(ImmutablePublicKeyCredentialUserEntity.class,
-				(r) -> TestPublicKeyCredentialUserEntity.userEntity().id(TestBytes.get()).build());
+				(r) -> TestPublicKeyCredentialUserEntities.userEntity().id(TestBytes.get()).build());
 		generatorByClassName.put(WebAuthnAuthentication.class, (r) -> {
-			PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntity.userEntity()
+			PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntities.userEntity()
 				.id(TestBytes.get())
 				.build();
 			List<GrantedAuthority> authorities = AuthorityUtils.createAuthorityList("ROLE_USER");

--- a/web/src/test/java/org/springframework/security/web/webauthn/api/TestAuthenticatorAttestationResponses.java
+++ b/web/src/test/java/org/springframework/security/web/webauthn/api/TestAuthenticatorAttestationResponses.java
@@ -16,7 +16,7 @@
 
 package org.springframework.security.web.webauthn.api;
 
-public final class TestAuthenticatorAttestationResponse {
+public final class TestAuthenticatorAttestationResponses {
 
 	public static AuthenticatorAttestationResponse.AuthenticatorAttestationResponseBuilder createAuthenticatorAttestationResponse() {
 		return AuthenticatorAttestationResponse.builder()
@@ -27,7 +27,7 @@ public final class TestAuthenticatorAttestationResponse {
 			.transports(AuthenticatorTransport.HYBRID, AuthenticatorTransport.INTERNAL);
 	}
 
-	private TestAuthenticatorAttestationResponse() {
+	private TestAuthenticatorAttestationResponses() {
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/webauthn/api/TestCredentialRecords.java
+++ b/web/src/test/java/org/springframework/security/web/webauthn/api/TestCredentialRecords.java
@@ -19,7 +19,7 @@ package org.springframework.security.web.webauthn.api;
 import java.time.Instant;
 import java.util.Set;
 
-public final class TestCredentialRecord {
+public final class TestCredentialRecords {
 
 	public static ImmutableCredentialRecord.ImmutableCredentialRecordBuilder userCredential() {
 		return ImmutableCredentialRecord.builder()
@@ -50,7 +50,7 @@ public final class TestCredentialRecord {
 			.backupState(true);
 	}
 
-	private TestCredentialRecord() {
+	private TestCredentialRecords() {
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/webauthn/api/TestPublicKeyCredentialUserEntities.java
+++ b/web/src/test/java/org/springframework/security/web/webauthn/api/TestPublicKeyCredentialUserEntities.java
@@ -18,13 +18,13 @@ package org.springframework.security.web.webauthn.api;
 
 import org.springframework.security.web.webauthn.api.ImmutablePublicKeyCredentialUserEntity.PublicKeyCredentialUserEntityBuilder;
 
-public final class TestPublicKeyCredentialUserEntity {
+public final class TestPublicKeyCredentialUserEntities {
 
 	public static PublicKeyCredentialUserEntityBuilder userEntity() {
 		return ImmutablePublicKeyCredentialUserEntity.builder().name("user").id(TestBytes.get()).displayName("user");
 	}
 
-	private TestPublicKeyCredentialUserEntity() {
+	private TestPublicKeyCredentialUserEntities() {
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/webauthn/api/TestPublicKeyCredentials.java
+++ b/web/src/test/java/org/springframework/security/web/webauthn/api/TestPublicKeyCredentials.java
@@ -16,10 +16,10 @@
 
 package org.springframework.security.web.webauthn.api;
 
-public final class TestPublicKeyCredential {
+public final class TestPublicKeyCredentials {
 
 	public static PublicKeyCredential.PublicKeyCredentialBuilder<AuthenticatorAttestationResponse> createPublicKeyCredential() {
-		AuthenticatorAttestationResponse response = TestAuthenticatorAttestationResponse
+		AuthenticatorAttestationResponse response = TestAuthenticatorAttestationResponses
 			.createAuthenticatorAttestationResponse()
 			.build();
 		return createPublicKeyCredential(response);
@@ -49,7 +49,7 @@ public final class TestPublicKeyCredential {
 			.clientExtensionResults(outputs);
 	}
 
-	private TestPublicKeyCredential() {
+	private TestPublicKeyCredentials() {
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/webauthn/authentication/WebAuthnAuthenticationFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/webauthn/authentication/WebAuthnAuthenticationFilterTests.java
@@ -39,7 +39,7 @@ import org.springframework.security.web.webauthn.api.PublicKeyCredential;
 import org.springframework.security.web.webauthn.api.PublicKeyCredentialRequestOptions;
 import org.springframework.security.web.webauthn.api.PublicKeyCredentialUserEntity;
 import org.springframework.security.web.webauthn.api.TestPublicKeyCredentialRequestOptions;
-import org.springframework.security.web.webauthn.api.TestPublicKeyCredentialUserEntity;
+import org.springframework.security.web.webauthn.api.TestPublicKeyCredentialUserEntities;
 import org.springframework.security.web.webauthn.management.RelyingPartyAuthenticationRequest;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -153,7 +153,7 @@ class WebAuthnAuthenticationFilterTests {
 	void doFilterWhenValidThenOk() throws Exception {
 		PublicKeyCredentialRequestOptions options = TestPublicKeyCredentialRequestOptions.create().build();
 		given(this.requestOptionsRepository.load(any())).willReturn(options);
-		PublicKeyCredentialUserEntity principal = TestPublicKeyCredentialUserEntity.userEntity().build();
+		PublicKeyCredentialUserEntity principal = TestPublicKeyCredentialUserEntities.userEntity().build();
 		WebAuthnAuthentication authentication = new WebAuthnAuthentication(principal,
 				AuthorityUtils.createAuthorityList("ROLE_USER"));
 		given(this.authenticationManager.authenticate(any())).willReturn(authentication);

--- a/web/src/test/java/org/springframework/security/web/webauthn/authentication/WebAuthnAuthenticationTests.java
+++ b/web/src/test/java/org/springframework/security/web/webauthn/authentication/WebAuthnAuthenticationTests.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.web.webauthn.api.PublicKeyCredentialUserEntity;
-import org.springframework.security.web.webauthn.api.TestPublicKeyCredentialUserEntity;
+import org.springframework.security.web.webauthn.api.TestPublicKeyCredentialUserEntities;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -32,7 +32,7 @@ class WebAuthnAuthenticationTests {
 
 	@Test
 	void isAuthenticatedThenTrue() {
-		PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntity.userEntity().build();
+		PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntities.userEntity().build();
 		List<GrantedAuthority> authorities = AuthorityUtils.createAuthorityList("ROLE_USER");
 		WebAuthnAuthentication authentication = new WebAuthnAuthentication(userEntity, authorities);
 		assertThat(authentication.isAuthenticated()).isTrue();
@@ -40,7 +40,7 @@ class WebAuthnAuthenticationTests {
 
 	@Test
 	void setAuthenticationWhenTrueThenException() {
-		PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntity.userEntity().build();
+		PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntities.userEntity().build();
 		List<GrantedAuthority> authorities = AuthorityUtils.createAuthorityList("ROLE_USER");
 		WebAuthnAuthentication authentication = new WebAuthnAuthentication(userEntity, authorities);
 		assertThatIllegalArgumentException().isThrownBy(() -> authentication.setAuthenticated(true));
@@ -48,7 +48,7 @@ class WebAuthnAuthenticationTests {
 
 	@Test
 	void setAuthenticationWhenFalseThenNotAuthenticated() {
-		PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntity.userEntity().build();
+		PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntities.userEntity().build();
 		List<GrantedAuthority> authorities = AuthorityUtils.createAuthorityList("ROLE_USER");
 		WebAuthnAuthentication authentication = new WebAuthnAuthentication(userEntity, authorities);
 		authentication.setAuthenticated(false);

--- a/web/src/test/java/org/springframework/security/web/webauthn/management/JdbcPublicKeyCredentialUserEntityRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/webauthn/management/JdbcPublicKeyCredentialUserEntityRepositoryTests.java
@@ -28,7 +28,7 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 import org.springframework.security.web.webauthn.api.Bytes;
 import org.springframework.security.web.webauthn.api.ImmutablePublicKeyCredentialUserEntity;
 import org.springframework.security.web.webauthn.api.PublicKeyCredentialUserEntity;
-import org.springframework.security.web.webauthn.api.TestPublicKeyCredentialUserEntity;
+import org.springframework.security.web.webauthn.api.TestPublicKeyCredentialUserEntities;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -107,7 +107,7 @@ public class JdbcPublicKeyCredentialUserEntityRepositoryTests {
 
 	@Test
 	void saveUserEntityWhenSaveThenReturnsSaved() {
-		PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntity.userEntity().build();
+		PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntities.userEntity().build();
 
 		this.repository.save(userEntity);
 
@@ -120,7 +120,7 @@ public class JdbcPublicKeyCredentialUserEntityRepositoryTests {
 
 	@Test
 	void saveUserEntityWhenUserEntityExistsThenUpdates() {
-		PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntity.userEntity().build();
+		PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntities.userEntity().build();
 		this.repository.save(userEntity);
 
 		this.repository.save(testUserEntity(userEntity.getId()));
@@ -134,7 +134,7 @@ public class JdbcPublicKeyCredentialUserEntityRepositoryTests {
 
 	@Test
 	void findUserEntityByUserNameWhenUserEntityExistsThenReturnsSaved() {
-		PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntity.userEntity().build();
+		PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntities.userEntity().build();
 		this.repository.save(userEntity);
 
 		PublicKeyCredentialUserEntity savedUserEntity = this.repository.findByUsername(userEntity.getName());
@@ -144,7 +144,7 @@ public class JdbcPublicKeyCredentialUserEntityRepositoryTests {
 
 	@Test
 	void deleteUserEntityWhenRecordExistThenSuccess() {
-		PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntity.userEntity().build();
+		PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntities.userEntity().build();
 		this.repository.save(userEntity);
 
 		this.repository.delete(userEntity.getId());
@@ -155,7 +155,7 @@ public class JdbcPublicKeyCredentialUserEntityRepositoryTests {
 
 	@Test
 	void findUserEntityByIdWhenUserEntityDoesNotExistThenReturnsNull() {
-		PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntity.userEntity().build();
+		PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntities.userEntity().build();
 
 		PublicKeyCredentialUserEntity savedUserEntity = this.repository.findById(userEntity.getId());
 		assertThat(savedUserEntity).isNull();
@@ -163,7 +163,7 @@ public class JdbcPublicKeyCredentialUserEntityRepositoryTests {
 
 	@Test
 	void findUserEntityByUserNameWhenUserEntityDoesNotExistThenReturnsEmpty() {
-		PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntity.userEntity().build();
+		PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntities.userEntity().build();
 
 		PublicKeyCredentialUserEntity savedUserEntity = this.repository.findByUsername(userEntity.getName());
 		assertThat(savedUserEntity).isNull();

--- a/web/src/test/java/org/springframework/security/web/webauthn/management/JdbcUserCredentialRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/webauthn/management/JdbcUserCredentialRepositoryTests.java
@@ -31,7 +31,7 @@ import org.springframework.security.web.webauthn.api.AuthenticatorTransport;
 import org.springframework.security.web.webauthn.api.CredentialRecord;
 import org.springframework.security.web.webauthn.api.ImmutableCredentialRecord;
 import org.springframework.security.web.webauthn.api.PublicKeyCredentialType;
-import org.springframework.security.web.webauthn.api.TestCredentialRecord;
+import org.springframework.security.web.webauthn.api.TestCredentialRecords;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -110,7 +110,7 @@ public class JdbcUserCredentialRepositoryTests {
 
 	@Test
 	void saveCredentialRecordWhenSaveThenReturnsSaved() {
-		CredentialRecord userCredential = TestCredentialRecord.fullUserCredential().build();
+		CredentialRecord userCredential = TestCredentialRecords.fullUserCredential().build();
 		this.jdbcUserCredentialRepository.save(userCredential);
 
 		CredentialRecord savedUserCredential = this.jdbcUserCredentialRepository
@@ -136,7 +136,7 @@ public class JdbcUserCredentialRepositoryTests {
 
 	@Test
 	void saveCredentialRecordWhenRecordExistsThenReturnsUpdated() {
-		CredentialRecord userCredential = TestCredentialRecord.fullUserCredential().build();
+		CredentialRecord userCredential = TestCredentialRecords.fullUserCredential().build();
 		this.jdbcUserCredentialRepository.save(userCredential);
 		// @formatter:off
 		CredentialRecord updatedRecord = ImmutableCredentialRecord.fromCredentialRecord(userCredential)
@@ -157,7 +157,7 @@ public class JdbcUserCredentialRepositoryTests {
 
 	@Test
 	void findCredentialRecordByUserIdWhenRecordExistsThenReturnsSaved() {
-		CredentialRecord userCredential = TestCredentialRecord.fullUserCredential().build();
+		CredentialRecord userCredential = TestCredentialRecords.fullUserCredential().build();
 		this.jdbcUserCredentialRepository.save(userCredential);
 
 		List<CredentialRecord> credentialRecords = this.jdbcUserCredentialRepository
@@ -169,7 +169,7 @@ public class JdbcUserCredentialRepositoryTests {
 
 	@Test
 	void findCredentialRecordByUserIdWhenRecordDoesNotExistThenReturnsEmpty() {
-		CredentialRecord userCredential = TestCredentialRecord.fullUserCredential().build();
+		CredentialRecord userCredential = TestCredentialRecords.fullUserCredential().build();
 
 		List<CredentialRecord> credentialRecords = this.jdbcUserCredentialRepository
 			.findByUserId(userCredential.getUserEntityUserId());
@@ -179,7 +179,7 @@ public class JdbcUserCredentialRepositoryTests {
 
 	@Test
 	void findCredentialRecordByCredentialIdWhenRecordDoesNotExistThenReturnsNull() {
-		CredentialRecord userCredential = TestCredentialRecord.fullUserCredential().build();
+		CredentialRecord userCredential = TestCredentialRecords.fullUserCredential().build();
 
 		CredentialRecord credentialRecord = this.jdbcUserCredentialRepository
 			.findByCredentialId(userCredential.getCredentialId());
@@ -189,7 +189,7 @@ public class JdbcUserCredentialRepositoryTests {
 
 	@Test
 	void deleteCredentialRecordWhenRecordExistThenSuccess() {
-		CredentialRecord userCredential = TestCredentialRecord.fullUserCredential().build();
+		CredentialRecord userCredential = TestCredentialRecords.fullUserCredential().build();
 		this.jdbcUserCredentialRepository.save(userCredential);
 
 		this.jdbcUserCredentialRepository.delete(userCredential.getCredentialId());

--- a/web/src/test/java/org/springframework/security/web/webauthn/management/MapPublicKeyCredentialUserEntityRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/webauthn/management/MapPublicKeyCredentialUserEntityRepositoryTests.java
@@ -19,7 +19,7 @@ package org.springframework.security.web.webauthn.management;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.security.web.webauthn.api.PublicKeyCredentialUserEntity;
-import org.springframework.security.web.webauthn.api.TestPublicKeyCredentialUserEntity;
+import org.springframework.security.web.webauthn.api.TestPublicKeyCredentialUserEntities;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -36,7 +36,7 @@ class MapPublicKeyCredentialUserEntityRepositoryTests {
 
 	private String username = "username";
 
-	private PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntity.userEntity()
+	private PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntities.userEntity()
 		.name(this.username)
 		.build();
 
@@ -75,7 +75,7 @@ class MapPublicKeyCredentialUserEntityRepositoryTests {
 
 	@Test
 	void saveWhenUpdateThenUpdated() {
-		PublicKeyCredentialUserEntity newUserEntity = TestPublicKeyCredentialUserEntity.userEntity()
+		PublicKeyCredentialUserEntity newUserEntity = TestPublicKeyCredentialUserEntities.userEntity()
 			.name(this.userEntity.getName())
 			.displayName("Updated")
 			.build();

--- a/web/src/test/java/org/springframework/security/web/webauthn/management/MapUserCredentialRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/webauthn/management/MapUserCredentialRepositoryTests.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.security.web.webauthn.api.CredentialRecord;
 import org.springframework.security.web.webauthn.api.ImmutableCredentialRecord;
 import org.springframework.security.web.webauthn.api.TestBytes;
-import org.springframework.security.web.webauthn.api.TestCredentialRecord;
+import org.springframework.security.web.webauthn.api.TestCredentialRecords;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -61,7 +61,7 @@ class MapUserCredentialRepositoryTests {
 
 	@Test
 	void deleteWhenCredentialNotFoundThenNoException() {
-		ImmutableCredentialRecord credentialRecord = TestCredentialRecord.userCredential().build();
+		ImmutableCredentialRecord credentialRecord = TestCredentialRecords.userCredential().build();
 		assertThatNoException().isThrownBy(() -> this.userCredentials.delete(credentialRecord.getCredentialId()));
 	}
 
@@ -72,7 +72,7 @@ class MapUserCredentialRepositoryTests {
 
 	@Test
 	void saveThenFound() {
-		ImmutableCredentialRecord credentialRecord = TestCredentialRecord.userCredential().build();
+		ImmutableCredentialRecord credentialRecord = TestCredentialRecords.userCredential().build();
 		this.userCredentials.save(credentialRecord);
 		assertThat(this.userCredentials.findByCredentialId(credentialRecord.getCredentialId()))
 			.isEqualTo(credentialRecord);
@@ -87,7 +87,7 @@ class MapUserCredentialRepositoryTests {
 
 	@Test
 	void saveAndDeleteThenNotFound() {
-		ImmutableCredentialRecord credentialRecord = TestCredentialRecord.userCredential().build();
+		ImmutableCredentialRecord credentialRecord = TestCredentialRecords.userCredential().build();
 		this.userCredentials.save(credentialRecord);
 		this.userCredentials.delete(credentialRecord.getCredentialId());
 		assertThat(this.userCredentials.findByCredentialId(credentialRecord.getCredentialId())).isNull();
@@ -96,7 +96,7 @@ class MapUserCredentialRepositoryTests {
 
 	@Test
 	void saveWhenUpdateThenUpdated() {
-		ImmutableCredentialRecord credentialRecord = TestCredentialRecord.userCredential().build();
+		ImmutableCredentialRecord credentialRecord = TestCredentialRecords.userCredential().build();
 		this.userCredentials.save(credentialRecord);
 		Instant updatedLastUsed = credentialRecord.getLastUsed().plusSeconds(120);
 		CredentialRecord updatedCredentialRecord = ImmutableCredentialRecord.fromCredentialRecord(credentialRecord)
@@ -111,7 +111,7 @@ class MapUserCredentialRepositoryTests {
 
 	@Test
 	void saveWhenSameUserThenUpdated() {
-		ImmutableCredentialRecord credentialRecord = TestCredentialRecord.userCredential().build();
+		ImmutableCredentialRecord credentialRecord = TestCredentialRecords.userCredential().build();
 		this.userCredentials.save(credentialRecord);
 		CredentialRecord newCredentialRecord = ImmutableCredentialRecord.fromCredentialRecord(credentialRecord)
 			.credentialId(TestBytes.get())
@@ -127,7 +127,7 @@ class MapUserCredentialRepositoryTests {
 
 	@Test
 	void saveWhenDifferentUserThenNewEntryAdded() {
-		ImmutableCredentialRecord credentialRecord = TestCredentialRecord.userCredential().build();
+		ImmutableCredentialRecord credentialRecord = TestCredentialRecords.userCredential().build();
 		this.userCredentials.save(credentialRecord);
 		CredentialRecord newCredentialRecord = ImmutableCredentialRecord.fromCredentialRecord(credentialRecord)
 			.userEntityUserId(TestBytes.get())

--- a/web/src/test/java/org/springframework/security/web/webauthn/management/TestPublicKeyCredentialRpEntities.java
+++ b/web/src/test/java/org/springframework/security/web/webauthn/management/TestPublicKeyCredentialRpEntities.java
@@ -18,13 +18,13 @@ package org.springframework.security.web.webauthn.management;
 
 import org.springframework.security.web.webauthn.api.PublicKeyCredentialRpEntity;
 
-public final class TestPublicKeyCredentialRpEntity {
+public final class TestPublicKeyCredentialRpEntities {
 
 	public static PublicKeyCredentialRpEntity.PublicKeyCredentialRpEntityBuilder createRpEntity() {
 		return PublicKeyCredentialRpEntity.builder().id("example.localhost").name("Spring Security Relying Party");
 	}
 
-	private TestPublicKeyCredentialRpEntity() {
+	private TestPublicKeyCredentialRpEntities() {
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/webauthn/management/Webauthn4jRelyingPartyOperationsTests.java
+++ b/web/src/test/java/org/springframework/security/web/webauthn/management/Webauthn4jRelyingPartyOperationsTests.java
@@ -55,11 +55,11 @@ import org.springframework.security.web.webauthn.api.PublicKeyCredentialParamete
 import org.springframework.security.web.webauthn.api.PublicKeyCredentialRequestOptions;
 import org.springframework.security.web.webauthn.api.PublicKeyCredentialRpEntity;
 import org.springframework.security.web.webauthn.api.PublicKeyCredentialUserEntity;
-import org.springframework.security.web.webauthn.api.TestAuthenticatorAttestationResponse;
-import org.springframework.security.web.webauthn.api.TestCredentialRecord;
-import org.springframework.security.web.webauthn.api.TestPublicKeyCredential;
+import org.springframework.security.web.webauthn.api.TestAuthenticatorAttestationResponses;
+import org.springframework.security.web.webauthn.api.TestCredentialRecords;
 import org.springframework.security.web.webauthn.api.TestPublicKeyCredentialCreationOptions;
-import org.springframework.security.web.webauthn.api.TestPublicKeyCredentialUserEntity;
+import org.springframework.security.web.webauthn.api.TestPublicKeyCredentialUserEntities;
+import org.springframework.security.web.webauthn.api.TestPublicKeyCredentials;
 import org.springframework.security.web.webauthn.api.UserVerificationRequirement;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -90,7 +90,7 @@ class Webauthn4jRelyingPartyOperationsTests {
 	private UsernamePasswordAuthenticationToken user = new UsernamePasswordAuthenticationToken("user", "password",
 			AuthorityUtils.createAuthorityList("ROLE_USER"));
 
-	private PublicKeyCredentialRpEntity rpEntity = TestPublicKeyCredentialRpEntity.createRpEntity().build();
+	private PublicKeyCredentialRpEntity rpEntity = TestPublicKeyCredentialRpEntities.createRpEntity().build();
 
 	private Webauthn4JRelyingPartyOperations rpOperations;
 
@@ -155,7 +155,7 @@ class Webauthn4jRelyingPartyOperationsTests {
 		PublicKeyCredentialCreationOptions expectedCreationOptions = TestPublicKeyCredentialCreationOptions
 			.createPublicKeyCredentialCreationOptions()
 			.rp(this.rpEntity)
-			.user(TestPublicKeyCredentialUserEntity.userEntity().build())
+			.user(TestPublicKeyCredentialUserEntities.userEntity().build())
 			.build();
 		PublicKeyCredentialCreationOptions creationOptions = this.rpOperations.createPublicKeyCredentialCreationOptions(
 				new ImmutablePublicKeyCredentialCreationOptionsRequest(this.user));
@@ -202,8 +202,8 @@ class Webauthn4jRelyingPartyOperationsTests {
 
 	@Test
 	void createPublicKeyCredentialCreationOptionsWhenExcludesThenSuccess() {
-		PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntity.userEntity().build();
-		CredentialRecord credentialRecord = TestCredentialRecord.userCredential().build();
+		PublicKeyCredentialUserEntity userEntity = TestPublicKeyCredentialUserEntities.userEntity().build();
+		CredentialRecord credentialRecord = TestCredentialRecords.userCredential().build();
 		PublicKeyCredentialDescriptor descriptor = PublicKeyCredentialDescriptor.builder()
 			.id(credentialRecord.getCredentialId())
 			.transports(credentialRecord.getTransports())
@@ -230,7 +230,7 @@ class Webauthn4jRelyingPartyOperationsTests {
 		PublicKeyCredentialCreationOptions creationOptions = TestPublicKeyCredentialCreationOptions
 			.createPublicKeyCredentialCreationOptions()
 			.build();
-		PublicKeyCredential<AuthenticatorAttestationResponse> publicKeyCredential = TestPublicKeyCredential
+		PublicKeyCredential<AuthenticatorAttestationResponse> publicKeyCredential = TestPublicKeyCredentials
 			.createPublicKeyCredential()
 			.build();
 		RelyingPartyPublicKey rpPublicKey = new RelyingPartyPublicKey(publicKeyCredential, this.label);
@@ -249,11 +249,11 @@ class Webauthn4jRelyingPartyOperationsTests {
 		PublicKeyCredentialCreationOptions creationOptions = TestPublicKeyCredentialCreationOptions
 			.createPublicKeyCredentialCreationOptions()
 			.build();
-		AuthenticatorAttestationResponse response = TestAuthenticatorAttestationResponse
+		AuthenticatorAttestationResponse response = TestAuthenticatorAttestationResponses
 			.createAuthenticatorAttestationResponse()
 			.transports(AuthenticatorTransport.INTERNAL)
 			.build();
-		PublicKeyCredential<AuthenticatorAttestationResponse> publicKeyCredential = TestPublicKeyCredential
+		PublicKeyCredential<AuthenticatorAttestationResponse> publicKeyCredential = TestPublicKeyCredentials
 			.createPublicKeyCredential()
 			.response(response)
 			.build();
@@ -271,7 +271,7 @@ class Webauthn4jRelyingPartyOperationsTests {
 		PublicKeyCredentialCreationOptions creationOptions = TestPublicKeyCredentialCreationOptions
 			.createPublicKeyCredentialCreationOptions()
 			.build();
-		PublicKeyCredential<AuthenticatorAttestationResponse> publicKeyCredential = TestPublicKeyCredential
+		PublicKeyCredential<AuthenticatorAttestationResponse> publicKeyCredential = TestPublicKeyCredentials
 			.createPublicKeyCredential()
 			.build();
 		RelyingPartyPublicKey rpPublicKey = new RelyingPartyPublicKey(publicKeyCredential, this.label);
@@ -279,7 +279,7 @@ class Webauthn4jRelyingPartyOperationsTests {
 		ImmutableRelyingPartyRegistrationRequest rpRegistrationRequest = new ImmutableRelyingPartyRegistrationRequest(
 				creationOptions, rpPublicKey);
 		given(this.userCredentials.findByCredentialId(publicKeyCredential.getRawId()))
-			.willReturn(TestCredentialRecord.userCredential().build());
+			.willReturn(TestCredentialRecords.userCredential().build());
 		assertThatRuntimeException().isThrownBy(() -> this.rpOperations.registerCredential(rpRegistrationRequest));
 	}
 
@@ -294,15 +294,16 @@ class Webauthn4jRelyingPartyOperationsTests {
 			.createPublicKeyCredentialCreationOptions()
 			.build();
 		String originalClientDataJSON = new String(
-				TestAuthenticatorAttestationResponse.createAuthenticatorAttestationResponse()
+				TestAuthenticatorAttestationResponses.createAuthenticatorAttestationResponse()
 					.build()
 					.getClientDataJSON()
 					.getBytes());
 		String invalidTypeClientDataJSON = originalClientDataJSON.replace("webauthn.create", "webauthn.INVALID");
-		AuthenticatorAttestationResponseBuilder responseBldr = TestAuthenticatorAttestationResponse
+		AuthenticatorAttestationResponseBuilder responseBldr = TestAuthenticatorAttestationResponses
 			.createAuthenticatorAttestationResponse()
 			.clientDataJSON(new Bytes(invalidTypeClientDataJSON.getBytes(StandardCharsets.UTF_8)));
-		PublicKeyCredential publicKey = TestPublicKeyCredential.createPublicKeyCredential(responseBldr.build()).build();
+		PublicKeyCredential publicKey = TestPublicKeyCredentials.createPublicKeyCredential(responseBldr.build())
+			.build();
 		ImmutableRelyingPartyRegistrationRequest registrationRequest = new ImmutableRelyingPartyRegistrationRequest(
 				options, new RelyingPartyPublicKey(publicKey, this.label));
 		assertThatRuntimeException().isThrownBy(() -> this.rpOperations.registerCredential(registrationRequest))
@@ -322,9 +323,10 @@ class Webauthn4jRelyingPartyOperationsTests {
 			// change the expected challenge so it does not match
 			.challenge(Bytes.fromBase64("h0vgwGQjoCzAzDUsmzPpk-JVIJRRgn0L4KVSYNRcEZc"))
 			.build();
-		AuthenticatorAttestationResponseBuilder responseBldr = TestAuthenticatorAttestationResponse
+		AuthenticatorAttestationResponseBuilder responseBldr = TestAuthenticatorAttestationResponses
 			.createAuthenticatorAttestationResponse();
-		PublicKeyCredential publicKey = TestPublicKeyCredential.createPublicKeyCredential(responseBldr.build()).build();
+		PublicKeyCredential publicKey = TestPublicKeyCredentials.createPublicKeyCredential(responseBldr.build())
+			.build();
 		ImmutableRelyingPartyRegistrationRequest registrationRequest = new ImmutableRelyingPartyRegistrationRequest(
 				options, new RelyingPartyPublicKey(publicKey, this.label));
 
@@ -345,9 +347,10 @@ class Webauthn4jRelyingPartyOperationsTests {
 		PublicKeyCredentialCreationOptions options = TestPublicKeyCredentialCreationOptions
 			.createPublicKeyCredentialCreationOptions()
 			.build();
-		AuthenticatorAttestationResponseBuilder responseBldr = TestAuthenticatorAttestationResponse
+		AuthenticatorAttestationResponseBuilder responseBldr = TestAuthenticatorAttestationResponses
 			.createAuthenticatorAttestationResponse();
-		PublicKeyCredential publicKey = TestPublicKeyCredential.createPublicKeyCredential(responseBldr.build()).build();
+		PublicKeyCredential publicKey = TestPublicKeyCredentials.createPublicKeyCredential(responseBldr.build())
+			.build();
 		ImmutableRelyingPartyRegistrationRequest registrationRequest = new ImmutableRelyingPartyRegistrationRequest(
 				options, new RelyingPartyPublicKey(publicKey, this.label));
 
@@ -370,9 +373,10 @@ class Webauthn4jRelyingPartyOperationsTests {
 			.createPublicKeyCredentialCreationOptions()
 			.rp(PublicKeyCredentialRpEntity.builder().id("invalid").name("Spring Security").build())
 			.build();
-		AuthenticatorAttestationResponseBuilder responseBldr = TestAuthenticatorAttestationResponse
+		AuthenticatorAttestationResponseBuilder responseBldr = TestAuthenticatorAttestationResponses
 			.createAuthenticatorAttestationResponse();
-		PublicKeyCredential publicKey = TestPublicKeyCredential.createPublicKeyCredential(responseBldr.build()).build();
+		PublicKeyCredential publicKey = TestPublicKeyCredentials.createPublicKeyCredential(responseBldr.build())
+			.build();
 		ImmutableRelyingPartyRegistrationRequest registrationRequest = new ImmutableRelyingPartyRegistrationRequest(
 				options, new RelyingPartyPublicKey(publicKey, this.label));
 
@@ -391,7 +395,7 @@ class Webauthn4jRelyingPartyOperationsTests {
 			.createPublicKeyCredentialCreationOptions()
 			.build();
 
-		PublicKeyCredential publicKey = TestPublicKeyCredential.createPublicKeyCredential(setFlag(UP)).build();
+		PublicKeyCredential publicKey = TestPublicKeyCredentials.createPublicKeyCredential(setFlag(UP)).build();
 		ImmutableRelyingPartyRegistrationRequest registrationRequest = new ImmutableRelyingPartyRegistrationRequest(
 				options, new RelyingPartyPublicKey(publicKey, this.label));
 
@@ -413,7 +417,7 @@ class Webauthn4jRelyingPartyOperationsTests {
 				.userVerification(UserVerificationRequirement.REQUIRED)
 				.build())
 			.build();
-		PublicKeyCredential publicKey = TestPublicKeyCredential.createPublicKeyCredential(setFlag(UV)).build();
+		PublicKeyCredential publicKey = TestPublicKeyCredentials.createPublicKeyCredential(setFlag(UV)).build();
 		ImmutableRelyingPartyRegistrationRequest registrationRequest = new ImmutableRelyingPartyRegistrationRequest(
 				options, new RelyingPartyPublicKey(publicKey, this.label));
 
@@ -432,7 +436,7 @@ class Webauthn4jRelyingPartyOperationsTests {
 		PublicKeyCredentialCreationOptions options = TestPublicKeyCredentialCreationOptions
 			.createPublicKeyCredentialCreationOptions()
 			.build();
-		PublicKeyCredential publicKey = TestPublicKeyCredential.createPublicKeyCredential(setFlag(BE)).build();
+		PublicKeyCredential publicKey = TestPublicKeyCredentials.createPublicKeyCredential(setFlag(BE)).build();
 		ImmutableRelyingPartyRegistrationRequest registrationRequest = new ImmutableRelyingPartyRegistrationRequest(
 				options, new RelyingPartyPublicKey(publicKey, this.label));
 
@@ -475,7 +479,7 @@ class Webauthn4jRelyingPartyOperationsTests {
 			.createPublicKeyCredentialCreationOptions()
 			.pubKeyCredParams(PublicKeyCredentialParameters.RS1)
 			.build();
-		PublicKeyCredential<AuthenticatorAttestationResponse> publicKey = TestPublicKeyCredential
+		PublicKeyCredential<AuthenticatorAttestationResponse> publicKey = TestPublicKeyCredentials
 			.createPublicKeyCredential()
 			.build();
 		ImmutableRelyingPartyRegistrationRequest registrationRequest = new ImmutableRelyingPartyRegistrationRequest(
@@ -513,7 +517,7 @@ class Webauthn4jRelyingPartyOperationsTests {
 		PublicKeyCredentialCreationOptions options = TestPublicKeyCredentialCreationOptions
 			.createPublicKeyCredentialCreationOptions()
 			.build();
-		PublicKeyCredential publicKey = TestPublicKeyCredential.createPublicKeyCredential() // setFmt("packed")
+		PublicKeyCredential publicKey = TestPublicKeyCredentials.createPublicKeyCredential() // setFmt("packed")
 			.build();
 		ImmutableRelyingPartyRegistrationRequest registrationRequest = new ImmutableRelyingPartyRegistrationRequest(
 				options, new RelyingPartyPublicKey(publicKey, this.label));
@@ -537,7 +541,7 @@ class Webauthn4jRelyingPartyOperationsTests {
 	}
 
 	private static AuthenticatorAttestationResponse setFlag(byte... flags) throws Exception {
-		AuthenticatorAttestationResponseBuilder authAttResponseBldr = TestAuthenticatorAttestationResponse
+		AuthenticatorAttestationResponseBuilder authAttResponseBldr = TestAuthenticatorAttestationResponses
 			.createAuthenticatorAttestationResponse();
 		byte[] originalAttestationObjBytes = authAttResponseBldr.build().getAttestationObject().getBytes();
 		ObjectMapper cbor = cbor();
@@ -563,7 +567,7 @@ class Webauthn4jRelyingPartyOperationsTests {
 	}
 
 	private static AuthenticatorAttestationResponse setFmt(String fmt) throws Exception {
-		AuthenticatorAttestationResponseBuilder authAttResponseBldr = TestAuthenticatorAttestationResponse
+		AuthenticatorAttestationResponseBuilder authAttResponseBldr = TestAuthenticatorAttestationResponses
 			.createAuthenticatorAttestationResponse();
 		byte[] originalAttestationObjBytes = authAttResponseBldr.build().getAttestationObject().getBytes();
 		ObjectMapper cbor = cbor();

--- a/web/src/test/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/webauthn/registration/DefaultWebAuthnRegistrationPageGeneratingFilterTests.java
@@ -35,7 +35,7 @@ import org.springframework.security.web.webauthn.api.ImmutableCredentialRecord;
 import org.springframework.security.web.webauthn.api.ImmutablePublicKeyCredentialUserEntity;
 import org.springframework.security.web.webauthn.api.PublicKeyCredentialUserEntity;
 import org.springframework.security.web.webauthn.api.TestBytes;
-import org.springframework.security.web.webauthn.api.TestCredentialRecord;
+import org.springframework.security.web.webauthn.api.TestCredentialRecords;
 import org.springframework.security.web.webauthn.management.PublicKeyCredentialUserEntityRepository;
 import org.springframework.security.web.webauthn.management.UserCredentialRepository;
 import org.springframework.test.web.servlet.MockMvc;
@@ -93,7 +93,7 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 			.build();
 		given(this.userEntities.findByUsername(any())).willReturn(userEntity);
 		given(this.userCredentials.findByUserId(userEntity.getId()))
-			.willReturn(Arrays.asList(TestCredentialRecord.userCredential().build()));
+			.willReturn(Arrays.asList(TestCredentialRecords.userCredential().build()));
 		String body = bodyAsString(matchingRequest());
 		assertThat(body).contains("setupRegistration({\"X-CSRF-TOKEN\" : \"CSRF_TOKEN\"}");
 		assertThat(body.replaceAll("\\s", "")).contains("""
@@ -133,7 +133,7 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 			.displayName("User")
 			.build();
 
-		ImmutableCredentialRecord credential = TestCredentialRecord.userCredential()
+		ImmutableCredentialRecord credential = TestCredentialRecords.userCredential()
 			.created(LocalDateTime.of(2024, 9, 17, 10, 10, 42, 999_999_999).toInstant(ZoneOffset.UTC))
 			.lastUsed(LocalDateTime.of(2024, 9, 18, 11, 11, 42, 999_999_999).toInstant(ZoneOffset.UTC))
 			.build();
@@ -228,7 +228,7 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 			.id(TestBytes.get())
 			.displayName("User")
 			.build();
-		ImmutableCredentialRecord credential = TestCredentialRecord.userCredential().label(label).build();
+		ImmutableCredentialRecord credential = TestCredentialRecords.userCredential().label(label).build();
 		given(this.userEntities.findByUsername(any())).willReturn(userEntity);
 		given(this.userCredentials.findByUserId(userEntity.getId())).willReturn(Arrays.asList(credential));
 		String body = bodyAsString(matchingRequest());
@@ -243,7 +243,7 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 			.id(TestBytes.get())
 			.displayName("User")
 			.build();
-		ImmutableCredentialRecord credential = TestCredentialRecord.userCredential().build();
+		ImmutableCredentialRecord credential = TestCredentialRecords.userCredential().build();
 		given(this.userEntities.findByUsername(any())).willReturn(userEntity);
 		given(this.userCredentials.findByUserId(userEntity.getId())).willReturn(Arrays.asList(credential));
 		String body = bodyAsString(matchingRequest());
@@ -259,7 +259,7 @@ class DefaultWebAuthnRegistrationPageGeneratingFilterTests {
 			.id(TestBytes.get())
 			.displayName("User")
 			.build();
-		ImmutableCredentialRecord credential = TestCredentialRecord.userCredential().build();
+		ImmutableCredentialRecord credential = TestCredentialRecords.userCredential().build();
 		given(this.userEntities.findByUsername(any())).willReturn(userEntity);
 		given(this.userCredentials.findByUserId(userEntity.getId())).willReturn(Arrays.asList(credential));
 		String body = bodyAsString(matchingRequest("/foo"));

--- a/web/src/test/java/org/springframework/security/web/webauthn/registration/WebAuthnRegistrationFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/webauthn/registration/WebAuthnRegistrationFilterTests.java
@@ -34,7 +34,7 @@ import org.springframework.mock.web.MockServletContext;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.security.web.webauthn.api.ImmutableCredentialRecord;
 import org.springframework.security.web.webauthn.api.PublicKeyCredentialCreationOptions;
-import org.springframework.security.web.webauthn.api.TestCredentialRecord;
+import org.springframework.security.web.webauthn.api.TestCredentialRecords;
 import org.springframework.security.web.webauthn.api.TestPublicKeyCredentialCreationOptions;
 import org.springframework.security.web.webauthn.management.UserCredentialRepository;
 import org.springframework.security.web.webauthn.management.WebAuthnRelyingPartyOperations;
@@ -196,7 +196,7 @@ class WebAuthnRegistrationFilterTests {
 			.createPublicKeyCredentialCreationOptions()
 			.build();
 		given(this.creationOptionsRepository.load(any())).willReturn(creationOptions);
-		ImmutableCredentialRecord userCredential = TestCredentialRecord.userCredential().build();
+		ImmutableCredentialRecord userCredential = TestCredentialRecords.userCredential().build();
 		given(this.operations.registerCredential(any())).willReturn(userCredential);
 		MockHttpServletRequest request = registerCredentialRequest(REGISTRATION_REQUEST_BODY);
 		this.filter.doFilter(request, this.response, this.chain);


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->

Description:
This pull request updates the class names of WebAuthn test objects to improve clarity and maintain consistency with the project's naming conventions.

Changes made:

Renamed test classes to follow a more consistent and descriptive naming pattern.

Updated references to the renamed classes across the codebase.

Ensured that all affected tests still pass successfully.

This change helps improve code readability and maintainability.

Closes #16604.
