### PR TITLE
Update kotlin.adoc to add required spread operator(*)

### DIFF
--- a/docs/modules/ROOT/pages/servlet/configuration/kotlin.adoc
+++ b/docs/modules/ROOT/pages/servlet/configuration/kotlin.adoc
@@ -288,7 +288,7 @@ class BankingSecurityConfig {
     open fun approvalsSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
         val approvalsPaths = arrayOf("/accounts/approvals/**", "/loans/approvals/**", "/credit-cards/approvals/**")
         http {
-            securityMatcher(approvalsPaths)
+            securityMatcher(*approvalsPaths)
             authorizeHttpRequests {
 				authorize(anyRequest, hasRole("ADMIN"))
             }
@@ -303,7 +303,7 @@ class BankingSecurityConfig {
         val bankingPaths = arrayOf("/accounts/**", "/loans/**", "/credit-cards/**", "/balances/**")
 		val viewBalancePaths = arrayOf("/balances/**")
         http {
-            securityMatcher(bankingPaths)
+            securityMatcher(*bankingPaths)
             authorizeHttpRequests {
                 authorize(viewBalancePaths, hasRole("VIEW_BALANCE"))
 				authorize(anyRequest, hasRole("USER"))


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->

During implementation of SecurityFilterChain in kotlin, it was noticed that the documented examples for 
public final fun securityMatcher(vararg pattern: String): Unit was missing the spread operator to turn the arrayOf into a varargs
