### PR TITLE
Add default redirect URI for OAuth2 client registration

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistration.java
@@ -476,6 +476,11 @@ public final class ClientRegistration implements Serializable {
 		 * Configuring uri template variables is especially useful when the client is
 		 * running behind a Proxy Server. This ensures that the X-Forwarded-* headers are
 		 * used when expanding the redirect-uri.
+		 *
+		 * <br />
+		 * If not specified and authorization grant type is
+		 * {@link AuthorizationGrantType#AUTHORIZATION_CODE}, defaults to
+		 * "{baseUrl}/login/oauth2/code/{registrationId}".
 		 * @param redirectUri the uri (or uri template) for the redirection endpoint
 		 * @return the {@link Builder}
 		 * @since 5.4
@@ -627,6 +632,10 @@ public final class ClientRegistration implements Serializable {
 		 */
 		public ClientRegistration build() {
 			Assert.notNull(this.authorizationGrantType, "authorizationGrantType cannot be null");
+			if (this.redirectUri == null && this.registrationId != null
+					&& AuthorizationGrantType.AUTHORIZATION_CODE.equals(this.authorizationGrantType)) {
+				this.redirectUri = "{baseUrl}/login/oauth2/code/" + this.registrationId;
+			}
 			if (AuthorizationGrantType.CLIENT_CREDENTIALS.equals(this.authorizationGrantType)) {
 				this.validateClientCredentialsGrantType();
 			}

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/ClientRegistrationTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/ClientRegistrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -258,24 +258,22 @@ public class ClientRegistrationTests {
 	}
 
 	@Test
-	public void buildWhenAuthorizationCodeGrantRedirectUriIsNullThenThrowIllegalArgumentException() {
-		assertThatIllegalArgumentException().isThrownBy(() ->
+	public void buildWhenAuthorizationCodeGrantRedirectUriIsNullThenDefaultsToLoginOAuth2Code() {
 		// @formatter:off
-			ClientRegistration.withRegistrationId(REGISTRATION_ID)
-					.clientId(CLIENT_ID)
-					.clientSecret(CLIENT_SECRET)
-					.clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
-					.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-					.redirectUri(null)
-					.scope(SCOPES.toArray(new String[0]))
-					.authorizationUri(AUTHORIZATION_URI)
-					.tokenUri(TOKEN_URI)
-					.userInfoAuthenticationMethod(AuthenticationMethod.FORM)
-					.jwkSetUri(JWK_SET_URI)
-					.clientName(CLIENT_NAME)
-					.build()
+		ClientRegistration registration = ClientRegistration.withRegistrationId(REGISTRATION_ID)
+				.clientId(CLIENT_ID)
+				.clientSecret(CLIENT_SECRET)
+				.clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+				.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+				.scope(SCOPES.toArray(new String[0]))
+				.authorizationUri(AUTHORIZATION_URI)
+				.tokenUri(TOKEN_URI)
+				.userInfoAuthenticationMethod(AuthenticationMethod.FORM)
+				.jwkSetUri(JWK_SET_URI)
+				.clientName(CLIENT_NAME)
+				.build();
 		// @formatter:on
-		);
+		assertThat(registration.getRedirectUri()).isEqualTo("{baseUrl}/login/oauth2/code/" + REGISTRATION_ID);
 	}
 
 	// gh-5494


### PR DESCRIPTION
Currently, OAuth2 client registration requires a redirect URI, and omitting it throws an exception during application startup. However, in most cases, users would use the standard pattern `{baseUrl}/login/oauth2/code/{registrationId}`.

Closes gh-16377

## Implementation
- Modified `ClientRegistration.Builder.build()` method to set a default redirectUri value when
  - redirectUri is null
  - authorizationGrantType is AUTHORIZATION_CODE
  - registrationId is available

## Testing
- Added a test to verify the default value is correctly applied when no redirect URI is provided
- Removed the previous test that expected an exception in this scenario
- Verified all existing tests continue to pass
