### PR TITLE
Update DeferredCsrfToken to implement Supplier

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurerServlet31Tests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurerServlet31Tests.java
@@ -87,7 +87,7 @@ public class SessionManagementConfigurerServlet31Tests {
 		HttpSessionCsrfTokenRepository repository = new HttpSessionCsrfTokenRepository();
 		CsrfTokenRequestHandler handler = new XorCsrfTokenRequestAttributeHandler();
 		DeferredCsrfToken deferredCsrfToken = repository.loadDeferredToken(request, this.response);
-		handler.handle(request, this.response, deferredCsrfToken::get);
+		handler.handle(request, this.response, deferredCsrfToken);
 		CsrfToken token = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
 		request.setParameter(token.getParameterName(), token.getToken());
 		request.getSession().setAttribute("attribute1", "value1");

--- a/test/src/main/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessors.java
+++ b/test/src/main/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessors.java
@@ -524,7 +524,7 @@ public final class SecurityMockMvcRequestPostProcessors {
 			TestCsrfTokenRepository.enable(request);
 			MockHttpServletResponse response = new MockHttpServletResponse();
 			DeferredCsrfToken deferredCsrfToken = repository.loadDeferredToken(request, response);
-			handler.handle(request, response, deferredCsrfToken::get);
+			handler.handle(request, response, deferredCsrfToken);
 			CsrfToken token = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
 			String tokenValue = this.useInvalidToken ? INVALID_TOKEN_VALUE : token.getToken();
 			if (this.asHeader) {

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsCsrfTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsCsrfTests.java
@@ -164,7 +164,7 @@ public class SecurityMockMvcRequestPostProcessorsCsrfTests {
 		HttpSessionCsrfTokenRepository repo = new HttpSessionCsrfTokenRepository();
 		CsrfTokenRequestHandler handler = new XorCsrfTokenRequestAttributeHandler();
 		DeferredCsrfToken deferredCsrfToken = repo.loadDeferredToken(request, response);
-		handler.handle(request, response, deferredCsrfToken::get);
+		handler.handle(request, response, deferredCsrfToken);
 		CsrfToken token = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
 		MockHttpServletRequestBuilder requestWithCsrf = post("/")
 			.param(token.getParameterName(), token.getToken())

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfAuthenticationStrategy.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfAuthenticationStrategy.java
@@ -69,7 +69,7 @@ public final class CsrfAuthenticationStrategy implements SessionAuthenticationSt
 		if (containsToken) {
 			this.tokenRepository.saveToken(null, request, response);
 			DeferredCsrfToken deferredCsrfToken = this.tokenRepository.loadDeferredToken(request, response);
-			this.requestHandler.handle(request, response, deferredCsrfToken::get);
+			this.requestHandler.handle(request, response, deferredCsrfToken);
 			this.logger.debug("Replaced CSRF Token");
 		}
 	}

--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
@@ -108,7 +108,7 @@ public final class CsrfFilter extends OncePerRequestFilter {
 			throws ServletException, IOException {
 		DeferredCsrfToken deferredCsrfToken = this.tokenRepository.loadDeferredToken(request, response);
 		request.setAttribute(DeferredCsrfToken.class.getName(), deferredCsrfToken);
-		this.requestHandler.handle(request, response, deferredCsrfToken::get);
+		this.requestHandler.handle(request, response, deferredCsrfToken);
 		if (!this.requireCsrfProtectionMatcher.matches(request)) {
 			if (this.logger.isTraceEnabled()) {
 				this.logger.trace("Did not protect against CSRF since request did not match "

--- a/web/src/main/java/org/springframework/security/web/csrf/DeferredCsrfToken.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/DeferredCsrfToken.java
@@ -16,6 +16,8 @@
 
 package org.springframework.security.web.csrf;
 
+import java.util.function.Supplier;
+
 /**
  * An interface that allows delayed access to a {@link CsrfToken} that may be generated.
  *
@@ -23,7 +25,7 @@ package org.springframework.security.web.csrf;
  * @author Steve Riesenberg
  * @since 5.8
  */
-public interface DeferredCsrfToken {
+public interface DeferredCsrfToken extends Supplier<CsrfToken> {
 
 	/**
 	 * Gets the {@link CsrfToken}


### PR DESCRIPTION
Issue Number: #16870 

- Modified DeferredCsrfToken interface to extend Supplier<CSRFToken>.
- Refactored code to pass deferredCsrfToken directly instead of deferredCsrfToken::get.
- Applied changes in both main and test folders.
