### PR TITLE
Fix HttpSessionRequestCache#getMatchingRequest query string parsing

### DIFF
--- a/web/src/main/java/org/springframework/security/web/savedrequest/HttpSessionRequestCache.java
+++ b/web/src/main/java/org/springframework/security/web/savedrequest/HttpSessionRequestCache.java
@@ -103,11 +103,11 @@ public class HttpSessionRequestCache implements RequestCache {
 	@Override
 	public HttpServletRequest getMatchingRequest(HttpServletRequest request, HttpServletResponse response) {
 		if (this.matchingRequestParameterName != null) {
-			if (!StringUtils.hasText(request.getQueryString())
-					|| !UriComponentsBuilder.fromUriString(UrlUtils.buildRequestUrl(request))
-						.build()
-						.getQueryParams()
-						.containsKey(this.matchingRequestParameterName)) {
+			if (!StringUtils.hasText(request.getQueryString()) || !UriComponentsBuilder.newInstance()
+				.query(request.getQueryString())
+				.build()
+				.getQueryParams()
+				.containsKey(this.matchingRequestParameterName)) {
 				this.logger.trace(
 						"matchingRequestParameterName is required for getMatchingRequest to lookup a value, but not provided");
 				return null;

--- a/web/src/test/java/org/springframework/security/web/savedrequest/HttpSessionRequestCacheTests.java
+++ b/web/src/test/java/org/springframework/security/web/savedrequest/HttpSessionRequestCacheTests.java
@@ -168,6 +168,21 @@ public class HttpSessionRequestCacheTests {
 		verify(request, never()).getParameterMap();
 	}
 
+	// gh-16656
+	@Test
+	public void getMatchingRequestWhenMatchingRequestPathContainsPercentSignThenLookedUp() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setServletPath("/30 % off");
+		HttpSessionRequestCache cache = new HttpSessionRequestCache();
+		cache.saveRequest(request, new MockHttpServletResponse());
+		MockHttpServletRequest requestToMatch = new MockHttpServletRequest();
+		requestToMatch.setServletPath("/30 % off");
+		requestToMatch.setQueryString("continue");
+		requestToMatch.setSession(request.getSession());
+		HttpServletRequest matchingRequest = cache.getMatchingRequest(requestToMatch, new MockHttpServletResponse());
+		assertThat(matchingRequest).isNotNull();
+	}
+
 	private static final class CustomSavedRequest implements SavedRequest {
 
 		private final SavedRequest delegate;


### PR DESCRIPTION
## Issue

URL parsing changed in framework 6.2 (security 6.4), and now fails when path contains a % sign. As such, the `HttpSessionRequestCache` fails on every request containing a % sign.

## Resolution

We do not need to parse a full URL, just to inspect the query string for the matching parameter. We don't use the current request path in `UriComponentsBuilder` to extract the query string.

Fixes gh-16656