### PR TITLE
Fix IllegalArgumentException message for unknown Argon2 types

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/argon2/Argon2EncodingUtils.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/argon2/Argon2EncodingUtils.java
@@ -111,7 +111,7 @@ final class Argon2EncodingUtils {
 			case "argon2d" -> new Argon2Parameters.Builder(Argon2Parameters.ARGON2_d);
 			case "argon2i" -> new Argon2Parameters.Builder(Argon2Parameters.ARGON2_i);
 			case "argon2id" -> new Argon2Parameters.Builder(Argon2Parameters.ARGON2_id);
-			default -> throw new IllegalArgumentException("Invalid algorithm type: " + parts[0]);
+			default -> throw new IllegalArgumentException("Invalid algorithm type: " + parts[1]);
 		};
 		if (parts[currentPart].startsWith("v=")) {
 			paramsBuilder.withVersion(Integer.parseInt(parts[currentPart].substring(2)));

--- a/crypto/src/test/java/org/springframework/security/crypto/argon2/Argon2EncodingUtilsTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/argon2/Argon2EncodingUtilsTests.java
@@ -95,7 +95,8 @@ public class Argon2EncodingUtilsTests {
 	@Test
 	public void decodeWhenNonexistingAlgorithmThenThrowException() {
 		assertThatIllegalArgumentException().isThrownBy(() -> Argon2EncodingUtils
-			.decode("$argon2x$v=19$m=1024,t=3,p=2$Y1JkRmJDdzIzZ3oyTWx4aw$cGE5Cbd/cx7micVhXVBdH5qTr66JI1iUyuNNVAnErXs"));
+			.decode("$argon2x$v=19$m=1024,t=3,p=2$Y1JkRmJDdzIzZ3oyTWx4aw$cGE5Cbd/cx7micVhXVBdH5qTr66JI1iUyuNNVAnErXs"))
+			.withMessageContaining("argon2x");
 	}
 
 	@Test

--- a/crypto/src/test/java/org/springframework/security/crypto/argon2/Argon2EncodingUtilsTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/argon2/Argon2EncodingUtilsTests.java
@@ -94,8 +94,9 @@ public class Argon2EncodingUtilsTests {
 
 	@Test
 	public void decodeWhenNonexistingAlgorithmThenThrowException() {
-		assertThatIllegalArgumentException().isThrownBy(() -> Argon2EncodingUtils
-			.decode("$argon2x$v=19$m=1024,t=3,p=2$Y1JkRmJDdzIzZ3oyTWx4aw$cGE5Cbd/cx7micVhXVBdH5qTr66JI1iUyuNNVAnErXs"))
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> Argon2EncodingUtils.decode(
+					"$argon2x$v=19$m=1024,t=3,p=2$Y1JkRmJDdzIzZ3oyTWx4aw$cGE5Cbd/cx7micVhXVBdH5qTr66JI1iUyuNNVAnErXs"))
 			.withMessageContaining("argon2x");
 	}
 


### PR DESCRIPTION
Parsing Argon2 params relies on `String[] parts = encodedHash.split("\\$")`. For a string beginning with a `$`, the first element of the resulting array will be empty. This is already addressed in the code, with the variable `int currentPart` being initialized with `1`. But the IllegalArgumentException message incorrectly refers to `part[0]`, which will be empty for a well-formed Argon2 string starting with `$`.

The fix is trivial in this case, just use the array index 1.

P.S. one could also check for the 0-th array element to be an empty string and throw an IllegalArgumentException if it's not. However, this requires additional domain expertise and as such goes beyond the scope.
