### PR TITLE
Example test showing the minimalist response to an empty Authorizatio…

### DIFF
--- a/config/src/test/java/org/springframework/security/config/web/server/OAuth2ResourceServerSpecTests.java
+++ b/config/src/test/java/org/springframework/security/config/web/server/OAuth2ResourceServerSpecTests.java
@@ -179,6 +179,19 @@ public class OAuth2ResourceServerSpecTests {
 	}
 
 	@Test
+	public void getWhenBearerMissingInvalidToken() {
+		this.spring.register(PublicKeyConfig.class).autowire();
+		// @formatter:off
+		this.client.get()
+				.headers((headers) -> headers
+						.set("Authorization", ""))
+				.exchange()
+				.expectStatus().isUnauthorized()
+				.expectHeader().value(HttpHeaders.WWW_AUTHENTICATE, startsWith("Bearer error=\"missing_token\""));
+		// @formatter:on
+	}
+
+	@Test
 	public void getWhenUnsignedThenReturnsInvalidToken() {
 		this.spring.register(PublicKeyConfig.class).autowire();
 		// @formatter:off


### PR DESCRIPTION
…n header

relates to #16977 

We recently had an application request fail to provide any bearer token in the Authorization header.  They received a 401 as expected.  However, the `www-authenticate` response header only had the word `Bearer` in the value.  This made it difficult to debug as it implied that they were sending a bearer token when they weren't.

I suggest an improvement in Spring Security to add an error message such as `missing_token` or some other similar value to help identify the root problem.

This PR contains a test case that will pass when the additional error message is provided.

I am willing to provide a fix for this as well.  However, I don't know where in Spring Security to implement such a fix.  I know about `BearerTokenAuthenticationEntryPoint` where other bearer token related errors have their details added.  However, that doesn't feel right in this case because we aren't 100% guaranteed the intent of the request was to provide a bearer token (some other form of Authorization may be supported along with OAuth2 Resource Server).
