### PR TITLE
Make AuthorizationProxyFactory.proxy generic 

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/AuthorizationProxyWebConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/AuthorizationProxyWebConfiguration.java
@@ -51,7 +51,7 @@ class AuthorizationProxyWebConfiguration {
 			if (target instanceof ModelAndView mav) {
 				View view = mav.getView();
 				String viewName = mav.getViewName();
-				Map<String, Object> model = (Map<String, Object>) proxyFactory.proxy(mav.getModel());
+				Map<String, Object> model = proxyFactory.proxy(mav.getModel());
 				ModelAndView proxied = (view != null) ? new ModelAndView(view, model)
 						: new ModelAndView(viewName, model);
 				proxied.setStatus(mav.getStatus());

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/AuthorizationProxyConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/AuthorizationProxyConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public class AuthorizationProxyConfigurationTests {
 	@Test
 	public void proxyWhenNotPreAuthorizedThenDenies() {
 		this.spring.register(DefaultsConfig.class).autowire();
-		Toaster toaster = (Toaster) this.proxyFactory.proxy(new Toaster());
+		Toaster toaster = this.proxyFactory.proxy(new Toaster());
 		assertThatExceptionOfType(AccessDeniedException.class).isThrownBy(toaster::makeToast)
 			.withMessage("Access Denied");
 		assertThatExceptionOfType(AccessDeniedException.class).isThrownBy(toaster::extractBread)
@@ -69,7 +69,7 @@ public class AuthorizationProxyConfigurationTests {
 	@Test
 	public void proxyWhenPreAuthorizedThenAllows() {
 		this.spring.register(DefaultsConfig.class).autowire();
-		Toaster toaster = (Toaster) this.proxyFactory.proxy(new Toaster());
+		Toaster toaster = this.proxyFactory.proxy(new Toaster());
 		toaster.makeToast();
 		assertThat(toaster.extractBread()).isEqualTo("yummy");
 	}
@@ -77,7 +77,7 @@ public class AuthorizationProxyConfigurationTests {
 	@Test
 	public void proxyReactiveWhenNotPreAuthorizedThenDenies() {
 		this.spring.register(ReactiveDefaultsConfig.class).autowire();
-		Toaster toaster = (Toaster) this.proxyFactory.proxy(new Toaster());
+		Toaster toaster = this.proxyFactory.proxy(new Toaster());
 		Authentication user = TestAuthentication.authenticatedUser();
 		StepVerifier
 			.create(toaster.reactiveMakeToast().contextWrite(ReactiveSecurityContextHolder.withAuthentication(user)))
@@ -90,7 +90,7 @@ public class AuthorizationProxyConfigurationTests {
 	@Test
 	public void proxyReactiveWhenPreAuthorizedThenAllows() {
 		this.spring.register(ReactiveDefaultsConfig.class).autowire();
-		Toaster toaster = (Toaster) this.proxyFactory.proxy(new Toaster());
+		Toaster toaster = this.proxyFactory.proxy(new Toaster());
 		Authentication admin = TestAuthentication.authenticatedAdmin();
 		StepVerifier
 			.create(toaster.reactiveMakeToast().contextWrite(ReactiveSecurityContextHolder.withAuthentication(admin)))

--- a/core/src/main/java/org/springframework/security/aot/hint/AuthorizeReturnObjectHintsRegistrar.java
+++ b/core/src/main/java/org/springframework/security/aot/hint/AuthorizeReturnObjectHintsRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,7 +109,7 @@ public final class AuthorizeReturnObjectHintsRegistrar implements SecurityHintsR
 	}
 
 	private void registerProxy(RuntimeHints hints, Class<?> clazz) {
-		Class<?> proxied = (Class<?>) this.proxyFactory.proxy(clazz);
+		Class<?> proxied = this.proxyFactory.proxy(clazz);
 		if (proxied == null) {
 			return;
 		}

--- a/core/src/main/java/org/springframework/security/authorization/AuthorizationProxyFactory.java
+++ b/core/src/main/java/org/springframework/security/authorization/AuthorizationProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ package org.springframework.security.authorization;
  * A factory for wrapping arbitrary objects in authorization-related advice
  *
  * @author Josh Cummings
+ * @author daewon kim
  * @since 6.3
  * @see org.springframework.security.authorization.method.AuthorizationAdvisorProxyFactory
  */
@@ -30,11 +31,12 @@ public interface AuthorizationProxyFactory {
 	 *
 	 * <p>
 	 * Please check the implementation for which kinds of objects it supports.
+	 * @param <T> the type of the object being proxied
 	 * @param object the object to proxy
 	 * @return the proxied object
 	 * @throws org.springframework.aop.framework.AopConfigException if a proxy cannot be
 	 * created
 	 */
-	Object proxy(Object object);
+	<T> T proxy(T object);
 
 }

--- a/core/src/main/java/org/springframework/security/authorization/method/AuthorizationAdvisorProxyFactory.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/AuthorizationAdvisorProxyFactory.java
@@ -172,16 +172,16 @@ public final class AuthorizationAdvisorProxyFactory implements AuthorizationProx
 	 * @return the proxied instance
 	 */
 	@Override
-	public Object proxy(Object target) {
+	public <T> T proxy(T target) {
 		if (target == null) {
 			return null;
 		}
 		if (target instanceof AuthorizationProxy proxied) {
-			return proxied;
+			return (T) proxied;
 		}
 		Object proxied = this.visitor.visit(this, target);
 		if (proxied != null) {
-			return proxied;
+			return (T) proxied;
 		}
 		ProxyFactory factory = new ProxyFactory(target);
 		factory.addAdvisors(this.authorizationProxy);
@@ -191,7 +191,7 @@ public final class AuthorizationAdvisorProxyFactory implements AuthorizationProx
 		factory.addInterface(AuthorizationProxy.class);
 		factory.setOpaque(true);
 		factory.setProxyTargetClass(!Modifier.isFinal(target.getClass().getModifiers()));
-		return factory.getProxy();
+		return (T) factory.getProxy();
 	}
 
 	/**
@@ -442,7 +442,7 @@ public final class AuthorizationAdvisorProxyFactory implements AuthorizationProx
 
 		@SuppressWarnings("unchecked")
 		private <T> T proxyCast(AuthorizationProxyFactory proxyFactory, T target) {
-			return (T) proxyFactory.proxy(target);
+			return proxyFactory.proxy(target);
 		}
 
 		private <T> Iterable<T> proxyIterable(AuthorizationProxyFactory proxyFactory, Iterable<T> iterable) {

--- a/core/src/test/java/org/springframework/security/authorization/AuthorizationAdvisorProxyFactoryTests.java
+++ b/core/src/test/java/org/springframework/security/authorization/AuthorizationAdvisorProxyFactoryTests.java
@@ -335,7 +335,7 @@ public class AuthorizationAdvisorProxyFactoryTests {
 	@Test
 	public void setTargetVisitorIgnoreValueTypesThenIgnores() {
 		AuthorizationAdvisorProxyFactory factory = AuthorizationAdvisorProxyFactory.withDefaults();
-		assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> ((Integer) factory.proxy(35)).intValue());
+		assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> factory.proxy(35).intValue());
 		factory.setTargetVisitor(TargetVisitor.defaultsSkipValueTypes());
 		assertThat(factory.proxy(35)).isEqualTo(35);
 	}


### PR DESCRIPTION
Overview
---
This pull request updates the AuthorizationProxyFactory interface to make its proxy method generic, ensuring that it returns the same type as the input object. 

The following changes are included:
- Refactored AuthorizationProxyFactory.proxy to use generics (<T> T proxy(T object)).
- Removed redundant casts from production and test code that are no longer necessary due to the type-safe proxy method.

<br>

Related
---
ISSUE: #16706 

<br>

Note
---
I’m aware that the issue is currently labeled with status: waiting-for-triage, which indicates that the final design direction may not be settled yet. This PR reflects my current understanding of the issue and is intended as a starting point for further discussion.

If this approach does not align with the intended direction, please feel free to close the PR or provide feedback. I am happy to revise or take a different direction as needed. Thank you!