### PR TITLE
Roles and authorities are being overridden in GrantedAuthority and are not accessible within the AuthenticationManager.

### DIFF
--- a/core/src/main/java/org/springframework/security/core/userdetails/User.java
+++ b/core/src/main/java/org/springframework/security/core/userdetails/User.java
@@ -441,7 +441,7 @@ public class User implements UserDetails, CredentialsContainer {
 		 */
 		public UserBuilder authorities(Collection<? extends GrantedAuthority> authorities) {
 			Assert.notNull(authorities, "authorities cannot be null");
-			this.authorities = new ArrayList<>(authorities);
+			this.authorities.addAll(authorities);
 			return this;
 		}
 


### PR DESCRIPTION
**Scenario 1**

```java
 UserDetails user = User.builder()
                .username("user")
                .password(passwordEncoder.encode("user"))
// first adding authorities and then role
                .authorities("read", "item:view") 
// authorities getting overridden by role
                .roles("USER")
                .accountExpired(false)
                .accountLocked(false)
                .credentialsExpired(false)
                .disabled(false)
                .build();
```
authorities = ["ROLE_USER"]

**Scenario 2**
```java
 UserDetails user = User.builder()
                .username("user")
                .password(passwordEncoder.encode("user"))
// first adding role and then authorities
                 .roles("USER")
// role getting overridden by authorities
                .authorities("read", "item:view") 
                .accountExpired(false)
                .accountLocked(false)
                .credentialsExpired(false)
                .disabled(false)
                .build();
```
authorities = ["read", "item:view"]




