### PR TITLE
Use proper configuration key in Opaque Token documentation

### DIFF
--- a/docs/modules/ROOT/pages/reactive/oauth2/resource-server/opaque-token.adoc
+++ b/docs/modules/ROOT/pages/reactive/oauth2/resource-server/opaque-token.adoc
@@ -29,7 +29,7 @@ spring:
   security:
     oauth2:
       resourceserver:
-        opaque-token:
+        opaquetoken:
           introspection-uri: https://idp.example.com/introspect
           client-id: client
           client-secret: secret
@@ -616,7 +616,7 @@ spring:
   security:
     oauth2:
       resourceserver:
-        opaque-token:
+        opaquetoken:
           introspection-uri: https://idp.example.org/introspection
           client-id: client
           client-secret: secret

--- a/docs/modules/ROOT/pages/servlet/oauth2/resource-server/opaque-token.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/resource-server/opaque-token.adoc
@@ -28,7 +28,7 @@ spring:
   security:
     oauth2:
       resourceserver:
-        opaque-token:
+        opaquetoken:
           introspection-uri: https://idp.example.com/introspect
           client-id: client
           client-secret: secret
@@ -782,7 +782,7 @@ spring:
   security:
     oauth2:
       resourceserver:
-        opaque-token:
+        opaquetoken:
           introspection-uri: https://idp.example.org/introspection
           client-id: client
           client-secret: secret


### PR DESCRIPTION
the getter method is `getOpaquetoken()` not `getOpaqueToken()`

See https://github.com/spring-projects/spring-boot/blob/c6045c3111c43bd7b0f99e6c2858bfb2999e358f/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/security/oauth2/resource/OAuth2ResourceServerProperties.java#L51