### PR TITLE
Remove deprecated Cookie method usage

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/rememberme/AbstractRememberMeServices.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/rememberme/AbstractRememberMeServices.java
@@ -372,9 +372,6 @@ public abstract class AbstractRememberMeServices
 		if (this.cookieDomain != null) {
 			cookie.setDomain(this.cookieDomain);
 		}
-		if (maxAge < 1) {
-			cookie.setVersion(1);
-		}
 		cookie.setSecure((this.useSecureCookie != null) ? this.useSecureCookie : request.isSecure());
 		cookie.setHttpOnly(true);
 

--- a/web/src/main/java/org/springframework/security/web/firewall/FirewalledResponse.java
+++ b/web/src/main/java/org/springframework/security/web/firewall/FirewalledResponse.java
@@ -67,7 +67,6 @@ class FirewalledResponse extends HttpServletResponseWrapper {
 			validateCrlf(SET_COOKIE_HEADER, cookie.getValue());
 			validateCrlf(SET_COOKIE_HEADER, cookie.getPath());
 			validateCrlf(SET_COOKIE_HEADER, cookie.getDomain());
-			validateCrlf(SET_COOKIE_HEADER, cookie.getComment());
 		}
 		super.addCookie(cookie);
 	}

--- a/web/src/main/java/org/springframework/security/web/jackson2/CookieDeserializer.java
+++ b/web/src/main/java/org/springframework/security/web/jackson2/CookieDeserializer.java
@@ -45,11 +45,9 @@ class CookieDeserializer extends JsonDeserializer<Cookie> {
 		ObjectMapper mapper = (ObjectMapper) jp.getCodec();
 		JsonNode jsonNode = mapper.readTree(jp);
 		Cookie cookie = new Cookie(readJsonNode(jsonNode, "name").asText(), readJsonNode(jsonNode, "value").asText());
-		cookie.setComment(readJsonNode(jsonNode, "comment").asText());
 		cookie.setDomain(readJsonNode(jsonNode, "domain").asText());
 		cookie.setMaxAge(readJsonNode(jsonNode, "maxAge").asInt(-1));
 		cookie.setSecure(readJsonNode(jsonNode, "secure").asBoolean());
-		cookie.setVersion(readJsonNode(jsonNode, "version").asInt());
 		cookie.setPath(readJsonNode(jsonNode, "path").asText());
 		JsonNode attributes = readJsonNode(jsonNode, "attributes");
 		cookie.setHttpOnly(readJsonNode(attributes, "HttpOnly") != null);

--- a/web/src/main/java/org/springframework/security/web/jackson2/SavedCookieMixin.java
+++ b/web/src/main/java/org/springframework/security/web/jackson2/SavedCookieMixin.java
@@ -44,10 +44,8 @@ abstract class SavedCookieMixin {
 
 	@JsonCreator
 	SavedCookieMixin(@JsonProperty("name") String name, @JsonProperty("value") String value,
-			@JsonProperty("comment") String comment, @JsonProperty("domain") String domain,
-			@JsonProperty("maxAge") int maxAge, @JsonProperty("path") String path,
-			@JsonProperty("secure") boolean secure, @JsonProperty("version") int version) {
-
+			@JsonProperty("domain") String domain, @JsonProperty("maxAge") int maxAge,
+			@JsonProperty("path") String path, @JsonProperty("secure") boolean secure) {
 	}
 
 }

--- a/web/src/main/java/org/springframework/security/web/savedrequest/SavedCookie.java
+++ b/web/src/main/java/org/springframework/security/web/savedrequest/SavedCookie.java
@@ -35,8 +35,6 @@ public class SavedCookie implements Serializable {
 
 	private final String value;
 
-	private final String comment;
-
 	private final String domain;
 
 	private final int maxAge;
@@ -45,28 +43,13 @@ public class SavedCookie implements Serializable {
 
 	private final boolean secure;
 
-	private final int version;
-
-	/**
-	 * @deprecated use
-	 * {@link org.springframework.security.web.savedrequest.SavedCookie#SavedCookie(String, String, String, int, String, boolean)}
-	 * instead
-	 */
-	@Deprecated(forRemoval = true, since = "6.1")
-	public SavedCookie(String name, String value, String comment, String domain, int maxAge, String path,
-			boolean secure, int version) {
+	public SavedCookie(String name, String value, String domain, int maxAge, String path, boolean secure) {
 		this.name = name;
 		this.value = value;
-		this.comment = comment;
 		this.domain = domain;
 		this.maxAge = maxAge;
 		this.path = path;
 		this.secure = secure;
-		this.version = version;
-	}
-
-	public SavedCookie(String name, String value, String domain, int maxAge, String path, boolean secure) {
-		this(name, value, null, domain, maxAge, path, secure, 0);
 	}
 
 	public SavedCookie(Cookie cookie) {
@@ -80,11 +63,6 @@ public class SavedCookie implements Serializable {
 
 	public String getValue() {
 		return this.value;
-	}
-
-	@Deprecated(forRemoval = true, since = "6.1")
-	public String getComment() {
-		return this.comment;
 	}
 
 	public String getDomain() {
@@ -103,23 +81,14 @@ public class SavedCookie implements Serializable {
 		return this.secure;
 	}
 
-	@Deprecated(forRemoval = true, since = "6.1")
-	public int getVersion() {
-		return this.version;
-	}
-
 	public Cookie getCookie() {
 		Cookie cookie = new Cookie(getName(), getValue());
-		if (getComment() != null) {
-			cookie.setComment(getComment());
-		}
 		if (getDomain() != null) {
 			cookie.setDomain(getDomain());
 		}
 		if (getPath() != null) {
 			cookie.setPath(getPath());
 		}
-		cookie.setVersion(getVersion());
 		cookie.setMaxAge(getMaxAge());
 		cookie.setSecure(isSecure());
 		return cookie;

--- a/web/src/test/java/org/springframework/security/web/authentication/rememberme/AbstractRememberMeServicesTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/rememberme/AbstractRememberMeServicesTests.java
@@ -362,17 +362,6 @@ public class AbstractRememberMeServicesTests {
 		assertThat(cookie.isHttpOnly()).isTrue();
 	}
 
-	// SEC-2791
-	@Test
-	public void setCookieMaxAge1VersionSet() {
-		MockRememberMeServices services = new MockRememberMeServices();
-		MockHttpServletRequest request = new MockHttpServletRequest();
-		MockHttpServletResponse response = new MockHttpServletResponse();
-		services.setCookie(new String[] { "value" }, 1, request, response);
-		Cookie cookie = response.getCookie(AbstractRememberMeServices.SPRING_SECURITY_REMEMBER_ME_COOKIE_KEY);
-		assertThat(cookie.getVersion()).isZero();
-	}
-
 	@Test
 	public void setCookieDomainValue() {
 		MockRememberMeServices services = new MockRememberMeServices();

--- a/web/src/test/java/org/springframework/security/web/firewall/FirewalledResponseTests.java
+++ b/web/src/test/java/org/springframework/security/web/firewall/FirewalledResponseTests.java
@@ -93,7 +93,6 @@ public class FirewalledResponseTests {
 		Cookie cookie = new Cookie("foo", "bar");
 		cookie.setPath("/foobar");
 		cookie.setDomain("foobar");
-		cookie.setComment("foobar");
 		this.fwResponse.addCookie(cookie);
 		verify(this.response).addCookie(cookie);
 	}

--- a/web/src/test/java/org/springframework/security/web/jackson2/DefaultSavedRequestMixinTests.java
+++ b/web/src/test/java/org/springframework/security/web/jackson2/DefaultSavedRequestMixinTests.java
@@ -45,11 +45,9 @@ public class DefaultSavedRequestMixinTests extends AbstractMixinTests {
 		+ "\"@class\": \"org.springframework.security.web.savedrequest.SavedCookie\", "
 		+ "\"name\": \"SESSION\", "
 		+ "\"value\": \"123456789\", "
-		+ "\"comment\": null, "
 		+ "\"maxAge\": -1, "
 		+ "\"path\": null, "
 		+ "\"secure\":false, "
-		+ "\"version\": 0, "
 		+ "\"domain\": null"
 	+ "}]]";
 	// @formatter:on

--- a/web/src/test/java/org/springframework/security/web/jackson2/SavedCookieMixinTests.java
+++ b/web/src/test/java/org/springframework/security/web/jackson2/SavedCookieMixinTests.java
@@ -42,11 +42,9 @@ public class SavedCookieMixinTests extends AbstractMixinTests {
 		+ "\"@class\": \"org.springframework.security.web.savedrequest.SavedCookie\", "
 		+ "\"name\": \"SESSION\", "
 		+ "\"value\": \"123456789\", "
-		+ "\"comment\": null, "
 		+ "\"maxAge\": -1, "
 		+ "\"path\": null, "
 		+ "\"secure\":false, "
-		+ "\"version\": 0, "
 		+ "\"domain\": null"
 	+ "}";
 	// @formatter:on
@@ -90,13 +88,11 @@ public class SavedCookieMixinTests extends AbstractMixinTests {
 
 	@Test
 	public void deserializeSavedCookieJsonTest() throws IOException {
-		SavedCookie savedCookie = (SavedCookie) this.mapper.readValue(COOKIE_JSON, Object.class);
+		SavedCookie savedCookie = this.mapper.readValue(COOKIE_JSON, SavedCookie.class);
 		assertThat(savedCookie).isNotNull();
 		assertThat(savedCookie.getName()).isEqualTo("SESSION");
 		assertThat(savedCookie.getValue()).isEqualTo("123456789");
 		assertThat(savedCookie.isSecure()).isEqualTo(false);
-		assertThat(savedCookie.getVersion()).isZero();
-		assertThat(savedCookie.getComment()).isNull();
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/jackson2/SavedCookieMixinTests.java
+++ b/web/src/test/java/org/springframework/security/web/jackson2/SavedCookieMixinTests.java
@@ -88,7 +88,7 @@ public class SavedCookieMixinTests extends AbstractMixinTests {
 
 	@Test
 	public void deserializeSavedCookieJsonTest() throws IOException {
-		SavedCookie savedCookie = this.mapper.readValue(COOKIE_JSON, SavedCookie.class);
+		SavedCookie savedCookie = (SavedCookie) this.mapper.readValue(COOKIE_JSON, Object.class);
 		assertThat(savedCookie).isNotNull();
 		assertThat(savedCookie.getName()).isEqualTo("SESSION");
 		assertThat(savedCookie.getValue()).isEqualTo("123456789");

--- a/web/src/test/java/org/springframework/security/web/savedrequest/SavedCookieTests.java
+++ b/web/src/test/java/org/springframework/security/web/savedrequest/SavedCookieTests.java
@@ -33,12 +33,10 @@ public class SavedCookieTests {
 	@BeforeEach
 	public void setUp() {
 		this.cookie = new Cookie("name", "value");
-		this.cookie.setComment("comment");
 		this.cookie.setDomain("domain");
 		this.cookie.setMaxAge(100);
 		this.cookie.setPath("path");
 		this.cookie.setSecure(true);
-		this.cookie.setVersion(11);
 		this.savedCookie = new SavedCookie(this.cookie);
 	}
 
@@ -50,11 +48,6 @@ public class SavedCookieTests {
 	@Test
 	public void testGetValue() {
 		assertThat(this.savedCookie.getValue()).isEqualTo(this.cookie.getValue());
-	}
-
-	@Test
-	public void testGetComment() {
-		assertThat(this.savedCookie.getComment()).isEqualTo(this.cookie.getComment());
 	}
 
 	@Test
@@ -73,21 +66,14 @@ public class SavedCookieTests {
 	}
 
 	@Test
-	public void testGetVersion() {
-		assertThat(this.savedCookie.getVersion()).isEqualTo(this.cookie.getVersion());
-	}
-
-	@Test
 	public void testGetCookie() {
 		Cookie other = this.savedCookie.getCookie();
-		assertThat(other.getComment()).isEqualTo(this.cookie.getComment());
 		assertThat(other.getDomain()).isEqualTo(this.cookie.getDomain());
 		assertThat(other.getMaxAge()).isEqualTo(this.cookie.getMaxAge());
 		assertThat(other.getName()).isEqualTo(this.cookie.getName());
 		assertThat(other.getPath()).isEqualTo(this.cookie.getPath());
 		assertThat(other.getSecure()).isEqualTo(this.cookie.getSecure());
 		assertThat(other.getValue()).isEqualTo(this.cookie.getValue());
-		assertThat(other.getVersion()).isEqualTo(this.cookie.getVersion());
 	}
 
 	@Test


### PR DESCRIPTION
**ISSUE:** gh-16889

Removing deprecated cookie methods comment & version.

These changes partly addresses the gh-16889. To prevent review fatigue, I'll create to additional PRs.


**Note:** `CookieMixinTests` will need to be updated when the `comment` & `version` methods are removed from the Jakarta Servlet API. [PR](https://github.com/jakartaee/servlet/pull/858) to deprecate the methods.