### PR TITLE
Support add nested security configurers during builder initialization

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/AbstractConfiguredSecurityBuilder.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/AbstractConfiguredSecurityBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ import org.springframework.web.filter.DelegatingFilterProxy;
  * @param <O> The object that this builder returns
  * @param <B> The type of this builder (that is returned by the base class)
  * @author Rob Winch
+ * @author DingHao
  * @see WebSecurity
  */
 public abstract class AbstractConfiguredSecurityBuilder<O, B extends SecurityBuilder<O>>
@@ -386,8 +387,10 @@ public abstract class AbstractConfiguredSecurityBuilder<O, B extends SecurityBui
 		for (SecurityConfigurer<O, B> configurer : configurers) {
 			configurer.init((B) this);
 		}
-		for (SecurityConfigurer<O, B> configurer : this.configurersAddedInInitializing) {
-			configurer.init((B) this);
+		while (!this.configurersAddedInInitializing.isEmpty()) {
+			for (SecurityConfigurer<O, B> configurer : getConfigurersInInitializing()) {
+				configurer.init((B) this);
+			}
 		}
 	}
 
@@ -404,6 +407,12 @@ public abstract class AbstractConfiguredSecurityBuilder<O, B extends SecurityBui
 		for (List<SecurityConfigurer<O, B>> configs : this.configurers.values()) {
 			result.addAll(configs);
 		}
+		return result;
+	}
+
+	private List<SecurityConfigurer<O, B>> getConfigurersInInitializing() {
+		List<SecurityConfigurer<O, B>> result = new ArrayList<>(this.configurersAddedInInitializing);
+		this.configurersAddedInInitializing.clear();
 		return result;
 	}
 

--- a/config/src/main/java/org/springframework/security/config/annotation/AbstractConfiguredSecurityBuilder.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/AbstractConfiguredSecurityBuilder.java
@@ -60,7 +60,7 @@ public abstract class AbstractConfiguredSecurityBuilder<O, B extends SecurityBui
 
 	private final LinkedHashMap<Class<? extends SecurityConfigurer<O, B>>, List<SecurityConfigurer<O, B>>> configurers = new LinkedHashMap<>();
 
-	private final List<SecurityConfigurer<O, B>> configurersAddedInInitializing = new ArrayList<>();
+	private List<SecurityConfigurer<O, B>> configurersAddedInInitializing = new ArrayList<>();
 
 	private final Map<Class<?>, Object> sharedObjects = new HashMap<>();
 
@@ -388,7 +388,9 @@ public abstract class AbstractConfiguredSecurityBuilder<O, B extends SecurityBui
 			configurer.init((B) this);
 		}
 		while (!this.configurersAddedInInitializing.isEmpty()) {
-			for (SecurityConfigurer<O, B> configurer : getConfigurersInInitializing()) {
+			List<SecurityConfigurer<O, B>> toInit = this.configurersAddedInInitializing;
+			this.configurersAddedInInitializing = new ArrayList<>();
+			for (SecurityConfigurer<O, B> configurer : toInit) {
 				configurer.init((B) this);
 			}
 		}
@@ -407,12 +409,6 @@ public abstract class AbstractConfiguredSecurityBuilder<O, B extends SecurityBui
 		for (List<SecurityConfigurer<O, B>> configs : this.configurers.values()) {
 			result.addAll(configs);
 		}
-		return result;
-	}
-
-	private List<SecurityConfigurer<O, B>> getConfigurersInInitializing() {
-		List<SecurityConfigurer<O, B>> result = new ArrayList<>(this.configurersAddedInInitializing);
-		this.configurersAddedInInitializing.clear();
 		return result;
 	}
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/AbstractConfiguredSecurityBuilderTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/AbstractConfiguredSecurityBuilderTests.java
@@ -165,29 +165,31 @@ public class AbstractConfiguredSecurityBuilderTests {
 
 	@Test
 	public void withWhenConfigurerAddInitializing() throws Exception {
-		this.builder.with(new FooConfigurer(), Customizer.withDefaults());
+		this.builder.with(new AppliesNestedConfigurer(), Customizer.withDefaults());
 		assertThat(this.builder.build()).isEqualTo("success");
 	}
 
-	private static class FooConfigurer extends SecurityConfigurerAdapter<Object, TestConfiguredSecurityBuilder> {
+	private static class AppliesNestedConfigurer
+			extends SecurityConfigurerAdapter<Object, TestConfiguredSecurityBuilder> {
 
 		@Override
 		public void init(TestConfiguredSecurityBuilder builder) throws Exception {
-			builder.with(new BarConfigurer(), Customizer.withDefaults());
+			builder.with(new NestedConfigurer(), Customizer.withDefaults());
 		}
 
 	}
 
-	private static class BarConfigurer extends SecurityConfigurerAdapter<Object, TestConfiguredSecurityBuilder> {
+	private static class NestedConfigurer extends SecurityConfigurerAdapter<Object, TestConfiguredSecurityBuilder> {
 
 		@Override
 		public void init(TestConfiguredSecurityBuilder http) throws Exception {
-			http.with(new CooConfigurer(), Customizer.withDefaults());
+			http.with(new DoubleNestedConfigurer(), Customizer.withDefaults());
 		}
 
 	}
 
-	private static class CooConfigurer extends SecurityConfigurerAdapter<Object, TestConfiguredSecurityBuilder> {
+	private static class DoubleNestedConfigurer
+			extends SecurityConfigurerAdapter<Object, TestConfiguredSecurityBuilder> {
 
 	}
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/AbstractConfiguredSecurityBuilderTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/AbstractConfiguredSecurityBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -161,6 +161,34 @@ public class AbstractConfiguredSecurityBuilderTests {
 		this.builder.with(new TestSecurityConfigurer(), Customizer.withDefaults());
 		this.builder.with(new TestSecurityConfigurer(), Customizer.withDefaults());
 		assertThat(this.builder.getConfigurers(TestSecurityConfigurer.class)).hasSize(1);
+	}
+
+	@Test
+	public void withWhenConfigurerAddInitializing() throws Exception {
+		this.builder.with(new FooConfigurer(), Customizer.withDefaults());
+		assertThat(this.builder.build()).isEqualTo("success");
+	}
+
+	private static class FooConfigurer extends SecurityConfigurerAdapter<Object, TestConfiguredSecurityBuilder> {
+
+		@Override
+		public void init(TestConfiguredSecurityBuilder builder) throws Exception {
+			builder.with(new BarConfigurer(), Customizer.withDefaults());
+		}
+
+	}
+
+	private static class BarConfigurer extends SecurityConfigurerAdapter<Object, TestConfiguredSecurityBuilder> {
+
+		@Override
+		public void init(TestConfiguredSecurityBuilder http) throws Exception {
+			http.with(new CooConfigurer(), Customizer.withDefaults());
+		}
+
+	}
+
+	private static class CooConfigurer extends SecurityConfigurerAdapter<Object, TestConfiguredSecurityBuilder> {
+
 	}
 
 	private static class ApplyAndRemoveSecurityConfigurer


### PR DESCRIPTION
Closes gh-17011

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
