### PR TITLE
LDAP: allow multiple roles to be fetched from group role attribute

### DIFF
--- a/ldap/src/integration-test/java/org/springframework/security/ldap/userdetails/DefaultLdapAuthoritiesPopulatorTests.java
+++ b/ldap/src/integration-test/java/org/springframework/security/ldap/userdetails/DefaultLdapAuthoritiesPopulatorTests.java
@@ -17,6 +17,7 @@
 package org.springframework.security.ldap.userdetails;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -188,7 +189,7 @@ public class DefaultLdapAuthoritiesPopulatorTests {
 		this.populator.setAuthorityMapper((record) -> {
 			String dn = record.get(SpringSecurityLdapTemplate.DN_KEY).get(0);
 			String role = record.get(this.populator.getGroupRoleAttribute()).get(0);
-			return new LdapAuthority(role, dn);
+			return Collections.singletonList(new LdapAuthority(role, dn));
 		});
 
 		DirContextAdapter ctx = new DirContextAdapter(

--- a/ldap/src/main/java/org/springframework/security/ldap/userdetails/DefaultLdapAuthoritiesPopulator.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/userdetails/DefaultLdapAuthoritiesPopulator.java
@@ -16,14 +16,8 @@
 
 package org.springframework.security.ldap.userdetails;
 
-import java.util.*;
-import java.util.function.Function;
-
-import javax.naming.directory.SearchControls;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.core.log.LogMessage;
 import org.springframework.ldap.core.ContextSource;
 import org.springframework.ldap.core.DirContextOperations;
@@ -32,7 +26,10 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.ldap.SpringSecurityLdapTemplate;
 import org.springframework.util.Assert;
-import org.springframework.util.CollectionUtils;
+
+import javax.naming.directory.SearchControls;
+import java.util.*;
+import java.util.function.Function;
 
 /**
  * The default strategy for obtaining user role information from the directory.
@@ -165,8 +162,8 @@ public class DefaultLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
 			logger.info("Will perform group search from the context source base since groupSearchBase is empty.");
 		}
 		this.authorityMapper = (record) -> {
-			List<String> roles = record.getOrDefault(this.groupRoleAttribute, Collections.EMPTY_LIST);
-			return roles.stream().filter(r -> r != null).map(role -> {
+			List<String> roles = record.getOrDefault(this.groupRoleAttribute, Collections.emptyList());
+			return roles.stream().filter(Objects::nonNull).map(role -> {
 				if (this.convertToUpperCase) {
 					return role.toUpperCase(Locale.ROOT);
 				}


### PR DESCRIPTION
For some weird reasons, only the first element of the list returned by the LDAP query is used to create authorities. This PR fixes it creating an authority for all the returned roles. 