### PR TITLE
Add warning about unsupported HTTP-Redirect binding for SAML 2.0 responses

### DIFF
--- a/docs/modules/ROOT/pages/migration-7/index.adoc
+++ b/docs/modules/ROOT/pages/migration-7/index.adoc
@@ -7,3 +7,9 @@ While Spring Security 7.0 does not have a release date yet, it is important to s
 This preparation guide is designed to summarize the biggest changes in Spring Security 7.0 and provide steps to prepare for them.
 
 It is important to keep your application up to date with the latest Spring Security 6 and Spring Boot 3 releases.
+
+[WARNING]
+====
+Spring Security does not support HTTP-Redirect binding for SAML Responses.
+If attempted, it will result in an invalid request handling.
+====


### PR DESCRIPTION
Spring Security does not support HTTP-Redirect binding for SAML 2.0 responses, as it is not permitted by the SAML specification.

This PR updates the migration guide to explicitly document this limitation using a warning block, helping users avoid potential confusion when integrating with SAML identity providers.

Fixes gh-11161