### PR TITLE
JwtTimestampsValidator can require exp and nbf claims

### DIFF
--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtTimestampValidatorTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtTimestampValidatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -156,6 +156,22 @@ public class JwtTimestampValidatorTests {
 		Jwt jwt = TestJwts.jwt().claims((c) -> c.remove(JwtClaimNames.EXP)).notBefore(Instant.MIN).build();
 		JwtTimestampValidator jwtValidator = new JwtTimestampValidator();
 		assertThat(jwtValidator.validate(jwt).hasErrors()).isFalse();
+	}
+
+	@Test
+	public void validateWhenNotAllowEmptyExpiryClaimAndNotBeforeIsValidAndExpiryIsNotSpecifiedThenReturnsSuccessfulResult() {
+		Jwt jwt = TestJwts.jwt().claims((c) -> c.remove(JwtClaimNames.EXP)).notBefore(Instant.MIN).build();
+		JwtTimestampValidator jwtValidator = new JwtTimestampValidator();
+		jwtValidator.setAllowEmptyExpiryClaim(false);
+		assertThat(jwtValidator.validate(jwt).hasErrors()).isTrue();
+	}
+
+	@Test
+	public void validateWhenNotAllowEmptyNotBeforeClaimAndNotBeforeIsNotSpecifiedThenReturnsSuccessfulResult() {
+		Jwt jwt = TestJwts.jwt().claims((c) -> c.remove(JwtClaimNames.NBF)).build();
+		JwtTimestampValidator jwtValidator = new JwtTimestampValidator();
+		jwtValidator.setAllowEmptyNotBeforeClaim(false);
+		assertThat(jwtValidator.validate(jwt).hasErrors()).isTrue();
 	}
 
 	@Test

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtTimestampValidatorTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtTimestampValidatorTests.java
@@ -129,6 +129,23 @@ public class JwtTimestampValidatorTests {
 
 	@Test
 	public void validateWhenNeitherExpiryNorNotBeforeIsSpecifiedThenReturnsSuccessfulResult() {
+		Jwt jwt = TestJwts.jwt().claims((c) -> {
+			c.remove(JwtClaimNames.EXP);
+			c.remove(JwtClaimNames.NBF);
+		}).build();
+		JwtTimestampValidator jwtValidator = new JwtTimestampValidator();
+		assertThat(jwtValidator.validate(jwt).hasErrors()).isFalse();
+	}
+
+	@Test
+	public void validateWhenExpiryIsSpecifiedThenReturnsSuccessfulResult() {
+		Jwt jwt = TestJwts.jwt().claims((c) -> c.remove(JwtClaimNames.EXP)).build();
+		JwtTimestampValidator jwtValidator = new JwtTimestampValidator();
+		assertThat(jwtValidator.validate(jwt).hasErrors()).isFalse();
+	}
+
+	@Test
+	public void validateWhenNotBeforeIsSpecifiedThenReturnsSuccessfulResult() {
 		Jwt jwt = TestJwts.jwt().claims((c) -> c.remove(JwtClaimNames.EXP)).build();
 		JwtTimestampValidator jwtValidator = new JwtTimestampValidator();
 		assertThat(jwtValidator.validate(jwt).hasErrors()).isFalse();


### PR DESCRIPTION
I implemented ```required``` parameter in ```JwtTimestampValidator```, ```JwtIssuerValidator``` and ```JwtAudienceValidator```. I left the function of the original constructors untouched. In the original implementation successful validation was returned even if timestamps, issues or audience claims were missing. So this way previous API, implementations are not breaking. With my changes it is possible now to specify more strict specification, to tell if the given claim is mandatory to present and indiate it with failed validation if the claim is missing.

This is the feature indicated in #17004 