### PR TITLE
Check for null Principal#getName

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilter.java
@@ -217,7 +217,8 @@ public class BasicAuthenticationFilter extends OncePerRequestFilter {
 		// Only reauthenticate if username doesn't match SecurityContextHolder and user
 		// isn't authenticated (see SEC-53)
 		Authentication existingAuth = this.securityContextHolderStrategy.getContext().getAuthentication();
-		if (existingAuth == null || !existingAuth.getName().equals(username) || !existingAuth.isAuthenticated()) {
+		if (existingAuth == null || existingAuth.getName() == null || !existingAuth.getName().equals(username)
+				|| !existingAuth.isAuthenticated()) {
 			return true;
 		}
 		// Handle unusual condition where an AnonymousAuthenticationToken is already


### PR DESCRIPTION
# Problem

`BasicAuthenticationFilter` is comparing existing `Authentication` with username but it assumes that `existingAuth.getName()` returns non-null `String` and calls `.equals(username)` on it. If `existingAuth != null` and `existingAuth.getName()` returns null, it leads to NullPointerException.

This is an unlikely scenario but I have encountered it in an application with highly customized security config.

# Solution

Add additonal `existingAuth.getName() == null` check before calling `.equals()` on it.