### PR TITLE
Implement UserDetailsPasswordService in JdbcUserDetailsManager

### DIFF
--- a/core/src/main/java/org/springframework/security/provisioning/JdbcUserDetailsManager.java
+++ b/core/src/main/java/org/springframework/security/provisioning/JdbcUserDetailsManager.java
@@ -64,6 +64,7 @@ import org.springframework.util.Assert;
  * using this implementation for managing your users.
  *
  * @author Luke Taylor
+ * @author Junhyeok Lee
  * @since 2.0
  */
 public class JdbcUserDetailsManager extends JdbcDaoImpl
@@ -621,6 +622,10 @@ public class JdbcUserDetailsManager extends JdbcDaoImpl
 		}
 	}
 
+	/**
+	 * Conditionally updates password based on the setting from
+	 * {@link #setEnableUpdatePassword(boolean)}. {@inheritDoc}
+	 */
 	@Override
 	public UserDetails updatePassword(UserDetails user, String newPassword) {
 		if (this.enableUpdatePassword) {

--- a/core/src/main/java/org/springframework/security/provisioning/JdbcUserDetailsManager.java
+++ b/core/src/main/java/org/springframework/security/provisioning/JdbcUserDetailsManager.java
@@ -46,6 +46,7 @@ import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserCache;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsPasswordService;
 import org.springframework.security.core.userdetails.cache.NullUserCache;
 import org.springframework.security.core.userdetails.jdbc.JdbcDaoImpl;
 import org.springframework.util.Assert;
@@ -65,7 +66,8 @@ import org.springframework.util.Assert;
  * @author Luke Taylor
  * @since 2.0
  */
-public class JdbcUserDetailsManager extends JdbcDaoImpl implements UserDetailsManager, GroupManager {
+public class JdbcUserDetailsManager extends JdbcDaoImpl
+		implements UserDetailsManager, GroupManager, UserDetailsPasswordService {
 
 	public static final String DEF_CREATE_USER_SQL = "insert into users (username, password, enabled) values (?,?,?)";
 
@@ -161,6 +163,8 @@ public class JdbcUserDetailsManager extends JdbcDaoImpl implements UserDetailsMa
 	private RowMapper<UserDetails> userDetailsMapper = this::mapToUser;
 
 	private RowMapper<GrantedAuthority> grantedAuthorityMapper = this::mapToGrantedAuthority;
+
+	private boolean enableUpdatePassword = false;
 
 	public JdbcUserDetailsManager() {
 	}
@@ -590,6 +594,20 @@ public class JdbcUserDetailsManager extends JdbcDaoImpl implements UserDetailsMa
 		this.userCache = userCache;
 	}
 
+	/**
+	 * Sets whether the {@link #updatePassword(UserDetails, String)} method should
+	 * actually update the password.
+	 * <p>
+	 * Defaults to {@code false} to prevent accidental password updates that might produce
+	 * passwords that are too large for the current database schema. Users must explicitly
+	 * set this to {@code true} to enable password updates.
+	 * @param enableUpdatePassword {@code true} to enable password updates, {@code false}
+	 * otherwise.
+	 */
+	public void setEnableUpdatePassword(boolean enableUpdatePassword) {
+		this.enableUpdatePassword = enableUpdatePassword;
+	}
+
 	private void validateUserDetails(UserDetails user) {
 		Assert.hasText(user.getUsername(), "Username may not be empty or null");
 		validateAuthorities(user.getAuthorities());
@@ -601,6 +619,16 @@ public class JdbcUserDetailsManager extends JdbcDaoImpl implements UserDetailsMa
 			Assert.notNull(authority, "Authorities list contains a null entry");
 			Assert.hasText(authority.getAuthority(), "getAuthority() method must return a non-empty string");
 		}
+	}
+
+	@Override
+	public UserDetails updatePassword(UserDetails user, String newPassword) {
+		if (this.enableUpdatePassword) {
+			UserDetails updated = User.withUserDetails(user).password(newPassword).build();
+			updateUser(updated);
+			return updated;
+		}
+		return user;
 	}
 
 }

--- a/core/src/test/java/org/springframework/security/provisioning/JdbcUserDetailsManagerTests.java
+++ b/core/src/test/java/org/springframework/security/provisioning/JdbcUserDetailsManagerTests.java
@@ -60,6 +60,7 @@ import static org.mockito.BDDMockito.verify;
  *
  * @author Luke Taylor
  * @author dae won
+ * @author Junhyeok Lee
  */
 public class JdbcUserDetailsManagerTests {
 

--- a/core/src/test/java/org/springframework/security/provisioning/JdbcUserDetailsManagerTests.java
+++ b/core/src/test/java/org/springframework/security/provisioning/JdbcUserDetailsManagerTests.java
@@ -405,6 +405,23 @@ public class JdbcUserDetailsManagerTests {
 		verify(mockMapper).mapRow(any(), anyInt());
 	}
 
+	@Test
+	void updatePasswordWhenDisabledReturnOriginalUser() {
+		insertJoe();
+		this.manager.updatePassword(joe, "new");
+		UserDetails newJoe = this.manager.loadUserByUsername("joe");
+		assertThat(newJoe.getPassword()).isEqualTo("password");
+	}
+
+	@Test
+	void updatePasswordWhenEnabledShouldUpdatePassword() {
+		insertJoe();
+		this.manager.setEnableUpdatePassword(true);
+		this.manager.updatePassword(joe, "new");
+		UserDetails newJoe = this.manager.loadUserByUsername("joe");
+		assertThat(newJoe.getPassword()).isEqualTo("new");
+	}
+
 	private Authentication authenticateJoe() {
 		UsernamePasswordAuthenticationToken auth = UsernamePasswordAuthenticationToken.authenticated("joe", "password",
 				joe.getAuthorities());


### PR DESCRIPTION
**Summary:**

Implements `UserDetailsPasswordService` in `JdbcUserDetailsManager` to allow password updates, controlled by a new flag.

**Changes:**

* Added `updatePassword(UserDetails user, String newPassword)` method.
* Introduced `enableUpdatePassword` boolean property (default: false) and setter `setEnableUpdatePassword(boolean)`.
* `updatePassword` method logic updated:
  * If `enableUpdatePassword` is true, it updates the user's password via updateUser.
  * If `enableUpdatePassword` is false, it returns the original `UserDetails` without performing any update.
* Added tests in `JdbcUserDetailsManagerTests` to verify both scenarios (`updatePasswordWhenDisabledReturnOriginalUser` and `updatePasswordWhenEnabledShouldUpdatePassword`).

Closes gh-16863