### PR TITLE
docs: Remove the redundant punctuation marks in the comments.

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/UsernamePasswordAuthenticationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/UsernamePasswordAuthenticationFilter.java
@@ -140,7 +140,7 @@ public class UsernamePasswordAuthenticationFilter extends AbstractAuthentication
 
 	/**
 	 * Sets the parameter name which will be used to obtain the password from the login
-	 * request..
+	 * request.
 	 * @param passwordParameter the parameter name. Defaults to "password".
 	 */
 	public void setPasswordParameter(String passwordParameter) {


### PR DESCRIPTION
Remove the redundant punctuation marks in the comments.
