### PR TITLE
Update the docs to use assertingparty instead of identityprovider to close #12810

### DIFF
--- a/docs/modules/ROOT/pages/servlet/saml2/login/authentication-requests.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/login/authentication-requests.adoc
@@ -66,10 +66,11 @@ spring:
   security:
     saml2:
       relyingparty:
-        okta:
-          assertingparty:
-            entity-id: ...
-            singlesignon.sign-request: false
+        registration:
+          okta:
+            assertingparty:
+              entity-id: ...
+              singlesignon.sign-request: false
 ----
 
 Java::

--- a/docs/modules/ROOT/pages/servlet/saml2/login/authentication-requests.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/login/authentication-requests.adoc
@@ -67,7 +67,7 @@ spring:
     saml2:
       relyingparty:
         okta:
-          identityprovider:
+          assertingparty:
             entity-id: ...
             singlesignon.sign-request: false
 ----

--- a/docs/modules/ROOT/pages/servlet/saml2/login/overview.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/login/overview.adoc
@@ -835,16 +835,17 @@ spring:
   security:
     saml2:
       relyingparty:
-        okta:
-          signing.credentials: &relying-party-credentials
-            - private-key-location: classpath:rp.key
-              certificate-location: classpath:rp.crt
-          assertingparty:
-            entity-id: ...
-        azure:
-          signing.credentials: *relying-party-credentials
-          assertingparty:
-            entity-id: ...
+        registration:
+          okta:
+            signing.credentials: &relying-party-credentials
+              - private-key-location: classpath:rp.key
+                certificate-location: classpath:rp.crt
+            assertingparty:
+              entity-id: ...
+          azure:
+            signing.credentials: *relying-party-credentials
+            assertingparty:
+              entity-id: ...
 ----
 
 Second, in a database, you need not replicate the model of `RelyingPartyRegistration`.

--- a/docs/modules/ROOT/pages/servlet/saml2/login/overview.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/login/overview.adoc
@@ -125,7 +125,7 @@ spring:
       relyingparty:
         registration:
           adfs:
-            identityprovider:
+            assertingparty:
               entity-id: https://idp.example.com/issuer
               verification.credentials:
                 - certificate-location: "classpath:idp.crt"
@@ -839,11 +839,11 @@ spring:
           signing.credentials: &relying-party-credentials
             - private-key-location: classpath:rp.key
               certificate-location: classpath:rp.crt
-          identityprovider:
+          assertingparty:
             entity-id: ...
         azure:
           signing.credentials: *relying-party-credentials
-          identityprovider:
+          assertingparty:
             entity-id: ...
 ----
 


### PR DESCRIPTION
As suggested in issue #12810, this PR updates the documentation to reflect the correct usage of the `assertingparty` Spring Boot auto-configuration property instead of `identityprovider`.

I also believe that the same documentation examples are missing the `registration` property; I added them in a separate commit (but I would gladly either squash the two commits, or create a separate PR entirely).