### PR TITLE
Remove 32-byte minimum keyLength restriction in `Base64StringKeyGenerator`

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/keygen/Base64StringKeyGenerator.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/keygen/Base64StringKeyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.util.Base64;
  *
  * @author Joe Grandja
  * @author Rob Winch
+ * @author Andrey Litvitski
  * @since 5.0
  */
 public class Base64StringKeyGenerator implements StringKeyGenerator {
@@ -67,8 +68,8 @@ public class Base64StringKeyGenerator implements StringKeyGenerator {
 		if (encoder == null) {
 			throw new IllegalArgumentException("encode cannot be null");
 		}
-		if (keyLength < DEFAULT_KEY_LENGTH) {
-			throw new IllegalArgumentException("keyLength must be greater than or equal to " + DEFAULT_KEY_LENGTH);
+		if (keyLength <= 0) {
+			throw new IllegalArgumentException("keyLength must be greater than 0");
 		}
 		this.encoder = encoder;
 		this.keyGenerator = KeyGenerators.secureRandom(keyLength);

--- a/crypto/src/test/java/org/springframework/security/crypto/keygen/Base64StringKeyGeneratorTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/keygen/Base64StringKeyGeneratorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2017 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,13 +25,14 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 
 /**
  * @author Rob Winch
+ * @author Andrey Litvitski
  * @since 5.0
  */
 public class Base64StringKeyGeneratorTests {
 
 	@Test
-	public void constructorIntWhenLessThan32ThenIllegalArgumentException() {
-		assertThatIllegalArgumentException().isThrownBy(() -> new Base64StringKeyGenerator(31));
+	public void constructorIntWhenEqual0ThenIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> new Base64StringKeyGenerator(0));
 	}
 
 	@Test


### PR DESCRIPTION
The main purpose of this change is to essentially remove the strict 32 byte key length limit to allow developers to generate shorter Base64 strings if needed. Now, when trying to pass `keyLength < DEFAULT_KEY_LENGTH (32)` into the constructor, an exception is thrown, which is not always justified for less critical token generation tasks.

I believe that we don't need such a strict condition and we can soften the condition and just check that the key length is not less than or equal to 0.

Fix: #17012