### PR TITLE
Remove GET request support from Saml2AuthenticationTokenConverter

### DIFF
--- a/docs/modules/ROOT/pages/migration/servlet/oauth2.adoc
+++ b/docs/modules/ROOT/pages/migration/servlet/oauth2.adoc
@@ -78,3 +78,42 @@ fun jwtDecoder(): JwtDecoder {
 ======
 <1> - `validateTypes` now defaults to `false`
 <2> - `JwtTypeValidator#jwt` is added by all `createDefaultXXX` methods
+
+== Do Not Process `<saml2:Response>` GET Requests with `Saml2AuthenticationTokenConverter`
+
+Spring Security does not support processing `<saml2:Response>` payloads over GET as this is not supported by the SAML 2.0 spec.
+
+To better comply with this, `Saml2AuthenticationTokenConverter` will not process GET requests by default as of Spring Security 8.
+To prepare for this, the property `shouldConvertGetRequests` is available.
+To use it, publish your own `Saml2AuthenticationTokenConverter` like so:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Bean
+Saml2AuthenticationTokenConverter authenticationConverter(RelyingPartyRegistrationRepository registrations) {
+	Saml2AuhenticationTokenConverter authenticationConverter = new Saml2AuthenticationTokenConverter(
+		new DefaultRelyingPartyRegistrationResolver(registrations));
+	authenticationConverter.setShouldConvertGetRequests(false);
+	return authenticationConverter;
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@Bean
+fun authenticationConverter(val registrations: RelyingPartyRegistrationRepository): Saml2AuthenticationTokenConverter {
+	val authenticationConverter = new Saml2AuthenticationTokenConverter(
+        DefaultRelyingPartyRegistrationResolver(registrations))
+	authenticationConverter.setShouldConvertGetRequests(false)
+	return authenticationConverter
+}
+----
+======
+
+If you must continue using `Saml2AuthenticationTokenConverter` to process GET requests, you can call `setShouldConvertGetRequests` to `true.`

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/web/Saml2AuthenticationTokenConverterTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/web/Saml2AuthenticationTokenConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -228,6 +228,21 @@ public class Saml2AuthenticationTokenConverterTests {
 				this.relyingPartyRegistrationResolver);
 		assertThatExceptionOfType(IllegalArgumentException.class)
 			.isThrownBy(() -> converter.setAuthenticationRequestRepository(null));
+	}
+
+	@Test
+	public void shouldNotConvertGetRequests() {
+		Saml2AuthenticationTokenConverter converter = new Saml2AuthenticationTokenConverter(
+				this.relyingPartyRegistrationResolver);
+		converter.setShouldConvertGetRequests(false);
+		given(this.relyingPartyRegistrationResolver.resolve(any(HttpServletRequest.class), any()))
+			.willReturn(this.relyingPartyRegistration);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("GET");
+		request.setParameter(Saml2ParameterNames.SAML_RESPONSE,
+				Saml2Utils.samlEncode("response".getBytes(StandardCharsets.UTF_8)));
+		Saml2AuthenticationToken token = converter.convert(request);
+		assertThat(token).isNull();
 	}
 
 	private void validateSsoCircleXml(String xml) {


### PR DESCRIPTION
I think we can define `Boolean shouldInflate` and method `decode` will be added

```java
if (this.shouldInflate == null) {
	this.shouldInflate = HttpMethod.GET.matches(request.getMethod());
}
```

If not, this will break `Saml2LoginBeanDefinitionParserTests` and `Saml2AuthenticationTokenConverterTests`

```text
Saml2LoginBeanDefinitionParserTests > authenticateWhenCustomAuthnRequestRepositoryThenUses() FAILED
    org.mockito.exceptions.verification.WantedButNotInvoked at Saml2LoginBeanDefinitionParserTests.java:323

Saml2LoginBeanDefinitionParserTests > authenticateWhenAuthenticationResponseValidThenAuthenticate() FAILED
    java.lang.AssertionError at Saml2LoginBeanDefinitionParserTests.java:213

Saml2LoginBeanDefinitionParserTests > authenticateWhenAuthenticationResponseValidThenAuthenticationSuccessEventPublished() FAILED
    java.lang.AssertionError at Saml2LoginBeanDefinitionParserTests.java:245

Saml2LoginBeanDefinitionParserTests > authenticateWhenCustomSecurityContextHolderStrategyThenUses() FAILED
    java.lang.AssertionError at Saml2LoginBeanDefinitionParserTests.java:228

Saml2LoginBeanDefinitionParserTests > authenticateWhenCustomAuthenticationManagerThenUses() FAILED
    java.lang.AssertionError at Saml2LoginBeanDefinitionParserTests.java:280
```

Issue: gh-17099