### PR TITLE
Add Password Advice Support

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
@@ -3321,7 +3321,9 @@ public final class HttpSecurity extends AbstractConfiguredSecurityBuilder<Defaul
 	 */
 	public HttpSecurity passwordManagement(
 			Customizer<PasswordManagementConfigurer<HttpSecurity>> passwordManagementCustomizer) throws Exception {
-		passwordManagementCustomizer.customize(getOrApply(new PasswordManagementConfigurer<>()));
+		PasswordManagementConfigurer<HttpSecurity> passwordManagement = new PasswordManagementConfigurer<>();
+		passwordManagement.setApplicationContext(getContext());
+		passwordManagementCustomizer.customize(getOrApply(passwordManagement));
 		return HttpSecurity.this;
 	}
 

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configuration/WebMvcSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configuration/WebMvcSecurityConfiguration.java
@@ -46,6 +46,9 @@ import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.HandlerMappingIntrospectorRequestTransformer;
+import org.springframework.security.web.authentication.password.ChangePasswordAdviceMethodArgumentResolver;
+import org.springframework.security.web.authentication.password.ChangePasswordAdviceRepository;
+import org.springframework.security.web.authentication.password.HttpSessionChangePasswordAdviceRepository;
 import org.springframework.security.web.context.AbstractSecurityWebApplicationInitializer;
 import org.springframework.security.web.debug.DebugFilter;
 import org.springframework.security.web.firewall.HttpFirewall;
@@ -87,6 +90,8 @@ class WebMvcSecurityConfiguration implements WebMvcConfigurer, ApplicationContex
 
 	private AnnotationTemplateExpressionDefaults templateDefaults;
 
+	private ChangePasswordAdviceRepository changePasswordAdviceRepository = new HttpSessionChangePasswordAdviceRepository();
+
 	@Override
 	@SuppressWarnings("deprecation")
 	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
@@ -103,6 +108,9 @@ class WebMvcSecurityConfiguration implements WebMvcConfigurer, ApplicationContex
 		currentSecurityContextArgumentResolver.setTemplateDefaults(this.templateDefaults);
 		argumentResolvers.add(currentSecurityContextArgumentResolver);
 		argumentResolvers.add(new CsrfTokenArgumentResolver());
+		ChangePasswordAdviceMethodArgumentResolver resolver = new ChangePasswordAdviceMethodArgumentResolver();
+		resolver.setChangePasswordAdviceRepository(this.changePasswordAdviceRepository);
+		argumentResolvers.add(resolver);
 	}
 
 	@Bean
@@ -118,6 +126,9 @@ class WebMvcSecurityConfiguration implements WebMvcConfigurer, ApplicationContex
 		}
 		if (applicationContext.getBeanNamesForType(AnnotationTemplateExpressionDefaults.class).length == 1) {
 			this.templateDefaults = applicationContext.getBean(AnnotationTemplateExpressionDefaults.class);
+		}
+		if (applicationContext.getBeanNamesForType(ChangePasswordAdviceRepository.class).length == 1) {
+			this.changePasswordAdviceRepository = applicationContext.getBean(ChangePasswordAdviceRepository.class);
 		}
 	}
 

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/FormLoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/FormLoginConfigurer.java
@@ -250,7 +250,7 @@ public final class FormLoginConfigurer<H extends HttpSecurityBuilder<H>> extends
 	 * Gets the HTTP parameter that is used to submit the password.
 	 * @return the HTTP parameter that is used to submit the password
 	 */
-	private String getPasswordParameter() {
+	String getPasswordParameter() {
 		return getAuthenticationFilter().getPasswordParameter();
 	}
 

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/PasswordManagementConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/PasswordManagementConfigurer.java
@@ -16,10 +16,33 @@
 
 package org.springframework.security.config.annotation.web.configurers;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.security.authentication.password.ChangePasswordAdvice;
+import org.springframework.security.authentication.password.ChangePasswordAdvisor;
+import org.springframework.security.authentication.password.ChangePasswordServiceAdvisor;
+import org.springframework.security.authentication.password.DelegatingChangePasswordAdvisor;
+import org.springframework.security.authentication.password.UserDetailsPasswordManager;
 import org.springframework.security.config.annotation.web.HttpSecurityBuilder;
 import org.springframework.security.config.annotation.web.RequestMatcherFactory;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.RequestMatcherRedirectFilter;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.password.ChangeCompromisedPasswordAdvisor;
+import org.springframework.security.web.authentication.password.ChangePasswordAdviceHandler;
+import org.springframework.security.web.authentication.password.ChangePasswordAdviceRepository;
+import org.springframework.security.web.authentication.password.ChangePasswordAdvisingFilter;
+import org.springframework.security.web.authentication.password.ChangePasswordProcessingFilter;
+import org.springframework.security.web.authentication.password.DefaultChangePasswordPageGeneratingFilter;
+import org.springframework.security.web.authentication.password.HttpSessionChangePasswordAdviceRepository;
+import org.springframework.security.web.authentication.password.SimpleChangePasswordAdviceHandler;
+import org.springframework.security.web.savedrequest.RequestCacheAwareFilter;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.util.Assert;
 
 /**
@@ -29,13 +52,27 @@ import org.springframework.util.Assert;
  * @since 5.6
  */
 public final class PasswordManagementConfigurer<B extends HttpSecurityBuilder<B>>
-		extends AbstractHttpConfigurer<PasswordManagementConfigurer<B>, B> {
+		extends AbstractHttpConfigurer<PasswordManagementConfigurer<B>, B> implements ApplicationContextAware {
 
 	private static final String WELL_KNOWN_CHANGE_PASSWORD_PATTERN = "/.well-known/change-password";
 
-	private static final String DEFAULT_CHANGE_PASSWORD_PAGE = "/change-password";
+	private static final String DEFAULT_CHANGE_PASSWORD_PAGE = DefaultChangePasswordPageGeneratingFilter.DEFAULT_CHANGE_PASSWORD_URL;
+
+	private ApplicationContext context;
+
+	private boolean customChangePasswordPage = false;
 
 	private String changePasswordPage = DEFAULT_CHANGE_PASSWORD_PAGE;
+
+	private String changePasswordProcessingUrl = ChangePasswordProcessingFilter.DEFAULT_PASSWORD_CHANGE_PROCESSING_URL;
+
+	private ChangePasswordAdviceRepository changePasswordAdviceRepository;
+
+	private ChangePasswordAdvisor changePasswordAdvisor;
+
+	private ChangePasswordAdviceHandler changePasswordAdviceHandler;
+
+	private UserDetailsPasswordManager userDetailsPasswordManager;
 
 	/**
 	 * Sets the change password page. Defaults to
@@ -46,7 +83,74 @@ public final class PasswordManagementConfigurer<B extends HttpSecurityBuilder<B>
 	public PasswordManagementConfigurer<B> changePasswordPage(String changePasswordPage) {
 		Assert.hasText(changePasswordPage, "changePasswordPage cannot be empty");
 		this.changePasswordPage = changePasswordPage;
+		this.customChangePasswordPage = true;
 		return this;
+	}
+
+	public PasswordManagementConfigurer<B> changePasswordProcessingUrl(String changePasswordProcessingUrl) {
+		this.changePasswordProcessingUrl = changePasswordProcessingUrl;
+		return this;
+	}
+
+	public PasswordManagementConfigurer<B> changePasswordAdviceRepository(
+			ChangePasswordAdviceRepository changePasswordAdviceRepository) {
+		this.changePasswordAdviceRepository = changePasswordAdviceRepository;
+		return this;
+	}
+
+	public PasswordManagementConfigurer<B> changePasswordAdvisor(ChangePasswordAdvisor changePasswordAdvisor) {
+		this.changePasswordAdvisor = changePasswordAdvisor;
+		return this;
+	}
+
+	public PasswordManagementConfigurer<B> changePasswordAdviceHandler(
+			ChangePasswordAdviceHandler changePasswordAdviceHandler) {
+		this.changePasswordAdviceHandler = changePasswordAdviceHandler;
+		return this;
+	}
+
+	public PasswordManagementConfigurer<B> userDetailsPasswordManager(
+			UserDetailsPasswordManager userDetailsPasswordManager) {
+		this.userDetailsPasswordManager = userDetailsPasswordManager;
+		return this;
+	}
+
+	@Override
+	public void init(B http) throws Exception {
+		UserDetailsPasswordManager passwordManager = (this.userDetailsPasswordManager == null)
+				? this.context.getBeanProvider(UserDetailsPasswordManager.class).getIfUnique()
+				: this.userDetailsPasswordManager;
+
+		if (passwordManager == null) {
+			return;
+		}
+
+		ChangePasswordAdviceRepository changePasswordAdviceRepository = (this.changePasswordAdviceRepository != null)
+				? this.changePasswordAdviceRepository
+				: this.context.getBeanProvider(ChangePasswordAdviceRepository.class)
+					.getIfUnique(HttpSessionChangePasswordAdviceRepository::new);
+
+		ChangePasswordAdvisor changePasswordAdvisor = (this.changePasswordAdvisor != null) ? this.changePasswordAdvisor
+				: this.context.getBeanProvider(ChangePasswordAdvisor.class).getIfUnique(() -> {
+					List<ChangePasswordAdvisor> advisors = new ArrayList<>();
+					advisors.add(new ChangeCompromisedPasswordAdvisor());
+					advisors.add(new ChangePasswordServiceAdvisor(passwordManager));
+					return new DelegatingChangePasswordAdvisor(advisors);
+				});
+
+		http.setSharedObject(ChangePasswordAdviceRepository.class, changePasswordAdviceRepository);
+		http.setSharedObject(UserDetailsPasswordManager.class, passwordManager);
+		http.setSharedObject(ChangePasswordAdvisor.class, changePasswordAdvisor);
+
+		FormLoginConfigurer form = http.getConfigurer(FormLoginConfigurer.class);
+		String passwordParameter = (form != null) ? form.getPasswordParameter() : "password";
+		http.getConfigurer(SessionManagementConfigurer.class)
+			.addSessionAuthenticationStrategy((authentication, request, response) -> {
+				UserDetails user = (UserDetails) authentication.getPrincipal();
+				String password = request.getParameter(passwordParameter);
+				ChangePasswordAdvice advice = changePasswordAdvisor.advise(user, password);
+				changePasswordAdviceRepository.savePasswordAdvice(request, response, advice);
+			});
 	}
 
 	/**
@@ -57,6 +161,42 @@ public final class PasswordManagementConfigurer<B extends HttpSecurityBuilder<B>
 		RequestMatcherRedirectFilter changePasswordFilter = new RequestMatcherRedirectFilter(
 				RequestMatcherFactory.matcher(WELL_KNOWN_CHANGE_PASSWORD_PATTERN), this.changePasswordPage);
 		http.addFilterBefore(postProcess(changePasswordFilter), UsernamePasswordAuthenticationFilter.class);
+
+		if (http.getSharedObject(UserDetailsPasswordManager.class) == null) {
+			return;
+		}
+
+		PasswordEncoder passwordEncoder = this.context.getBeanProvider(PasswordEncoder.class)
+			.getIfUnique(PasswordEncoderFactories::createDelegatingPasswordEncoder);
+
+		ChangePasswordAdviceHandler changePasswordAdviceHandler = (this.changePasswordAdviceHandler != null)
+				? this.changePasswordAdviceHandler : this.context.getBeanProvider(ChangePasswordAdviceHandler.class)
+					.getIfUnique(() -> new SimpleChangePasswordAdviceHandler(this.changePasswordPage));
+
+		if (!this.customChangePasswordPage) {
+			DefaultChangePasswordPageGeneratingFilter page = new DefaultChangePasswordPageGeneratingFilter();
+			http.addFilterBefore(page, RequestCacheAwareFilter.class);
+		}
+
+		ChangePasswordProcessingFilter processing = new ChangePasswordProcessingFilter(
+				http.getSharedObject(UserDetailsPasswordManager.class));
+		processing
+			.setRequestMatcher(PathPatternRequestMatcher.withDefaults().matcher(this.changePasswordProcessingUrl));
+		processing.setChangePasswordAdvisor(http.getSharedObject(ChangePasswordAdvisor.class));
+		processing.setChangePasswordAdviceRepository(http.getSharedObject(ChangePasswordAdviceRepository.class));
+		processing.setPasswordEncoder(passwordEncoder);
+		processing.setSecurityContextHolderStrategy(getSecurityContextHolderStrategy());
+		http.addFilterBefore(processing, RequestCacheAwareFilter.class);
+
+		ChangePasswordAdvisingFilter advising = new ChangePasswordAdvisingFilter();
+		advising.setChangePasswordAdviceRepository(http.getSharedObject(ChangePasswordAdviceRepository.class));
+		advising.setChangePasswordAdviceHandler(changePasswordAdviceHandler);
+		http.addFilterBefore(advising, RequestCacheAwareFilter.class);
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext context) {
+		this.context = context;
 	}
 
 }

--- a/core/src/main/java/org/springframework/security/authentication/password/ChangeLengthPasswordAdvisor.java
+++ b/core/src/main/java/org/springframework/security/authentication/password/ChangeLengthPasswordAdvisor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authentication.password;
+
+import org.springframework.security.authentication.password.ChangePasswordAdvice.Action;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class ChangeLengthPasswordAdvisor implements ChangePasswordAdvisor {
+
+	private final int minLength;
+
+	private final int maxLength;
+
+	private Action tooShortAction = Action.MUST_CHANGE;
+
+	private Action tooLongAction = Action.SHOULD_CHANGE;
+
+	public ChangeLengthPasswordAdvisor(int minLength) {
+		this(minLength, Integer.MAX_VALUE);
+	}
+
+	public ChangeLengthPasswordAdvisor(int minLength, int maxLength) {
+		this.minLength = minLength;
+		this.maxLength = maxLength;
+	}
+
+	@Override
+	public ChangePasswordAdvice advise(UserDetails user, String password) {
+		if (password.length() < this.minLength) {
+			return new SimpleChangePasswordAdvice(this.tooShortAction, ChangePasswordReason.TOO_SHORT);
+		}
+		if (password.length() > this.maxLength) {
+			return new SimpleChangePasswordAdvice(this.tooLongAction, ChangePasswordReason.TOO_LONG);
+		}
+		return ChangePasswordAdvice.keep();
+	}
+
+	public void setTooShortAction(Action tooShortAction) {
+		this.tooShortAction = tooShortAction;
+	}
+
+	public void setTooLongAction(Action tooLongAction) {
+		this.tooLongAction = tooLongAction;
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/authentication/password/ChangePasswordAdvice.java
+++ b/core/src/main/java/org/springframework/security/authentication/password/ChangePasswordAdvice.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authentication.password;
+
+import java.util.Collection;
+
+public interface ChangePasswordAdvice {
+
+	Action getAction();
+
+	Collection<ChangePasswordReason> getReasons();
+
+	static ChangePasswordAdvice keep() {
+		return new SimpleChangePasswordAdvice(Action.KEEP);
+	}
+
+	enum Action {
+
+		KEEP, SHOULD_CHANGE, MUST_CHANGE
+
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/authentication/password/ChangePasswordAdvisor.java
+++ b/core/src/main/java/org/springframework/security/authentication/password/ChangePasswordAdvisor.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authentication.password;
+
+import org.springframework.security.core.userdetails.UserDetails;
+
+public interface ChangePasswordAdvisor {
+
+	ChangePasswordAdvice advise(UserDetails user, String password);
+
+	default ChangePasswordAdvice adviseForUpdate(UserDetails user, String password) {
+		return advise(user, password);
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/authentication/password/ChangePasswordReason.java
+++ b/core/src/main/java/org/springframework/security/authentication/password/ChangePasswordReason.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authentication.password;
+
+public enum ChangePasswordReason {
+
+	COMPROMISED, EXPIRED, MISSING_CHARACTERS, REPEATED, TOO_SHORT, TOO_LONG, UNSUPPORTED_CHARACTERS
+
+}

--- a/core/src/main/java/org/springframework/security/authentication/password/ChangePasswordServiceAdvisor.java
+++ b/core/src/main/java/org/springframework/security/authentication/password/ChangePasswordServiceAdvisor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authentication.password;
+
+import org.springframework.security.core.userdetails.UserDetails;
+
+public final class ChangePasswordServiceAdvisor implements ChangePasswordAdvisor {
+
+	private final UserDetailsPasswordManager passwordManager;
+
+	public ChangePasswordServiceAdvisor(UserDetailsPasswordManager passwordManager) {
+		this.passwordManager = passwordManager;
+	}
+
+	@Override
+	public ChangePasswordAdvice advise(UserDetails user, String password) {
+		return this.passwordManager.loadPasswordAdvice(user);
+	}
+
+	@Override
+	public ChangePasswordAdvice adviseForUpdate(UserDetails user, String password) {
+		return null;
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/authentication/password/ChangeRepeatedPasswordAdvisor.java
+++ b/core/src/main/java/org/springframework/security/authentication/password/ChangeRepeatedPasswordAdvisor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authentication.password;
+
+import org.springframework.security.authentication.password.ChangePasswordAdvice.Action;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.util.Assert;
+
+public final class ChangeRepeatedPasswordAdvisor implements ChangePasswordAdvisor {
+
+	private final UserDetailsService userDetailsService;
+
+	private PasswordEncoder passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+
+	private Action action = Action.MUST_CHANGE;
+
+	public ChangeRepeatedPasswordAdvisor(UserDetailsService userDetailsService) {
+		this.userDetailsService = userDetailsService;
+	}
+
+	@Override
+	public ChangePasswordAdvice advise(UserDetails user, String password) {
+		return null;
+	}
+
+	@Override
+	public ChangePasswordAdvice adviseForUpdate(UserDetails user, String password) {
+		UserDetails withPassword = this.userDetailsService.loadUserByUsername(user.getUsername());
+		if (this.passwordEncoder.matches(password, withPassword.getPassword())) {
+			return new SimpleChangePasswordAdvice(this.action, ChangePasswordReason.REPEATED);
+		}
+		return ChangePasswordAdvice.keep();
+	}
+
+	public void setPasswordEncoder(PasswordEncoder passwordEncoder) {
+		Assert.notNull(passwordEncoder, "passwordEncoder cannot be null");
+		this.passwordEncoder = passwordEncoder;
+	}
+
+	public void setAction(Action action) {
+		this.action = action;
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/authentication/password/DelegatingChangePasswordAdvisor.java
+++ b/core/src/main/java/org/springframework/security/authentication/password/DelegatingChangePasswordAdvisor.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authentication.password;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.security.core.userdetails.UserDetails;
+
+public final class DelegatingChangePasswordAdvisor implements ChangePasswordAdvisor {
+
+	private final List<ChangePasswordAdvisor> advisors;
+
+	public DelegatingChangePasswordAdvisor(List<ChangePasswordAdvisor> advisors) {
+		this.advisors = advisors;
+	}
+
+	@Override
+	public ChangePasswordAdvice advise(UserDetails user, String password) {
+		Collection<ChangePasswordAdvice> advice = this.advisors.stream()
+			.map((advisor) -> advisor.advise(user, password))
+			.filter(Objects::nonNull)
+			.toList();
+		return new CompositeChangePasswordAdvice(advice);
+	}
+
+	@Override
+	public ChangePasswordAdvice adviseForUpdate(UserDetails user, String password) {
+		Collection<ChangePasswordAdvice> advice = this.advisors.stream()
+			.map((advisor) -> advisor.adviseForUpdate(user, password))
+			.filter(Objects::nonNull)
+			.toList();
+		return new CompositeChangePasswordAdvice(advice);
+	}
+
+	private static final class CompositeChangePasswordAdvice implements ChangePasswordAdvice {
+
+		private final Collection<ChangePasswordAdvice> advice;
+
+		private final Action action;
+
+		private final Collection<ChangePasswordReason> reasons;
+
+		private CompositeChangePasswordAdvice(Collection<ChangePasswordAdvice> advice) {
+			this.advice = advice;
+			Action action = Action.KEEP;
+			Collection<ChangePasswordReason> reasons = new ArrayList<>();
+			for (ChangePasswordAdvice a : advice) {
+				if (a.getAction() == Action.KEEP) {
+					continue;
+				}
+				if (action.ordinal() < a.getAction().ordinal()) {
+					action = a.getAction();
+				}
+				reasons.addAll(a.getReasons());
+			}
+			this.action = action;
+			this.reasons = reasons;
+		}
+
+		@Override
+		public Action getAction() {
+			return this.action;
+		}
+
+		@Override
+		public Collection<ChangePasswordReason> getReasons() {
+			return this.reasons;
+		}
+
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/authentication/password/SimpleChangePasswordAdvice.java
+++ b/core/src/main/java/org/springframework/security/authentication/password/SimpleChangePasswordAdvice.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authentication.password;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public final class SimpleChangePasswordAdvice implements ChangePasswordAdvice {
+
+	private final Action action;
+
+	private final Collection<ChangePasswordReason> reasons;
+
+	public SimpleChangePasswordAdvice(Action action, ChangePasswordReason... reasons) {
+		this(action, List.of(reasons));
+	}
+
+	public SimpleChangePasswordAdvice(Action action, Collection<ChangePasswordReason> reasons) {
+		this.action = action;
+		this.reasons = new ArrayList<>(reasons);
+	}
+
+	@Override
+	public Action getAction() {
+		return this.action;
+	}
+
+	@Override
+	public Collection<ChangePasswordReason> getReasons() {
+		return this.reasons;
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/authentication/password/UserDetailsPasswordManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/password/UserDetailsPasswordManager.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authentication.password;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsPasswordService;
+
+public interface UserDetailsPasswordManager extends UserDetailsPasswordService {
+
+	/**
+	 * Update the password and remove any related password advice
+	 * @param user the user to modify the password for
+	 * @param newPassword the password to change to, encoded by the configured
+	 * {@code PasswordEncoder}
+	 * @return the updated {@link UserDetails}
+	 */
+	@Override
+	UserDetails updatePassword(UserDetails user, String newPassword);
+
+	ChangePasswordAdvice loadPasswordAdvice(UserDetails user);
+
+	void savePasswordAdvice(UserDetails user, ChangePasswordAdvice advice);
+
+	void removePasswordAdvice(UserDetails user);
+
+}

--- a/core/src/main/java/org/springframework/security/provisioning/InMemoryUserDetailsManager.java
+++ b/core/src/main/java/org/springframework/security/provisioning/InMemoryUserDetailsManager.java
@@ -30,13 +30,14 @@ import org.springframework.core.log.LogMessage;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.password.ChangePasswordAdvice;
+import org.springframework.security.authentication.password.UserDetailsPasswordManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.CredentialsContainer;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsPasswordService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.core.userdetails.memory.UserAttribute;
 import org.springframework.security.core.userdetails.memory.UserAttributeEditor;
@@ -52,11 +53,13 @@ import org.springframework.util.Assert;
  * @author Luke Taylor
  * @since 3.1
  */
-public class InMemoryUserDetailsManager implements UserDetailsManager, UserDetailsPasswordService {
+public class InMemoryUserDetailsManager implements UserDetailsManager, UserDetailsPasswordManager {
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
 	private final Map<String, MutableUserDetails> users = new HashMap<>();
+
+	private final Map<String, ChangePasswordAdvice> advice = new HashMap<>();
 
 	private SecurityContextHolderStrategy securityContextHolderStrategy = SecurityContextHolder
 		.getContextHolderStrategy();
@@ -157,6 +160,7 @@ public class InMemoryUserDetailsManager implements UserDetailsManager, UserDetai
 		String username = user.getUsername();
 		MutableUserDetails mutableUser = this.users.get(username.toLowerCase(Locale.ROOT));
 		mutableUser.setPassword(newPassword);
+		removePasswordAdvice(mutableUser);
 		return mutableUser;
 	}
 
@@ -171,6 +175,23 @@ public class InMemoryUserDetailsManager implements UserDetailsManager, UserDetai
 		}
 		return new User(user.getUsername(), user.getPassword(), user.isEnabled(), user.isAccountNonExpired(),
 				user.isCredentialsNonExpired(), user.isAccountNonLocked(), user.getAuthorities());
+	}
+
+	@Override
+	public ChangePasswordAdvice loadPasswordAdvice(UserDetails user) {
+		return this.advice.get(user.getUsername());
+	}
+
+	@Override
+	public void savePasswordAdvice(UserDetails user, ChangePasswordAdvice advice) {
+		Assert.notNull(advice,
+				"advice must not be null; if you want to remove advice, please call removePasswordAdvice");
+		this.advice.put(user.getUsername(), advice);
+	}
+
+	@Override
+	public void removePasswordAdvice(UserDetails user) {
+		this.advice.remove(user.getUsername());
 	}
 
 	/**

--- a/web/src/main/java/org/springframework/security/web/authentication/password/ChangeCompromisedPasswordAdvisor.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/password/ChangeCompromisedPasswordAdvisor.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication.password;
+
+import java.util.Collection;
+
+import org.springframework.security.authentication.password.ChangePasswordAdvice;
+import org.springframework.security.authentication.password.ChangePasswordAdvice.Action;
+import org.springframework.security.authentication.password.ChangePasswordAdvisor;
+import org.springframework.security.authentication.password.ChangePasswordReason;
+import org.springframework.security.authentication.password.CompromisedPasswordChecker;
+import org.springframework.security.authentication.password.CompromisedPasswordDecision;
+import org.springframework.security.authentication.password.SimpleChangePasswordAdvice;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public final class ChangeCompromisedPasswordAdvisor implements ChangePasswordAdvisor {
+
+	private final CompromisedPasswordChecker pwned = new HaveIBeenPwnedRestApiPasswordChecker();
+
+	private Action action = Action.SHOULD_CHANGE;
+
+	@Override
+	public ChangePasswordAdvice advise(UserDetails user, String password) {
+		return new Advice(this.action, this.pwned.check(password));
+	}
+
+	public void setAction(Action action) {
+		this.action = action;
+	}
+
+	public static final class Advice implements ChangePasswordAdvice {
+
+		private final CompromisedPasswordDecision decision;
+
+		private final ChangePasswordAdvice advice;
+
+		public Advice(Action action, CompromisedPasswordDecision decision) {
+			this.decision = decision;
+			if (decision.isCompromised()) {
+				this.advice = new SimpleChangePasswordAdvice(action, ChangePasswordReason.COMPROMISED);
+			}
+			else {
+				this.advice = ChangePasswordAdvice.keep();
+			}
+		}
+
+		public CompromisedPasswordDecision getDecision() {
+			return this.decision;
+		}
+
+		@Override
+		public Action getAction() {
+			return this.advice.getAction();
+		}
+
+		@Override
+		public Collection<ChangePasswordReason> getReasons() {
+			return this.advice.getReasons();
+		}
+
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/password/ChangePasswordAdviceHandler.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/password/ChangePasswordAdviceHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication.password;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.security.authentication.password.ChangePasswordAdvice;
+
+public interface ChangePasswordAdviceHandler {
+
+	void handle(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
+			ChangePasswordAdvice advice) throws ServletException, IOException;
+
+}
+
+// authentication request process
+// -------------- ------- -------
+// KEEP redirect to home continue filter redirect to home
+// RESET redirect to home continue filter redirect to home
+// REQUIRE_RESET redirect to home redirect to reset redirect to home

--- a/web/src/main/java/org/springframework/security/web/authentication/password/ChangePasswordAdviceMethodArgumentResolver.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/password/ChangePasswordAdviceMethodArgumentResolver.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication.password;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.password.ChangePasswordAdvice;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public final class ChangePasswordAdviceMethodArgumentResolver implements HandlerMethodArgumentResolver {
+
+	ChangePasswordAdviceRepository changePasswordAdviceRepository = new HttpSessionChangePasswordAdviceRepository();
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return ChangePasswordAdvice.class.isAssignableFrom(parameter.getParameterType());
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+			NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+		return this.changePasswordAdviceRepository
+			.loadPasswordAdvice(webRequest.getNativeRequest(HttpServletRequest.class));
+	}
+
+	public void setChangePasswordAdviceRepository(ChangePasswordAdviceRepository changePasswordAdviceRepository) {
+		this.changePasswordAdviceRepository = changePasswordAdviceRepository;
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/password/ChangePasswordAdviceRepository.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/password/ChangePasswordAdviceRepository.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication.password;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.security.authentication.password.ChangePasswordAdvice;
+
+public interface ChangePasswordAdviceRepository {
+
+	ChangePasswordAdvice loadPasswordAdvice(HttpServletRequest request);
+
+	void savePasswordAdvice(HttpServletRequest request, HttpServletResponse response, ChangePasswordAdvice advice);
+
+	void removePasswordAdvice(HttpServletRequest request, HttpServletResponse response);
+
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/password/ChangePasswordAdvisingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/password/ChangePasswordAdvisingFilter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication.password;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.security.authentication.password.ChangePasswordAdvice;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class ChangePasswordAdvisingFilter extends OncePerRequestFilter {
+
+	private ChangePasswordAdviceHandler changePasswordAdviceHandler = new SimpleChangePasswordAdviceHandler(
+			DefaultChangePasswordPageGeneratingFilter.DEFAULT_CHANGE_PASSWORD_URL);
+
+	private ChangePasswordAdviceRepository changePasswordAdviceRepository = new HttpSessionChangePasswordAdviceRepository();
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+			throws ServletException, IOException {
+		ChangePasswordAdvice advice = this.changePasswordAdviceRepository.loadPasswordAdvice(request);
+		this.changePasswordAdviceHandler.handle(request, response, chain, advice);
+	}
+
+	public void setChangePasswordAdviceRepository(ChangePasswordAdviceRepository changePasswordAdviceRepository) {
+		this.changePasswordAdviceRepository = changePasswordAdviceRepository;
+	}
+
+	public void setChangePasswordAdviceHandler(ChangePasswordAdviceHandler changePasswordAdviceHandler) {
+		this.changePasswordAdviceHandler = changePasswordAdviceHandler;
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/password/ChangePasswordProcessingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/password/ChangePasswordProcessingFilter.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication.password;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.authentication.password.ChangePasswordAdvice;
+import org.springframework.security.authentication.password.ChangePasswordAdvisor;
+import org.springframework.security.authentication.password.UserDetailsPasswordManager;
+import org.springframework.security.authorization.AuthenticatedAuthorizationManager;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.authorization.AuthorizationResult;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.access.HttpStatusAccessDeniedHandler;
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
+import org.springframework.security.web.authentication.AuthenticationEntryPointFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class ChangePasswordProcessingFilter extends OncePerRequestFilter {
+
+	public static final String DEFAULT_PASSWORD_CHANGE_PROCESSING_URL = "/change-password";
+
+	private final AuthenticationFailureHandler failureHandler = new AuthenticationEntryPointFailureHandler(
+			new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED));
+
+	private final AuthorizationManager<RequestAuthorizationContext> authorizationManager = AuthenticatedAuthorizationManager
+		.authenticated();
+
+	private final AccessDeniedHandler deniedHandler = new HttpStatusAccessDeniedHandler(HttpStatus.FORBIDDEN);
+
+	private final AuthenticationSuccessHandler successHandler = new SavedRequestAwareAuthenticationSuccessHandler();
+
+	private SecurityContextHolderStrategy securityContextHolderStrategy = SecurityContextHolder
+		.getContextHolderStrategy();
+
+	private RequestMatcher requestMatcher = PathPatternRequestMatcher.withDefaults()
+		.matcher(HttpMethod.POST, DEFAULT_PASSWORD_CHANGE_PROCESSING_URL);
+
+	private PasswordEncoder passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+
+	private ChangePasswordAdviceRepository changePasswordAdviceRepository = new HttpSessionChangePasswordAdviceRepository();
+
+	private ChangePasswordAdvisor changePasswordAdvisor = new ChangeCompromisedPasswordAdvisor();
+
+	private final UserDetailsPasswordManager passwordManager;
+
+	public ChangePasswordProcessingFilter(UserDetailsPasswordManager passwordManager) {
+		this.passwordManager = passwordManager;
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+			throws ServletException, IOException {
+		RequestMatcher.MatchResult match = this.requestMatcher.matcher(request);
+		if (!match.isMatch()) {
+			chain.doFilter(request, response);
+			return;
+		}
+		String password = request.getParameter("newPassword");
+		if (password == null) {
+			chain.doFilter(request, response);
+			return;
+		}
+		Authentication authentication = this.securityContextHolderStrategy.getContext().getAuthentication();
+		if (authentication == null) {
+			this.failureHandler.onAuthenticationFailure(request, response,
+					new InsufficientAuthenticationException("Authentication required to change password"));
+			return;
+		}
+		AuthorizationResult authorization = this.authorizationManager.authorize(() -> authentication,
+				new RequestAuthorizationContext(request, match.getVariables()));
+		if (authorization == null) {
+			this.deniedHandler.handle(request, response, new AuthorizationDeniedException("denied"));
+			return;
+		}
+		if (!authorization.isGranted()) {
+			this.deniedHandler.handle(request, response,
+					new AuthorizationDeniedException("access denied", authorization));
+			return;
+		}
+		UserDetails user = (UserDetails) authentication.getPrincipal();
+		ChangePasswordAdvice advice = this.changePasswordAdvisor.adviseForUpdate(user, password);
+		if (advice.getAction() == ChangePasswordAdvice.Action.KEEP) {
+			this.passwordManager.updatePassword(user, this.passwordEncoder.encode(password));
+			this.changePasswordAdviceRepository.removePasswordAdvice(request, response);
+		}
+		else {
+			this.changePasswordAdviceRepository.savePasswordAdvice(request, response, advice);
+		}
+		this.successHandler.onAuthenticationSuccess(request, response, authentication);
+	}
+
+	public void setChangePasswordAdviceRepository(ChangePasswordAdviceRepository advice) {
+		this.changePasswordAdviceRepository = advice;
+	}
+
+	public void setChangePasswordAdvisor(ChangePasswordAdvisor advisor) {
+		this.changePasswordAdvisor = advisor;
+	}
+
+	public void setRequestMatcher(RequestMatcher requestMatcher) {
+		this.requestMatcher = requestMatcher;
+	}
+
+	public void setPasswordEncoder(PasswordEncoder passwordEncoder) {
+		this.passwordEncoder = passwordEncoder;
+	}
+
+	public void setSecurityContextHolderStrategy(SecurityContextHolderStrategy securityContextHolderStrategy) {
+		this.securityContextHolderStrategy = securityContextHolderStrategy;
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/password/DefaultChangePasswordPageGeneratingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/password/DefaultChangePasswordPageGeneratingFilter.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication.password;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class DefaultChangePasswordPageGeneratingFilter extends OncePerRequestFilter {
+
+	public static final String DEFAULT_CHANGE_PASSWORD_URL = "/change-password";
+
+	private RequestMatcher requestMatcher = PathPatternRequestMatcher.withDefaults()
+		.matcher(HttpMethod.GET, DEFAULT_CHANGE_PASSWORD_URL);
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+			throws ServletException, IOException {
+		if (!this.requestMatcher.matches(request)) {
+			chain.doFilter(request, response);
+			return;
+		}
+		String page = PASSWORD_RESET_TEMPLATE;
+		CsrfToken token = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+		if (token != null) {
+			page = page.replace("{{parameter}}", token.getParameterName()).replace("{{value}}", token.getToken());
+		}
+		response.setContentType("text/html;charset=UTF-8");
+		response.getWriter().println(page);
+	}
+
+	private static final String PASSWORD_RESET_TEMPLATE = """
+			<!DOCTYPE html>
+			<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org" lang="en">
+			<head>
+				<meta charset="utf-8" />
+				<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+				<title>Change Your Password</title>
+				<link href="/default-ui.css" rel="stylesheet" />
+			</head>
+			<body>
+				<div class="content">
+					<form class="login-form" th:action="/change-password" method="post">
+						<h2>Enter your new password below:</h2>
+						<p>
+							<label for="newPassword">New Password:</label>
+							<input type="password" id="newPassword" name="newPassword">
+						</p>
+						<input type="hidden" name="{{parameter}}" value="{{value}}"/>
+						<button class="primary" id="submit" type="submit">Change Password</button>
+					</form>
+				</div>
+			</body>
+			</html>
+			""";
+
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/password/HttpSessionChangePasswordAdviceRepository.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/password/HttpSessionChangePasswordAdviceRepository.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication.password;
+
+import java.util.Collection;
+import java.util.function.Supplier;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.password.ChangePasswordAdvice;
+import org.springframework.security.authentication.password.ChangePasswordReason;
+import org.springframework.util.function.SingletonSupplier;
+
+public final class HttpSessionChangePasswordAdviceRepository implements ChangePasswordAdviceRepository {
+
+	private static final String PASSWORD_ADVICE_ATTRIBUTE_NAME = HttpSessionChangePasswordAdviceRepository.class
+		.getName() + ".PASSWORD_ADVICE";
+
+	@Override
+	@NonNull
+	public ChangePasswordAdvice loadPasswordAdvice(HttpServletRequest request) {
+		return new DeferredChangePasswordAdvice(() -> {
+			ChangePasswordAdvice advice = (ChangePasswordAdvice) request.getSession()
+				.getAttribute(PASSWORD_ADVICE_ATTRIBUTE_NAME);
+			if (advice != null) {
+				return advice;
+			}
+			return ChangePasswordAdvice.keep();
+		});
+	}
+
+	@Override
+	public void savePasswordAdvice(HttpServletRequest request, HttpServletResponse response,
+			ChangePasswordAdvice advice) {
+		if (advice.getAction() == ChangePasswordAdvice.Action.KEEP) {
+			removePasswordAdvice(request, response);
+			return;
+		}
+		request.getSession().setAttribute(PASSWORD_ADVICE_ATTRIBUTE_NAME, advice);
+	}
+
+	@Override
+	public void removePasswordAdvice(HttpServletRequest request, HttpServletResponse response) {
+		request.getSession().removeAttribute(PASSWORD_ADVICE_ATTRIBUTE_NAME);
+	}
+
+	private static final class DeferredChangePasswordAdvice implements ChangePasswordAdvice {
+
+		private final Supplier<ChangePasswordAdvice> advice;
+
+		DeferredChangePasswordAdvice(Supplier<ChangePasswordAdvice> advice) {
+			this.advice = SingletonSupplier.of(advice);
+		}
+
+		@Override
+		public Action getAction() {
+			return this.advice.get().getAction();
+		}
+
+		@Override
+		public Collection<ChangePasswordReason> getReasons() {
+			return this.advice.get().getReasons();
+		}
+
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/password/SimpleChangePasswordAdviceHandler.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/password/SimpleChangePasswordAdviceHandler.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication.password;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.security.authentication.password.ChangePasswordAdvice;
+import org.springframework.security.web.DefaultRedirectStrategy;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.security.web.savedrequest.NullRequestCache;
+import org.springframework.security.web.savedrequest.RequestCache;
+import org.springframework.security.web.util.matcher.AnyRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.util.Assert;
+
+public final class SimpleChangePasswordAdviceHandler implements ChangePasswordAdviceHandler {
+
+	private final RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
+
+	private final String changePasswordUrl;
+
+	private RequestCache requestCache = new NullRequestCache();
+
+	private RequestMatcher requestMatcher = AnyRequestMatcher.INSTANCE;
+
+	public SimpleChangePasswordAdviceHandler(String changePasswordUrl) {
+		Assert.hasText(changePasswordUrl, "changePasswordUrl cannot be empty");
+		this.changePasswordUrl = changePasswordUrl;
+	}
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response, FilterChain chain,
+			ChangePasswordAdvice advice) throws IOException, ServletException {
+		if (!this.requestMatcher.matches(request)) {
+			return;
+		}
+		if (request.getRequestURI().equals(this.changePasswordUrl)) {
+			chain.doFilter(request, response);
+			return;
+		}
+		if (advice.getAction() != ChangePasswordAdvice.Action.MUST_CHANGE) {
+			chain.doFilter(request, response);
+			return;
+		}
+		this.requestCache.saveRequest(request, response);
+		this.redirectStrategy.sendRedirect(request, response, this.changePasswordUrl);
+	}
+
+	public void setRequestCache(RequestCache requestCache) {
+		this.requestCache = requestCache;
+	}
+
+	public void setRequestMatcher(RequestMatcher requestMatcher) {
+		this.requestMatcher = requestMatcher;
+	}
+
+}


### PR DESCRIPTION
This commit adds configuration options to `.passwordManagement` to allow for additional password management flows:

1. Show a default change password page and enforce configured password rules
2. Enforce configured password rules at login time; either request or require that the user change their password accordingly
3. Allow admin to force password changes

You can activate by publishing a `UserDetailsPasswordManager` bean and using the PasswordManagement DSL:

```java
@Bean 
UserDetailsService users() {
    // ...
    return new InMemoryUserDetailsManager(...);
}

...
@Bean 
SecurityFilterChain securityFilters(HttpSecurity http) throws Exception {
    http
        // ...
        .passwordManagement(Customizer.withDefaults());

    return http.build();
}
```

Since these flows require a `UserDetailsPasswordManager` bean, and because `.passwordManagement` is a pre-existing DSL, they remain inactive until that bean is provided.

Some things to try:

* `ChangePasswordAdvisor` - the PR contains several sample implementations of this interface. They can be composed in `DelegatingChangePasswordAdvisor` to form a custom set of password requirements. By default, two advisors are active; the compromised password advisor and the password advice advisor checking for any existing advice
* `ChangePasswordAdvice.Action` - the existing advisors can be configured to have a different action, for example changing the failure action to `Action.MUST_CHANGE` instead of `Action.SHOULD_CHANGE`
* `UserDetailsPasswordManager` contains any advice tied to a user. By default, `.passwordManagement` only checks at login time and when a password changes. However, you can write a `ChangePasswordAdviceRepository` implementation that checks the `UserDetailsPasswordManager` on each request so that the user is advised mid-session if changes are needed.