### PR TITLE
ClearSiteDataHeaderWriter log is misleading 

### DIFF
--- a/web/src/main/java/org/springframework/security/web/header/writers/ClearSiteDataHeaderWriter.java
+++ b/web/src/main/java/org/springframework/security/web/header/writers/ClearSiteDataHeaderWriter.java
@@ -74,11 +74,12 @@ public final class ClearSiteDataHeaderWriter implements HeaderWriter {
 		if (this.requestMatcher.matches(request)) {
 			if (!response.containsHeader(CLEAR_SITE_DATA_HEADER)) {
 				response.setHeader(CLEAR_SITE_DATA_HEADER, this.headerValue);
-			}
+			}			
+		} else {
+			this.logger.debug(
+					LogMessage.format("Not injecting Clear-Site-Data header since it did not match the requestMatcher %s",
+							this.requestMatcher));
 		}
-		this.logger.debug(
-				LogMessage.format("Not injecting Clear-Site-Data header since it did not match the requestMatcher %s",
-						this.requestMatcher));
 	}
 
 	private String transformToHeaderValue(Directive... directives) {


### PR DESCRIPTION
Hello,
this is just a simple log typo which could be misleading, whether the requestmatcher matches or not, it's logging that it isn't.