### PR TITLE
Fix traceId discrepancy in case error in servlet web

### DIFF
--- a/web/src/test/java/org/springframework/security/web/FilterChainProxyTests.java
+++ b/web/src/test/java/org/springframework/security/web/FilterChainProxyTests.java
@@ -310,6 +310,65 @@ public class FilterChainProxyTests {
 		assertFilterChainObservation(contexts.next(), "after", 1);
 	}
 
+	// gh-12610
+	@Test
+	void parentObservationIsTakenIntoAccountDuringDispatchError() throws Exception {
+		ObservationHandler<Observation.Context> handler = mock(ObservationHandler.class);
+		given(handler.supportsContext(any())).willReturn(true);
+		ObservationRegistry registry = ObservationRegistry.create();
+		registry.observationConfig().observationHandler(handler);
+
+		given(this.matcher.matches(any())).willReturn(true);
+		SecurityFilterChain sec = new DefaultSecurityFilterChain(this.matcher, Arrays.asList(this.filter));
+		FilterChainProxy fcp = new FilterChainProxy(sec);
+		fcp.setFilterChainDecorator(new ObservationFilterChainDecorator(registry));
+		Filter initialFilter = ObservationFilterChainDecorator.FilterObservation
+			.create(Observation.createNotStarted("wrap", registry))
+			.wrap(fcp);
+
+		ServletRequest initialRequest = new MockHttpServletRequest("GET", "/");
+		initialFilter.doFilter(initialRequest, new MockHttpServletResponse(), this.chain);
+
+		// simulate request attribute copying in case dispatching to ERROR
+		ObservationFilterChainDecorator.AroundFilterObservation parentObservation = (ObservationFilterChainDecorator.AroundFilterObservation) initialRequest
+			.getAttribute(ObservationFilterChainDecorator.ATTRIBUTE);
+		assertThat(parentObservation).isNotNull();
+
+		// simulate dispatching error-related request
+		Filter errorRelatedFilter = ObservationFilterChainDecorator.FilterObservation
+			.create(Observation.createNotStarted("wrap", registry))
+			.wrap(fcp);
+		ServletRequest errorRelatedRequest = new MockHttpServletRequest("GET", "/error");
+		errorRelatedRequest.setAttribute(ObservationFilterChainDecorator.ATTRIBUTE, parentObservation);
+		errorRelatedFilter.doFilter(errorRelatedRequest, new MockHttpServletResponse(), this.chain);
+
+		ArgumentCaptor<Observation.Context> captor = ArgumentCaptor.forClass(Observation.Context.class);
+		verify(handler, times(8)).onStart(captor.capture());
+		verify(handler, times(8)).onStop(any());
+		List<Observation.Context> contexts = captor.getAllValues();
+
+		Observation.Context initialRequestObservationContextBefore = contexts.get(1);
+		Observation.Context initialRequestObservationContextAfter = contexts.get(3);
+		assertFilterChainObservation(initialRequestObservationContextBefore, "before", 1);
+		assertFilterChainObservation(initialRequestObservationContextAfter, "after", 1);
+
+		assertThat(initialRequestObservationContextBefore.getParentObservation()).isNotNull();
+		assertThat(initialRequestObservationContextBefore.getParentObservation())
+			.isSameAs(initialRequestObservationContextAfter.getParentObservation());
+
+		Observation.Context errorRelatedRequestObservationContextBefore = contexts.get(5);
+		Observation.Context errorRelatedRequestObservationContextAfter = contexts.get(7);
+		assertFilterChainObservation(errorRelatedRequestObservationContextBefore, "before", 1);
+		assertFilterChainObservation(errorRelatedRequestObservationContextAfter, "after", 1);
+
+		assertThat(errorRelatedRequestObservationContextBefore.getParentObservation()).isNotNull();
+		assertThat(errorRelatedRequestObservationContextBefore.getParentObservation())
+			.isSameAs(initialRequestObservationContextBefore.getParentObservation());
+		assertThat(errorRelatedRequestObservationContextAfter.getParentObservation()).isNotNull();
+		assertThat(errorRelatedRequestObservationContextAfter.getParentObservation())
+			.isSameAs(initialRequestObservationContextBefore.getParentObservation());
+	}
+
 	@Test
 	public void doFilterWhenMultipleFiltersThenObservationRegistryObserves() throws Exception {
 		ObservationHandler<Observation.Context> handler = mock(ObservationHandler.class);


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-security/issues/12610

---
As I see from my research, the bug happens only in the real servlet environment, supposedly because of HttpServletResponse.sendError(), I didn't manage to reproduce it via mockMvc.
Tomcat creates a new HttpServletRequest in case error, which is related to "/error" path, which will be served by ErrorController.
Fortunately, request attributes are copied from the original request to the "/error"-related one, so we can put the ObservationView into the original request in order to extract this ObservationView from "/error"-related request and create a new parent observation with a given parent ObservationView. The last ObservationView propagates TraceContext to the new Observation so we have the same traceId.


---
Reproducer is here https://github.com/nkonev/trace-discrepancy-reproducer

```bash
curl -i 'http://localhost:8060/internal/profile/auth' -X GET -H 'Accept: text/plain, */*'
```

To check that the bug is fixed, you can run `publishMavenJavaPublicationToMavenLocal` in spring-security:web
```bash
./gradlew :spring-security-web:publishMavenJavaPublicationToMavenLocal --offline
```
or via IDE
![image](https://github.com/user-attachments/assets/223a5d1b-97ca-42fc-9c6a-81c426daf910)

then switch to the SNAPSHOT dependency https://github.com/nkonev/trace-discrepancy-reproducer/commit/131a271130726f8332db19d1e286f1debae18ff2

Before:
![Screenshot From 2025-05-21 17-45-08](https://github.com/user-attachments/assets/3d1e7dc0-5d4a-4b3f-b7eb-8d49fd761fd0)
![Screenshot From 2025-05-21 17-45-31](https://github.com/user-attachments/assets/7c1497a8-80c3-40f4-80ef-00f8a4d2bc2d)

After:
![Screenshot From 2025-05-21 17-54-26](https://github.com/user-attachments/assets/672c6910-27ed-4277-b155-6ca125163ef4)
![Screenshot From 2025-05-21 17-54-45](https://github.com/user-attachments/assets/b23fcbe0-6fc3-442a-b6ee-e48e6d0109dc)

---

UPD:
I also checked this PR with [jetty](https://github.com/nkonev/trace-discrepancy-reproducer/tree/jetty) and [undertow](https://github.com/nkonev/trace-discrepancy-reproducer/tree/undertow), it works fine.