### PR TITLE
Advise overriding equals() and hashCode() in UserDetails implementations

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/session-management.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/session-management.adoc
@@ -534,6 +534,13 @@ public class MaximumSessionsPreventLoginTests {
 If you are using a customized authentication filter for form-based login, then you have to configure concurrent session control support explicitly.
 You can try it using the {gh-samples-url}/servlet/spring-boot/java/session-management/maximum-sessions-prevent-login[Maximum Sessions Prevent Login sample].
 
+[NOTE]
+=====
+If you are using a custom implementation of `UserDetails`, ensure you override the **equals()** and **hashCode()** methods.
+The default `SessionRegistry` implementation in Spring Security relies on an in-memory Map that uses these methods to correctly identify and manage user sessions.
+Failing to override them may lead to issues where session tracking and user comparison behave unexpectedly.
+=====
+
 == Detecting Timeouts
 
 Sessions expire on their own, and there is nothing that needs to be done to ensure that a security context gets removed.


### PR DESCRIPTION
This commit adds a documentation note explaining the importance of overriding equals() and hashCode() in custom UserDetails implementations.

The default SessionRegistryImpl in Spring Security uses an in-memory ConcurrentMap<Object, Set<String>>, Map<String,SessionInformation> to associate principals with sessions. If a custom UserDetails class does not properly override equals() and hashCode(), user sessions may not be tracked or matched correctly.

I believe this helps developers avoid subtle session management issues when implementing custom authentication logic.

Reference: org.springframework.security.core.session.SessionRegistryImpl

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
