### PR TITLE
Make X509CertificateThumbprintValidator to be public and non-final class

### DIFF
--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/X509CertificateThumbprintValidator.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/X509CertificateThumbprintValidator.java
@@ -50,15 +50,15 @@ import org.springframework.web.context.request.RequestContextHolder;
  * "https://datatracker.ietf.org/doc/html/rfc8705#section-3.1">3.1. JWT Certificate
  * Thumbprint Confirmation Method</a>
  */
-final class X509CertificateThumbprintValidator implements OAuth2TokenValidator<Jwt> {
+public class X509CertificateThumbprintValidator implements OAuth2TokenValidator<Jwt> {
 
-	static final Supplier<X509Certificate> DEFAULT_X509_CERTIFICATE_SUPPLIER = new DefaultX509CertificateSupplier();
+	public static final Supplier<X509Certificate> DEFAULT_X509_CERTIFICATE_SUPPLIER = new DefaultX509CertificateSupplier();
 
 	private final Log logger = LogFactory.getLog(getClass());
 
 	private final Supplier<X509Certificate> x509CertificateSupplier;
 
-	X509CertificateThumbprintValidator(Supplier<X509Certificate> x509CertificateSupplier) {
+	public X509CertificateThumbprintValidator(Supplier<X509Certificate> x509CertificateSupplier) {
 		Assert.notNull(x509CertificateSupplier, "x509CertificateSupplier cannot be null");
 		this.x509CertificateSupplier = x509CertificateSupplier;
 	}
@@ -109,7 +109,7 @@ final class X509CertificateThumbprintValidator implements OAuth2TokenValidator<J
 		return OAuth2TokenValidatorResult.success();
 	}
 
-	static String computeSHA256Thumbprint(X509Certificate x509Certificate) throws Exception {
+	public static String computeSHA256Thumbprint(X509Certificate x509Certificate) throws Exception {
 		MessageDigest md = MessageDigest.getInstance("SHA-256");
 		byte[] digest = md.digest(x509Certificate.getEncoded());
 		return Base64.getUrlEncoder().withoutPadding().encodeToString(digest);


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->

gh-17131

Make X509CertificateThumbprintValidator to be public and non-final class

With the current `package` visibility and `final` class, it is not usable with `JwtValidators#createDefaultWithValidators`. `JwtValidators#createDefaultWithValidators` is following, as of v6.4.6:
```java
	public static OAuth2TokenValidator<Jwt> createDefaultWithValidators(List<OAuth2TokenValidator<Jwt>> validators) {
		Assert.notEmpty(validators, "validators cannot be null or empty");
		List<OAuth2TokenValidator<Jwt>> tokenValidators = new ArrayList<>(validators);
		X509CertificateThumbprintValidator x509CertificateThumbprintValidator = CollectionUtils
			.findValueOfType(tokenValidators, X509CertificateThumbprintValidator.class);
		if (x509CertificateThumbprintValidator == null) {
			tokenValidators.add(0, new X509CertificateThumbprintValidator(
					X509CertificateThumbprintValidator.DEFAULT_X509_CERTIFICATE_SUPPLIER));
		}
		JwtTimestampValidator jwtTimestampValidator = CollectionUtils.findValueOfType(tokenValidators,
				JwtTimestampValidator.class);
		if (jwtTimestampValidator == null) {
			tokenValidators.add(0, new JwtTimestampValidator());
		}
		return new DelegatingOAuth2TokenValidator<>(tokenValidators);
	}
```
By looking at this, I could understand the purpose is for consumer to have their own implementation of `X509CertificateThumbprintValidator`. However, currently that is not possible. This PR is to let consumers customize or build their own implementation of `X509CertificateThumbprintValidator` and keep using other default validators provided by Spring Security.