### PR TITLE
Support custom `OAuth2AuthenticatedPrincipal` in Jwt-based authentication flow

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationToken.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2018 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.security.oauth2.server.resource.authentication;
 import java.util.Collection;
 import java.util.Map;
 
+import org.springframework.security.core.AuthenticatedPrincipal;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.SpringSecurityCoreVersion;
 import org.springframework.security.core.Transient;
@@ -29,6 +30,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
  * {@link Jwt} {@code Authentication}.
  *
  * @author Joe Grandja
+ * @author Andrey Litvitski
  * @since 5.1
  * @see AbstractOAuth2TokenAuthenticationToken
  * @see Jwt
@@ -70,6 +72,22 @@ public class JwtAuthenticationToken extends AbstractOAuth2TokenAuthenticationTok
 		super(jwt, authorities);
 		this.setAuthenticated(true);
 		this.name = name;
+	}
+
+	/**
+	 * Constructs a {@code JwtAuthenticationToken} using the provided parameters.
+	 * @param jwt the JWT
+	 * @param principal the principal
+	 * @param authorities the authorities assigned to the JWT
+	 */
+	public JwtAuthenticationToken(Jwt jwt, Object principal, Collection<? extends GrantedAuthority> authorities) {
+		super(jwt, principal, jwt, authorities);
+		this.setAuthenticated(true);
+		if (principal instanceof AuthenticatedPrincipal) {
+			this.name = ((AuthenticatedPrincipal) principal).getName();
+		} else {
+			this.name = jwt.getSubject();
+		}
 	}
 
 	@Override

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtBearerTokenAuthenticationConverter.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtBearerTokenAuthenticationConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.springframework.security.oauth2.core.DefaultOAuth2AuthenticatedPrinci
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.util.Assert;
 
 /**
  * A {@link Converter} that takes a {@link Jwt} and converts it into a
@@ -41,6 +42,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
  * {@link BearerTokenAuthentication}.
  *
  * @author Josh Cummings
+ * @author Andrey Litvitski
  * @since 5.2
  */
 public final class JwtBearerTokenAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
@@ -56,6 +58,18 @@ public final class JwtBearerTokenAuthenticationConverter implements Converter<Jw
 		Collection<GrantedAuthority> authorities = token.getAuthorities();
 		OAuth2AuthenticatedPrincipal principal = new DefaultOAuth2AuthenticatedPrincipal(attributes, authorities);
 		return new BearerTokenAuthentication(principal, accessToken, authorities);
+	}
+
+	/**
+	 * Sets the {@link Converter Converter&lt;Jwt, Collection&lt;OAuth2AuthenticatedPrincipal&gt;&gt;}
+	 * to use.
+	 * @param jwtPrincipalConverter The converter
+	 * @since 6.5.0
+	 */
+	public void setJwtPrincipalConverter(
+			Converter<Jwt, OAuth2AuthenticatedPrincipal> jwtPrincipalConverter) {
+		Assert.notNull(jwtPrincipalConverter, "jwtPrincipalConverter cannot be null");
+		this.jwtAuthenticationConverter.setJwtPrincipalConverter(jwtPrincipalConverter);
 	}
 
 }


### PR DESCRIPTION
This PR implements a simpler approach, as suggested by @jzheaux, to support `OAuth2AuthenticatedPrincipal` injection into `JwtAuthenticationToken`

Resolves: #6237