### PR TITLE
Make `WebClient.Builder` configurable in `SpringReactiveOpaqueTokenIntrospector`

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/SpringReactiveOpaqueTokenIntrospector.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/introspection/SpringReactiveOpaqueTokenIntrospector.java
@@ -268,6 +268,7 @@ public class SpringReactiveOpaqueTokenIntrospector implements ReactiveOpaqueToke
 	 * Used to build {@link SpringReactiveOpaqueTokenIntrospector}.
 	 *
 	 * @author Ngoc Nhan
+	 * @author Andrey Litvitski
 	 * @since 6.5
 	 */
 	public static final class Builder {
@@ -277,6 +278,8 @@ public class SpringReactiveOpaqueTokenIntrospector implements ReactiveOpaqueToke
 		private String clientId;
 
 		private String clientSecret;
+
+		private WebClient.Builder webClientBuilder;
 
 		private Builder(String introspectionUri) {
 			this.introspectionUri = introspectionUri;
@@ -309,12 +312,30 @@ public class SpringReactiveOpaqueTokenIntrospector implements ReactiveOpaqueToke
 		}
 
 		/**
+		 * The builder will use the provided {@link WebClient.Builder} to build the
+		 * {@link WebClient} used for token introspection requests. If not provided, a
+		 * default builder will be used.
+		 * @param webClientBuilder The {@link WebClient.Builder} to customize the HTTP
+		 * client
+		 * @return the {@link SpringReactiveOpaqueTokenIntrospector.Builder}
+		 * @since 6.5
+		 */
+		public Builder webClientBuilder(WebClient.Builder webClientBuilder) {
+			Assert.notNull(webClientBuilder, "webClientBuilder cannot be null");
+			this.webClientBuilder = webClientBuilder;
+			return this;
+		}
+
+		/**
 		 * Creates a {@code SpringReactiveOpaqueTokenIntrospector}
 		 * @return the {@link SpringReactiveOpaqueTokenIntrospector}
 		 * @since 6.5
 		 */
 		public SpringReactiveOpaqueTokenIntrospector build() {
-			WebClient webClient = WebClient.builder()
+			if (this.webClientBuilder == null) {
+				this.webClientBuilder = WebClient.builder();
+			}
+			WebClient webClient = this.webClientBuilder
 				.defaultHeaders((h) -> h.setBasicAuth(this.clientId, this.clientSecret))
 				.build();
 			return new SpringReactiveOpaqueTokenIntrospector(this.introspectionUri, webClient);

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/introspection/SpringReactiveOpaqueTokenIntrospectorTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/introspection/SpringReactiveOpaqueTokenIntrospectorTests.java
@@ -297,6 +297,7 @@ public class SpringReactiveOpaqueTokenIntrospectorTests {
 				.withIntrospectionUri(introspectUri)
 				.clientId("client&1")
 				.clientSecret("secret@$2")
+				.webClientBuilder(WebClient.builder())
 				.build();
 			OAuth2AuthenticatedPrincipal authority = introspectionClient.introspect("token").block();
 			// @formatter:off


### PR DESCRIPTION
This will help us to throw our own `WebClient.Builder` into `SpringReactiveOpaqueTokenIntrospector.Builder` with our own parameters that we specify.

Also for this class we have one test where a builder is used. I decided to just throw `WebClient.Builder` in there in order to use the method, I think it doesn't make much sense to test it, wdyt?

Resolves: #17194