### PR TITLE
Fix inconsistent constructor declaration for `ReactiveAuthorizationManagerMethodSecurityConfiguration`

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/ReactiveAuthorizationManagerMethodSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/ReactiveAuthorizationManagerMethodSecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,10 +83,11 @@ final class ReactiveAuthorizationManagerMethodSecurityConfiguration
 
 	private final AuthorizationManagerAfterReactiveMethodInterceptor postAuthorizeMethodInterceptor;
 
-	@Autowired(required = false)
-	ReactiveAuthorizationManagerMethodSecurityConfiguration(MethodSecurityExpressionHandler expressionHandler,
+	ReactiveAuthorizationManagerMethodSecurityConfiguration(
+			ObjectProvider<MethodSecurityExpressionHandler> expressionHandlers,
 			ObjectProvider<ObjectPostProcessor<ReactiveAuthorizationManager<MethodInvocation>>> preAuthorizePostProcessor,
 			ObjectProvider<ObjectPostProcessor<ReactiveAuthorizationManager<MethodInvocationResult>>> postAuthorizePostProcessor) {
+		MethodSecurityExpressionHandler expressionHandler = expressionHandlers.getIfUnique();
 		if (expressionHandler != null) {
 			this.preFilterMethodInterceptor = new PreFilterAuthorizationReactiveMethodInterceptor(expressionHandler);
 			this.preAuthorizeAuthorizationManager = new PreAuthorizeReactiveAuthorizationManager(expressionHandler);


### PR DESCRIPTION
Closes gh-16325

A [previous solution](https://github.com/spring-projects/spring-security/pull/16326) was rejected where it was stated the `expressionHandler` parameter should remain optional.

This alternative allows an optional `expressionHandler` without producing the inconsistent constructor declaration log.