### PR TITLE
WebAuthn: Fix credential parameters conversion to WebAuthn4j object model when used with Spring Session

### DIFF
--- a/web/src/main/java/org/springframework/security/web/webauthn/management/Webauthn4JRelyingPartyOperations.java
+++ b/web/src/main/java/org/springframework/security/web/webauthn/management/Webauthn4JRelyingPartyOperations.java
@@ -304,7 +304,7 @@ public class Webauthn4JRelyingPartyOperations implements WebAuthnRelyingPartyOpe
 
 	private com.webauthn4j.data.PublicKeyCredentialParameters convertParamToWebauthn4j(
 			PublicKeyCredentialParameters parameter) {
-		if (parameter.getType() != PublicKeyCredentialType.PUBLIC_KEY) {
+		if (!PublicKeyCredentialType.PUBLIC_KEY.getValue().equals(parameter.getType().getValue())) {
 			throw new IllegalArgumentException(
 					"Cannot convert unknown credential type " + parameter.getType() + " to webauthn4j");
 		}


### PR DESCRIPTION
Replace comparison based on the != operator by an .equals() comparison based on the text value. The 2 objects have the same value in most setups, but not when used in conjunction with Spring Session for example, as the object in session is built for each request.

Fixes gh-17164 
