### PR TITLE
Add null check for authentication token in JwtAuthenticationProvider

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationProvider.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationProvider.java
@@ -87,6 +87,7 @@ public final class JwtAuthenticationProvider implements AuthenticationProvider {
 		BearerTokenAuthenticationToken bearer = (BearerTokenAuthenticationToken) authentication;
 		Jwt jwt = getJwt(bearer);
 		AbstractAuthenticationToken token = this.jwtAuthenticationConverter.convert(jwt);
+		Assert.notNull(token, "token cannot be null");
 		if (token.getDetails() == null) {
 			token.setDetails(bearer.getDetails());
 		}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationProviderTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationProviderTests.java
@@ -35,8 +35,7 @@ import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.security.oauth2.jwt.TestJwts;
 import org.springframework.security.oauth2.server.resource.BearerTokenErrorCodes;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -149,6 +148,19 @@ public class JwtAuthenticationProviderTests {
 		assertThat(this.provider.authenticate(token))
 				.isEqualTo(authentication).hasFieldOrPropertyWithValue("details",
 						expectedDetails);
+		// @formatter:on
+	}
+
+	@Test
+	public void authenticateWhenConverterReturnsNullThenThrowException() {
+		BearerTokenAuthenticationToken token = this.authentication();
+		Jwt jwt = TestJwts.jwt().build();
+		given(this.jwtDecoder.decode("token")).willReturn(jwt);
+		given(this.jwtAuthenticationConverter.convert(jwt)).willReturn(null);
+		// @formatter:off
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> this.provider.authenticate(token))
+				.withMessageContaining("token cannot be null");
 		// @formatter:on
 	}
 

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationProviderTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationProviderTests.java
@@ -35,7 +35,9 @@ import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.security.oauth2.jwt.TestJwts;
 import org.springframework.security.oauth2.server.resource.BearerTokenErrorCodes;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 


### PR DESCRIPTION
## Summary
Add `Assert.notNull` validation in `JwtAuthenticationProvider.authenticate()` to ensure the authentication token returned by `jwtAuthenticationConverter` is not null.

## Problem
While the `JwtAuthenticationConverter.convert()` method typically returns a valid `AbstractAuthenticationToken`, there's no explicit null check before accessing the token's properties. This could potentially lead to a `NullPointerException`  if:
- Custom converter implementations return null
- Unexpected edge cases occur during token conversion
- External factors affect the conversion process

## Changes
- Added `Assert.notNull(token, "token cannot be null")` validation
- Added comprehensive test to verify the null check behavior

## Testing
- New test passes and verifies proper exception handling
- All existing tests continue to pass
- No breaking changes to existing functionality
