### PR TITLE
WebSecurity#ignoring should not be warned

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/WebSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/WebSecurity.java
@@ -309,8 +309,6 @@ public final class WebSecurity extends AbstractConfiguredSecurityBuilder<Filter,
 			.builder();
 		boolean mappings = false;
 		for (RequestMatcher ignoredRequest : this.ignoredRequests) {
-			WebSecurity.this.logger.warn("You are asking Spring Security to ignore " + ignoredRequest
-					+ ". This is not recommended -- please use permitAll via HttpSecurity#authorizeHttpRequests instead.");
 			SecurityFilterChain securityFilterChain = new DefaultSecurityFilterChain(ignoredRequest);
 			securityFilterChains.add(securityFilterChain);
 			builder.add(ignoredRequest, SingleResultAuthorizationManager.permitAll());


### PR DESCRIPTION
For years Spring Security exposes method WebSecurity#ignoring but pollutes logs with false positive warning.

Let's analyze my case.
Spring Security authorizes by default access to actuator endpoints and that is OK. 

However, nowadays applications are often cogs in machine and is important to distinguish application responsibility and cloud/Kubernetes/service mesh responsibility.
Actuator endpoints, identical for hundreds application, should be protected by Kubernetes, not by application. 
Application responsibility is configuring business endpoint access

See this snippet
```
httpSecurity.authorizeHttpRequests ( configurer -> configurer
                .requestMatchers("/illness/covid/statistics/2021").permitAll()
                .requestMatchers("/illness/myillness").authenticated()
---        
webSecurity.ignoring().requestMatchers("/actuator")
```
It clearly shows that application responsibily is expose public statistics and restrict access to private data.
And, what more important, it clearly shows that actuator access IS NOT application responsibility

I think it is more readable than
```
httpSecurity.authorizeHttpRequests ( configurer -> configurer
                .requestMatchers("/illness/covid/statistics/2021/europe").permitAll()
                .requestMatchers("/actuator").permitAll()
                .requestMatchers("/illness/my-illness").authenticated()
```

Conclusion:
I want remove warning WebSecurity#ignoring because I want promote clear, straightforwad, readable code.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
