### PR TITLE
Allow specifying a ServerAuthenticationConverter for x509()

### DIFF
--- a/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
@@ -3256,7 +3256,7 @@ public class ServerHttpSecurity {
 			X509PrincipalExtractor principalExtractor = getPrincipalExtractor();
 			ServerAuthenticationConverter converter = getServerAuthenticationConverter(principalExtractor);
 			AuthenticationWebFilter filter = new AuthenticationWebFilter(authenticationManager);
-			filter.setServerAuthenticationConverter(serverAuthenticationConverter);
+			filter.setServerAuthenticationConverter(converter);
 			http.addFilterAt(filter, SecurityWebFiltersOrder.AUTHENTICATION);
 		}
 

--- a/config/src/test/java/org/springframework/security/config/web/server/ServerHttpSecurityTests.java
+++ b/config/src/test/java/org/springframework/security/config/web/server/ServerHttpSecurityTests.java
@@ -504,7 +504,7 @@ public class ServerHttpSecurityTests {
 		this.http.x509((x509) -> x509.serverAuthenticationConverter(mockConverter));
 		SecurityWebFilterChain securityWebFilterChain = this.http.build();
 		WebFilter x509WebFilter = securityWebFilterChain.getWebFilters()
-			.filter(filter -> matchesX509Converter(filter, mockConverter))
+			.filter((filter) -> matchesX509Converter(filter, mockConverter))
 			.blockFirst();
 		assertThat(x509WebFilter).isNotNull();
 	}


### PR DESCRIPTION
Spring Security's x509 configuration for WebFlux does not currently allow for a custom ServerAuthenticationConverter that provides additional attributes to the initial Authentication token.

This PR allows an application to supply a custom ServerAuthenticationConverter for x509 instead of using the default implementation.