### PR TITLE
Improve logging clarity in CsrfFilter

### DIFF
--- a/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
+++ b/web/src/main/java/org/springframework/security/web/csrf/CsrfFilter.java
@@ -214,7 +214,7 @@ public final class CsrfFilter extends OncePerRequestFilter {
 
 		@Override
 		public String toString() {
-			return "CsrfNotRequired " + this.allowedMethods;
+			return "IsNotHttpMethod " + this.allowedMethods;
 		}
 
 	}


### PR DESCRIPTION
Update toString() method in DefaultRequiresCsrfMatcher to better reflect its logic during trace-level logging. 

The current log message was ambiguous:
"Did not protect against CSRF since request did not match CsrfNotRequired [TRACE, HEAD, GET, OPTIONS]"

Now it clearly shows:
"Did not protect against CSRF since request did not match IsNotHttpMethod [TRACE, HEAD, GET, OPTIONS]"

Closes gh-17250
