### PR TITLE
docs: fix typo in @AuthenticationPrincipal documentation

### DIFF
--- a/docs/modules/ROOT/pages/servlet/integrations/mvc.adoc
+++ b/docs/modules/ROOT/pages/servlet/integrations/mvc.adoc
@@ -375,7 +375,7 @@ Java::
 ----
 @Bean
 public AnnotationTemplateExpressionDefaults templateDefaults() {
-	return new AnnotationTemplateExpressionDeafults();
+	return new AnnotationTemplateExpressionDefaults();
 }
 ----
 
@@ -385,7 +385,7 @@ Kotlin::
 ----
 @Bean
 fun templateDefaults(): AnnotationTemplateExpressionDefaults {
-	return AnnotationTemplateExpressionDeafults()
+	return AnnotationTemplateExpressionDefaults()
 }
 ----
 


### PR DESCRIPTION
There is a small typo in the code snippets for `@AuthenticationPrincipal`, this PR fixes it.

No GitHub issue created for this change.
