### PR TITLE
Make stricter IP format check in `IpAddressMatcher`

### DIFF
--- a/web/src/main/java/org/springframework/security/web/util/matcher/IpAddressMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/IpAddressMatcher.java
@@ -35,11 +35,12 @@ import org.springframework.util.StringUtils;
  *
  * @author Luke Taylor
  * @author Steve Riesenberg
+ * @author Andrey Litvitski
  * @since 3.0.2
  */
 public final class IpAddressMatcher implements RequestMatcher {
 
-	private static Pattern IPV4 = Pattern.compile("\\d{0,3}.\\d{0,3}.\\d{0,3}.\\d{0,3}(/\\d{0,3})?");
+	private static Pattern IPV4 = Pattern.compile("^\\d{1,3}(?:\\.\\d{1,3}){0,3}(?:/\\d{1,2})?$");
 
 	private final InetAddress requiredAddress;
 

--- a/web/src/test/java/org/springframework/security/web/util/matcher/IpAddressMatcherTests.java
+++ b/web/src/test/java/org/springframework/security/web/util/matcher/IpAddressMatcherTests.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 
 /**
  * @author Luke Taylor
+ * @author Andrey Litvitski
  */
 public class IpAddressMatcherTests {
 
@@ -165,6 +166,14 @@ public class IpAddressMatcherTests {
 	public void toStringWhenOnlyIpIsProvidedThenReturnsIpAddressOnly() {
 		IpAddressMatcher matcher = new IpAddressMatcher("127.0.0.1");
 		assertThat(matcher.toString()).hasToString("IpAddress [127.0.0.1]");
+	}
+
+	// gh-17499
+	@Test
+	public void constructorRejectsInvalidIpv4WithX() {
+		String badIp = "10x1x1x1";
+		assertThatIllegalArgumentException().isThrownBy(() -> new IpAddressMatcher(badIp))
+			.withMessage("ipAddress 10x1x1x1 doesn't look like an IP Address. Is it a host name?");
 	}
 
 }


### PR DESCRIPTION
I think we won't lose anything if we make the regex in the matcher class more strict.

Closes: gh-17499