### PR TITLE
Update Angular documentation links in csrf.adoc

### DIFF
--- a/docs/modules/ROOT/pages/servlet/exploits/csrf.adoc
+++ b/docs/modules/ROOT/pages/servlet/exploits/csrf.adoc
@@ -206,7 +206,7 @@ These defaults come from Angular and its predecessor https://docs.angularjs.org/
 
 [TIP]
 ====
-See the https://angular.io/guide/http-security-xsrf-protection[Cross-Site Request Forgery (XSRF) protection] guide and the https://angular.io/api/common/http/HttpClientXsrfModule[HttpClientXsrfModule] for more recent information on this topic.
+See the https://angular.dev/best-practices/security#httpclient-xsrf-csrf-security[HttpClient XSRF/CSRF security] and the https://angular.dev/api/common/http/withXsrfConfiguration[withXsrfConfiguration] for more recent information on this topic.
 ====
 
 You can configure the `CookieCsrfTokenRepository` using the following configuration:


### PR DESCRIPTION
Replaced `angular.io` links with their corresponding `angular.dev` URLs.
This change ensures that users referencing CSRF documentation are directed to the most current Angular resources.
