### PR TITLE
Adapt `UnboundIdContainer` to `SmartLifecycle` to support `ApplicationContext` restart

### DIFF
--- a/ldap/src/integration-test/java/org/springframework/security/ldap/DefaultSpringSecurityContextSourceTests.java
+++ b/ldap/src/integration-test/java/org/springframework/security/ldap/DefaultSpringSecurityContextSourceTests.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ldap.AuthenticationException;
 import org.springframework.ldap.core.support.AbstractContextSource;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -40,8 +39,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = UnboundIdContainerConfig.class)
-// FIXME: See https://github.com/spring-projects/spring-security/issues/17543
-@DirtiesContext
 public class DefaultSpringSecurityContextSourceTests {
 
 	@Autowired

--- a/ldap/src/integration-test/java/org/springframework/security/ldap/SpringSecurityLdapTemplateITests.java
+++ b/ldap/src/integration-test/java/org/springframework/security/ldap/SpringSecurityLdapTemplateITests.java
@@ -34,7 +34,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ldap.UncategorizedLdapException;
 import org.springframework.ldap.core.ContextExecutor;
 import org.springframework.security.crypto.codec.Utf8;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -47,8 +46,6 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = UnboundIdContainerConfig.class)
-// FIXME: See https://github.com/spring-projects/spring-security/issues/17543
-@DirtiesContext
 public class SpringSecurityLdapTemplateITests {
 
 	@Autowired

--- a/ldap/src/integration-test/java/org/springframework/security/ldap/authentication/BindAuthenticatorTests.java
+++ b/ldap/src/integration-test/java/org/springframework/security/ldap/authentication/BindAuthenticatorTests.java
@@ -36,7 +36,6 @@ import org.springframework.security.core.SpringSecurityMessageSource;
 import org.springframework.security.ldap.DefaultSpringSecurityContextSource;
 import org.springframework.security.ldap.UnboundIdContainerConfig;
 import org.springframework.security.ldap.search.FilterBasedLdapUserSearch;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -55,8 +54,6 @@ import static org.mockito.Mockito.spy;
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = UnboundIdContainerConfig.class)
-// FIXME: See https://github.com/spring-projects/spring-security/issues/17543
-@DirtiesContext
 public class BindAuthenticatorTests {
 
 	@Autowired

--- a/ldap/src/integration-test/java/org/springframework/security/ldap/authentication/PasswordComparisonAuthenticatorTests.java
+++ b/ldap/src/integration-test/java/org/springframework/security/ldap/authentication/PasswordComparisonAuthenticatorTests.java
@@ -32,7 +32,6 @@ import org.springframework.security.crypto.password.LdapShaPasswordEncoder;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.ldap.DefaultSpringSecurityContextSource;
 import org.springframework.security.ldap.UnboundIdContainerConfig;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -48,8 +47,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = UnboundIdContainerConfig.class)
-// FIXME: See https://github.com/spring-projects/spring-security/issues/17543
-@DirtiesContext
 public class PasswordComparisonAuthenticatorTests {
 
 	@Autowired

--- a/ldap/src/integration-test/java/org/springframework/security/ldap/search/FilterBasedLdapUserSearchTests.java
+++ b/ldap/src/integration-test/java/org/springframework/security/ldap/search/FilterBasedLdapUserSearchTests.java
@@ -27,7 +27,6 @@ import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.ldap.DefaultSpringSecurityContextSource;
 import org.springframework.security.ldap.UnboundIdContainerConfig;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -42,8 +41,6 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = UnboundIdContainerConfig.class)
-// FIXME: See https://github.com/spring-projects/spring-security/issues/17543
-@DirtiesContext
 public class FilterBasedLdapUserSearchTests {
 
 	@Autowired

--- a/ldap/src/integration-test/java/org/springframework/security/ldap/userdetails/DefaultLdapAuthoritiesPopulatorTests.java
+++ b/ldap/src/integration-test/java/org/springframework/security/ldap/userdetails/DefaultLdapAuthoritiesPopulatorTests.java
@@ -33,7 +33,6 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.ldap.SpringSecurityLdapTemplate;
 import org.springframework.security.ldap.UnboundIdContainerConfig;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -46,8 +45,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = UnboundIdContainerConfig.class)
-// FIXME: See https://github.com/spring-projects/spring-security/issues/17543
-@DirtiesContext
 @SuppressWarnings({ "deprecation" })
 public class DefaultLdapAuthoritiesPopulatorTests {
 

--- a/ldap/src/integration-test/java/org/springframework/security/ldap/userdetails/LdapUserDetailsManagerTests.java
+++ b/ldap/src/integration-test/java/org/springframework/security/ldap/userdetails/LdapUserDetailsManagerTests.java
@@ -37,7 +37,6 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.ldap.DefaultLdapUsernameToDnMapper;
 import org.springframework.security.ldap.SpringSecurityLdapTemplate;
 import org.springframework.security.ldap.UnboundIdContainerConfig;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -54,8 +53,6 @@ import static org.mockito.Mockito.verify;
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = UnboundIdContainerConfig.class)
-// FIXME: See https://github.com/spring-projects/spring-security/issues/17543
-@DirtiesContext
 public class LdapUserDetailsManagerTests {
 
 	@Autowired

--- a/ldap/src/integration-test/java/org/springframework/security/ldap/userdetails/NestedLdapAuthoritiesPopulatorTests.java
+++ b/ldap/src/integration-test/java/org/springframework/security/ldap/userdetails/NestedLdapAuthoritiesPopulatorTests.java
@@ -29,7 +29,6 @@ import org.springframework.ldap.core.ContextSource;
 import org.springframework.ldap.core.DirContextAdapter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.ldap.UnboundIdContainerConfig;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -41,8 +40,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = UnboundIdContainerConfig.class)
-// FIXME: See https://github.com/spring-projects/spring-security/issues/17543
-@DirtiesContext
 public class NestedLdapAuthoritiesPopulatorTests {
 
 	@Autowired

--- a/ldap/src/main/java/org/springframework/security/ldap/server/UnboundIdContainer.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/server/UnboundIdContainer.java
@@ -32,15 +32,17 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.Lifecycle;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.core.io.Resource;
 import org.springframework.lang.NonNull;
 import org.springframework.util.StringUtils;
 
 /**
  * @author Eddú Meléndez
+ * @author Andrey Litvitski
  */
-public class UnboundIdContainer
-		implements EmbeddedLdapServerContainer, InitializingBean, DisposableBean, Lifecycle, ApplicationContextAware {
+public class UnboundIdContainer implements EmbeddedLdapServerContainer, InitializingBean, DisposableBean,
+		SmartLifecycle, ApplicationContextAware {
 
 	private InMemoryDirectoryServer directoryServer;
 
@@ -140,6 +142,22 @@ public class UnboundIdContainer
 	@Override
 	public boolean isRunning() {
 		return this.running;
+	}
+
+	@Override
+	public boolean isAutoStartup() {
+		return true;
+	}
+
+	@Override
+	public void stop(Runnable callback) {
+		stop();
+		callback.run();
+	}
+
+	@Override
+	public int getPhase() {
+		return 0;
 	}
 
 }


### PR DESCRIPTION
`UnboundIdContainer` now implements `SmartLifecycle`, which allows Spring TestContext to correctly manage its lifecycle when using `pause()` and `resume()`. Thanks to this, `UnboundIdContainer` starts and stops correctly without the need for `@DirtiesContext`.

Closes: gh-17543
