### PR TITLE
Update index.adoc

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/passwords/index.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/passwords/index.adoc
@@ -34,6 +34,8 @@ public class SecurityConfig {
 
 	@Bean
 	public UserDetailsService userDetailsService() {
+		// User.withDefaultPasswordEncoder() is considered unsafe for production
+		// and is only intended for sample applications.
 		UserDetails userDetails = User.withDefaultPasswordEncoder()
 			.username("user")
 			.password("password")


### PR DESCRIPTION
Make sure users are aware that `User.withDefaultPasswordEncoder` is deprecated to avoid using it on production 