### PR TITLE
Fix `ChannelProcessingFilter` to skip decision if response already committed

### DIFF
--- a/web/src/main/java/org/springframework/security/web/access/channel/ChannelProcessingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/access/channel/ChannelProcessingFilter.java
@@ -83,6 +83,7 @@ import org.springframework.web.filter.GenericFilterBean;
  * over HTTPS.
  *
  * @author Ben Alex
+ * @author Andrey Litvitski
  * @deprecated see {@link org.springframework.security.web.transport.HttpsRedirectFilter}
  */
 @Deprecated
@@ -125,10 +126,12 @@ public class ChannelProcessingFilter extends GenericFilterBean {
 		HttpServletResponse response = (HttpServletResponse) res;
 		FilterInvocation filterInvocation = new FilterInvocation(request, response, chain);
 		Collection<ConfigAttribute> attributes = this.securityMetadataSource.getAttributes(filterInvocation);
-		if (attributes != null) {
+		boolean committedBefore = filterInvocation.getResponse().isCommitted();
+		if (attributes != null && !committedBefore) {
 			this.logger.debug(LogMessage.format("Request: %s; ConfigAttributes: %s", filterInvocation, attributes));
 			this.channelDecisionManager.decide(filterInvocation, attributes);
-			if (filterInvocation.getResponse().isCommitted()) {
+			boolean committedAfter = filterInvocation.getResponse().isCommitted();
+			if (committedAfter) {
 				return;
 			}
 		}


### PR DESCRIPTION
In this commit, we quickly fix a bug in ChannelProcessingFilter#doFilter where if filterInvocation.getResponse().isCommitted() is checked before decide, it will not pass further into the filter, which is an error. Perhaps in the future it would be better to extend the ChannelDecisionManager interface directly, but it is deprecated and this would be difficult and beyond the scope of this commit.

Closes: gh-6721
