### PR TITLE
Align NimbusJwtDecoder HTTP timeout defaults with Nimbus by setting to 500ms

### DIFF
--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtDecoder.java
@@ -66,6 +66,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
@@ -293,7 +294,7 @@ public final class NimbusJwtDecoder implements JwtDecoder {
 
 		private final Set<SignatureAlgorithm> signatureAlgorithms = new HashSet<>();
 
-		private RestOperations restOperations = new RestTemplate();
+		private RestOperations restOperations = new RestTemplateWithNimbusDefaultTimeouts();
 
 		private Cache cache = new NoOpCache("default");
 
@@ -541,6 +542,21 @@ public final class NimbusJwtDecoder implements JwtDecoder {
 
 			}
 
+		}
+
+	}
+
+	/**
+	 * A RestTemplate with timeouts configured to avoid blocking indefinitely when
+	 * fetching JWK Sets while holding the reentrantLock.
+	 */
+	private static final class RestTemplateWithNimbusDefaultTimeouts extends RestTemplate {
+
+		private RestTemplateWithNimbusDefaultTimeouts() {
+			SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+			requestFactory.setConnectTimeout(JWKSourceBuilder.DEFAULT_HTTP_CONNECT_TIMEOUT);
+			requestFactory.setReadTimeout(JWKSourceBuilder.DEFAULT_HTTP_READ_TIMEOUT);
+			setRequestFactory(requestFactory);
 		}
 
 	}


### PR DESCRIPTION
Summary
This change proposes a potential fix for [spring-security#15866](https://github.com/spring-projects/spring-security/issues/15866), which we encountered in a production environment.

Problem
We experienced a critical "stop-the-world" event lasting approximately 15 minutes due to the absence of connection and read timeouts in the default RestTemplate configuration used by NimbusJwtDecoder. Specifically, the underlying SimpleClientHttpRequestFactory does not define any timeouts, which can cause the application to hang indefinitely in certain network failure scenarios.

Current Workaround
To mitigate this in our own application, we use a JwkSetUriJwtDecoderBuilderCustomizer to configure the RestTemplate with appropriate timeouts. While this works, the current default behavior is problematic and may impact other users as well.

```
@Configuration
public class JwtDecoderConfig {

    @Bean
    public JwkSetUriJwtDecoderBuilderCustomizer jwkSetUriJwtDecoderBuilderCustomizer() {
        return builder -> {
            SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
            requestFactory.setConnectTimeout(RemoteJWKSet.DEFAULT_HTTP_CONNECT_TIMEOUT);
            requestFactory.setReadTimeout(RemoteJWKSet.DEFAULT_HTTP_READ_TIMEOUT);

            builder.restOperations(new RestTemplate(requestFactory));
        };
    }
}
```

Proposal
We suggest that reasonable default timeouts (both connect and read) should be applied to the RestTemplate used by default in NimbusJwtDecoder. This change will help prevent similar problems for others.

