### PR TITLE
Allow authenticationManagerResolver to take precedence over jwt/opaqueToken

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
@@ -256,8 +256,11 @@ public final class OAuth2ResourceServerConfigurer<H extends HttpSecurityBuilder<
 
 	@Override
 	public void configure(H http) {
+		// Use the authenticationManagerResolver if configured, as it takes precedence
+		// over any jwt() or opaqueToken() configuration
 		AuthenticationManagerResolver resolver = this.authenticationManagerResolver;
 		if (resolver == null) {
+			// Fall back to jwt() or opaqueToken() configuration
 			AuthenticationManager authenticationManager = getAuthenticationManager(http);
 			resolver = (request) -> authenticationManager;
 		}
@@ -282,11 +285,9 @@ public final class OAuth2ResourceServerConfigurer<H extends HttpSecurityBuilder<
 			Assert.state(this.jwtConfigurer == null || this.opaqueTokenConfigurer == null,
 					"Spring Security only supports JWTs or Opaque Tokens, not both at the " + "same time.");
 		}
-		else {
-			Assert.state(this.jwtConfigurer == null && this.opaqueTokenConfigurer == null,
-					"If an authenticationManagerResolver() is configured, then it takes "
-							+ "precedence over any jwt() or opaqueToken() configuration.");
-		}
+		// When authenticationManagerResolver is configured, it takes precedence over
+		// jwt() or opaqueToken()
+		// configuration, so no validation is needed for that case
 	}
 
 	private void registerDefaultAccessDeniedHandler(H http) {

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurerTests.java
@@ -1339,10 +1339,18 @@ public class OAuth2ResourceServerConfigurerTests {
 	}
 
 	@Test
-	public void configureWhenUsingBothAuthenticationManagerResolverAndOpaqueThenWiringException() {
-		assertThatExceptionOfType(BeanCreationException.class)
-			.isThrownBy(() -> this.spring.register(AuthenticationManagerResolverPlusOtherConfig.class).autowire())
-			.withMessageContaining("authenticationManagerResolver");
+	public void configureWhenUsingBothAuthenticationManagerResolverAndOpaqueThenAuthenticationManagerResolverTakesPrecedence() {
+		// authenticationManagerResolver should take precedence over opaqueToken
+		// configuration
+		this.spring.register(AuthenticationManagerResolverPlusOtherConfig.class).autowire();
+		// No exception should be thrown
+	}
+
+	@Test
+	public void configureWhenUsingBothAuthenticationManagerResolverAndJwtThenAuthenticationManagerResolverTakesPrecedence() {
+		// authenticationManagerResolver should take precedence over jwt configuration
+		this.spring.register(AuthenticationManagerResolverPlusJwtConfig.class).autowire();
+		// No exception should be thrown
 	}
 
 	@Test
@@ -2602,14 +2610,19 @@ public class OAuth2ResourceServerConfigurerTests {
 	static class AuthenticationManagerResolverPlusOtherConfig {
 
 		@Bean
+		OpaqueTokenIntrospector opaqueTokenIntrospector() {
+			return mock(OpaqueTokenIntrospector.class);
+		}
+
+		@Bean
 		SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 			// @formatter:off
 			http
 				.authorizeHttpRequests((requests) -> requests
 					.anyRequest().authenticated())
 				.oauth2ResourceServer((server) -> server
-					.authenticationManagerResolver(mock(AuthenticationManagerResolver.class))
-					.opaqueToken(Customizer.withDefaults()));
+					.opaqueToken(Customizer.withDefaults())
+					.authenticationManagerResolver(mock(AuthenticationManagerResolver.class)));
 			return http.build();
 			// @formatter:on
 		}
@@ -2784,6 +2797,30 @@ public class OAuth2ResourceServerConfigurerTests {
 				request.addHeader("Authorization", "Bearer " + this.token);
 			}
 			return request;
+		}
+
+	}
+
+	@Configuration
+	@EnableWebSecurity
+	static class AuthenticationManagerResolverPlusJwtConfig {
+
+		@Bean
+		JwtDecoder jwtDecoder() {
+			return mock(JwtDecoder.class);
+		}
+
+		@Bean
+		SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+			// @formatter:off
+			http
+				.authorizeHttpRequests((requests) -> requests
+					.anyRequest().authenticated())
+				.oauth2ResourceServer((server) -> server
+					.jwt(Customizer.withDefaults())
+					.authenticationManagerResolver(mock(AuthenticationManagerResolver.class)));
+			return http.build();
+			// @formatter:on
 		}
 
 	}


### PR DESCRIPTION
When `OAuth2ResourceServerConfigurer.authenticationManagerResolver()` is configured, it now takes precedence over any `jwt()` or `opaqueToken()` configuration without throwing an exception. This follows Spring Security's convention where specialized configurations take precedence over general ones at runtime.

## Problem
The current implementation throws an exception when `authenticationManagerResolver()` is used together with `jwt()` or `opaqueToken()` configurations. This prevents legitimate use cases such as Spring Authorization Server needing to support both JWT and opaque tokens dynamically.

## Solution
The solution removes the validation check that prevented `authenticationManagerResolver` from being used with jwt/opaqueToken configurations. The precedence is now handled at runtime where:
- If `authenticationManagerResolver` is configured, it takes precedence
- If not, the framework falls back to `jwt()` or `opaqueToken()` configuration

This is a non-destructive approach that maintains all configurations and applies precedence at execution time, following Spring Security's established patterns.

## Changes
- Modified `validateConfiguration()` to skip validation when `authenticationManagerResolver` is present
- Added clarifying comments in `configure()` method about precedence rules
- Updated test to verify no exception is thrown when both are configured
- Added new test cases for both JWT and OpaqueToken scenarios

## Testing
- Modified `configureWhenUsingBothAuthenticationManagerResolverAndOpaqueThenAuthenticationManagerResolverTakesPrecedence()`
- Added `configureWhenUsingBothAuthenticationManagerResolverAndJwtThenAuthenticationManagerResolverTakesPrecedence()`
- All existing tests continue to pass

Closes gh-16406