### PR TITLE
Provide custom WebClient and RestOperations to ReactiveJwtDecoders and JwtDecoders

### DIFF
--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoders.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtDecoders.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.util.Assert;
+import org.springframework.web.client.RestOperations;
 
 /**
  * Allows creating a {@link JwtDecoder} from an <a href=
@@ -52,10 +53,29 @@ public final class JwtDecoders {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T extends JwtDecoder> T fromOidcIssuerLocation(String oidcIssuerLocation) {
+		return fromOidcIssuerLocation(oidcIssuerLocation, null);
+	}
+
+	/**
+	 * Creates a {@link JwtDecoder} using the provided <a href=
+	 * "https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a>
+	 * by making an <a href=
+	 * "https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest">OpenID
+	 * Provider Configuration Request</a> and using the values in the <a href=
+	 * "https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse">OpenID
+	 * Provider Configuration Response</a> to initialize the {@link JwtDecoder}.
+	 * @param oidcIssuerLocation the <a href=
+	 * "https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a>
+	 * @param restOperations customized {@link RestOperations}
+	 * @return a {@link JwtDecoder} that was initialized by the OpenID Provider
+	 * Configuration.
+	 */
+	public static <T extends JwtDecoder> T fromOidcIssuerLocation(String oidcIssuerLocation,
+			RestOperations restOperations) {
 		Assert.hasText(oidcIssuerLocation, "oidcIssuerLocation cannot be empty");
 		Map<String, Object> configuration = JwtDecoderProviderConfigurationUtils
 			.getConfigurationForOidcIssuerLocation(oidcIssuerLocation);
-		return (T) withProviderConfiguration(configuration, oidcIssuerLocation);
+		return (T) withProviderConfiguration(configuration, oidcIssuerLocation, restOperations);
 	}
 
 	/**
@@ -88,8 +108,46 @@ public final class JwtDecoders {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T extends JwtDecoder> T fromIssuerLocation(String issuer) {
+		return fromIssuerLocation(issuer, null);
+	}
+
+	/**
+	 * Creates a {@link JwtDecoder} using the provided <a href=
+	 * "https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a>
+	 * by querying three different discovery endpoints serially, using the values in the
+	 * first successful response to initialize. If an endpoint returns anything other than
+	 * a 200 or a 4xx, the method will exit without attempting subsequent endpoints.
+	 *
+	 * The three endpoints are computed as follows, given that the {@code issuer} is
+	 * composed of a {@code host} and a {@code path}:
+	 *
+	 * <ol>
+	 * <li>{@code host/.well-known/openid-configuration/path}, as defined in
+	 * <a href="https://tools.ietf.org/html/rfc8414#section-5">RFC 8414's Compatibility
+	 * Notes</a>.</li>
+	 * <li>{@code issuer/.well-known/openid-configuration}, as defined in <a href=
+	 * "https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest">
+	 * OpenID Provider Configuration</a>.</li>
+	 * <li>{@code host/.well-known/oauth-authorization-server/path}, as defined in
+	 * <a href="https://tools.ietf.org/html/rfc8414#section-3.1">Authorization Server
+	 * Metadata Request</a>.</li>
+	 * </ol>
+	 *
+	 * Note that the second endpoint is the equivalent of calling
+	 * {@link JwtDecoders#fromOidcIssuerLocation(String)}
+	 * @param issuer the <a href=
+	 * "https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a>
+	 * @param restOperations customized {@link RestOperations}
+	 * @return a {@link JwtDecoder} that was initialized by one of the described endpoints
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T extends JwtDecoder> T fromIssuerLocation(String issuer, RestOperations restOperations) {
 		Assert.hasText(issuer, "issuer cannot be empty");
-		NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder.withIssuerLocation(issuer).build();
+		NimbusJwtDecoder.JwkSetUriJwtDecoderBuilder builder = NimbusJwtDecoder.withIssuerLocation(issuer);
+		if (restOperations != null) {
+			builder = builder.restOperations(restOperations);
+		}
+		NimbusJwtDecoder jwtDecoder = builder.build();
 		OAuth2TokenValidator<Jwt> jwtValidator = JwtValidators.createDefaultWithIssuer(issuer);
 		jwtDecoder.setJwtValidator(jwtValidator);
 		return (T) jwtDecoder;
@@ -104,15 +162,20 @@ public final class JwtDecoders {
 	 * @param configuration the configuration values
 	 * @param issuer the <a href=
 	 * "https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a>
+	 * @param restOperations customized {@link RestOperations}
 	 * @return {@link JwtDecoder}
 	 */
-	private static JwtDecoder withProviderConfiguration(Map<String, Object> configuration, String issuer) {
+	private static JwtDecoder withProviderConfiguration(Map<String, Object> configuration, String issuer,
+			RestOperations restOperations) {
 		JwtDecoderProviderConfigurationUtils.validateIssuer(configuration, issuer);
 		OAuth2TokenValidator<Jwt> jwtValidator = JwtValidators.createDefaultWithIssuer(issuer);
 		String jwkSetUri = configuration.get("jwks_uri").toString();
-		NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder.withJwkSetUri(jwkSetUri)
-			.jwtProcessorCustomizer(JwtDecoderProviderConfigurationUtils::addJWSAlgorithms)
-			.build();
+		NimbusJwtDecoder.JwkSetUriJwtDecoderBuilder builder = NimbusJwtDecoder.withJwkSetUri(jwkSetUri)
+			.jwtProcessorCustomizer(JwtDecoderProviderConfigurationUtils::addJWSAlgorithms);
+		if (restOperations != null) {
+			builder = builder.restOperations(restOperations);
+		}
+		NimbusJwtDecoder jwtDecoder = builder.build();
 		jwtDecoder.setJwtValidator(jwtValidator);
 		return jwtDecoder;
 	}

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/ReactiveJwtDecoders.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/ReactiveJwtDecoders.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.util.Assert;
+import org.springframework.web.reactive.function.client.WebClient;
 
 /**
  * Allows creating a {@link ReactiveJwtDecoder} from an <a href=
@@ -51,10 +52,29 @@ public final class ReactiveJwtDecoders {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T extends ReactiveJwtDecoder> T fromOidcIssuerLocation(String oidcIssuerLocation) {
+		return fromOidcIssuerLocation(oidcIssuerLocation, null);
+	}
+
+	/**
+	 * Creates a {@link ReactiveJwtDecoder} using the provided <a href=
+	 * "https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a>
+	 * by making an <a href=
+	 * "https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest">OpenID
+	 * Provider Configuration Request</a> and using the values in the <a href=
+	 * "https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationResponse">OpenID
+	 * Provider Configuration Response</a> to initialize the {@link ReactiveJwtDecoder}.
+	 * @param oidcIssuerLocation the <a href=
+	 * "https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a>
+	 * @param webClient customized {@link WebClient}
+	 * @return a {@link ReactiveJwtDecoder} that was initialized by the OpenID Provider
+	 * Configuration.
+	 */
+	public static <T extends ReactiveJwtDecoder> T fromOidcIssuerLocation(String oidcIssuerLocation,
+			WebClient webClient) {
 		Assert.hasText(oidcIssuerLocation, "oidcIssuerLocation cannot be empty");
 		Map<String, Object> configuration = JwtDecoderProviderConfigurationUtils
 			.getConfigurationForOidcIssuerLocation(oidcIssuerLocation);
-		return (T) withProviderConfiguration(configuration, oidcIssuerLocation);
+		return (T) withProviderConfiguration(configuration, oidcIssuerLocation, webClient);
 	}
 
 	/**
@@ -88,10 +108,45 @@ public final class ReactiveJwtDecoders {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T extends ReactiveJwtDecoder> T fromIssuerLocation(String issuer) {
+		return fromIssuerLocation(issuer, null);
+	}
+
+	/**
+	 * Creates a {@link ReactiveJwtDecoder} using the provided <a href=
+	 * "https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a>
+	 * by querying three different discovery endpoints serially, using the values in the
+	 * first successful response to initialize. If an endpoint returns anything other than
+	 * a 200 or a 4xx, the method will exit without attempting subsequent endpoints.
+	 *
+	 * The three endpoints are computed as follows, given that the {@code issuer} is
+	 * composed of a {@code host} and a {@code path}:
+	 *
+	 * <ol>
+	 * <li>{@code host/.well-known/openid-configuration/path}, as defined in
+	 * <a href="https://tools.ietf.org/html/rfc8414#section-5">RFC 8414's Compatibility
+	 * Notes</a>.</li>
+	 * <li>{@code issuer/.well-known/openid-configuration}, as defined in <a href=
+	 * "https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest">
+	 * OpenID Provider Configuration</a>.</li>
+	 * <li>{@code host/.well-known/oauth-authorization-server/path}, as defined in
+	 * <a href="https://tools.ietf.org/html/rfc8414#section-3.1">Authorization Server
+	 * Metadata Request</a>.</li>
+	 * </ol>
+	 *
+	 * Note that the second endpoint is the equivalent of calling
+	 * {@link ReactiveJwtDecoders#fromOidcIssuerLocation(String)}
+	 * @param issuer the <a href=
+	 * "https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a>
+	 * @param webClient customized {@link WebClient}
+	 * @return a {@link ReactiveJwtDecoder} that was initialized by one of the described
+	 * endpoints
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T extends ReactiveJwtDecoder> T fromIssuerLocation(String issuer, WebClient webClient) {
 		Assert.hasText(issuer, "issuer cannot be empty");
 		Map<String, Object> configuration = JwtDecoderProviderConfigurationUtils
 			.getConfigurationForIssuerLocation(issuer);
-		return (T) withProviderConfiguration(configuration, issuer);
+		return (T) withProviderConfiguration(configuration, issuer, webClient);
 	}
 
 	/**
@@ -103,15 +158,21 @@ public final class ReactiveJwtDecoders {
 	 * @param configuration the configuration values
 	 * @param issuer the <a href=
 	 * "https://openid.net/specs/openid-connect-core-1_0.html#IssuerIdentifier">Issuer</a>
+	 * @param webClient customized {@link WebClient}
 	 * @return {@link ReactiveJwtDecoder}
 	 */
-	private static ReactiveJwtDecoder withProviderConfiguration(Map<String, Object> configuration, String issuer) {
+	private static ReactiveJwtDecoder withProviderConfiguration(Map<String, Object> configuration, String issuer,
+			WebClient webClient) {
 		JwtDecoderProviderConfigurationUtils.validateIssuer(configuration, issuer);
 		OAuth2TokenValidator<Jwt> jwtValidator = JwtValidators.createDefaultWithIssuer(issuer);
 		String jwkSetUri = configuration.get("jwks_uri").toString();
-		NimbusReactiveJwtDecoder jwtDecoder = NimbusReactiveJwtDecoder.withJwkSetUri(jwkSetUri)
-			.jwtProcessorCustomizer(ReactiveJwtDecoderProviderConfigurationUtils::addJWSAlgorithms)
-			.build();
+		NimbusReactiveJwtDecoder.JwkSetUriReactiveJwtDecoderBuilder builder = NimbusReactiveJwtDecoder
+			.withJwkSetUri(jwkSetUri)
+			.jwtProcessorCustomizer(ReactiveJwtDecoderProviderConfigurationUtils::addJWSAlgorithms);
+		if (webClient != null) {
+			builder = builder.webClient(webClient);
+		}
+		NimbusReactiveJwtDecoder jwtDecoder = builder.build();
 		jwtDecoder.setJwtValidator(jwtValidator);
 		return jwtDecoder;
 	}


### PR DESCRIPTION
While [Customize the WebClient used by OAuth2 Client Components](https://docs.spring.io/spring-security/reference/reactive/oauth2/index.html#oauth2-client-customize-web-client) provides a way to customize the `ReactiveOAuth2AccessTokenResponseClient` by providing a custom WebClient. 

Spring security doesn't provide a clear way to customize the WebClient and RestOperation objects involved in the JWT decode flow of the OAuth2 authentication. This pull includes changes that allows a user to provide a custom WebClient/RestOperations to `ReactiveJwtDecoders` and `JwtDecoders` and leverage the already existing internal customizations Spring security is already doing.