### PR TITLE
Update servlet test method docs to use include-code

### DIFF
--- a/docs/modules/ROOT/pages/servlet/test/method.adoc
+++ b/docs/modules/ROOT/pages/servlet/test/method.adoc
@@ -4,36 +4,7 @@
 This section demonstrates how to use Spring Security's Test support to test method-based security.
 We first introduce a `MessageService` that requires the user to be authenticated to be able to access it:
 
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-public class HelloMessageService implements MessageService {
-
-	@PreAuthorize("authenticated")
-	public String getMessage() {
-		Authentication authentication = SecurityContextHolder.getContext()
-			.getAuthentication();
-		return "Hello " + authentication;
-	}
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-class HelloMessageService : MessageService {
-    @PreAuthorize("authenticated")
-    fun getMessage(): String {
-        val authentication: Authentication = SecurityContextHolder.getContext().authentication
-        return "Hello $authentication"
-    }
-}
-----
-======
+include-code::./HelloMessageService[tag=authenticated,indent=0]
 
 The result of `getMessage` is a `String` that says "`Hello`" to the current Spring Security `Authentication`.
 The following listing shows example output:
@@ -48,30 +19,8 @@ Hello org.springframework.security.authentication.UsernamePasswordAuthentication
 
 Before we can use the Spring Security test support, we must perform some setup:
 
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-@ExtendWith(SpringExtension.class) // <1>
-@ContextConfiguration // <2>
-public class WithMockUserTests {
-	// ...
-}
-----
+include-code::./WithMockUserTests[tag=setup,indent=0]
 
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration
-class WithMockUserTests {
-    // ...
-}
-----
-======
 <1> `@ExtendWith` instructs the spring-test module that it should create an `ApplicationContext`. For additional information, refer to the {spring-framework-reference-url}testing.html#testcontext-junit-jupiter-extension[Spring reference].
 <2> `@ContextConfiguration` instructs the spring-test the configuration to use to create the `ApplicationContext`. Since no configuration is specified, the default configuration locations will be tried. This is no different than using the existing Spring Test support. For additional information, refer to the {spring-framework-reference-url}testing.html#spring-testing-annotation-contextconfiguration[Spring Reference].
 
@@ -87,28 +36,7 @@ If you need only Spring Security related support, you can replace `@ContextConfi
 Remember, we added the `@PreAuthorize` annotation to our `HelloMessageService`, so it requires an authenticated user to invoke it.
 If we run the tests, we expect the following test will pass:
 
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-@Test(expected = AuthenticationCredentialsNotFoundException.class)
-public void getMessageUnauthenticated() {
-	messageService.getMessage();
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Test(expected = AuthenticationCredentialsNotFoundException::class)
-fun getMessageUnauthenticated() {
-    messageService.getMessage()
-}
-----
-======
+include-code::./WithMockUserSampleTests[tag=snippet,indent=0]
 
 [[test-method-withmockuser]]
 == @WithMockUser
@@ -117,32 +45,7 @@ The question is "How could we most easily run the test as a specific user?"
 The answer is to use `@WithMockUser`.
 The following test will be run as a user with the username "user", the password "password", and the roles "ROLE_USER".
 
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-@Test
-@WithMockUser
-public void getMessageWithMockUser() {
-String message = messageService.getMessage();
-...
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Test
-@WithMockUser
-fun getMessageWithMockUser() {
-    val message: String = messageService.getMessage()
-    // ...
-}
-----
-======
+include-code::./WithMockUserTests[tag=mock-user,indent=0]
 
 Specifically the following is true:
 
@@ -157,168 +60,28 @@ The preceding example is handy, because it lets us use a lot of defaults.
 What if we wanted to run the test with a different username?
 The following test would run with a username of `customUser` (again, the user does not need to actually exist):
 
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-@Test
-@WithMockUser("customUsername")
-public void getMessageWithMockUserCustomUsername() {
-	String message = messageService.getMessage();
-...
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Test
-@WithMockUser("customUsername")
-fun getMessageWithMockUserCustomUsername() {
-    val message: String = messageService.getMessage()
-    // ...
-}
-----
-======
+include-code::./WithMockUserTests[tag=custom-user,indent=0]
 
 We can also easily customize the roles.
 For example, the following test is invoked with a username of `admin` and roles of `ROLE_USER` and `ROLE_ADMIN`.
 
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-@Test
-@WithMockUser(username="admin",roles={"USER","ADMIN"})
-public void getMessageWithMockUserCustomUser() {
-	String message = messageService.getMessage();
-	...
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Test
-@WithMockUser(username="admin",roles=["USER","ADMIN"])
-fun getMessageWithMockUserCustomUser() {
-    val message: String = messageService.getMessage()
-    // ...
-}
-----
-======
+include-code::./WithMockUserTests[tag=custom-roles,indent=0]
 
 If we do not want the value to automatically be prefixed with `ROLE_` we can use the `authorities` attribute.
 For example, the following test is invoked with a username of `admin` and the `USER` and `ADMIN` authorities.
 
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-@Test
-@WithMockUser(username = "admin", authorities = { "ADMIN", "USER" })
-public void getMessageWithMockUserCustomAuthorities() {
-	String message = messageService.getMessage();
-	...
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Test
-@WithMockUser(username = "admin", authorities = ["ADMIN", "USER"])
-fun getMessageWithMockUserCustomUsername() {
-    val message: String = messageService.getMessage()
-    // ...
-}
-----
-======
+include-code::./WithMockUserTests[tag=custom-authorities,indent=0]
 
 It can be a bit tedious to place the annotation on every test method.
 Instead, we can place the annotation at the class level. Then every test uses the specified user.
 The following example runs every test with a user whose username is `admin`, whose password is `password`, and who has the `ROLE_USER` and `ROLE_ADMIN` roles:
 
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration
-@WithMockUser(username="admin",roles={"USER","ADMIN"})
-public class WithMockUserTests {
-	// ...
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration
-@WithMockUser(username="admin",roles=["USER","ADMIN"])
-class WithMockUserTests {
-    // ...
-}
-----
-======
+include-code::./WithMockUserClassTests[tag=snippet,indent=0]
 
 If you use JUnit 5's `@Nested` test support, you can also place the annotation on the enclosing class to apply to all nested classes.
 The following example runs every test with a user whose username is `admin`, whose password is `password`, and who has the `ROLE_USER` and `ROLE_ADMIN` roles for both test methods.
 
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration
-@WithMockUser(username="admin",roles={"USER","ADMIN"})
-public class WithMockUserTests {
-
-	@Nested
-	public class TestSuite1 {
-		// ... all test methods use admin user
-	}
-
-	@Nested
-	public class TestSuite2 {
-		// ... all test methods use admin user
-	}
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@ExtendWith(SpringExtension::class)
-@ContextConfiguration
-@WithMockUser(username = "admin", roles = ["USER", "ADMIN"])
-class WithMockUserTests {
-    @Nested
-    inner class TestSuite1 { // ... all test methods use admin user
-    }
-
-    @Nested
-    inner class TestSuite2 { // ... all test methods use admin user
-    }
-}
-----
-======
+include-code::./WithMockUserNestedTests[tag=snippet,indent=0]
 
 By default, the `SecurityContext` is set during the `TestExecutionListener.beforeTestMethod` event.
 This is the equivalent of happening before JUnit's `@Before`.
@@ -337,55 +100,7 @@ Using `@WithAnonymousUser` allows running as an anonymous user.
 This is especially convenient when you wish to run most of your tests with a specific user but want to run a few tests as an anonymous user.
 The following example runs `withMockUser1` and `withMockUser2` by using <<test-method-withmockuser,@WithMockUser>> and `anonymous` as an anonymous user:
 
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-@ExtendWith(SpringExtension.class)
-@WithMockUser
-public class WithUserClassLevelAuthenticationTests {
-
-	@Test
-	public void withMockUser1() {
-	}
-
-	@Test
-	public void withMockUser2() {
-	}
-
-	@Test
-	@WithAnonymousUser
-	public void anonymous() throws Exception {
-		// override default to run as anonymous user
-	}
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@ExtendWith(SpringExtension.class)
-@WithMockUser
-class WithUserClassLevelAuthenticationTests {
-    @Test
-    fun withMockUser1() {
-    }
-
-    @Test
-    fun withMockUser2() {
-    }
-
-    @Test
-    @WithAnonymousUser
-    fun anonymous() {
-        // override default to run as anonymous user
-    }
-}
-----
-======
+include-code::./WithUserClassLevelAuthenticationTests[tag=snippet,indent=0]
 
 By default, the `SecurityContext` is set during the `TestExecutionListener.beforeTestMethod` event.
 This is the equivalent of happening before JUnit's `@Before`.
@@ -410,92 +125,17 @@ That is exactly what `@WithUserDetails` does.
 
 Assuming we have a `UserDetailsService` exposed as a bean, the following test is invoked with an `Authentication` of type `UsernamePasswordAuthenticationToken` and a principal that is returned from the `UserDetailsService` with the username of `user`:
 
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-@Test
-@WithUserDetails
-public void getMessageWithUserDetails() {
-	String message = messageService.getMessage();
-	...
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Test
-@WithUserDetails
-fun getMessageWithUserDetails() {
-    val message: String = messageService.getMessage()
-    // ...
-}
-----
-======
+include-code::./WithUserDetailsTests[tag=user-details,indent=0]
 
 We can also customize the username used to lookup the user from our `UserDetailsService`.
 For example, this test can be run with a principal that is returned from the `UserDetailsService` with the username of `customUsername`:
 
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-@Test
-@WithUserDetails("customUsername")
-public void getMessageWithUserDetailsCustomUsername() {
-	String message = messageService.getMessage();
-	...
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Test
-@WithUserDetails("customUsername")
-fun getMessageWithUserDetailsCustomUsername() {
-    val message: String = messageService.getMessage()
-    // ...
-}
-----
-======
+include-code::./WithUserDetailsTests[tag=user-details-custom-username,indent=0]
 
 We can also provide an explicit bean name to look up the `UserDetailsService`.
 The following test looks up the username of `customUsername` by using the `UserDetailsService` with a bean name of `myUserDetailsService`:
 
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-@Test
-@WithUserDetails(value="customUsername", userDetailsServiceBeanName="myUserDetailsService")
-public void getMessageWithUserDetailsServiceBeanName() {
-	String message = messageService.getMessage();
-	...
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Test
-@WithUserDetails(value="customUsername", userDetailsServiceBeanName="myUserDetailsService")
-fun getMessageWithUserDetailsServiceBeanName() {
-    val message: String = messageService.getMessage()
-    // ...
-}
-----
-======
+include-code::./WithCustomUserDetailsTests[tag=custom-user-details-service,indent=0]
 
 As we did with `@WithMockUser`, we can also place our annotation at the class level so that every test uses the same user.
 However, unlike `@WithMockUser`, `@WithUserDetails` requires the user to exist.
@@ -519,128 +159,21 @@ We now see an option that allows the most flexibility.
 We can create our own annotation that uses the `@WithSecurityContext` to create any `SecurityContext` we want.
 For example, we might create an annotation named `@WithMockCustomUser`:
 
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-@Retention(RetentionPolicy.RUNTIME)
-@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
-public @interface WithMockCustomUser {
-
-	String username() default "rob";
-
-	String name() default "Rob Winch";
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Retention(AnnotationRetention.RUNTIME)
-@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory::class)
-annotation class WithMockCustomUser(val username: String = "rob", val name: String = "Rob Winch")
-----
-======
+include-code::./WithMockCustomUser[tag=snippet,indent=0]
 
 You can see that `@WithMockCustomUser` is annotated with the `@WithSecurityContext` annotation.
 This is what signals to Spring Security test support that we intend to create a `SecurityContext` for the test.
 The `@WithSecurityContext` annotation requires that we specify a `SecurityContextFactory` to create a new `SecurityContext`, given our `@WithMockCustomUser` annotation.
 The following listing shows our `WithMockCustomUserSecurityContextFactory` implementation:
 
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-public class WithMockCustomUserSecurityContextFactory
-	implements WithSecurityContextFactory<WithMockCustomUser> {
-	@Override
-	public SecurityContext createSecurityContext(WithMockCustomUser customUser) {
-		SecurityContext context = SecurityContextHolder.createEmptyContext();
-
-		CustomUserDetails principal =
-			new CustomUserDetails(customUser.name(), customUser.username());
-		Authentication auth =
-			UsernamePasswordAuthenticationToken.authenticated(principal, "password", principal.getAuthorities());
-		context.setAuthentication(auth);
-		return context;
-	}
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-class WithMockCustomUserSecurityContextFactory : WithSecurityContextFactory<WithMockCustomUser> {
-    override fun createSecurityContext(customUser: WithMockCustomUser): SecurityContext {
-        val context = SecurityContextHolder.createEmptyContext()
-        val principal = CustomUserDetails(customUser.name, customUser.username)
-        val auth: Authentication =
-            UsernamePasswordAuthenticationToken(principal, "password", principal.authorities)
-        context.authentication = auth
-        return context
-    }
-}
-----
-======
+include-code::./WithMockCustomUserSecurityContextFactory[tag=snippet,indent=0]
 
 We can now annotate a test class or a test method with our new annotation and Spring Security's `WithSecurityContextTestExecutionListener` to ensure that our `SecurityContext` is populated appropriately.
 
 When creating your own `WithSecurityContextFactory` implementations, it is nice to know that they can be annotated with standard Spring annotations.
 For example, the `WithUserDetailsSecurityContextFactory` uses the `@Autowired` annotation to acquire the `UserDetailsService`:
 
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-final class WithUserDetailsSecurityContextFactory
-	implements WithSecurityContextFactory<WithUserDetails> {
-
-	private UserDetailsService userDetailsService;
-
-	@Autowired
-	public WithUserDetailsSecurityContextFactory(UserDetailsService userDetailsService) {
-		this.userDetailsService = userDetailsService;
-	}
-
-	public SecurityContext createSecurityContext(WithUserDetails withUser) {
-		String username = withUser.value();
-		Assert.hasLength(username, "value() must be non-empty String");
-		UserDetails principal = userDetailsService.loadUserByUsername(username);
-		Authentication authentication = UsernamePasswordAuthenticationToken.authenticated(principal, principal.getPassword(), principal.getAuthorities());
-		SecurityContext context = SecurityContextHolder.createEmptyContext();
-		context.setAuthentication(authentication);
-		return context;
-	}
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-class WithUserDetailsSecurityContextFactory @Autowired constructor(private val userDetailsService: UserDetailsService) :
-    WithSecurityContextFactory<WithUserDetails> {
-    override fun createSecurityContext(withUser: WithUserDetails): SecurityContext {
-        val username: String = withUser.value
-        Assert.hasLength(username, "value() must be non-empty String")
-        val principal = userDetailsService.loadUserByUsername(username)
-        val authentication: Authentication =
-            UsernamePasswordAuthenticationToken(principal, principal.password, principal.authorities)
-        val context = SecurityContextHolder.createEmptyContext()
-        context.authentication = authentication
-        return context
-    }
-}
-----
-======
+include-code::./WithUserDetailsSecurityContextFactory[tag=snippet,indent=0]
 
 By default, the `SecurityContext` is set during the `TestExecutionListener.beforeTestMethod` event.
 This is the equivalent of happening before JUnit's `@Before`.
@@ -658,46 +191,12 @@ You can change this to happen during the `TestExecutionListener.beforeTestExecut
 If you reuse the same user within your tests often, it is not ideal to have to repeatedly specify the attributes.
 For example, if you have many tests related to an administrative user with a username of `admin` and roles of `ROLE_USER` and `ROLE_ADMIN`, you have to write:
 
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-@WithMockUser(username="admin",roles={"USER","ADMIN"})
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@WithMockUser(username="admin",roles=["USER","ADMIN"])
-----
-======
+include-code::./WithMockUserTests[tag=snippet,indent=0]
 
 Rather than repeating this everywhere, we can use a meta annotation.
 For example, we could create a meta annotation named `WithMockAdmin`:
 
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-@Retention(RetentionPolicy.RUNTIME)
-@WithMockUser(value="rob",roles="ADMIN")
-public @interface WithMockAdmin { }
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Retention(AnnotationRetention.RUNTIME)
-@WithMockUser(value = "rob", roles = ["ADMIN"])
-annotation class WithMockAdmin
-----
-======
+include-code::./WithMockAdmin[tag=snippet,indent=0]
 
 Now we can use `@WithMockAdmin` in the same way as the more verbose `@WithMockUser`.
 

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethod/HelloMessageService.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethod/HelloMessageService.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.docs.servlet.test.testmethod;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.config.core.MessageService;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * A message service for demonstrating test support for method-based security.
+ */
+// tag::authenticated[]
+public class HelloMessageService implements MessageService {
+
+	@Override
+	@PreAuthorize("isAuthenticated()")
+	public String getMessage() {
+		Authentication authentication = SecurityContextHolder.getContext()
+				.getAuthentication();
+		return "Hello " + authentication;
+	}
+
+	@Override
+	@PreAuthorize("isAuthenticated()")
+	public String getJsrMessage() {
+		Authentication authentication = SecurityContextHolder.getContext()
+				.getAuthentication();
+		return "Hello JSR " + authentication;
+	}
+}
+// end::authenticated[]

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethod/HelloMessageService.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethod/HelloMessageService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethod/HelloServiceTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethod/HelloServiceTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.docs.servlet.test.testmethod;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.core.MessageService;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+class HelloServiceTests {
+
+	@Autowired
+	MessageService messageService;
+
+	@BeforeEach
+	void setup() {
+		UsernamePasswordAuthenticationToken user = UsernamePasswordAuthenticationToken.authenticated("user", "password", AuthorityUtils.createAuthorityList("ROLE_USER"));
+		SecurityContextHolder.getContext().setAuthentication(user);
+	}
+
+	@Test
+	void helloServiceTest() {
+		assertThat(messageService.getMessage())
+				.contains("user")
+				.contains("ROLE_USER");
+	}
+
+	@EnableMethodSecurity(prePostEnabled = true, jsr250Enabled = true)
+	@Configuration
+	static class Config {
+
+		@Bean
+		MessageService messageService() {
+			return new HelloMessageService();
+		}
+	}
+}

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethod/HelloServiceTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethod/HelloServiceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodmetaannotations/WithMockAdmin.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodmetaannotations/WithMockAdmin.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.docs.servlet.test.testmethodmetaannotations;
+
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+// tag::snippet[]
+@Retention(RetentionPolicy.RUNTIME)
+@WithMockUser(value="rob",roles={"USER","ADMIN"})
+public @interface WithMockAdmin { }
+// end::snippet[]

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodmetaannotations/WithMockAdmin.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodmetaannotations/WithMockAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodmetaannotations/WithMockAdminTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodmetaannotations/WithMockAdminTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.docs.servlet.test.testmethodmetaannotations;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.core.MessageService;
+import org.springframework.security.docs.servlet.test.testmethod.HelloMessageService;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+public class WithMockAdminTests {
+
+	@Autowired
+	MessageService messageService;
+
+	@Test
+	@WithMockAdmin
+	void getMessageWithMockUserAdminRoles() {
+		String message = messageService.getMessage();
+		assertThat(message)
+				.contains("rob")
+				.contains("ROLE_ADMIN")
+				.contains("ROLE_USER");
+	}
+
+	@EnableMethodSecurity
+	@Configuration
+	static class Config {
+
+		@Bean
+		MessageService messageService() {
+			return new HelloMessageService();
+		}
+	}
+}

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodmetaannotations/WithMockAdminTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodmetaannotations/WithMockAdminTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodmetaannotations/WithMockUserTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodmetaannotations/WithMockUserTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.docs.servlet.test.testmethodmetaannotations;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.core.MessageService;
+import org.springframework.security.docs.servlet.test.testmethod.HelloMessageService;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+public class WithMockUserTests {
+
+	@Autowired
+	MessageService messageService;
+
+	@Test
+	// tag::snippet[]
+	@WithMockUser(username = "admin", roles = {"USER", "ADMIN"})
+	// end::snippet[]
+	void getMessageWithMockUserAdminRoles() {
+		String message = messageService.getMessage();
+		assertThat(message)
+				.contains("admin")
+				.contains("ROLE_ADMIN")
+				.contains("ROLE_USER");
+	}
+
+	@EnableMethodSecurity
+	@Configuration
+	static class Config {
+
+		@Bean
+		MessageService messageService() {
+			return new HelloMessageService();
+		}
+	}
+}

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodmetaannotations/WithMockUserTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodmetaannotations/WithMockUserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodsetup/WithMockUserSampleTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodsetup/WithMockUserSampleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodsetup/WithMockUserSampleTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodsetup/WithMockUserSampleTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.docs.servlet.test.testmethodsetup;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.docs.servlet.test.testmethod.HelloMessageService;
+import org.springframework.security.config.core.MessageService;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+class WithMockUserSampleTests {
+
+	@Autowired
+	MessageService messageService;
+
+	// tag::snippet[]
+	@Test
+	void getMessageUnauthenticated() {
+		assertThatExceptionOfType(AuthenticationCredentialsNotFoundException.class)
+				.isThrownBy(() -> messageService.getMessage());
+	}
+	// end::snippet[]
+
+	@EnableMethodSecurity(prePostEnabled = true, jsr250Enabled = true)
+	@Configuration
+	static class Config {
+
+		@Bean
+		MessageService messageService() {
+			return new HelloMessageService();
+		}
+	}
+}

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodsetup/WithMockUserSampleTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodsetup/WithMockUserSampleTests.java
@@ -46,7 +46,7 @@ class WithMockUserSampleTests {
 	}
 	// end::snippet[]
 
-	@EnableMethodSecurity(prePostEnabled = true, jsr250Enabled = true)
+	@EnableMethodSecurity
 	@Configuration
 	static class Config {
 

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodsetup/WithMockUserTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodsetup/WithMockUserTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.docs.servlet.test.testmethodsetup;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+// tag::setup[]
+@ExtendWith(SpringExtension.class) // <1>
+@ContextConfiguration // <2>
+class WithMockUserTests {
+	// ...
+}
+// end::setup[]

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodsetup/WithMockUserTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodsetup/WithMockUserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithanonymoususer/WithUserClassLevelAuthenticationTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithanonymoususer/WithUserClassLevelAuthenticationTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.docs.servlet.test.testmethodwithanonymoususer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+// tag::snippet[]
+@ExtendWith(SpringExtension.class)
+@WithMockUser
+class WithUserClassLevelAuthenticationTests {
+
+	@Test
+	void withMockUser1() {
+	}
+
+	@Test
+	void withMockUser2() {
+	}
+
+	@Test
+	@WithAnonymousUser
+	void anonymous() throws Exception {
+		// override default to run as anonymous user
+	}
+}
+// end::snippet[]

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithanonymoususer/WithUserClassLevelAuthenticationTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithanonymoususer/WithUserClassLevelAuthenticationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithmockuser/WithMockUserClassTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithmockuser/WithMockUserClassTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.docs.servlet.test.testmethodwithmockuser;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+// tag::snippet[]
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+@WithMockUser(username = "admin", roles = {"USER", "ADMIN"})
+class WithMockUserClassTests {
+	// ...
+}
+// end::snippet[]

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithmockuser/WithMockUserClassTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithmockuser/WithMockUserClassTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithmockuser/WithMockUserNestedTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithmockuser/WithMockUserNestedTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.docs.servlet.test.testmethodwithmockuser;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+// tag::snippet[]
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+@WithMockUser(username = "admin", roles = {"USER", "ADMIN"})
+class WithMockUserNestedTests {
+
+	@Nested
+	class TestSuite1 {
+		// ... all test methods use admin user
+	}
+
+	@Nested
+	class TestSuite2 {
+		// ... all test methods use admin user
+	}
+}
+// end::snippet[]

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithmockuser/WithMockUserNestedTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithmockuser/WithMockUserNestedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithmockuser/WithMockUserTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithmockuser/WithMockUserTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.docs.servlet.test.testmethodwithmockuser;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.core.MessageService;
+import org.springframework.security.docs.servlet.test.testmethod.HelloMessageService;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+class WithMockUserTests {
+
+	@Autowired
+	MessageService messageService;
+
+	// tag::mock-user[]
+	@Test
+	@WithMockUser
+	void getMessageWithMockUser() {
+		String message = messageService.getMessage();
+		assertThat(message).contains("user");
+	}
+	// end::mock-user[]
+
+	// tag::custom-user[]
+	@Test
+	@WithMockUser("customUser")
+	void getMessageWithMockUserCustomUsername() {
+		String message = messageService.getMessage();
+		assertThat(message).contains("customUser");
+	}
+	// end::custom-user[]
+
+	// tag::custom-roles[]
+	@Test
+	@WithMockUser(username = "admin", roles = {"USER", "ADMIN"})
+	void getMessageWithMockUserCustomRoles() {
+		String message = messageService.getMessage();
+		assertThat(message)
+				.contains("admin")
+				.contains("ROLE_ADMIN")
+				.contains("ROLE_USER");
+	}
+	// end::custom-roles[]
+
+	// tag::custom-authorities[]
+	@Test
+	@WithMockUser(username = "admin", authorities = {"ADMIN", "USER"})
+	public void getMessageWithMockUserCustomAuthorities() {
+		String message = messageService.getMessage();
+		assertThat(message)
+				.contains("admin")
+				.contains("ADMIN")
+				.contains("USER")
+				.doesNotContain("ROLE_");
+	}
+	// end::custom-authorities[]
+
+	@EnableMethodSecurity(prePostEnabled = true, jsr250Enabled = true)
+	@Configuration
+	static class Config {
+
+		@Bean
+		MessageService messageService() {
+			return new HelloMessageService();
+		}
+	}
+}

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithmockuser/WithMockUserTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithmockuser/WithMockUserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithmockuser/WithMockUserTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithmockuser/WithMockUserTests.java
@@ -82,7 +82,7 @@ class WithMockUserTests {
 	}
 	// end::custom-authorities[]
 
-	@EnableMethodSecurity(prePostEnabled = true, jsr250Enabled = true)
+	@EnableMethodSecurity
 	@Configuration
 	static class Config {
 

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithsecuritycontext/CustomUserDetails.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithsecuritycontext/CustomUserDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithsecuritycontext/CustomUserDetails.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithsecuritycontext/CustomUserDetails.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.docs.servlet.test.testmethodwithsecuritycontext;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+public class CustomUserDetails implements UserDetails {
+
+	private final String name;
+
+	private final String username;
+
+	private final Collection<? extends GrantedAuthority> authorities;
+
+	public CustomUserDetails(String name, String username) {
+		this.name = name;
+		this.username = username;
+		this.authorities = AuthorityUtils.createAuthorityList("ROLE_USER");
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return this.authorities;
+	}
+
+	@Override
+	public String getPassword() {
+		return null;
+	}
+
+	@Override
+	public String getUsername() {
+		return this.username;
+	}
+
+	@Override
+	public String toString() {
+		return "CustomUserDetails{" + "username='" + this.username + '\'' + '}';
+	}
+
+}

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithsecuritycontext/WithMockCustomUser.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithsecuritycontext/WithMockCustomUser.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.docs.servlet.test.testmethodwithsecuritycontext;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+// tag::snippet[]
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+
+	String username() default "rob";
+
+	String name() default "Rob Winch";
+}
+// end::snippet[]

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithsecuritycontext/WithMockCustomUser.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithsecuritycontext/WithMockCustomUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithsecuritycontext/WithMockCustomUserSecurityContextFactory.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithsecuritycontext/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.docs.servlet.test.testmethodwithsecuritycontext;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+// tag::snippet[]
+public class WithMockCustomUserSecurityContextFactory
+		implements WithSecurityContextFactory<WithMockCustomUser> {
+
+	@Override
+	public SecurityContext createSecurityContext(WithMockCustomUser customUser) {
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
+		CustomUserDetails principal = new CustomUserDetails(customUser.name(), customUser.username());
+		Authentication auth = UsernamePasswordAuthenticationToken.authenticated(principal, "password",
+				principal.getAuthorities());
+		context.setAuthentication(auth);
+		return context;
+	}
+
+}
+// end::snippet[]

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithsecuritycontext/WithMockCustomUserSecurityContextFactory.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithsecuritycontext/WithMockCustomUserSecurityContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithsecuritycontext/WithUserDetailsSecurityContextFactory.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithsecuritycontext/WithUserDetailsSecurityContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithsecuritycontext/WithUserDetailsSecurityContextFactory.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithsecuritycontext/WithUserDetailsSecurityContextFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.docs.servlet.test.testmethodwithsecuritycontext;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.util.Assert;
+
+// tag::snippet[]
+final class WithUserDetailsSecurityContextFactory
+		implements WithSecurityContextFactory<WithUserDetails> {
+
+	private final UserDetailsService userDetailsService;
+
+	@Autowired
+	public WithUserDetailsSecurityContextFactory(UserDetailsService userDetailsService) {
+		this.userDetailsService = userDetailsService;
+	}
+
+	public SecurityContext createSecurityContext(WithUserDetails withUser) {
+		String username = withUser.value();
+		Assert.hasLength(username, "value() must be non-empty String");
+		UserDetails principal = userDetailsService.loadUserByUsername(username);
+		Authentication authentication = UsernamePasswordAuthenticationToken.authenticated(principal, principal.getPassword(), principal.getAuthorities());
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
+		context.setAuthentication(authentication);
+		return context;
+	}
+}
+// end::snippet[]

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithuserdetails/WithCustomUserDetailsTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithuserdetails/WithCustomUserDetailsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithuserdetails/WithCustomUserDetailsTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithuserdetails/WithCustomUserDetailsTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.docs.servlet.test.testmethodwithuserdetails;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.core.MessageService;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.docs.servlet.test.testmethod.HelloMessageService;
+import org.springframework.security.docs.servlet.test.testmethodwithsecuritycontext.CustomUserDetails;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+class WithCustomUserDetailsTests {
+
+	@Autowired
+	MessageService messageService;
+
+	// tag::custom-user-details-service[]
+	@Test
+	@WithUserDetails(value="customUsername", userDetailsServiceBeanName="myUserDetailsService")
+	void getMessageWithUserDetailsServiceBeanName() {
+		String message = messageService.getMessage();
+		assertThat(message).contains("customUsername");
+		Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+		assertThat(principal).isInstanceOf(CustomUserDetails.class);
+	}
+	// end::custom-user-details-service[]
+
+	@EnableWebSecurity
+	@Configuration
+	static class Config {
+
+		@Bean
+		UserDetailsService myUserDetailsService() {
+			return new CustomUserDetailsService();
+		}
+
+		@Bean
+		MessageService messageService() {
+			return new HelloMessageService();
+		}
+	}
+
+	static class CustomUserDetailsService implements UserDetailsService {
+
+		@Override
+		public UserDetails loadUserByUsername(final String username) throws UsernameNotFoundException {
+			return new CustomUserDetails("name", username);
+		}
+	}
+
+}

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithuserdetails/WithUserDetailsTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithuserdetails/WithUserDetailsTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.docs.servlet.test.testmethodwithuserdetails;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.core.MessageService;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.docs.servlet.test.testmethod.HelloMessageService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+class WithUserDetailsTests {
+
+	@Autowired
+	MessageService messageService;
+
+	// tag::user-details[]
+	@Test
+	@WithUserDetails
+	void getMessageWithUserDetails() {
+		String message = messageService.getMessage();
+		assertThat(message).contains("user");
+	}
+	// end::user-details[]
+
+	// tag::user-details-custom-username[]
+	@Test
+	@WithUserDetails("customUsername")
+	void getMessageWithUserDetailsCustomUsername() {
+		String message = messageService.getMessage();
+		assertThat(message).contains("customUsername");
+	}
+	// end::user-details-custom-username[]
+
+	@EnableWebSecurity
+	@Configuration
+	static class Config {
+
+		@Bean
+		UserDetailsService userDetailsService() {
+			UserDetails user1 = User.withDefaultPasswordEncoder()
+					.username("user")
+					.password("password")
+					.build();
+			UserDetails customUser = User.withDefaultPasswordEncoder()
+					.username("customUsername")
+					.password("password")
+					.build();
+			return new InMemoryUserDetailsManager(user1, customUser);
+		}
+
+		@Bean
+		MessageService messageService() {
+			return new HelloMessageService();
+		}
+	}
+}

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithuserdetails/WithUserDetailsTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/testmethodwithuserdetails/WithUserDetailsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethod/HelloMessageService.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethod/HelloMessageService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethod/HelloMessageService.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethod/HelloMessageService.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.kt.docs.servlet.test.testmethod
+
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.config.core.MessageService
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContextHolder
+
+/**
+ * A message service for demonstrating test support for method-based security.
+ */
+// tag::authenticated[]
+class HelloMessageService : MessageService {
+
+	@PreAuthorize("isAuthenticated()")
+	override fun getMessage(): String {
+		val authentication: Authentication = SecurityContextHolder.getContext().authentication
+		return "Hello $authentication"
+	}
+
+	@PreAuthorize("isAuthenticated()")
+	override fun getJsrMessage(): String {
+		val authentication = SecurityContextHolder.getContext().authentication
+		return "Hello JSR $authentication"
+	}
+}
+// end::authenticated[]

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethod/HelloServiceTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethod/HelloServiceTests.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.kt.docs.servlet.test.testmethod
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.core.MessageService
+import org.springframework.security.core.authority.AuthorityUtils
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration
+class HelloServiceTests {
+
+    @Autowired
+    lateinit var messageService: MessageService
+
+    @BeforeEach
+    fun setup() {
+        val user = UsernamePasswordAuthenticationToken.authenticated(
+            "user",
+            "password",
+            AuthorityUtils.createAuthorityList("ROLE_USER")
+        )
+        SecurityContextHolder.getContext().authentication = user
+    }
+
+    @Test
+    fun helloServiceTest() {
+        Assertions.assertThat(messageService.message)
+            .contains("user")
+            .contains("ROLE_USER")
+    }
+
+    @EnableMethodSecurity(prePostEnabled = true, jsr250Enabled = true)
+    @Configuration
+    open class Config {
+        @Bean
+        open fun messageService(): MessageService {
+            return HelloMessageService()
+        }
+    }
+}

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethod/HelloServiceTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethod/HelloServiceTests.kt
@@ -16,7 +16,7 @@
 
 package org.springframework.security.kt.docs.servlet.test.testmethod
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -50,7 +50,7 @@ class HelloServiceTests {
 
     @Test
     fun helloServiceTest() {
-        Assertions.assertThat(messageService.message)
+        assertThat(messageService.message)
             .contains("user")
             .contains("ROLE_USER")
     }

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethod/HelloServiceTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethod/HelloServiceTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodmetaannotations/WithMockAdmin.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodmetaannotations/WithMockAdmin.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.kt.docs.servlet.test.testmethodmetaannotations
+
+import org.springframework.security.test.context.support.WithMockUser
+
+// tag::snippet[]
+@Retention(AnnotationRetention.RUNTIME)
+@WithMockUser(value = "rob", roles = ["USER", "ADMIN"])
+annotation class WithMockAdmin
+// end::snippet[]

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodmetaannotations/WithMockAdmin.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodmetaannotations/WithMockAdmin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodmetaannotations/WithMockAdminTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodmetaannotations/WithMockAdminTests.kt
@@ -16,7 +16,7 @@
 
 package org.springframework.security.kt.docs.servlet.test.testmethodmetaannotations
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -39,7 +39,7 @@ class WithMockAdminTests {
     @WithMockAdmin
     fun getMessageWithMockUserAdminRoles() {
         val message = messageService.message
-        Assertions.assertThat(message)
+        assertThat(message)
             .contains("rob")
             .contains("ROLE_ADMIN")
             .contains("ROLE_USER")

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodmetaannotations/WithMockAdminTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodmetaannotations/WithMockAdminTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodmetaannotations/WithMockAdminTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodmetaannotations/WithMockAdminTests.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.kt.docs.servlet.test.testmethodmetaannotations
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.core.MessageService
+import org.springframework.security.kt.docs.servlet.test.testmethod.HelloMessageService
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration
+class WithMockAdminTests {
+
+    @Autowired
+    lateinit var messageService: MessageService
+
+    @Test
+    @WithMockAdmin
+    fun getMessageWithMockUserAdminRoles() {
+        val message = messageService.message
+        Assertions.assertThat(message)
+            .contains("rob")
+            .contains("ROLE_ADMIN")
+            .contains("ROLE_USER")
+    }
+
+    @EnableMethodSecurity(prePostEnabled = true, jsr250Enabled = true)
+    @Configuration
+    open class Config {
+        @Bean
+        open fun messageService(): MessageService {
+            return HelloMessageService()
+        }
+    }
+}

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodmetaannotations/WithMockAdminTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodmetaannotations/WithMockAdminTests.kt
@@ -45,7 +45,7 @@ class WithMockAdminTests {
             .contains("ROLE_USER")
     }
 
-    @EnableMethodSecurity(prePostEnabled = true, jsr250Enabled = true)
+    @EnableMethodSecurity
     @Configuration
     open class Config {
         @Bean

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodmetaannotations/WithMockUserTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodmetaannotations/WithMockUserTests.kt
@@ -16,7 +16,7 @@
 
 package org.springframework.security.kt.docs.servlet.test.testmethodmetaannotations
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -42,7 +42,7 @@ class WithMockUserTests {
     // end::snippet[]
     fun getMessageWithMockUserAdminRoles() {
         val message = messageService.message
-        Assertions.assertThat(message)
+        assertThat(message)
             .contains("admin")
             .contains("ROLE_ADMIN")
             .contains("ROLE_USER")

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodmetaannotations/WithMockUserTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodmetaannotations/WithMockUserTests.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.kt.docs.servlet.test.testmethodmetaannotations
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.core.MessageService
+import org.springframework.security.kt.docs.servlet.test.testmethod.HelloMessageService
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration
+class WithMockUserTests {
+
+    @Autowired
+    lateinit var messageService: MessageService
+
+    @Test
+    // tag::snippet[]
+    @WithMockUser(username = "admin", roles = ["USER", "ADMIN"])
+    // end::snippet[]
+    fun getMessageWithMockUserAdminRoles() {
+        val message = messageService.message
+        Assertions.assertThat(message)
+            .contains("admin")
+            .contains("ROLE_ADMIN")
+            .contains("ROLE_USER")
+    }
+
+    @EnableMethodSecurity
+    @Configuration
+    open class Config {
+        @Bean
+        open fun messageService(): MessageService {
+            return HelloMessageService()
+        }
+    }
+}

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodmetaannotations/WithMockUserTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodmetaannotations/WithMockUserTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodsetup/WithMockUserSampleTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodsetup/WithMockUserSampleTests.kt
@@ -44,7 +44,7 @@ class WithMockUserSampleTests {
 	}
 	// end::snippet[]
 
-	@EnableMethodSecurity(prePostEnabled = true, jsr250Enabled = true)
+	@EnableMethodSecurity
 	@Configuration
 	open class Config {
 		@Bean

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodsetup/WithMockUserSampleTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodsetup/WithMockUserSampleTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodsetup/WithMockUserSampleTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodsetup/WithMockUserSampleTests.kt
@@ -16,7 +16,7 @@
 
 package org.springframework.security.kt.docs.servlet.test.testmethodsetup
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -39,7 +39,7 @@ class WithMockUserSampleTests {
 	// tag::snippet[]
 	@Test
 	fun getMessageUnauthenticated() {
-		Assertions.assertThatExceptionOfType(AuthenticationCredentialsNotFoundException::class.java)
+		assertThatExceptionOfType(AuthenticationCredentialsNotFoundException::class.java)
 			.isThrownBy { messageService.getMessage() }
 	}
 	// end::snippet[]

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodsetup/WithMockUserSampleTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodsetup/WithMockUserSampleTests.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.kt.docs.servlet.test.testmethodsetup
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.core.MessageService
+import org.springframework.security.kt.docs.servlet.test.testmethod.HelloMessageService
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration
+class WithMockUserSampleTests {
+
+	@Autowired
+	lateinit var messageService: MessageService
+
+	// tag::snippet[]
+	@Test
+	fun getMessageUnauthenticated() {
+		Assertions.assertThatExceptionOfType(AuthenticationCredentialsNotFoundException::class.java)
+			.isThrownBy { messageService.getMessage() }
+	}
+	// end::snippet[]
+
+	@EnableMethodSecurity(prePostEnabled = true, jsr250Enabled = true)
+	@Configuration
+	open class Config {
+		@Bean
+		open fun messageService(): MessageService {
+			return HelloMessageService()
+		}
+	}
+
+}

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodsetup/WithMockUserTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodsetup/WithMockUserTests.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.kt.docs.servlet.test.testmethodsetup
+
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+// tag::setup[]
+@ExtendWith(SpringExtension::class) // <1>
+@ContextConfiguration // <2>
+class WithMockUserTests {
+}
+// end::setup[]

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodsetup/WithMockUserTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodsetup/WithMockUserTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithanonymoususer/WithUserClassLevelAuthenticationTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithanonymoususer/WithUserClassLevelAuthenticationTests.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.kt.docs.servlet.test.testmethodwithanonymoususer
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.security.test.context.support.WithAnonymousUser
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+
+// tag::snippet[]
+@ExtendWith(SpringExtension::class)
+@WithMockUser
+class WithUserClassLevelAuthenticationTests {
+
+	@Test
+	fun withMockUser1() {
+	}
+
+	@Test
+	fun withMockUser2() {
+	}
+
+	@Test
+	@WithAnonymousUser
+	@Throws(Exception::class)
+	fun anonymous() {
+		// override default to run as anonymous user
+	}
+
+}
+// end::snippet[]

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithanonymoususer/WithUserClassLevelAuthenticationTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithanonymoususer/WithUserClassLevelAuthenticationTests.kt
@@ -38,7 +38,6 @@ class WithUserClassLevelAuthenticationTests {
 
 	@Test
 	@WithAnonymousUser
-	@Throws(Exception::class)
 	fun anonymous() {
 		// override default to run as anonymous user
 	}

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithanonymoususer/WithUserClassLevelAuthenticationTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithanonymoususer/WithUserClassLevelAuthenticationTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithmockuser/WithMockUserClassTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithmockuser/WithMockUserClassTests.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.kt.docs.servlet.test.testmethodwithmockuser
+
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+// tag::snippet[]
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration
+@WithMockUser(username = "admin", roles = ["USER", "ADMIN"])
+class WithMockUserClassTests {
+	// ...
+}
+// end::snippet[]

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithmockuser/WithMockUserClassTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithmockuser/WithMockUserClassTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithmockuser/WithMockUserNestedTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithmockuser/WithMockUserNestedTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithmockuser/WithMockUserNestedTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithmockuser/WithMockUserNestedTests.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.kt.docs.servlet.test.testmethodwithmockuser
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+// tag::snippet[]
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration
+@WithMockUser(username = "admin", roles = ["USER", "ADMIN"])
+class WithMockUserNestedTests {
+
+	@Nested
+	inner class TestSuite1 {
+		// ... all test methods use admin user
+	}
+
+	@Nested
+	inner class TestSuite2 {
+		// ... all test methods use admin user
+	}
+
+}
+// end::snippet[]

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithmockuser/WithMockUserTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithmockuser/WithMockUserTests.kt
@@ -79,7 +79,7 @@ class WithMockUserTests {
     }
     // end::custom-authorities[]
 
-    @EnableMethodSecurity(prePostEnabled = true, jsr250Enabled = true)
+    @EnableMethodSecurity
     @Configuration
     open class Config {
         @Bean

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithmockuser/WithMockUserTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithmockuser/WithMockUserTests.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.kt.docs.servlet.test.testmethodwithmockuser
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.core.MessageService
+import org.springframework.security.kt.docs.servlet.test.testmethod.HelloMessageService
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration
+class WithMockUserTests {
+
+    @Autowired
+    lateinit var messageService: MessageService
+
+    // tag::mock-user[]
+    @Test
+    @WithMockUser
+    fun getMessageWithMockUser() {
+        val message = messageService.message
+        Assertions.assertThat(message).contains("user")
+    }
+    // end::mock-user[]
+
+    // tag::custom-user[]
+    @Test
+    @WithMockUser("customUser")
+    fun getMessageWithMockUserCustomUsername() {
+        val message = messageService.message
+        Assertions.assertThat(message).contains("customUser")
+    }
+    // end::custom-user[]
+
+    // tag::custom-roles[]
+    @Test
+    @WithMockUser(username = "admin", roles = ["USER", "ADMIN"])
+    fun getMessageWithMockUserCustomRoles() {
+        val message = messageService.message
+        Assertions.assertThat(message)
+            .contains("admin")
+            .contains("ROLE_ADMIN")
+            .contains("ROLE_USER")
+    }
+    // end::custom-roles[]
+
+    // tag::custom-authorities[]
+    @Test
+    @WithMockUser(username = "admin", authorities = ["ADMIN", "USER"])
+    fun getMessageWithMockUserCustomAuthorities() {
+        val message = messageService.message
+        Assertions.assertThat(message)
+            .contains("admin")
+            .contains("ADMIN")
+            .contains("USER")
+            .doesNotContain("ROLE_")
+    }
+    // end::custom-authorities[]
+
+    @EnableMethodSecurity(prePostEnabled = true, jsr250Enabled = true)
+    @Configuration
+    open class Config {
+        @Bean
+        open fun messageService(): MessageService {
+            return HelloMessageService()
+        }
+    }
+}

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithmockuser/WithMockUserTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithmockuser/WithMockUserTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithmockuser/WithMockUserTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithmockuser/WithMockUserTests.kt
@@ -16,7 +16,7 @@
 
 package org.springframework.security.kt.docs.servlet.test.testmethodwithmockuser
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -41,7 +41,7 @@ class WithMockUserTests {
     @WithMockUser
     fun getMessageWithMockUser() {
         val message = messageService.message
-        Assertions.assertThat(message).contains("user")
+        assertThat(message).contains("user")
     }
     // end::mock-user[]
 
@@ -50,7 +50,7 @@ class WithMockUserTests {
     @WithMockUser("customUser")
     fun getMessageWithMockUserCustomUsername() {
         val message = messageService.message
-        Assertions.assertThat(message).contains("customUser")
+        assertThat(message).contains("customUser")
     }
     // end::custom-user[]
 
@@ -59,7 +59,7 @@ class WithMockUserTests {
     @WithMockUser(username = "admin", roles = ["USER", "ADMIN"])
     fun getMessageWithMockUserCustomRoles() {
         val message = messageService.message
-        Assertions.assertThat(message)
+        assertThat(message)
             .contains("admin")
             .contains("ROLE_ADMIN")
             .contains("ROLE_USER")
@@ -71,7 +71,7 @@ class WithMockUserTests {
     @WithMockUser(username = "admin", authorities = ["ADMIN", "USER"])
     fun getMessageWithMockUserCustomAuthorities() {
         val message = messageService.message
-        Assertions.assertThat(message)
+        assertThat(message)
             .contains("admin")
             .contains("ADMIN")
             .contains("USER")

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithsecuritycontext/CustomUserDetails.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithsecuritycontext/CustomUserDetails.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.kt.docs.servlet.test.testmethodwithsecuritycontext
+
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.AuthorityUtils
+import org.springframework.security.core.userdetails.UserDetails
+
+class CustomUserDetails(
+    name: String,
+    username: String,
+    authorities: MutableCollection<GrantedAuthority> = AuthorityUtils.createAuthorityList("ROLE_USER")) : UserDetails {
+
+    override fun getAuthorities(): MutableCollection<out GrantedAuthority> {
+        return authorities
+    }
+
+    override fun getPassword(): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun getUsername(): String {
+        return username
+    }
+}

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithsecuritycontext/CustomUserDetails.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithsecuritycontext/CustomUserDetails.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithsecuritycontext/WithMockCustomUser.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithsecuritycontext/WithMockCustomUser.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.kt.docs.servlet.test.testmethodwithsecuritycontext
+
+import org.springframework.security.test.context.support.WithSecurityContext
+
+// tag::snippet[]
+@Retention(AnnotationRetention.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory::class)
+annotation class WithMockCustomUser(val username: String = "rob", val name: String = "Rob Winch")
+// end::snippet[]

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithsecuritycontext/WithMockCustomUser.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithsecuritycontext/WithMockCustomUser.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithsecuritycontext/WithMockCustomUserSecurityContextFactory.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithsecuritycontext/WithMockCustomUserSecurityContextFactory.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.kt.docs.servlet.test.testmethodwithsecuritycontext;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.test.context.support.WithSecurityContextFactory
+
+// tag::snippet[]
+class WithMockCustomUserSecurityContextFactory : WithSecurityContextFactory<WithMockCustomUser> {
+	override fun createSecurityContext(customUser: WithMockCustomUser): SecurityContext {
+		val context = SecurityContextHolder.createEmptyContext()
+		val principal = CustomUserDetails(customUser.name, customUser.username)
+		val auth: Authentication =
+				UsernamePasswordAuthenticationToken(principal, "password", principal.authorities)
+		context.authentication = auth
+		return context
+	}
+}
+// end::snippet[]

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithsecuritycontext/WithMockCustomUserSecurityContextFactory.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithsecuritycontext/WithMockCustomUserSecurityContextFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithsecuritycontext/WithUserDetailsSecurityContextFactory.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithsecuritycontext/WithUserDetailsSecurityContextFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithsecuritycontext/WithUserDetailsSecurityContextFactory.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithsecuritycontext/WithUserDetailsSecurityContextFactory.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.kt.docs.servlet.test.testmethodwithsecuritycontext
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.test.context.support.WithSecurityContextFactory
+import org.springframework.security.test.context.support.WithUserDetails
+import org.springframework.util.Assert
+
+// tag::snippet[]
+class WithUserDetailsSecurityContextFactory @Autowired constructor(private val userDetailsService: UserDetailsService) :
+    WithSecurityContextFactory<WithUserDetails> {
+
+    override fun createSecurityContext(withUser: WithUserDetails): SecurityContext {
+        val username: String = withUser.value
+        Assert.hasLength(username, "value() must be non-empty String")
+        val principal = userDetailsService.loadUserByUsername(username)
+        val authentication: Authentication =
+            UsernamePasswordAuthenticationToken(principal, principal.password, principal.authorities)
+        val context = SecurityContextHolder.createEmptyContext()
+        context.authentication = authentication
+        return context
+    }
+
+}
+// end::snippet[]

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithuserdetails/WithCustomUserDetailsTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithuserdetails/WithCustomUserDetailsTests.kt
@@ -16,7 +16,7 @@
 
 package org.springframework.security.kt.docs.servlet.test.testmethodwithuserdetails
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -46,9 +46,9 @@ class WithCustomUserDetailsTests {
     @WithUserDetails(value = "customUsername", userDetailsServiceBeanName = "myUserDetailsService")
     fun getMessageWithUserDetailsServiceBeanName() {
         val message: String = messageService.getMessage()
-        Assertions.assertThat(message).contains("customUsername");
+        assertThat(message).contains("customUsername");
         val principal = SecurityContextHolder.getContext().authentication.principal
-        Assertions.assertThat(principal).isInstanceOf(CustomUserDetails::class.java)
+        assertThat(principal).isInstanceOf(CustomUserDetails::class.java)
     }
     // end::custom-user-details-service[]
 

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithuserdetails/WithCustomUserDetailsTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithuserdetails/WithCustomUserDetailsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithuserdetails/WithCustomUserDetailsTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithuserdetails/WithCustomUserDetailsTests.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.kt.docs.servlet.test.testmethodwithuserdetails
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.core.MessageService
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import org.springframework.security.docs.servlet.test.testmethodwithsecuritycontext.CustomUserDetails
+import org.springframework.security.kt.docs.servlet.test.testmethod.HelloMessageService
+import org.springframework.security.test.context.support.WithUserDetails
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration
+class WithCustomUserDetailsTests {
+
+    @Autowired
+    lateinit var messageService: MessageService
+
+    // tag::custom-user-details-service[]
+    @Test
+    @WithUserDetails(value = "customUsername", userDetailsServiceBeanName = "myUserDetailsService")
+    fun getMessageWithUserDetailsServiceBeanName() {
+        val message: String = messageService.getMessage()
+        Assertions.assertThat(message).contains("customUsername");
+        val principal = SecurityContextHolder.getContext().authentication.principal
+        Assertions.assertThat(principal).isInstanceOf(CustomUserDetails::class.java)
+    }
+    // end::custom-user-details-service[]
+
+    @EnableMethodSecurity
+    @Configuration
+    open class Config {
+
+        @Bean
+        open fun myUserDetailsService(): UserDetailsService {
+            return CustomUserDetailsService()
+        }
+
+        @Bean
+        open fun messageService(): MessageService {
+            return HelloMessageService()
+        }
+    }
+
+    open class CustomUserDetailsService : UserDetailsService {
+
+        @Throws(UsernameNotFoundException::class)
+        override fun loadUserByUsername(username: String): UserDetails {
+            return CustomUserDetails("name", username)
+        }
+    }
+
+}

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithuserdetails/WithUserDetailsTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithuserdetails/WithUserDetailsTests.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.kt.docs.servlet.test.testmethodwithuserdetails
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.core.MessageService
+import org.springframework.security.core.userdetails.User
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.kt.docs.servlet.test.testmethod.HelloMessageService
+import org.springframework.security.provisioning.InMemoryUserDetailsManager
+import org.springframework.security.test.context.support.WithUserDetails
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+@ContextConfiguration
+class WithUserDetailsTests {
+
+    @Autowired
+    lateinit var messageService: MessageService
+
+    // tag::user-details[]
+    @Test
+    @WithUserDetails
+    fun getMessageWithUserDetails() {
+        val message: String = messageService.message
+        Assertions.assertThat(message).contains("user")
+    }
+    // end::user-details[]
+
+    // tag::user-details-custom-username[]
+    @Test
+    @WithUserDetails("customUsername")
+    fun getMessageWithUserDetailsCustomUsername() {
+        val message: String = messageService.message
+        Assertions.assertThat(message).contains("customUsername")
+    }
+    // end::user-details-custom-username[]
+
+    @EnableMethodSecurity
+    @Configuration
+    open class Config {
+
+        @Bean
+        open fun userDetailsService(): UserDetailsService {
+            val user1 = User.withDefaultPasswordEncoder()
+                .username("user")
+                .password("password")
+                .build();
+            val customUser = User.withDefaultPasswordEncoder()
+                .username("customUsername")
+                .password("password")
+                .build();
+            return InMemoryUserDetailsManager(user1, customUser);
+        }
+
+        @Bean
+        open fun messageService(): MessageService {
+            return HelloMessageService()
+        }
+    }
+}

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithuserdetails/WithUserDetailsTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithuserdetails/WithUserDetailsTests.kt
@@ -16,7 +16,7 @@
 
 package org.springframework.security.kt.docs.servlet.test.testmethodwithuserdetails
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -44,7 +44,7 @@ class WithUserDetailsTests {
     @WithUserDetails
     fun getMessageWithUserDetails() {
         val message: String = messageService.message
-        Assertions.assertThat(message).contains("user")
+        assertThat(message).contains("user")
     }
     // end::user-details[]
 
@@ -53,7 +53,7 @@ class WithUserDetailsTests {
     @WithUserDetails("customUsername")
     fun getMessageWithUserDetailsCustomUsername() {
         val message: String = messageService.message
-        Assertions.assertThat(message).contains("customUsername")
+        assertThat(message).contains("customUsername")
     }
     // end::user-details-custom-username[]
 

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithuserdetails/WithUserDetailsTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/testmethodwithuserdetails/WithUserDetailsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2025 the original author or authors.
+ * Copyright 2004-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This commit updates the Servlet test method ascii docs to use `include-code` block macro. 

Also, added additional tests demonstrating usage of the  `@WithMockUser`, `@WithUserDetails`, `@WithMockUser`, and a custom `@WithMockCustomUser` annotations based on existing tests in `org/springframework/security/test/context/showcase` in the `spring-security-test` module.

References #16226 
