### PR TITLE
Fix misleading variable name in authentication filter

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/UsernamePasswordAuthenticationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/UsernamePasswordAuthenticationFilter.java
@@ -53,7 +53,7 @@ public class UsernamePasswordAuthenticationFilter extends AbstractAuthentication
 
 	public static final String SPRING_SECURITY_FORM_PASSWORD_KEY = "password";
 
-	private static final RequestMatcher DEFAULT_ANT_PATH_REQUEST_MATCHER = PathPatternRequestMatcher.withDefaults()
+	private static final RequestMatcher DEFAULT_PATH_REQUEST_MATCHER = PathPatternRequestMatcher.withDefaults()
 		.matcher(HttpMethod.POST, "/login");
 
 	private String usernameParameter = SPRING_SECURITY_FORM_USERNAME_KEY;
@@ -63,11 +63,11 @@ public class UsernamePasswordAuthenticationFilter extends AbstractAuthentication
 	private boolean postOnly = true;
 
 	public UsernamePasswordAuthenticationFilter() {
-		super(DEFAULT_ANT_PATH_REQUEST_MATCHER);
+		super(DEFAULT_PATH_REQUEST_MATCHER);
 	}
 
 	public UsernamePasswordAuthenticationFilter(AuthenticationManager authenticationManager) {
-		super(DEFAULT_ANT_PATH_REQUEST_MATCHER, authenticationManager);
+		super(DEFAULT_PATH_REQUEST_MATCHER, authenticationManager);
 	}
 
 	@Override


### PR DESCRIPTION
Rename DEFAULT_ANT_PATH_REQUEST_MATCHER to DEFAULT_PATH_REQUEST_MATCHER to reflect PathPatternRequestMatcher usage instead of legacy Ant pattern terminology.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->


## Description
This PR improves code clarity by fixing a misleading variable name in `UsernamePasswordAuthenticationFilter` and removing outdated terminology.

## Problem
The current variable `DEFAULT_ANT_PATH_REQUEST_MATCHER` incorrectly suggests that Ant pattern matching is being used, when the actual implementation uses `PathPatternRequestMatcher`. This naming inconsistency can confuse developers reading the code.

## Solution
Rename the variable to `DEFAULT_PATH_REQUEST_MATCHER` to:
- Accurately reflect the `PathPatternRequestMatcher` implementation
- Remove misleading references to legacy Ant pattern terminology
- Improve code readability and maintainability

## Changes
- Rename `DEFAULT_ANT_PATH_REQUEST_MATCHER` to `DEFAULT_PATH_REQUEST_MATCHER`
- Update constructor references to use the new variable name
- No functional changes - purely a documentation/naming improvement