### PR TITLE
Add XML configuration guidance to deprecation warnings

### DIFF
--- a/config/src/main/java/org/springframework/security/config/http/DefaultFilterChainValidator.java
+++ b/config/src/main/java/org/springframework/security/config/http/DefaultFilterChainValidator.java
@@ -126,11 +126,15 @@ public class DefaultFilterChainValidator implements FilterChainProxy.FilterChain
 			}
 			if (authorizationFilter != null && filterSecurityInterceptor != null) {
 				this.logger.warn(
-						"It is not recommended to use authorizeRequests or FilterSecurityInterceptor in the configuration. Please only use authorizeHttpRequests");
+						"It is not recommended to use authorizeRequests or FilterSecurityInterceptor in the configuration. Please only use authorizeHttpRequests. "
+								+ "Note: If using XML configuration, this warning can be ignored as XML <intercept-url> elements internally use the deprecated mechanism. "
+								+ "XML users should continue using standard <intercept-url> configuration.");
 			}
 			if (filterSecurityInterceptor != null) {
 				this.logger.warn(
-						"Usage of authorizeRequests and FilterSecurityInterceptor are deprecated. Please use authorizeHttpRequests in the configuration");
+						"Usage of authorizeRequests and FilterSecurityInterceptor are deprecated. Please use authorizeHttpRequests in the configuration. "
+								+ "Note: If using XML configuration, this warning can be ignored as XML <intercept-url> elements internally use the deprecated mechanism. "
+								+ "XML users should continue using standard <intercept-url> configuration.");
 			}
 			authorizationFilter = null;
 			filterSecurityInterceptor = null;


### PR DESCRIPTION
## Description
This PR adds XML configuration guidance to the deprecation warnings in `DefaultFilterChainValidator`.

## Problem
After upgrading to Spring Security 6.5.0, XML-configured applications receive deprecation warnings about `authorizeRequests` usage, even though they're using the officially supported XML `<intercept-url>` configuration. This creates confusion as XML users have no way to resolve these warnings.

## Solution
Added clarifying notes to the deprecation warning messages that:
- Inform XML users that the warning can be ignored for XML configurations
- Clarify that XML users should continue using standard `<intercept-url>` elements
- Make it clear that the deprecation only affects Java/Kotlin configuration users

## Changes
- Updated warning messages in `DefaultFilterChainValidator.java` to include XML-specific guidance

## Testing
- The changes are documentation-only and don't affect functionality
- Existing tests should continue to pass

Closes gh-17259