### PR TITLE
Annotate AuthenticationTrustResolver methods with `@Nullable`

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/AuthenticationTrustResolver.java
+++ b/core/src/main/java/org/springframework/security/authentication/AuthenticationTrustResolver.java
@@ -16,6 +16,8 @@
 
 package org.springframework.security.authentication;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.security.core.Authentication;
 
 /**
@@ -37,7 +39,7 @@ public interface AuthenticationTrustResolver {
 	 * @return <code>true</code> the passed authentication token represented an anonymous
 	 * principal, <code>false</code> otherwise
 	 */
-	boolean isAnonymous(Authentication authentication);
+	boolean isAnonymous(@Nullable Authentication authentication);
 
 	/**
 	 * Indicates whether the passed <code>Authentication</code> token represents user that
@@ -51,7 +53,7 @@ public interface AuthenticationTrustResolver {
 	 * @return <code>true</code> the passed authentication token represented a principal
 	 * authenticated using a remember-me token, <code>false</code> otherwise
 	 */
-	boolean isRememberMe(Authentication authentication);
+	boolean isRememberMe(@Nullable Authentication authentication);
 
 	/**
 	 * Indicates whether the passed <code>Authentication</code> token represents a fully
@@ -66,7 +68,7 @@ public interface AuthenticationTrustResolver {
 	 * {@link #isRememberMe(Authentication)}, <code>false</code> otherwise
 	 * @since 6.1
 	 */
-	default boolean isFullyAuthenticated(Authentication authentication) {
+	default boolean isFullyAuthenticated(@Nullable Authentication authentication) {
 		return isAuthenticated(authentication) && !isRememberMe(authentication);
 	}
 
@@ -78,7 +80,7 @@ public interface AuthenticationTrustResolver {
 	 * {@link Authentication#isAuthenticated()} is true.
 	 * @since 6.1.7
 	 */
-	default boolean isAuthenticated(Authentication authentication) {
+	default boolean isAuthenticated(@Nullable Authentication authentication) {
 		return authentication != null && authentication.isAuthenticated() && !isAnonymous(authentication);
 	}
 

--- a/core/src/main/java/org/springframework/security/authentication/AuthenticationTrustResolverImpl.java
+++ b/core/src/main/java/org/springframework/security/authentication/AuthenticationTrustResolverImpl.java
@@ -16,6 +16,8 @@
 
 package org.springframework.security.authentication;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.security.core.Authentication;
 
 /**
@@ -44,7 +46,7 @@ public class AuthenticationTrustResolverImpl implements AuthenticationTrustResol
 	}
 
 	@Override
-	public boolean isAnonymous(Authentication authentication) {
+	public boolean isAnonymous(@Nullable Authentication authentication) {
 		if ((this.anonymousClass == null) || (authentication == null)) {
 			return false;
 		}
@@ -52,7 +54,7 @@ public class AuthenticationTrustResolverImpl implements AuthenticationTrustResol
 	}
 
 	@Override
-	public boolean isRememberMe(Authentication authentication) {
+	public boolean isRememberMe(@Nullable Authentication authentication) {
 		if ((this.rememberMeClass == null) || (authentication == null)) {
 			return false;
 		}


### PR DESCRIPTION
Since `AuthenticationTrustResolver` can handle null arguments (this is also stated in the implementation of this interface), we should mark these arguments as `@Nullable`.

Closes: gh-17764

