### PR TITLE
Add Multi-factor Authentication Support

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/DefaultLoginPageConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/DefaultLoginPageConfigurer.java
@@ -68,6 +68,7 @@ public final class DefaultLoginPageConfigurer<H extends HttpSecurityBuilder<H>>
 
 	@Override
 	public void init(H http) {
+		this.loginPageGeneratingFilter.setSecurityContextHolderStrategy(getSecurityContextHolderStrategy());
 		this.loginPageGeneratingFilter.setResolveHiddenInputs(DefaultLoginPageConfigurer.this::hiddenInputs);
 		this.logoutPageGeneratingFilter.setResolveHiddenInputs(DefaultLoginPageConfigurer.this::hiddenInputs);
 		http.setSharedObject(DefaultLoginPageGeneratingFilter.class, this.loginPageGeneratingFilter);

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ExceptionHandlingConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ExceptionHandlingConfigurer.java
@@ -80,8 +80,7 @@ public final class ExceptionHandlingConfigurer<H extends HttpSecurityBuilder<H>>
 
 	private LinkedHashMap<RequestMatcher, AccessDeniedHandler> defaultDeniedHandlerMappings = new LinkedHashMap<>();
 
-	private final DelegatingMissingAuthorityAccessDeniedHandler.Builder missingAuthoritiesHandlerBuilder = DelegatingMissingAuthorityAccessDeniedHandler
-		.builder();
+	private DelegatingMissingAuthorityAccessDeniedHandler.@Nullable Builder missingAuthoritiesHandlerBuilder;
 
 	/**
 	 * Creates a new instance
@@ -142,8 +141,11 @@ public final class ExceptionHandlingConfigurer<H extends HttpSecurityBuilder<H>>
 	 * @return the {@link ExceptionHandlingConfigurer} for further customizations
 	 * @since 7.0
 	 */
-	public ExceptionHandlingConfigurer<H> defaultAuthenticationEntryPointFor(AuthenticationEntryPoint entryPoint,
+	public ExceptionHandlingConfigurer<H> defaultDeniedHandlerForMissingAuthority(AuthenticationEntryPoint entryPoint,
 			String authority) {
+		if (this.missingAuthoritiesHandlerBuilder == null) {
+			this.missingAuthoritiesHandlerBuilder = DelegatingMissingAuthorityAccessDeniedHandler.builder();
+		}
 		this.missingAuthoritiesHandlerBuilder.addEntryPointFor(entryPoint, authority);
 		return this;
 	}
@@ -158,8 +160,11 @@ public final class ExceptionHandlingConfigurer<H extends HttpSecurityBuilder<H>>
 	 * @return the {@link ExceptionHandlingConfigurer} for further customizations
 	 * @since 7.0
 	 */
-	public ExceptionHandlingConfigurer<H> defaultAuthenticationEntryPointFor(
+	public ExceptionHandlingConfigurer<H> defaultDeniedHandlerForMissingAuthority(
 			Consumer<DelegatingAuthenticationEntryPoint.Builder> entryPoint, String authority) {
+		if (this.missingAuthoritiesHandlerBuilder == null) {
+			this.missingAuthoritiesHandlerBuilder = DelegatingMissingAuthorityAccessDeniedHandler.builder();
+		}
 		this.missingAuthoritiesHandlerBuilder.addEntryPointFor(entryPoint, authority);
 		return this;
 	}
@@ -267,6 +272,9 @@ public final class ExceptionHandlingConfigurer<H extends HttpSecurityBuilder<H>>
 
 	private AccessDeniedHandler createDefaultDeniedHandler(H http) {
 		AccessDeniedHandler defaults = createDefaultAccessDeniedHandler(http);
+		if (this.missingAuthoritiesHandlerBuilder == null) {
+			return defaults;
+		}
 		DelegatingMissingAuthorityAccessDeniedHandler deniedHandler = this.missingAuthoritiesHandlerBuilder.build();
 		deniedHandler.setRequestCache(getRequestCache(http));
 		deniedHandler.setDefaultAccessDeniedHandler(defaults);

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/FormLoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/FormLoginConfigurer.java
@@ -233,7 +233,10 @@ public final class FormLoginConfigurer<H extends HttpSecurityBuilder<H>> extends
 		initDefaultLoginFilter(http);
 		ExceptionHandlingConfigurer<H> exceptions = http.getConfigurer(ExceptionHandlingConfigurer.class);
 		if (exceptions != null) {
-			exceptions.defaultAuthenticationEntryPointFor(getAuthenticationEntryPoint(), "FACTOR_PASSWORD");
+			AuthenticationEntryPoint entryPoint = getAuthenticationEntryPoint();
+			RequestMatcher requestMatcher = getAuthenticationEntryPointMatcher(http);
+			exceptions.defaultAuthenticationEntryPointFor((ep) -> ep.addEntryPointFor(entryPoint, requestMatcher),
+					"FACTOR_PASSWORD");
 		}
 	}
 

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/FormLoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/FormLoginConfigurer.java
@@ -235,7 +235,7 @@ public final class FormLoginConfigurer<H extends HttpSecurityBuilder<H>> extends
 		if (exceptions != null) {
 			AuthenticationEntryPoint entryPoint = getAuthenticationEntryPoint();
 			RequestMatcher requestMatcher = getAuthenticationEntryPointMatcher(http);
-			exceptions.defaultAuthenticationEntryPointFor((ep) -> ep.addEntryPointFor(entryPoint, requestMatcher),
+			exceptions.defaultDeniedHandlerForMissingAuthority((ep) -> ep.addEntryPointFor(entryPoint, requestMatcher),
 					"FACTOR_PASSWORD");
 		}
 	}

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/FormLoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/FormLoginConfigurer.java
@@ -231,6 +231,10 @@ public final class FormLoginConfigurer<H extends HttpSecurityBuilder<H>> extends
 	public void init(H http) throws Exception {
 		super.init(http);
 		initDefaultLoginFilter(http);
+		ExceptionHandlingConfigurer<H> exceptions = http.getConfigurer(ExceptionHandlingConfigurer.class);
+		if (exceptions != null) {
+			exceptions.defaultAuthenticationEntryPointFor(getAuthenticationEntryPoint(), "FACTOR_PASSWORD");
+		}
 	}
 
 	@Override

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HttpBasicConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HttpBasicConfigurer.java
@@ -194,8 +194,8 @@ public final class HttpBasicConfigurer<B extends HttpSecurityBuilder<B>>
 		}
 		AuthenticationEntryPoint entryPoint = postProcess(this.authenticationEntryPoint);
 		exceptionHandling.defaultAuthenticationEntryPointFor(entryPoint, preferredMatcher);
-		exceptionHandling.defaultAuthenticationEntryPointFor((ep) -> ep.addEntryPointFor(entryPoint, preferredMatcher),
-				"FACTOR_PASSWORD");
+		exceptionHandling.defaultDeniedHandlerForMissingAuthority(
+				(ep) -> ep.addEntryPointFor(entryPoint, preferredMatcher), "FACTOR_PASSWORD");
 	}
 
 	private void registerDefaultLogoutSuccessHandler(B http, RequestMatcher preferredMatcher) {

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HttpBasicConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HttpBasicConfigurer.java
@@ -192,8 +192,10 @@ public final class HttpBasicConfigurer<B extends HttpSecurityBuilder<B>>
 		if (exceptionHandling == null) {
 			return;
 		}
-		exceptionHandling.defaultAuthenticationEntryPointFor(postProcess(this.authenticationEntryPoint),
-				preferredMatcher);
+		AuthenticationEntryPoint entryPoint = postProcess(this.authenticationEntryPoint);
+		exceptionHandling.defaultAuthenticationEntryPointFor(entryPoint, preferredMatcher);
+		exceptionHandling.defaultAuthenticationEntryPointFor((ep) -> ep.addEntryPointFor(entryPoint, preferredMatcher),
+				"FACTOR_PASSWORD");
 	}
 
 	private void registerDefaultLogoutSuccessHandler(B http, RequestMatcher preferredMatcher) {

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/WebAuthnConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/WebAuthnConfigurer.java
@@ -28,6 +28,7 @@ import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.web.HttpSecurityBuilder;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.authentication.ui.DefaultLoginPageGeneratingFilter;
 import org.springframework.security.web.authentication.ui.DefaultResourcesFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
@@ -148,6 +149,15 @@ public class WebAuthnConfigurer<H extends HttpSecurityBuilder<H>>
 		Assert.notNull(creationOptionsRepository, "creationOptionsRepository can't be null");
 		this.creationOptionsRepository = creationOptionsRepository;
 		return this;
+	}
+
+	@Override
+	public void init(H http) throws Exception {
+		ExceptionHandlingConfigurer<H> exceptions = http.getConfigurer(ExceptionHandlingConfigurer.class);
+		if (exceptions != null) {
+			exceptions.defaultAuthenticationEntryPointFor(new LoginUrlAuthenticationEntryPoint("/login"),
+					"FACTOR_WEBAUTHN");
+		}
 	}
 
 	@Override

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/WebAuthnConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/WebAuthnConfigurer.java
@@ -158,7 +158,7 @@ public class WebAuthnConfigurer<H extends HttpSecurityBuilder<H>>
 		ExceptionHandlingConfigurer<H> exceptions = http.getConfigurer(ExceptionHandlingConfigurer.class);
 		if (exceptions != null) {
 			AuthenticationEntryPoint entryPoint = new LoginUrlAuthenticationEntryPoint("/login");
-			exceptions.defaultAuthenticationEntryPointFor(
+			exceptions.defaultDeniedHandlerForMissingAuthority(
 					(ep) -> ep.addEntryPointFor(entryPoint, AnyRequestMatcher.INSTANCE), "FACTOR_WEBAUTHN");
 		}
 	}

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/WebAuthnConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/WebAuthnConfigurer.java
@@ -27,12 +27,14 @@ import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.web.HttpSecurityBuilder;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.authentication.ui.DefaultLoginPageGeneratingFilter;
 import org.springframework.security.web.authentication.ui.DefaultResourcesFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.util.matcher.AnyRequestMatcher;
 import org.springframework.security.web.webauthn.api.PublicKeyCredentialRpEntity;
 import org.springframework.security.web.webauthn.authentication.PublicKeyCredentialRequestOptionsFilter;
 import org.springframework.security.web.webauthn.authentication.WebAuthnAuthenticationFilter;
@@ -155,8 +157,9 @@ public class WebAuthnConfigurer<H extends HttpSecurityBuilder<H>>
 	public void init(H http) throws Exception {
 		ExceptionHandlingConfigurer<H> exceptions = http.getConfigurer(ExceptionHandlingConfigurer.class);
 		if (exceptions != null) {
-			exceptions.defaultAuthenticationEntryPointFor(new LoginUrlAuthenticationEntryPoint("/login"),
-					"FACTOR_WEBAUTHN");
+			AuthenticationEntryPoint entryPoint = new LoginUrlAuthenticationEntryPoint("/login");
+			exceptions.defaultAuthenticationEntryPointFor(
+					(ep) -> ep.addEntryPointFor(entryPoint, AnyRequestMatcher.INSTANCE), "FACTOR_WEBAUTHN");
 		}
 	}
 

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/X509Configurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/X509Configurer.java
@@ -184,7 +184,8 @@ public final class X509Configurer<H extends HttpSecurityBuilder<H>>
 			.setSharedObject(AuthenticationEntryPoint.class, new Http403ForbiddenEntryPoint());
 		ExceptionHandlingConfigurer<H> exceptions = http.getConfigurer(ExceptionHandlingConfigurer.class);
 		if (exceptions != null) {
-			exceptions.defaultAuthenticationEntryPointFor(new Http403ForbiddenEntryPoint(), AnyRequestMatcher.INSTANCE);
+			exceptions.defaultAuthenticationEntryPointFor(new Http403ForbiddenEntryPoint(), AnyRequestMatcher.INSTANCE,
+					"FACTOR_X509");
 		}
 	}
 

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/X509Configurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/X509Configurer.java
@@ -186,7 +186,7 @@ public final class X509Configurer<H extends HttpSecurityBuilder<H>>
 		if (exceptions != null) {
 			AuthenticationEntryPoint forbidden = new Http403ForbiddenEntryPoint();
 			exceptions.defaultAuthenticationEntryPointFor(forbidden, AnyRequestMatcher.INSTANCE);
-			exceptions.defaultAuthenticationEntryPointFor(
+			exceptions.defaultDeniedHandlerForMissingAuthority(
 					(ep) -> ep.addEntryPointFor(forbidden, AnyRequestMatcher.INSTANCE), "FACTOR_X509");
 		}
 	}

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/X509Configurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/X509Configurer.java
@@ -184,8 +184,10 @@ public final class X509Configurer<H extends HttpSecurityBuilder<H>>
 			.setSharedObject(AuthenticationEntryPoint.class, new Http403ForbiddenEntryPoint());
 		ExceptionHandlingConfigurer<H> exceptions = http.getConfigurer(ExceptionHandlingConfigurer.class);
 		if (exceptions != null) {
-			exceptions.defaultAuthenticationEntryPointFor(new Http403ForbiddenEntryPoint(), AnyRequestMatcher.INSTANCE,
-					"FACTOR_X509");
+			AuthenticationEntryPoint forbidden = new Http403ForbiddenEntryPoint();
+			exceptions.defaultAuthenticationEntryPointFor(forbidden, AnyRequestMatcher.INSTANCE);
+			exceptions.defaultAuthenticationEntryPointFor(
+					(ep) -> ep.addEntryPointFor(forbidden, AnyRequestMatcher.INSTANCE), "FACTOR_X509");
 		}
 	}
 

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2LoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2LoginConfigurer.java
@@ -565,8 +565,8 @@ public final class OAuth2LoginConfigurer<B extends HttpSecurityBuilder<B>>
 		ExceptionHandlingConfigurer<B> exceptions = http.getConfigurer(ExceptionHandlingConfigurer.class);
 		if (exceptions != null) {
 			RequestMatcher requestMatcher = getAuthenticationEntryPointMatcher(http);
-			exceptions.defaultAuthenticationEntryPointFor((ep) -> ep.addEntryPointFor(loginEntryPoint, requestMatcher),
-					"FACTOR_AUTHORIZATION_CODE");
+			exceptions.defaultDeniedHandlerForMissingAuthority(
+					(ep) -> ep.addEntryPointFor(loginEntryPoint, requestMatcher), "FACTOR_AUTHORIZATION_CODE");
 		}
 		return loginEntryPoint;
 	}

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2LoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2LoginConfigurer.java
@@ -40,6 +40,7 @@ import org.springframework.security.config.annotation.web.HttpSecurityBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractAuthenticationFilterConfigurer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.ExceptionHandlingConfigurer;
 import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
 import org.springframework.security.context.DelegatingApplicationListener;
 import org.springframework.security.core.Authentication;
@@ -372,6 +373,10 @@ public final class OAuth2LoginConfigurer<B extends HttpSecurityBuilder<B>>
 			http.authenticationProvider(new OidcAuthenticationRequestChecker());
 		}
 		this.initDefaultLoginFilter(http);
+		ExceptionHandlingConfigurer<B> exceptions = http.getConfigurer(ExceptionHandlingConfigurer.class);
+		if (exceptions != null) {
+			exceptions.defaultAuthenticationEntryPointFor(getAuthenticationEntryPoint(), "FACTOR_AUTHORIZATION_CODE");
+		}
 	}
 
 	@Override

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
@@ -259,6 +259,10 @@ public final class OAuth2ResourceServerConfigurer<H extends HttpSecurityBuilder<
 		if (authenticationProvider != null) {
 			http.authenticationProvider(authenticationProvider);
 		}
+		ExceptionHandlingConfigurer<H> exceptions = http.getConfigurer(ExceptionHandlingConfigurer.class);
+		if (exceptions != null) {
+			exceptions.defaultAuthenticationEntryPointFor(this.authenticationEntryPoint, "FACTOR_BEARER");
+		}
 	}
 
 	@Override

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
@@ -259,10 +259,6 @@ public final class OAuth2ResourceServerConfigurer<H extends HttpSecurityBuilder<
 		if (authenticationProvider != null) {
 			http.authenticationProvider(authenticationProvider);
 		}
-		ExceptionHandlingConfigurer<H> exceptions = http.getConfigurer(ExceptionHandlingConfigurer.class);
-		if (exceptions != null) {
-			exceptions.defaultAuthenticationEntryPointFor(this.authenticationEntryPoint, "FACTOR_BEARER");
-		}
 	}
 
 	@Override
@@ -331,6 +327,8 @@ public final class OAuth2ResourceServerConfigurer<H extends HttpSecurityBuilder<
 			RequestMatcher preferredMatcher = new OrRequestMatcher(
 					Arrays.asList(this.requestMatcher, X_REQUESTED_WITH, restNotHtmlMatcher, allMatcher));
 			exceptionHandling.defaultAuthenticationEntryPointFor(this.authenticationEntryPoint, preferredMatcher);
+			exceptionHandling.defaultAuthenticationEntryPointFor(
+					(ep) -> ep.addEntryPointFor(this.authenticationEntryPoint, preferredMatcher), "FACTOR_BEARER");
 		}
 	}
 

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
@@ -327,7 +327,7 @@ public final class OAuth2ResourceServerConfigurer<H extends HttpSecurityBuilder<
 			RequestMatcher preferredMatcher = new OrRequestMatcher(
 					Arrays.asList(this.requestMatcher, X_REQUESTED_WITH, restNotHtmlMatcher, allMatcher));
 			exceptionHandling.defaultAuthenticationEntryPointFor(this.authenticationEntryPoint, preferredMatcher);
-			exceptionHandling.defaultAuthenticationEntryPointFor(
+			exceptionHandling.defaultDeniedHandlerForMissingAuthority(
 					(ep) -> ep.addEntryPointFor(this.authenticationEntryPoint, preferredMatcher), "FACTOR_BEARER");
 		}
 	}

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ott/OneTimeTokenLoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ott/OneTimeTokenLoginConfigurer.java
@@ -140,7 +140,7 @@ public final class OneTimeTokenLoginConfigurer<H extends HttpSecurityBuilder<H>>
 		if (exceptions != null) {
 			AuthenticationEntryPoint entryPoint = getAuthenticationEntryPoint();
 			RequestMatcher requestMatcher = getAuthenticationEntryPointMatcher(http);
-			exceptions.defaultAuthenticationEntryPointFor((ep) -> ep.addEntryPointFor(entryPoint, requestMatcher),
+			exceptions.defaultDeniedHandlerForMissingAuthority((ep) -> ep.addEntryPointFor(entryPoint, requestMatcher),
 					"FACTOR_OTT");
 		}
 	}

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ott/OneTimeTokenLoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ott/OneTimeTokenLoginConfigurer.java
@@ -16,10 +16,15 @@
 
 package org.springframework.security.config.annotation.web.configurers.ott;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpMethod;
@@ -35,8 +40,15 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractAuthenticationFilterConfigurer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.ExceptionHandlingConfigurer;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.FormPostRedirectStrategy;
+import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.authentication.AuthenticationConverter;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
@@ -55,6 +67,7 @@ import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * An {@link AbstractHttpConfigurer} for One-Time Token Login.
@@ -134,6 +147,12 @@ public final class OneTimeTokenLoginConfigurer<H extends HttpSecurityBuilder<H>>
 		AuthenticationProvider authenticationProvider = getAuthenticationProvider();
 		http.authenticationProvider(postProcess(authenticationProvider));
 		intiDefaultLoginFilter(http);
+		ExceptionHandlingConfigurer<H> exceptions = http.getConfigurer(ExceptionHandlingConfigurer.class);
+		if (exceptions != null) {
+			AuthenticationEntryPoint entryPoint = new PostAuthenticationEntryPoint(
+					this.tokenGeneratingUrl + "?username={u}", Map.of("u", Authentication::getName));
+			exceptions.defaultAuthenticationEntryPointFor(entryPoint, "FACTOR_OTT");
+		}
 	}
 
 	private void intiDefaultLoginFilter(H http) {
@@ -389,6 +408,54 @@ public final class OneTimeTokenLoginConfigurer<H extends HttpSecurityBuilder<H>>
 	@Deprecated
 	public ApplicationContext getContext() {
 		return this.context;
+	}
+
+	private static final class PostAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+		private final String entryPointUri;
+
+		private final Map<String, Function<Authentication, String>> params;
+
+		private SecurityContextHolderStrategy securityContextHolderStrategy = SecurityContextHolder
+			.getContextHolderStrategy();
+
+		private RedirectStrategy redirectStrategy = new FormPostRedirectStrategy();
+
+		private PostAuthenticationEntryPoint(String entryPointUri,
+				Map<String, Function<Authentication, String>> params) {
+			this.entryPointUri = entryPointUri;
+			this.params = params;
+		}
+
+		@Override
+		public void commence(HttpServletRequest request, HttpServletResponse response,
+				AuthenticationException authException) throws IOException, ServletException {
+			Authentication authentication = getAuthentication(authException);
+			Assert.notNull(authentication, "could not find authentication in order to perform post");
+			Map<String, String> params = this.params.entrySet()
+				.stream()
+				.collect(Collectors.toMap(Map.Entry::getKey, (entry) -> entry.getValue().apply(authentication)));
+			UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(this.entryPointUri);
+			CsrfToken csrf = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+			if (csrf != null) {
+				builder.queryParam(csrf.getParameterName(), csrf.getToken());
+			}
+			String entryPointUrl = builder.build(false).expand(params).toUriString();
+			this.redirectStrategy.sendRedirect(request, response, entryPointUrl);
+		}
+
+		private Authentication getAuthentication(AuthenticationException authException) {
+			Authentication authentication = authException.getAuthenticationRequest();
+			if (authentication != null && authentication.isAuthenticated()) {
+				return authentication;
+			}
+			authentication = this.securityContextHolderStrategy.getContext().getAuthentication();
+			if (authentication != null && authentication.isAuthenticated()) {
+				return authentication;
+			}
+			return null;
+		}
+
 	}
 
 }

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ott/OneTimeTokenLoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ott/OneTimeTokenLoginConfigurer.java
@@ -16,15 +16,10 @@
 
 package org.springframework.security.config.annotation.web.configurers.ott;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpMethod;
@@ -42,13 +37,8 @@ import org.springframework.security.config.annotation.web.configurers.AbstractAu
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.ExceptionHandlingConfigurer;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.AuthenticationEntryPoint;
-import org.springframework.security.web.FormPostRedirectStrategy;
-import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.authentication.AuthenticationConverter;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
@@ -67,7 +57,6 @@ import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
-import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * An {@link AbstractHttpConfigurer} for One-Time Token Login.
@@ -149,9 +138,10 @@ public final class OneTimeTokenLoginConfigurer<H extends HttpSecurityBuilder<H>>
 		intiDefaultLoginFilter(http);
 		ExceptionHandlingConfigurer<H> exceptions = http.getConfigurer(ExceptionHandlingConfigurer.class);
 		if (exceptions != null) {
-			AuthenticationEntryPoint entryPoint = new PostAuthenticationEntryPoint(
-					this.tokenGeneratingUrl + "?username={u}", Map.of("u", Authentication::getName));
-			exceptions.defaultAuthenticationEntryPointFor(entryPoint, "FACTOR_OTT");
+			AuthenticationEntryPoint entryPoint = getAuthenticationEntryPoint();
+			RequestMatcher requestMatcher = getAuthenticationEntryPointMatcher(http);
+			exceptions.defaultAuthenticationEntryPointFor((ep) -> ep.addEntryPointFor(entryPoint, requestMatcher),
+					"FACTOR_OTT");
 		}
 	}
 
@@ -408,54 +398,6 @@ public final class OneTimeTokenLoginConfigurer<H extends HttpSecurityBuilder<H>>
 	@Deprecated
 	public ApplicationContext getContext() {
 		return this.context;
-	}
-
-	private static final class PostAuthenticationEntryPoint implements AuthenticationEntryPoint {
-
-		private final String entryPointUri;
-
-		private final Map<String, Function<Authentication, String>> params;
-
-		private SecurityContextHolderStrategy securityContextHolderStrategy = SecurityContextHolder
-			.getContextHolderStrategy();
-
-		private RedirectStrategy redirectStrategy = new FormPostRedirectStrategy();
-
-		private PostAuthenticationEntryPoint(String entryPointUri,
-				Map<String, Function<Authentication, String>> params) {
-			this.entryPointUri = entryPointUri;
-			this.params = params;
-		}
-
-		@Override
-		public void commence(HttpServletRequest request, HttpServletResponse response,
-				AuthenticationException authException) throws IOException, ServletException {
-			Authentication authentication = getAuthentication(authException);
-			Assert.notNull(authentication, "could not find authentication in order to perform post");
-			Map<String, String> params = this.params.entrySet()
-				.stream()
-				.collect(Collectors.toMap(Map.Entry::getKey, (entry) -> entry.getValue().apply(authentication)));
-			UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(this.entryPointUri);
-			CsrfToken csrf = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
-			if (csrf != null) {
-				builder.queryParam(csrf.getParameterName(), csrf.getToken());
-			}
-			String entryPointUrl = builder.build(false).expand(params).toUriString();
-			this.redirectStrategy.sendRedirect(request, response, entryPointUrl);
-		}
-
-		private Authentication getAuthentication(AuthenticationException authException) {
-			Authentication authentication = authException.getAuthenticationRequest();
-			if (authentication != null && authentication.isAuthenticated()) {
-				return authentication;
-			}
-			authentication = this.securityContextHolderStrategy.getContext().getAuthentication();
-			if (authentication != null && authentication.isAuthenticated()) {
-				return authentication;
-			}
-			return null;
-		}
-
 	}
 
 }

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LoginConfigurer.java
@@ -352,8 +352,8 @@ public final class Saml2LoginConfigurer<B extends HttpSecurityBuilder<B>>
 		ExceptionHandlingConfigurer<B> exceptions = http.getConfigurer(ExceptionHandlingConfigurer.class);
 		if (exceptions != null) {
 			RequestMatcher requestMatcher = getAuthenticationEntryPointMatcher(http);
-			exceptions.defaultAuthenticationEntryPointFor((ep) -> ep.addEntryPointFor(loginEntryPoint, requestMatcher),
-					"FACTOR_SAML_RESPONSE");
+			exceptions.defaultDeniedHandlerForMissingAuthority(
+					(ep) -> ep.addEntryPointFor(loginEntryPoint, requestMatcher), "FACTOR_SAML_RESPONSE");
 		}
 		return loginEntryPoint;
 	}

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LoginConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LoginConfigurer.java
@@ -33,6 +33,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractAuthenticationFilterConfigurer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.ExceptionHandlingConfigurer;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.saml2.provider.service.authentication.AbstractSaml2AuthenticationRequest;
 import org.springframework.security.saml2.provider.service.authentication.OpenSaml5AuthenticationProvider;
@@ -303,6 +304,10 @@ public final class Saml2LoginConfigurer<B extends HttpSecurityBuilder<B>>
 		this.initDefaultLoginFilter(http);
 		if (this.authenticationManager == null) {
 			registerDefaultAuthenticationProvider(http);
+		}
+		ExceptionHandlingConfigurer<B> exceptions = http.getConfigurer(ExceptionHandlingConfigurer.class);
+		if (exceptions != null) {
+			exceptions.defaultAuthenticationEntryPointFor(getAuthenticationEntryPoint(), "FACTOR_SAML_RESPONSE");
 		}
 	}
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/FormLoginConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/FormLoginConfigurerTests.java
@@ -402,7 +402,7 @@ public class FormLoginConfigurerTests {
 		UserDetails user = PasswordEncodedUser.user();
 		this.mockMvc.perform(get("/profile").with(user(user)))
 			.andExpect(status().is3xxRedirection())
-			.andExpect(redirectedUrl("http://localhost/login?authority=FACTOR_PASSWORD"));
+			.andExpect(redirectedUrl("http://localhost/login?factor=password"));
 		this.mockMvc
 			.perform(post("/ott/generate").param("username", "rod")
 				.with(user(user))
@@ -418,11 +418,11 @@ public class FormLoginConfigurerTests {
 		user = PasswordEncodedUser.withUserDetails(user).authorities("profile:read", "FACTOR_OTT").build();
 		this.mockMvc.perform(get("/profile").with(user(user)))
 			.andExpect(status().is3xxRedirection())
-			.andExpect(redirectedUrl("http://localhost/login?authority=FACTOR_PASSWORD"));
+			.andExpect(redirectedUrl("http://localhost/login?factor=password"));
 		user = PasswordEncodedUser.withUserDetails(user).authorities("profile:read", "FACTOR_PASSWORD").build();
 		this.mockMvc.perform(get("/profile").with(user(user)))
 			.andExpect(status().is3xxRedirection())
-			.andExpect(redirectedUrl("http://localhost/login?authority=FACTOR_OTT"));
+			.andExpect(redirectedUrl("http://localhost/login?factor=ott"));
 		user = PasswordEncodedUser.withUserDetails(user)
 			.authorities("profile:read", "FACTOR_PASSWORD", "FACTOR_OTT")
 			.build();
@@ -431,14 +431,14 @@ public class FormLoginConfigurerTests {
 
 	@Test
 	void requestWhenUnauthenticatedX509ThenRequiresTwoSteps() throws Exception {
-		this.spring.register(MfaDslX509Config.class, UserConfig.class, org.springframework.security.config.annotation.web.configurers.FormLoginConfigurerTests.BasicMfaController.class).autowire();
+		this.spring.register(MfaDslX509Config.class, UserConfig.class, BasicMfaController.class).autowire();
 		this.mockMvc.perform(get("/profile")).andExpect(status().isForbidden());
 		this.mockMvc.perform(get("/profile").with(user(User.withUsername("rod").authorities("profile:read").build())))
 			.andExpect(status().isForbidden());
 		this.mockMvc.perform(get("/login")).andExpect(status().isOk());
 		this.mockMvc.perform(get("/profile").with(SecurityMockMvcRequestPostProcessors.x509("rod.cer")))
 			.andExpect(status().is3xxRedirection())
-			.andExpect(redirectedUrl("http://localhost/login?authority=FACTOR_PASSWORD"));
+			.andExpect(redirectedUrl("http://localhost/login?factor=password"));
 		this.mockMvc
 			.perform(post("/login").param("username", "rod")
 				.param("password", "password")
@@ -793,7 +793,8 @@ public class FormLoginConfigurerTests {
 	static class MfaDslConfig {
 
 		@Bean
-		SecurityFilterChain filterChain(HttpSecurity http, AuthorizationManagerFactory<RequestAuthorizationContext> authz) throws Exception {
+		SecurityFilterChain filterChain(HttpSecurity http,
+				AuthorizationManagerFactory<RequestAuthorizationContext> authz) throws Exception {
 			// @formatter:off
 			http
 				.formLogin(Customizer.withDefaults())
@@ -824,7 +825,8 @@ public class FormLoginConfigurerTests {
 	static class MfaDslX509Config {
 
 		@Bean
-		SecurityFilterChain filterChain(HttpSecurity http, AuthorizationManagerFactory<RequestAuthorizationContext> authz) throws Exception {
+		SecurityFilterChain filterChain(HttpSecurity http,
+				AuthorizationManagerFactory<RequestAuthorizationContext> authz) throws Exception {
 			// @formatter:off
 			http
 				.x509(Customizer.withDefaults())

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/FormLoginConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/FormLoginConfigurerTests.java
@@ -64,7 +64,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeastOnce;
@@ -79,7 +78,6 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -423,8 +421,8 @@ public class FormLoginConfigurerTests {
 			.andExpect(redirectedUrl("http://localhost/login"));
 		user = PasswordEncodedUser.withUserDetails(user).authorities("profile:read", "FACTOR_PASSWORD").build();
 		this.mockMvc.perform(get("/profile").with(user(user)))
-			.andExpect(status().isOk())
-			.andExpect(content().string(containsString("/ott/generate")));
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("http://localhost/login"));
 		user = PasswordEncodedUser.withUserDetails(user)
 			.authorities("profile:read", "FACTOR_PASSWORD", "FACTOR_OTT")
 			.build();

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/FormLoginConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/FormLoginConfigurerTests.java
@@ -402,7 +402,7 @@ public class FormLoginConfigurerTests {
 		UserDetails user = PasswordEncodedUser.user();
 		this.mockMvc.perform(get("/profile").with(user(user)))
 			.andExpect(status().is3xxRedirection())
-			.andExpect(redirectedUrl("http://localhost/login"));
+			.andExpect(redirectedUrl("http://localhost/login?authority=FACTOR_PASSWORD"));
 		this.mockMvc
 			.perform(post("/ott/generate").param("username", "rod")
 				.with(user(user))
@@ -418,11 +418,11 @@ public class FormLoginConfigurerTests {
 		user = PasswordEncodedUser.withUserDetails(user).authorities("profile:read", "FACTOR_OTT").build();
 		this.mockMvc.perform(get("/profile").with(user(user)))
 			.andExpect(status().is3xxRedirection())
-			.andExpect(redirectedUrl("http://localhost/login"));
+			.andExpect(redirectedUrl("http://localhost/login?authority=FACTOR_PASSWORD"));
 		user = PasswordEncodedUser.withUserDetails(user).authorities("profile:read", "FACTOR_PASSWORD").build();
 		this.mockMvc.perform(get("/profile").with(user(user)))
 			.andExpect(status().is3xxRedirection())
-			.andExpect(redirectedUrl("http://localhost/login"));
+			.andExpect(redirectedUrl("http://localhost/login?authority=FACTOR_OTT"));
 		user = PasswordEncodedUser.withUserDetails(user)
 			.authorities("profile:read", "FACTOR_PASSWORD", "FACTOR_OTT")
 			.build();
@@ -438,7 +438,7 @@ public class FormLoginConfigurerTests {
 		this.mockMvc.perform(get("/login")).andExpect(status().isOk());
 		this.mockMvc.perform(get("/profile").with(SecurityMockMvcRequestPostProcessors.x509("rod.cer")))
 			.andExpect(status().is3xxRedirection())
-			.andExpect(redirectedUrl("http://localhost/login"));
+			.andExpect(redirectedUrl("http://localhost/login?authority=FACTOR_PASSWORD"));
 		this.mockMvc
 			.perform(post("/login").param("username", "rod")
 				.param("password", "password")

--- a/core/src/main/java/org/springframework/security/core/GrantedAuthority.java
+++ b/core/src/main/java/org/springframework/security/core/GrantedAuthority.java
@@ -31,6 +31,8 @@ import org.springframework.security.authorization.AuthorizationManager;
  */
 public interface GrantedAuthority extends Serializable {
 
+	String MISSING_AUTHORITIES_ATTRIBUTE = GrantedAuthority.class + ".missingAuthorities";
+
 	/**
 	 * If the <code>GrantedAuthority</code> can be represented as a <code>String</code>
 	 * and that <code>String</code> is sufficient in precision to be relied upon for an

--- a/core/src/main/java/org/springframework/security/core/GrantedAuthority.java
+++ b/core/src/main/java/org/springframework/security/core/GrantedAuthority.java
@@ -31,8 +31,6 @@ import org.springframework.security.authorization.AuthorizationManager;
  */
 public interface GrantedAuthority extends Serializable {
 
-	String MISSING_AUTHORITIES_ATTRIBUTE = GrantedAuthority.class + ".missingAuthorities";
-
 	/**
 	 * If the <code>GrantedAuthority</code> can be represented as a <code>String</code>
 	 * and that <code>String</code> is sufficient in precision to be relied upon for an

--- a/docs/modules/ROOT/pages/servlet/authentication/adaptive.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/adaptive.adoc
@@ -1,0 +1,528 @@
+= Adaptive Authentication
+
+Since authentication needs can vary from person-to-person and even from one login attempt to the next, Spring Security supports adapting authentication requirements to each situation.
+
+Some of the most common applications of this principal are:
+
+1. *Re-authentication* - Users need to provide authentication again in order to enter an area of elevated security
+2. *Multi-factor Authentication* - Users need more than one authentication mechanism to pass in order to access secured resources
+3. *Authorizing More Scopes* - Users are allowed to consent to a subset of scopes from an OAuth 2.0 Authorization Server.
+Then, if later on a scope that they did not grant is needed, consent can be re-requested for just that scope.
+4. *Opting-in to Stronger Authentication Mechanisms* - Users may not be ready yet to start using MFA, but the application wants to allow the subset of security-minded users to opt-in.
+5. *Requiring Additional Steps for Suspicious Logins* - The application may notice that the user's IP address has changed, that they are behind a VPN, or some other consideration that requires additional verification
+
+== Re-authentication
+
+The most common of these is re-authentication.
+Imagine an application configured in the following way:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Bean
+public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    // @formatter:off
+    http
+        .authorizeHttpRequests((authorize) -> authorize.anyRequest().authenticated())
+        .formLogin(Customizer.withDefaults())
+        .oneTimeTokenLogin(Customizer.withDefaults());
+    // @formatter:on
+    return http.build();
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@Bean
+public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    // @formatter:off
+    http {
+        authorizeHttpRequests {
+            authorize(anyRequest, authenticated)
+        }
+        formLogin { }
+        oneTimeTokenLogin { }
+    }
+    // @formatter:on
+    return http.build()
+}
+----
+======
+
+By default, this application has two authentication mechanisms that it allows, meaning that the user could use either one and be fully-authenticated.
+
+If there is a set of endpoints that require a specific factor, we can specify that in `authorizeHttpRequests` as follows:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Bean
+public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    // @formatter:off
+    http
+        .authorizeHttpRequests((authorize) -> authorize
+            .requestMatchers("/profile/**").hasAuthority("FACTOR_OTT") <1>
+            .anyRequest().authenticated()
+        )
+        .formLogin(Customizer.withDefaults())
+        .oneTimeTokenLogin(Customizer.withDefaults());
+    // @formatter:on
+    return http.build();
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@Bean
+public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    // @formatter:off
+    http {
+        authorizeHttpRequests {
+            authorize("/profile/**", hasAuthority("FACTOR_OTT")) <1>
+            authorize(anyRequest, authenticated)
+        }
+        formLogin { }
+        oneTimeTokenLogin { }
+    }
+    // @formatter:on
+    return http.build()
+}
+----
+======
+<1> - States that all `/profile/**` endpoints require one-time-token login to be authorized
+
+Given the above configuration, users can log in with any mechanism that you support.
+And, if they want to visit the profile page, then Spring Security will redirect them to the One-Time-Token Login page to obtain it.
+
+In this way, the authority given to a user is directly proportional to the amount of proof given.
+This adaptive approach allows users to give only the proof needed to perform their intended operations.
+
+== Multi-Factor Authentication
+
+You may require that all users require both One-Time-Token login and Username/Password login to access any part of your site.
+
+To require both, you can state an authorization rule with `anyRequest` like so:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Bean
+public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    // @formatter:off
+    http
+        .authorizeHttpRequests((authorize) -> authorize
+            .anyRequest().access(allOf(hasAuthority("FACTOR_PASSWORD"), hasAuthority("FACTOR_OTT"))) <1>
+        )
+        .formLogin(Customizer.withDefaults())
+        .oneTimeTokenLogin(Customizer.withDefaults());
+    // @formatter:on
+    return http.build();
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@Bean
+public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    // @formatter:off
+    http {
+        authorizeHttpRequests {
+            authorize(anyRequest, allOf(hasAuthority("FACTOR_PASSWORD"), hasAuthority("FACTOR_OTT"))) <1>
+        }
+        formLogin { }
+        oneTimeTokenLogin { }
+    }
+    // @formatter:on
+    return http.build()
+}
+----
+======
+<1> - This states that both `FACTOR_PASSWORD` and `FACTOR_OTT` are needed to use any part of the application
+
+Spring Security behind the scenes knows which endpoint to go to depending on which authority is missing.
+If the user logged in initially with their username and password, then Spring Security redirects to the One-Time-Token Login page.
+If the user logged in initially with a token, then Spring Security redirects to the Username/Password Login page.
+
+=== Requiring MFA For All Endpoints
+
+Specifying all authorities for each request pattern could be unwanted boilerplate:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Bean
+public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    // @formatter:off
+    http
+        .authorizeHttpRequests((authorize) -> authorize
+            .anyRequest("/admin/**").access(allOf(hasAuthority("FACTOR_PASSWORD"), hasAuthority("FACTOR_OTT"), hasRole("ADMIN"))) <1>
+            .anyRequest().access(allOf(hasAuthority("FACTOR_PASSWORD"), hasAuthority("FACTOR_OTT")))
+        )
+        .formLogin(Customizer.withDefaults())
+        .oneTimeTokenLogin(Customizer.withDefaults());
+    // @formatter:on
+    return http.build();
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@Bean
+public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    // @formatter:off
+    http {
+        authorizeHttpRequests {
+            authorize("/admin/**", allOf(hasAuthority("FACTOR_PASSWORD"), hasAuthority("FACTOR_OTT"), hasRole("ADMIN"))) <1>
+            authorize(anyRequest, allOf(hasAuthority("FACTOR_PASSWORD"), hasAuthority("FACTOR_OTT")))
+        }
+        formLogin { }
+        oneTimeTokenLogin { }
+    }
+    // @formatter:on
+    return http.build()
+}
+----
+======
+<1> - Since all authorities need to be specified for each endpoint, deploying MFA in this way can create unwanted boilerplate
+
+This can be remedied by publishing an `AuthorizationManagerFactory` bean like so:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Bean
+DefaultAuthorizationManagerFactory<RequestAuthorizationContext> authz() {
+	return DefaultAuthorizationManager.withAuthorities("FACTOR_PASSWORD", "FACTOR_OTT");
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@Bean
+fun authz(): DefaultAuthorizationManagerFactory<RequestAuthorizationContext> {
+	return DefaultAuthorizationManager.withAuthorities("FACTOR_PASSWORD", "FACTOR_OTT")
+}
+----
+======
+
+This yields a more familiar configuration:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Bean
+public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    // @formatter:off
+    http
+        .authorizeHttpRequests((authorize) -> authorize
+            .requestMatchers("/admin/**").hasRole("ADMIN")
+            .anyRequest().authenticated()
+        )
+        .formLogin(Customizer.withDefaults())
+        .oneTimeTokenLogin(Customizer.withDefaults());
+    // @formatter:on
+    return http.build();
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@Bean
+public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    // @formatter:off
+    http {
+        authorizeHttpRequests {
+            authorize("/admin/**", hasRole("ADMIN"))
+            authorize(anyRequest, authenticated)
+        }
+        formLogin { }
+        oneTimeTokenLogin { }
+    }
+    // @formatter:on
+    return http.build()
+}
+----
+======
+
+== Authorizing More Scopes
+
+You can also configure exception handling to direct Spring Security on how to obtain a missing scope.
+
+Consider an application that requires a specific OAuth 2.0 scope for a given endpoint:
+
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Bean
+public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    // @formatter:off
+    http
+        .authorizeHttpRequests((authorize) -> authorize
+            .requestMatchers("/profile/**").hasAuthority("SCOPE_profile:read")
+            .anyRequest().authenticated()
+        )
+        .x509(Customizer.withDefaults())
+        .oauth2Login(Customizer.withDefaults());
+    // @formatter:on
+    return http.build();
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@Bean
+public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    // @formatter:off
+    http {
+        authorizeHttpRequests {
+            authorize("/profile/**", hasAuthority("SCOPE_profile:read"))
+            authorize(anyRequest, authenticated)
+        }
+        x509 { }
+        oauth2Login { }
+    }
+    // @formatter:on
+    return http.build()
+}
+----
+======
+
+If this is also configured with an `AuthorizationManagerFactory` bean like this one:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Bean
+DefaultAuthorizationManagerFactory<RequestAuthorizationContext> authz() {
+	return DefaultAuthorizationManager.withAuthorities("FACTOR_X509", "FACTOR_AUTHORIZATION_CODE");
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@Bean
+fun authz(): DefaultAuthorizationManagerFactory<RequestAuthorizationContext> {
+	return DefaultAuthorizationManager.withAuthorities("FACTOR_X509", "FACTOR_AUTHORIZATION_CODE")
+}
+----
+======
+
+Then the application will require an X.509 certificate as well as authorization from an OAuth 2.0 authorization server.
+
+In the event that the user does not consent to `profile:read`, this application as it stands will issue a 403.
+However, if you have a way for the application to re-ask for consent, then you can implement this in an `AuthenticationEntryPoint` like the following:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Component
+class ScopeRetrievingAuthenticationEntryPoint implements AuthenticationEntryPoint {
+	// ... redirects to authorization server to request profile:read scope
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@Component
+class ScopeRetrievingAuthenticationEntryPoint : AuthenticationEntryPoint {
+	// ... redirects to authorization server to request profile:read scope
+}
+----
+======
+
+Then, your filter chain declaration can bind this entry point to the given authority like so:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Bean
+public SecurityFilterChain securityFilterChain(HttpSecurity http, ScopeRetrievingAuthenticationEntryPoint oauth2) throws Exception {
+    // @formatter:off
+    http
+        .authorizeHttpRequests((authorize) -> authorize
+            .requestMatchers("/profile/**").hasAuthority("SCOPE_profile:read")
+            .anyRequest().authenticated()
+        )
+        .x509(Customizer.withDefaults())
+        .oauth2Login(Customizer.withDefaults())
+        .exceptionHandling((exceptions) -> exceptions
+            .defaultAuthenticationEntryPointFor(oauth2, "SCOPE_profile:read")
+        );
+    // @formatter:on
+    return http.build();
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@Bean
+public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    // @formatter:off
+    http {
+        authorizeHttpRequests {
+            authorize("/profile/**", hasAuthority("SCOPE_profile:read"))
+            authorize(anyRequest, authenticated)
+        }
+        x509 { }
+        oauth2Login { }
+        .exceptionHandling {
+            exceptions.defaultAuthenticationEntryPointFor(oauth2, "SCOPE_profile:read")
+        }
+    }
+    // @formatter:on
+    return http.build()
+}
+----
+======
+
+== Programmatically Decide Which Authorities Are Required
+
+`AuthorizationManager` is the core interface for making authorization decisions.
+Consider an authorization manager that looks at the logged in user to decide which factors are necessary:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Component
+class OptInToMfaAuthorizationManager implements AuthorizationManager<RequestAuthorizationContext> {
+	@Override
+    public AuthorizationResult authorize(Supplier<? extends Authentication> authentication, RequestAuthorizationContext context) {
+		MyPrincipal principal = (MyPrincipal) authentication.get().getPrincipal();
+		if (principal.isOptedIn()) {
+			WebSecurityExpressionRoot root = new WebSecurityExpressionRoot(authentication, context);
+			return new AuthorityAuthorizationDecision(root.hasAuthority("FACTOR_OTT"), List.of("FACTOR_OTT"));
+		}
+		return AuthorizationDecision(true);
+    }
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@Component
+class OptInToMfaAuthorizationManager : AuthorizationManager<RequestAuthorizationContext> {
+    override fun authorize(authentication : Supplier<Authentication>, context: RequestAuthorizationContext) {
+		val principal = authentication.get().getPrincipal() as MyPrincipal
+		if (principal.isOptedIn()) {
+			val root = WebSecurityExpressionRoot(authentication, context)
+			return AuthorityAuthorizationDecision(root.hasAuthority("FACTOR_OTT"), List.of("FACTOR_OTT"))
+		}
+		return AuthorizationDecision(true)
+    }
+}
+----
+======
+
+In this case, using One-Time-Token is only required for those who have opted in.
+
+This can then be enforced by a custom `AuthorizationManagerFactory` implementation:
+
+[tabs]
+======
+Java::
++
+[source,java,role="primary"]
+----
+@Component
+class OptInAuthorizationManagerFactory implements AuthorizationManagerFactory<RequestAuthorizationContext> {
+	private final OptInAuthorizationManager optIn;
+	private final DefaultAuthorizationManagerFactory<RequestAuthorizationContext> delegate =
+            new DefaultAuthorizationManagerFactory<>();
+
+	// ...
+
+    @Override
+    public AuthorizationManager<RequestAuthorizationContext> hasRole(String role) {
+		return AuthorizationManagers.allOf(new AuthorizationDecision(false), this.optIn, this.delegate.hasRole(role));
+    }
+
+    @Override
+    public AuthorizationManager<RequestAuthorizationContext> authenticated() {
+		return AuthorizationManagers.allOf(new AuthorizationDecision(false), this.optIn, this.delegate.authenicated());
+    }
+
+	// ...
+
+}
+----
+
+Kotlin::
++
+[source,kotlin,role="secondary"]
+----
+@Component
+class OptInAuthorizationManagerFactory : AuthorizationManagerFactory<RequestAuthorizationContext> {
+	val optIn: OptInAuthorizationManager
+	val delegate = DefaultAuthorizationManagerFactory()
+
+	// ...
+
+    override fun hasRole(role: String): AuthorizationManager<RequestAuthorizationContext> {
+		return AuthorizationManagers.allOf(AuthorizationDecision(false), this.optIn, this.delegate.hasRole(role))
+    }
+
+    override fun authenticated(): AuthorizationManager<RequestAuthorizationContext>  {
+		return AuthorizationManagers.allOf(AuthorizationDecision(false), this.optIn, this.delegate.authenicated())
+    }
+
+	// ...
+
+}
+----
+======

--- a/docs/modules/ROOT/pages/whats-new.adoc
+++ b/docs/modules/ROOT/pages/whats-new.adoc
@@ -15,6 +15,7 @@ Each section that follows will indicate the more notable removals as well as the
 
 == Core
 
+* Added Support for xref:servlet/authentication/adaptive.adoc[Multi-factor Authentication]
 * Removed `AuthorizationManager#check` in favor of `AuthorizationManager#authorize`
 * Added javadoc:org.springframework.security.authorization.AllAuthoritiesAuthorizationManager[] and javadoc:org.springframework.security.authorization.AllAuthoritiesReactiveAuthorizationManager[] along with corresponding methods for xref:servlet/authorization/authorize-http-requests.adoc#authorize-requests[Authorizing `HttpServletRequests`] and xref:servlet/authorization/method-security.adoc#using-authorization-expression-fields-and-methods[method security expressions].
 * Added xref:servlet/authorization/architecture.adoc#authz-authorization-manager-factory[`AuthorizationManagerFactory`] for creating `AuthorizationManager` instances in xref:servlet/authorization/authorize-http-requests.adoc#customizing-authorization-managers[request-based] and xref:servlet/authorization/method-security.adoc#customizing-authorization-managers[method-based] authorization components

--- a/web/src/main/java/org/springframework/security/web/WebAttributes.java
+++ b/web/src/main/java/org/springframework/security/web/WebAttributes.java
@@ -16,6 +16,7 @@
 
 package org.springframework.security.web;
 
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.security.web.access.WebInvocationPrivilegeEvaluator;
 
 /**
@@ -51,6 +52,15 @@ public final class WebAttributes {
 	 */
 	public static final String WEB_INVOCATION_PRIVILEGE_EVALUATOR_ATTRIBUTE = WebAttributes.class.getName()
 			+ ".WEB_INVOCATION_PRIVILEGE_EVALUATOR_ATTRIBUTE";
+
+	/**
+	 * Used to specify to the view layer what missing authorities caused an
+	 * {@link AuthorizationDeniedException}
+	 *
+	 * @since 7.0
+	 * @see org.springframework.security.web.access.DelegatingMissingAuthorityAccessDeniedHandler
+	 */
+	public static final String MISSING_AUTHORITIES = WebAttributes.class + ".MISSING_AUTHORITIES";
 
 	private WebAttributes() {
 	}

--- a/web/src/main/java/org/springframework/security/web/access/DelegatingMissingAuthorityAccessDeniedHandler.java
+++ b/web/src/main/java/org/springframework/security/web/access/DelegatingMissingAuthorityAccessDeniedHandler.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.access;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.authorization.AuthorityAuthorizationDecision;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.authentication.DelegatingAuthenticationEntryPoint;
+import org.springframework.security.web.savedrequest.NullRequestCache;
+import org.springframework.security.web.savedrequest.RequestCache;
+import org.springframework.security.web.util.ThrowableAnalyzer;
+import org.springframework.security.web.util.matcher.AnyRequestMatcher;
+
+/**
+ * An {@link AccessDeniedHandler} that adapts {@link AuthenticationEntryPoint}s based on
+ * missing {@link GrantedAuthority}s. These authorities are specified in an
+ * {@link AuthorityAuthorizationDecision} inside an {@link AuthorizationDeniedException}.
+ *
+ * <p>
+ * This is helpful in adaptive authentication scenarios where an
+ * {@link org.springframework.security.authorization.AuthorizationManager} indicates
+ * additional authorities needed to access a given resource.
+ * </p>
+ *
+ * <p>
+ * For example, if an
+ * {@link org.springframework.security.authorization.AuthorizationManager} states that to
+ * access the home page, the user needs the {@code FACTOR_OTT} authority, then this
+ * handler can be configured in the following way to redirect to the one-time-token login
+ * page:
+ * </p>
+ *
+ * <code>
+ *     AccessDeniedHandler handler = DelegatingMissingAuthorityAccessDeniedHandler.builder()
+ *         .authorities("FACTOR_OTT").commence(new LoginUrlAuthenticationEntryPoint("/login"))
+ *         .authorities("FACTOR_PASSWORD")...
+ *         .build();
+ * </code>
+ *
+ * @author Josh Cummings
+ * @since 7.0
+ * @see AuthorizationDeniedException
+ * @see AuthorityAuthorizationDecision
+ * @see org.springframework.security.config.annotation.web.configurers.ExceptionHandlingConfigurer
+ */
+public final class DelegatingMissingAuthorityAccessDeniedHandler implements AccessDeniedHandler {
+
+	private final ThrowableAnalyzer throwableAnalyzer = new ThrowableAnalyzer();
+
+	private final Map<String, AuthenticationEntryPoint> entryPoints;
+
+	private RequestCache requestCache = new NullRequestCache();
+
+	private AccessDeniedHandler defaultAccessDeniedHandler = new AccessDeniedHandlerImpl();
+
+	private DelegatingMissingAuthorityAccessDeniedHandler(Map<String, AuthenticationEntryPoint> entryPoints) {
+		this.entryPoints = entryPoints;
+	}
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException denied)
+			throws IOException, ServletException {
+		Collection<GrantedAuthority> authorities = missingAuthorities(denied);
+		AuthenticationEntryPoint entryPoint = entryPoint(authorities);
+		if (entryPoint == null) {
+			this.defaultAccessDeniedHandler.handle(request, response, denied);
+			return;
+		}
+		this.requestCache.saveRequest(request, response);
+		AuthenticationException ex = new InsufficientAuthenticationException("missing authorities", denied);
+		entryPoint.commence(request, response, ex);
+	}
+
+	/**
+	 * Use this {@link AccessDeniedHandler} for {@link AccessDeniedException}s that this
+	 * handler doesn't support. By default, this uses {@link AccessDeniedHandlerImpl}.
+	 * @param defaultAccessDeniedHandler the default {@link AccessDeniedHandler} to use
+	 */
+	public void setDefaultAccessDeniedHandler(AccessDeniedHandler defaultAccessDeniedHandler) {
+		this.defaultAccessDeniedHandler = defaultAccessDeniedHandler;
+	}
+
+	/**
+	 * Use this {@link RequestCache} to remember the current request.
+	 * <p>
+	 * Uses {@link NullRequestCache} by default
+	 * </p>
+	 * @param requestCache the {@link RequestCache} to use
+	 */
+	public void setRequestCache(RequestCache requestCache) {
+		this.requestCache = requestCache;
+	}
+
+	private @Nullable AuthenticationEntryPoint entryPoint(Collection<GrantedAuthority> authorities) {
+		for (GrantedAuthority needed : authorities) {
+			AuthenticationEntryPoint entryPoint = this.entryPoints.get(needed.getAuthority());
+			if (entryPoint == null) {
+				continue;
+			}
+			return entryPoint;
+		}
+		return null;
+	}
+
+	private Collection<GrantedAuthority> missingAuthorities(AccessDeniedException ex) {
+		AuthorizationDeniedException denied = findAuthorizationDeniedException(ex);
+		if (denied == null) {
+			return List.of();
+		}
+		if (!(denied.getAuthorizationResult() instanceof AuthorityAuthorizationDecision authorization)) {
+			return List.of();
+		}
+		return authorization.getAuthorities();
+	}
+
+	private @Nullable AuthorizationDeniedException findAuthorizationDeniedException(AccessDeniedException ex) {
+		if (ex instanceof AuthorizationDeniedException denied) {
+			return denied;
+		}
+		Throwable[] chain = this.throwableAnalyzer.determineCauseChain(ex);
+		return (AuthorizationDeniedException) this.throwableAnalyzer
+			.getFirstThrowableOfType(AuthorizationDeniedException.class, chain);
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * A builder for configuring the set of authority/entry-point pairs
+	 *
+	 * @author Josh Cummings
+	 * @since 7.0
+	 */
+	public static final class Builder {
+
+		private final Map<String, DelegatingAuthenticationEntryPoint.Builder> entryPointByRequestMatcherByAuthority = new LinkedHashMap<>();
+
+		private Builder() {
+
+		}
+
+		DelegatingAuthenticationEntryPoint.Builder entryPointBuilder(String authority) {
+			return this.entryPointByRequestMatcherByAuthority.computeIfAbsent(authority,
+					(k) -> DelegatingAuthenticationEntryPoint.builder());
+		}
+
+		void entryPoint(String authority, AuthenticationEntryPoint entryPoint) {
+			DelegatingAuthenticationEntryPoint.Builder builder = DelegatingAuthenticationEntryPoint.builder()
+				.addEntryPointFor(entryPoint, AnyRequestMatcher.INSTANCE);
+			this.entryPointByRequestMatcherByAuthority.put(authority, builder);
+		}
+
+		/**
+		 * Bind these authorities to the given {@link AuthenticationEntryPoint}
+		 * @param entryPoint the {@link AuthenticationEntryPoint} for the given
+		 * authorities
+		 * @param authorities the authorities
+		 * @return the {@link Builder} for further configurations
+		 */
+		public Builder addEntryPointFor(AuthenticationEntryPoint entryPoint, String... authorities) {
+			for (String authority : authorities) {
+				Builder.this.entryPoint(authority, entryPoint);
+			}
+			return this;
+		}
+
+		/**
+		 * Bind these authorities to the given {@link AuthenticationEntryPoint}
+		 * @param entryPoint a consumer to configure the underlying
+		 * {@link DelegatingAuthenticationEntryPoint}
+		 * @param authorities the authorities
+		 * @return the {@link Builder} for further configurations
+		 */
+		public Builder addEntryPointFor(Consumer<DelegatingAuthenticationEntryPoint.Builder> entryPoint,
+				String... authorities) {
+			for (String authority : authorities) {
+				entryPoint.accept(Builder.this.entryPointBuilder(authority));
+			}
+			return this;
+		}
+
+		public DelegatingMissingAuthorityAccessDeniedHandler build() {
+			Map<String, AuthenticationEntryPoint> entryPointByAuthority = new LinkedHashMap<>();
+			for (String authority : this.entryPointByRequestMatcherByAuthority.keySet()) {
+				entryPointByAuthority.put(authority, this.entryPointByRequestMatcherByAuthority.get(authority).build());
+			}
+			return new DelegatingMissingAuthorityAccessDeniedHandler(entryPointByAuthority);
+		}
+
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/access/ExceptionTranslationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/access/ExceptionTranslationFilter.java
@@ -196,7 +196,8 @@ public class ExceptionTranslationFilter extends GenericFilterBean implements Mes
 			}
 			AuthenticationException ex = new InsufficientAuthenticationException(
 					this.messages.getMessage("ExceptionTranslationFilter.insufficientAuthentication",
-							"Full authentication is required to access this resource"));
+							"Full authentication is required to access this resource"),
+					exception);
 			ex.setAuthenticationRequest(authentication);
 			sendStartAuthentication(request, response, chain, ex);
 		}

--- a/web/src/main/java/org/springframework/security/web/authentication/LoginUrlAuthenticationEntryPoint.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/LoginUrlAuthenticationEntryPoint.java
@@ -17,6 +17,7 @@
 package org.springframework.security.web.authentication;
 
 import java.io.IOException;
+import java.util.Collection;
 
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletException;
@@ -30,6 +31,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.log.LogMessage;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.DefaultRedirectStrategy;
 import org.springframework.security.web.PortMapper;
@@ -40,6 +42,7 @@ import org.springframework.security.web.util.RedirectUrlBuilder;
 import org.springframework.security.web.util.UrlUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * Used by the {@link ExceptionTranslationFilter} to commence a form login authentication
@@ -109,6 +112,12 @@ public class LoginUrlAuthenticationEntryPoint implements AuthenticationEntryPoin
 	 */
 	protected String determineUrlToUseForThisRequest(HttpServletRequest request, HttpServletResponse response,
 			AuthenticationException exception) {
+		Object value = request.getAttribute(GrantedAuthority.MISSING_AUTHORITIES_ATTRIBUTE);
+		if (value instanceof Collection<?> authorities) {
+			return UriComponentsBuilder.fromUriString(getLoginFormUrl())
+				.queryParam("authority", authorities)
+				.toUriString();
+		}
 		return getLoginFormUrl();
 	}
 

--- a/web/src/main/java/org/springframework/security/web/authentication/LoginUrlAuthenticationEntryPoint.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/LoginUrlAuthenticationEntryPoint.java
@@ -38,6 +38,7 @@ import org.springframework.security.web.DefaultRedirectStrategy;
 import org.springframework.security.web.PortMapper;
 import org.springframework.security.web.PortMapperImpl;
 import org.springframework.security.web.RedirectStrategy;
+import org.springframework.security.web.WebAttributes;
 import org.springframework.security.web.access.ExceptionTranslationFilter;
 import org.springframework.security.web.util.RedirectUrlBuilder;
 import org.springframework.security.web.util.UrlUtils;
@@ -117,7 +118,7 @@ public class LoginUrlAuthenticationEntryPoint implements AuthenticationEntryPoin
 	@SuppressWarnings("unchecked")
 	protected String determineUrlToUseForThisRequest(HttpServletRequest request, HttpServletResponse response,
 			AuthenticationException exception) {
-		Collection<GrantedAuthority> authorities = getAttribute(request, GrantedAuthority.MISSING_AUTHORITIES_ATTRIBUTE,
+		Collection<GrantedAuthority> authorities = getAttribute(request, WebAttributes.MISSING_AUTHORITIES,
 				Collection.class);
 		if (CollectionUtils.isEmpty(authorities)) {
 			return getLoginFormUrl();
@@ -130,7 +131,7 @@ public class LoginUrlAuthenticationEntryPoint implements AuthenticationEntryPoin
 	}
 
 	private static <T> @Nullable T getAttribute(HttpServletRequest request, String name, Class<T> clazz) {
-		Object value = request.getAttribute(GrantedAuthority.MISSING_AUTHORITIES_ATTRIBUTE);
+		Object value = request.getAttribute(name);
 		if (value == null) {
 			return null;
 		}

--- a/web/src/main/java/org/springframework/security/web/authentication/ui/DefaultLoginPageGeneratingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/ui/DefaultLoginPageGeneratingFilter.java
@@ -88,7 +88,9 @@ public class DefaultLoginPageGeneratingFilter extends GenericFilterBean {
 
 	private @Nullable String rememberMeParameter;
 
-	private final Collection<String> allowedParameters = List.of("authority");
+	private final String factorParameter = "factor";
+
+	private final Collection<String> allowedParameters = List.of(this.factorParameter);
 
 	@SuppressWarnings("NullAway.Init")
 	private Map<String, String> oauth2AuthenticationUrlToClientName;
@@ -257,29 +259,29 @@ public class DefaultLoginPageGeneratingFilter extends GenericFilterBean {
 			.withRawHtml("passkeyLogin", "");
 
 		Predicate<String> wantsAuthority = wantsAuthority(request);
-		if (wantsAuthority.test("FACTOR_WEBAUTHN")) {
+		if (wantsAuthority.test("webauthn")) {
 			builder.withRawHtml("javaScript", renderJavaScript(request, contextPath))
 				.withRawHtml("passkeyLogin", renderPasskeyLogin());
 		}
-		if (wantsAuthority.test("FACTOR_PASSWORD")) {
+		if (wantsAuthority.test("password")) {
 			builder.withRawHtml("formLogin",
 					renderFormLogin(request, loginError, logoutSuccess, contextPath, errorMsg));
 		}
-		if (wantsAuthority.test("FACTOR_OTT")) {
+		if (wantsAuthority.test("ott")) {
 			builder.withRawHtml("oneTimeTokenLogin",
 					renderOneTimeTokenLogin(request, loginError, logoutSuccess, contextPath, errorMsg));
 		}
-		if (wantsAuthority.test("FACTOR_AUTHORIZATION_CODE")) {
+		if (wantsAuthority.test("authorization_code")) {
 			builder.withRawHtml("oauth2Login", renderOAuth2Login(loginError, logoutSuccess, errorMsg, contextPath));
 		}
-		if (wantsAuthority.test("FACTOR_SAML_RESPONSE")) {
+		if (wantsAuthority.test("saml_response")) {
 			builder.withRawHtml("saml2Login", renderSaml2Login(loginError, logoutSuccess, errorMsg, contextPath));
 		}
 		return builder.render();
 	}
 
 	private Predicate<String> wantsAuthority(HttpServletRequest request) {
-		String[] authorities = request.getParameterValues("authority");
+		String[] authorities = request.getParameterValues(this.factorParameter);
 		if (authorities == null) {
 			return (authority) -> true;
 		}

--- a/web/src/test/java/org/springframework/security/web/access/DelegatingMissingAuthorityAccessDeniedHandlerTests.java
+++ b/web/src/test/java/org/springframework/security/web/access/DelegatingMissingAuthorityAccessDeniedHandlerTests.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.access;
+
+import java.util.Collection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorityAuthorizationDecision;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.savedrequest.RequestCache;
+import org.springframework.security.web.util.matcher.RequestHeaderRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class DelegatingMissingAuthorityAccessDeniedHandlerTests {
+
+	DelegatingMissingAuthorityAccessDeniedHandler.Builder builder;
+
+	MockHttpServletRequest request;
+
+	MockHttpServletResponse response;
+
+	@Mock
+	AuthenticationEntryPoint factorEntryPoint;
+
+	@Mock
+	AccessDeniedHandler defaultAccessDeniedHandler;
+
+	@BeforeEach
+	void setUp() {
+		this.builder = DelegatingMissingAuthorityAccessDeniedHandler.builder();
+		this.builder.addEntryPointFor(this.factorEntryPoint, "FACTOR");
+		this.request = new MockHttpServletRequest();
+		this.response = new MockHttpServletResponse();
+	}
+
+	@Test
+	void whenKnownAuthorityThenCommences() throws Exception {
+		AccessDeniedHandler accessDeniedHandler = this.builder.build();
+		accessDeniedHandler.handle(this.request, this.response, missingAuthorities("FACTOR"));
+		verify(this.factorEntryPoint).commence(any(), any(), any());
+	}
+
+	@Test
+	void whenUnknownAuthorityThenDefaultCommences() throws Exception {
+		DelegatingMissingAuthorityAccessDeniedHandler accessDeniedHandler = this.builder.build();
+		accessDeniedHandler.setDefaultAccessDeniedHandler(this.defaultAccessDeniedHandler);
+		accessDeniedHandler.handle(this.request, this.response, missingAuthorities("ROLE_USER"));
+		verify(this.defaultAccessDeniedHandler).handle(any(), any(), any());
+		verifyNoInteractions(this.factorEntryPoint);
+	}
+
+	@Test
+	void whenNoAuthoritiesFoundThenDefaultCommences() throws Exception {
+		DelegatingMissingAuthorityAccessDeniedHandler accessDeniedHandler = this.builder.build();
+		accessDeniedHandler.setDefaultAccessDeniedHandler(this.defaultAccessDeniedHandler);
+		accessDeniedHandler.handle(this.request, this.response, new AccessDeniedException("access denied"));
+		verify(this.defaultAccessDeniedHandler).handle(any(), any(), any());
+	}
+
+	@Test
+	void whenMultipleAuthoritiesThenFirstMatchCommences() throws Exception {
+		AuthenticationEntryPoint passwordEntryPoint = mock(AuthenticationEntryPoint.class);
+		this.builder.addEntryPointFor(passwordEntryPoint, "PASSWORD");
+		AccessDeniedHandler accessDeniedHandler = this.builder.build();
+		accessDeniedHandler.handle(this.request, this.response, missingAuthorities("PASSWORD", "FACTOR"));
+		verify(passwordEntryPoint).commence(any(), any(), any());
+		accessDeniedHandler.handle(this.request, this.response, missingAuthorities("FACTOR", "PASSWORD"));
+		verify(this.factorEntryPoint).commence(any(), any(), any());
+	}
+
+	@Test
+	void whenCustomRequestCacheThenUses() throws Exception {
+		RequestCache requestCache = mock(RequestCache.class);
+		DelegatingMissingAuthorityAccessDeniedHandler accessDeniedHandler = this.builder.build();
+		accessDeniedHandler.setRequestCache(requestCache);
+		accessDeniedHandler.handle(this.request, this.response, missingAuthorities("FACTOR"));
+		verify(requestCache).saveRequest(any(), any());
+		verify(this.factorEntryPoint).commence(any(), any(), any());
+	}
+
+	@Test
+	void whenKnownAuthorityButNoRequestMatchThenCommences() throws Exception {
+		AuthenticationEntryPoint passwordEntryPoint = mock(AuthenticationEntryPoint.class);
+		RequestMatcher xhr = new RequestHeaderRequestMatcher("X-Requested-With");
+		this.builder.addEntryPointFor((ep) -> ep.addEntryPointFor(passwordEntryPoint, xhr), "PASSWORD");
+		AccessDeniedHandler accessDeniedHandler = this.builder.build();
+		accessDeniedHandler.handle(this.request, this.response, missingAuthorities("PASSWORD"));
+		verify(passwordEntryPoint).commence(any(), any(), any());
+	}
+
+	@Test
+	void whenMultipleEntryPointsThenFirstRequestMatchCommences() throws Exception {
+		AuthenticationEntryPoint basicPasswordEntryPoint = mock(AuthenticationEntryPoint.class);
+		AuthenticationEntryPoint formPasswordEntryPoint = mock(AuthenticationEntryPoint.class);
+		RequestMatcher xhr = new RequestHeaderRequestMatcher("X-Requested-With");
+		this.builder.addEntryPointFor(
+				(ep) -> ep.addEntryPointFor(basicPasswordEntryPoint, xhr).defaultEntryPoint(formPasswordEntryPoint),
+				"PASSWORD");
+		AccessDeniedHandler accessDeniedHandler = this.builder.build();
+		accessDeniedHandler.handle(this.request, this.response, missingAuthorities("PASSWORD"));
+		verify(formPasswordEntryPoint).commence(any(), any(), any());
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("X-Requested-With", "XmlHttpRequest");
+		accessDeniedHandler.handle(request, this.response, missingAuthorities("PASSWORD"));
+		verify(basicPasswordEntryPoint).commence(any(), any(), any());
+	}
+
+	AuthorizationDeniedException missingAuthorities(String... authorities) {
+		Collection<GrantedAuthority> granted = AuthorityUtils.createAuthorityList(authorities);
+		AuthorityAuthorizationDecision decision = new AuthorityAuthorizationDecision(false, granted);
+		return new AuthorizationDeniedException("access denied", decision);
+	}
+
+}

--- a/web/src/test/java/org/springframework/security/web/authentication/DefaultLoginPageGeneratingFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/DefaultLoginPageGeneratingFilterTests.java
@@ -204,7 +204,7 @@ public class DefaultLoginPageGeneratingFilterTests {
 		filter.setOneTimeTokenEnabled(true);
 		filter.setOneTimeTokenGenerationUrl("/ott/authenticate");
 		MockHttpServletResponse response = new MockHttpServletResponse();
-		filter.doFilter(TestMockHttpServletRequests.get("/login?authority=FACTOR_OTT").build(), response, this.chain);
+		filter.doFilter(TestMockHttpServletRequests.get("/login?factor=ott").build(), response, this.chain);
 		assertThat(response.getContentAsString()).contains("Request a One-Time Token");
 		assertThat(response.getContentAsString()).contains("""
 				      <form id="ott-form" class="login-form" method="post" action="/ott/authenticate">
@@ -231,9 +231,8 @@ public class DefaultLoginPageGeneratingFilterTests {
 		filter.setOneTimeTokenEnabled(true);
 		filter.setOneTimeTokenGenerationUrl("/ott/authenticate");
 		MockHttpServletResponse response = new MockHttpServletResponse();
-		filter.doFilter(
-				TestMockHttpServletRequests.get("/login?authority=FACTOR_OTT&authority=FACTOR_PASSWORD").build(),
-				response, this.chain);
+		filter.doFilter(TestMockHttpServletRequests.get("/login?factor=ott&factor=password").build(), response,
+				this.chain);
 		assertThat(response.getContentAsString()).contains("Request a One-Time Token");
 		assertThat(response.getContentAsString()).contains("""
 				      <form id="ott-form" class="login-form" method="post" action="/ott/authenticate">


### PR DESCRIPTION
Related to https://github.com/spring-projects/spring-security-samples/pull/351

Implement N authentication factors and they will be required in the order that they are declared:

```java
http
    .authorizeHttpRequests((authorize) -> authorize.anyRequest()
        .access(allOf(hasAuthority("FACTOR_PASSWORD"), hasAuthority("FACTOR_OTT")))
    )
    .formLogin(Customizer.withDefaults())
    .oneTimeTokenLogin(Customizer.withDefaults())
    // ...
```

This will ask for a username/password first and a one-time token second. Thereafter, the user will be considered sufficiently authenticated.

Note that you can also publish an `AuthorizationManagerFactory<Object>` bean that checks for `FACTOR_PASSWORD` and `FACTOR_OTT`; however, this has not been added to this PR.

You can also specify a custom action to perform when a given factor is missing:

```java
http
    .authorizeHttpRequests((authorize) -> authorize.anyRequest()
        .access(allOf(hasAuthority("FACTOR_PASSWORD"), hasAuthority("FACTOR_WEBAUTHN")))
    )
    .formLogin(Customizer.withDefaults())
    .webauthn((webauthn) -> ...)
    .exceptionHandling((exceptions) -> exceptions
        .defaultAuthenticationEntryPointFor(new LoginUrlAuthenticationEntryPoint("/webauthn"), "FACTOR_WEBAUTHN")
    )
    // ...
```

Note that authentication factors already integrate with `defaultAuthenticationEntryPointFor`  in this PR. The above is needed for WebAuthn since it doesn't expose a custom entry point page in its DSL.