### PR TITLE
Add Jackson 3 support and deprecate Jackson 2 one

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="CheckStyle-IDEA">
-    <option name="configuration">
-      <map>
-        <entry key="checkstyle-version" value="8.14" />
-        <entry key="copy-libs" value="false" />
-        <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
-        <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
-        <entry key="scan-before-checkin" value="false" />
-        <entry key="scanscope" value="JavaOnlyWithTests" />
-        <entry key="suppress-errors" value="false" />
-      </map>
+  <component name="CheckStyle-IDEA" serialisationVersion="2">
+    <checkstyleVersion>9.0.1</checkstyleVersion>
+    <scanScope>JavaOnlyWithTests</scanScope>
+    <option name="thirdPartyClasspath" />
+    <option name="activeLocationIds" />
+    <option name="locations">
+      <list>
+        <ConfigurationLocation id="bundled-sun-checks" type="BUNDLED" scope="All" description="Sun Checks">(bundled)</ConfigurationLocation>
+        <ConfigurationLocation id="bundled-google-checks" type="BUNDLED" scope="All" description="Google Checks">(bundled)</ConfigurationLocation>
+      </list>
     </option>
   </component>
 </project>

--- a/cas/spring-security-cas.gradle
+++ b/cas/spring-security-cas.gradle
@@ -15,6 +15,7 @@ dependencies {
 	api 'org.springframework:spring-web'
 
 	optional 'com.fasterxml.jackson.core:jackson-databind'
+	optional 'tools.jackson.core:jackson-databind'
 
 	provided 'jakarta.servlet:jakarta.servlet-api'
 

--- a/cas/src/main/java/org/springframework/security/cas/jackson/AssertionImplMixin.java
+++ b/cas/src/main/java/org/springframework/security/cas/jackson/AssertionImplMixin.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.cas.jackson;
+
+import java.util.Date;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apereo.cas.client.authentication.AttributePrincipal;
+
+/**
+ * Helps in jackson deserialization of class
+ * {@link org.apereo.cas.client.validation.AssertionImpl}, which is used with
+ * {@link org.springframework.security.cas.authentication.CasAuthenticationToken}. To use
+ * this class we need to register with
+ * {@link com.fasterxml.jackson.databind.ObjectMapper}. Type information will be stored
+ * in @class property.
+ * <p>
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new CasJacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Jitendra Singh
+ * @since 7.0
+ * @see CasJacksonModule
+ * @see org.springframework.security.jackson.SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+class AssertionImplMixin {
+
+	/**
+	 * Mixin Constructor helps in deserialize
+	 * {@link org.apereo.cas.client.validation.AssertionImpl}
+	 * @param principal the Principal to associate with the Assertion.
+	 * @param validFromDate when the assertion is valid from.
+	 * @param validUntilDate when the assertion is valid to.
+	 * @param authenticationDate when the assertion is authenticated.
+	 * @param attributes the key/value pairs for this attribute.
+	 */
+	@JsonCreator
+	AssertionImplMixin(@JsonProperty("principal") AttributePrincipal principal,
+			@JsonProperty("validFromDate") Date validFromDate, @JsonProperty("validUntilDate") Date validUntilDate,
+			@JsonProperty("authenticationDate") Date authenticationDate,
+			@JsonProperty("attributes") Map<String, Object> attributes) {
+	}
+
+}

--- a/cas/src/main/java/org/springframework/security/cas/jackson/AttributePrincipalImplMixin.java
+++ b/cas/src/main/java/org/springframework/security/cas/jackson/AttributePrincipalImplMixin.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.cas.jackson;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apereo.cas.client.proxy.ProxyRetriever;
+
+/**
+ * Helps in deserialize
+ * {@link org.apereo.cas.client.authentication.AttributePrincipalImpl} which is used with
+ * {@link org.springframework.security.cas.authentication.CasAuthenticationToken}. Type
+ * information will be stored in property named @class.
+ * <p>
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new CasJacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Jitendra Singh
+ * @since 7.0
+ * @see CasJacksonModule
+ * @see org.springframework.security.jackson.SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+class AttributePrincipalImplMixin {
+
+	/**
+	 * Mixin Constructor helps in deserialize
+	 * {@link org.apereo.cas.client.authentication.AttributePrincipalImpl}
+	 * @param name the unique identifier for the principal.
+	 * @param attributes the key/value pairs for this principal.
+	 * @param proxyGrantingTicket the ticket associated with this principal.
+	 * @param proxyRetriever the ProxyRetriever implementation to call back to the CAS
+	 * server.
+	 */
+	@JsonCreator
+	AttributePrincipalImplMixin(@JsonProperty("name") String name,
+			@JsonProperty("attributes") Map<String, Object> attributes,
+			@JsonProperty("proxyGrantingTicket") String proxyGrantingTicket,
+			@JsonProperty("proxyRetriever") ProxyRetriever proxyRetriever) {
+	}
+
+}

--- a/cas/src/main/java/org/springframework/security/cas/jackson/CasAuthenticationTokenMixin.java
+++ b/cas/src/main/java/org/springframework/security/cas/jackson/CasAuthenticationTokenMixin.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.cas.jackson;
+
+import java.util.Collection;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apereo.cas.client.validation.Assertion;
+
+import org.springframework.security.cas.authentication.CasAuthenticationProvider;
+import org.springframework.security.cas.authentication.CasAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+/**
+ * Mixin class which helps in deserialize {@link CasAuthenticationToken} using jackson.
+ * Two more dependent classes needs to register along with this mixin class.
+ * <ol>
+ * <li>{@link AssertionImplMixin}</li>
+ * <li>{@link AttributePrincipalImplMixin}</li>
+ * </ol>
+ *
+ * <p>
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new CasJacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Jitendra Singh
+ * @since 7.0
+ * @see CasJacksonModule
+ * @see org.springframework.security.jackson.SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+		getterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+class CasAuthenticationTokenMixin {
+
+	/**
+	 * Mixin Constructor helps in deserialize {@link CasAuthenticationToken}
+	 * @param keyHash hashCode of provided key to identify if this object made by a given
+	 * {@link CasAuthenticationProvider}
+	 * @param principal typically the UserDetails object (cannot be <code>null</code>)
+	 * @param credentials the service/proxy ticket ID from CAS (cannot be
+	 * <code>null</code>)
+	 * @param authorities the authorities granted to the user (from the
+	 * {@link org.springframework.security.core.userdetails.UserDetailsService}) (cannot
+	 * be <code>null</code>)
+	 * @param userDetails the user details (from the
+	 * {@link org.springframework.security.core.userdetails.UserDetailsService}) (cannot
+	 * be <code>null</code>)
+	 * @param assertion the assertion returned from the CAS servers. It contains the
+	 * principal and how to obtain a proxy ticket for the user.
+	 */
+	@JsonCreator
+	CasAuthenticationTokenMixin(@JsonProperty("keyHash") Integer keyHash, @JsonProperty("principal") Object principal,
+			@JsonProperty("credentials") Object credentials,
+			@JsonProperty("authorities") Collection<? extends GrantedAuthority> authorities,
+			@JsonProperty("userDetails") UserDetails userDetails, @JsonProperty("assertion") Assertion assertion) {
+	}
+
+}

--- a/cas/src/main/java/org/springframework/security/cas/jackson/CasJacksonModule.java
+++ b/cas/src/main/java/org/springframework/security/cas/jackson/CasJacksonModule.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.cas.jackson;
+
+import org.apereo.cas.client.authentication.AttributePrincipalImpl;
+import org.apereo.cas.client.validation.AssertionImpl;
+import tools.jackson.core.Version;
+import tools.jackson.databind.cfg.MapperBuilder;
+import tools.jackson.databind.module.SimpleModule;
+
+import org.springframework.security.cas.authentication.CasAuthenticationToken;
+import org.springframework.security.jackson.AllowlistTypeResolverBuilder;
+import org.springframework.security.jackson.SecurityJacksonModules;
+
+/**
+ * Jackson module for spring-security-cas. This module register
+ * {@link AssertionImplMixin}, {@link AttributePrincipalImplMixin} and
+ * {@link CasAuthenticationTokenMixin}. If no default typing enabled by default then it'll
+ * enable it because typing info is needed to properly serialize/deserialize objects. In
+ * order to use this module just add this module into your ObjectMapper configuration.
+ *
+ * <pre>
+ * JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new CasJacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * <b>Note: use {@link SecurityJacksonModules#getModules(ClassLoader)} to get list of all
+ * security modules on the classpath.</b>
+ *
+ * @author Sebastien Deleuze
+ * @author Jitendra Singh
+ * @since 7.0
+ * @see SecurityJacksonModules
+ */
+public class CasJacksonModule extends SimpleModule {
+
+	public CasJacksonModule() {
+		super(CasJacksonModule.class.getName(), new Version(1, 0, 0, null, null, null));
+	}
+
+	@Override
+	public void setupModule(SetupContext context) {
+		((MapperBuilder<?, ?>) context.getOwner()).setDefaultTyping(new AllowlistTypeResolverBuilder());
+		context.setMixIn(AssertionImpl.class, AssertionImplMixin.class);
+		context.setMixIn(AttributePrincipalImpl.class, AttributePrincipalImplMixin.class);
+		context.setMixIn(CasAuthenticationToken.class, CasAuthenticationTokenMixin.class);
+	}
+
+}

--- a/cas/src/main/java/org/springframework/security/cas/jackson/package-info.java
+++ b/cas/src/main/java/org/springframework/security/cas/jackson/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Jackson 3+ serialization support for CAS.
+ */
+package org.springframework.security.cas.jackson;

--- a/cas/src/main/java/org/springframework/security/cas/jackson2/AssertionImplMixin.java
+++ b/cas/src/main/java/org/springframework/security/cas/jackson2/AssertionImplMixin.java
@@ -33,6 +33,7 @@ import org.apereo.cas.client.authentication.AttributePrincipal;
  * this class we need to register with
  * {@link com.fasterxml.jackson.databind.ObjectMapper}. Type information will be stored
  * in @class property.
+ *
  * <p>
  * <pre>
  *     ObjectMapper mapper = new ObjectMapper();
@@ -43,7 +44,10 @@ import org.apereo.cas.client.authentication.AttributePrincipal;
  * @since 4.2
  * @see CasJackson2Module
  * @see org.springframework.security.jackson2.SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.cas.jackson.AssertionImplMixin} based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/cas/src/main/java/org/springframework/security/cas/jackson2/AttributePrincipalImplMixin.java
+++ b/cas/src/main/java/org/springframework/security/cas/jackson2/AttributePrincipalImplMixin.java
@@ -30,6 +30,7 @@ import org.apereo.cas.client.proxy.ProxyRetriever;
  * {@link org.apereo.cas.client.authentication.AttributePrincipalImpl} which is used with
  * {@link org.springframework.security.cas.authentication.CasAuthenticationToken}. Type
  * information will be stored in property named @class.
+ *
  * <p>
  * <pre>
  *     ObjectMapper mapper = new ObjectMapper();
@@ -40,7 +41,11 @@ import org.apereo.cas.client.proxy.ProxyRetriever;
  * @since 4.2
  * @see CasJackson2Module
  * @see org.springframework.security.jackson2.SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.cas.jackson.AttributePrincipalImplMixin} based on
+ * Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/cas/src/main/java/org/springframework/security/cas/jackson2/CasAuthenticationTokenMixin.java
+++ b/cas/src/main/java/org/springframework/security/cas/jackson2/CasAuthenticationTokenMixin.java
@@ -40,7 +40,6 @@ import org.springframework.security.core.userdetails.UserDetails;
  * </ol>
  *
  * <p>
- *
  * <pre>
  *     ObjectMapper mapper = new ObjectMapper();
  *     mapper.registerModule(new CasJackson2Module());
@@ -50,7 +49,11 @@ import org.springframework.security.core.userdetails.UserDetails;
  * @since 4.2
  * @see CasJackson2Module
  * @see org.springframework.security.jackson2.SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.cas.jackson.CasAuthenticationTokenMixin} based on
+ * Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, isGetterVisibility = JsonAutoDetect.Visibility.NONE,
 		getterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.ANY)

--- a/cas/src/main/java/org/springframework/security/cas/jackson2/CasJackson2Module.java
+++ b/cas/src/main/java/org/springframework/security/cas/jackson2/CasJackson2Module.java
@@ -37,11 +37,14 @@ import org.springframework.security.jackson2.SecurityJackson2Modules;
  * </pre> <b>Note: use {@link SecurityJackson2Modules#getModules(ClassLoader)} to get list
  * of all security modules on the classpath.</b>
  *
- * @author Jitendra Singh.
+ * @author Jitendra Singh
  * @since 4.2
  * @see org.springframework.security.jackson2.SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@link org.springframework.security.cas.jackson.CasJacksonModule} based on Jackson 3
  */
-@SuppressWarnings("serial")
+@Deprecated(forRemoval = true)
+@SuppressWarnings({ "serial", "removal" })
 public class CasJackson2Module extends SimpleModule {
 
 	public CasJackson2Module() {

--- a/cas/src/main/java/org/springframework/security/cas/jackson2/package-info.java
+++ b/cas/src/main/java/org/springframework/security/cas/jackson2/package-info.java
@@ -15,7 +15,7 @@
  */
 
 /**
- * Jackson support for CAS.
+ * Jackson 2 support for CAS.
  */
 @NullMarked
 package org.springframework.security.cas.jackson2;

--- a/cas/src/test/java/org/springframework/security/cas/jackson/CasAuthenticationTokenMixinTests.java
+++ b/cas/src/test/java/org/springframework/security/cas/jackson/CasAuthenticationTokenMixinTests.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.cas.jackson;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+
+import org.apereo.cas.client.authentication.AttributePrincipalImpl;
+import org.apereo.cas.client.validation.Assertion;
+import org.apereo.cas.client.validation.AssertionImpl;
+import org.json.JSONException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.security.cas.authentication.CasAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.jackson.SecurityJacksonModules;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Jitendra Singh
+ * @since 4.2
+ */
+public class CasAuthenticationTokenMixinTests {
+
+	private static final String KEY = "casKey";
+
+	private static final String PASSWORD = "\"1234\"";
+
+	private static final Date START_DATE = new Date();
+
+	private static final Date END_DATE = new Date();
+
+	public static final String AUTHORITY_JSON = "{\"@class\": \"org.springframework.security.core.authority.SimpleGrantedAuthority\", \"authority\": \"ROLE_USER\"}";
+
+	public static final String AUTHORITIES_SET_JSON = "[\"java.util.Collections$UnmodifiableSet\", [" + AUTHORITY_JSON
+			+ "]]";
+
+	public static final String AUTHORITIES_ARRAYLIST_JSON = "[\"java.util.Collections$UnmodifiableRandomAccessList\", ["
+			+ AUTHORITY_JSON + "]]";
+
+	// @formatter:off
+	public static final String USER_JSON = "{"
+		+ "\"@class\": \"org.springframework.security.core.userdetails.User\", "
+		+ "\"username\": \"admin\","
+		+ " \"password\": " + PASSWORD + ", "
+		+ "\"accountNonExpired\": true, "
+		+ "\"accountNonLocked\": true, "
+		+ "\"credentialsNonExpired\": true, "
+		+ "\"enabled\": true, "
+		+ "\"authorities\": " + AUTHORITIES_SET_JSON
+	+ "}";
+	// @formatter:on
+	private static final String CAS_TOKEN_JSON = "{"
+			+ "\"@class\": \"org.springframework.security.cas.authentication.CasAuthenticationToken\", "
+			+ "\"keyHash\": " + KEY.hashCode() + "," + "\"principal\": " + USER_JSON + ", " + "\"credentials\": "
+			+ PASSWORD + ", " + "\"authorities\": " + AUTHORITIES_ARRAYLIST_JSON + "," + "\"userDetails\": " + USER_JSON
+			+ "," + "\"authenticated\": true, " + "\"details\": null," + "\"assertion\": {"
+			+ "\"@class\": \"org.apereo.cas.client.validation.AssertionImpl\", " + "\"principal\": {"
+			+ "\"@class\": \"org.apereo.cas.client.authentication.AttributePrincipalImpl\", "
+			+ "\"name\": \"assertName\", " + "\"attributes\": {\"@class\": \"java.util.Collections$EmptyMap\"}, "
+			+ "\"proxyGrantingTicket\": null, " + "\"proxyRetriever\": null" + "}, "
+			+ "\"validFromDate\": [\"java.util.Date\", " + START_DATE.getTime() + "], "
+			+ "\"validUntilDate\": [\"java.util.Date\", " + END_DATE.getTime() + "],"
+			+ "\"authenticationDate\": [\"java.util.Date\", " + START_DATE.getTime() + "], "
+			+ "\"attributes\": {\"@class\": \"java.util.Collections$EmptyMap\"},"
+			+ "\"context\": {\"@class\":\"java.util.HashMap\"}" + "}" + "}";
+
+	private static final String CAS_TOKEN_CLEARED_JSON = CAS_TOKEN_JSON.replaceFirst(PASSWORD, "null");
+
+	protected JsonMapper mapper;
+
+	@BeforeEach
+	public void setup() {
+		ClassLoader loader = getClass().getClassLoader();
+		this.mapper = JsonMapper.builder()
+			.addModules(SecurityJacksonModules.getModules(loader))
+			.enable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+			.build();
+	}
+
+	@Test
+	public void serializeCasAuthenticationTest() throws JSONException {
+		CasAuthenticationToken token = createCasAuthenticationToken();
+		String actualJson = this.mapper.writeValueAsString(token);
+		JSONAssert.assertEquals(CAS_TOKEN_JSON, actualJson, true);
+	}
+
+	@Test
+	public void serializeCasAuthenticationTestAfterEraseCredentialInvoked() throws JSONException {
+		CasAuthenticationToken token = createCasAuthenticationToken();
+		token.eraseCredentials();
+		String actualJson = this.mapper.writeValueAsString(token);
+		JSONAssert.assertEquals(CAS_TOKEN_CLEARED_JSON, actualJson, true);
+	}
+
+	@Test
+	public void deserializeCasAuthenticationTestAfterEraseCredentialInvoked() {
+		CasAuthenticationToken token = this.mapper.readValue(CAS_TOKEN_CLEARED_JSON, CasAuthenticationToken.class);
+		assertThat(((UserDetails) token.getPrincipal()).getPassword()).isNull();
+	}
+
+	@Test
+	public void deserializeCasAuthenticationTest() throws IOException {
+		CasAuthenticationToken token = this.mapper.readValue(CAS_TOKEN_JSON, CasAuthenticationToken.class);
+		assertThat(token).isNotNull();
+		assertThat(token.getPrincipal()).isNotNull().isInstanceOf(User.class);
+		assertThat(((User) token.getPrincipal()).getUsername()).isEqualTo("admin");
+		assertThat(((User) token.getPrincipal()).getPassword()).isEqualTo("1234");
+		assertThat(token.getUserDetails()).isNotNull().isInstanceOf(User.class);
+		assertThat(token.getAssertion()).isNotNull().isInstanceOf(AssertionImpl.class);
+		assertThat(token.getKeyHash()).isEqualTo(KEY.hashCode());
+		assertThat(token.getUserDetails().getAuthorities()).extracting(GrantedAuthority::getAuthority)
+			.containsOnly("ROLE_USER");
+		assertThat(token.getAssertion().getAuthenticationDate()).isEqualTo(START_DATE);
+		assertThat(token.getAssertion().getValidFromDate()).isEqualTo(START_DATE);
+		assertThat(token.getAssertion().getValidUntilDate()).isEqualTo(END_DATE);
+		assertThat(token.getAssertion().getPrincipal().getName()).isEqualTo("assertName");
+		assertThat(token.getAssertion().getAttributes()).hasSize(0);
+	}
+
+	private CasAuthenticationToken createCasAuthenticationToken() {
+		User principal = new User("admin", "1234", Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
+		Collection<? extends GrantedAuthority> authorities = Collections
+			.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+		Assertion assertion = new AssertionImpl(new AttributePrincipalImpl("assertName"), START_DATE, END_DATE,
+				START_DATE, Collections.<String, Object>emptyMap());
+		return new CasAuthenticationToken(KEY, principal, principal.getPassword(), authorities,
+				new User("admin", "1234", authorities), assertion);
+	}
+
+}

--- a/cas/src/test/java/org/springframework/security/cas/jackson2/CasAuthenticationTokenMixinTests.java
+++ b/cas/src/test/java/org/springframework/security/cas/jackson2/CasAuthenticationTokenMixinTests.java
@@ -44,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Jitendra Singh
  * @since 4.2
  */
+@SuppressWarnings("removal")
 public class CasAuthenticationTokenMixinTests {
 
 	private static final String KEY = "casKey";

--- a/core/spring-security-core.gradle
+++ b/core/spring-security-core.gradle
@@ -25,6 +25,7 @@ dependencies {
 	optional 'org.springframework:spring-jdbc'
 	optional 'org.springframework:spring-tx'
 	optional 'org.jetbrains.kotlinx:kotlinx-coroutines-reactor'
+	optional 'tools.jackson.core:jackson-databind'
 
 	testImplementation 'commons-collections:commons-collections'
 	testImplementation 'io.projectreactor:reactor-test'

--- a/core/src/main/java/org/springframework/security/jackson/AbstractUnmodifiableCollectionDeserializer.java
+++ b/core/src/main/java/org/springframework/security/jackson/AbstractUnmodifiableCollectionDeserializer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.node.ArrayNode;
+
+/**
+ * Abstract base class for deserializers that create unmodifiable collections from JSON
+ * data. Subclasses like {@link UnmodifiableListDeserializer} and
+ * {@link UnmodifiableSetDeserializer} should implement the method to define the specific
+ * collection type and handle the deserialization logic.
+ *
+ * @param <T> the type of the unmodifiable collection, such as {@link List} or
+ * {@link Set}.
+ * @author Sebastien Deleuze
+ * @author Hyunmin Choi
+ * @since 7.0
+ */
+abstract class AbstractUnmodifiableCollectionDeserializer<T> extends ValueDeserializer<T> {
+
+	@Override
+	public T deserialize(JsonParser jp, DeserializationContext ctxt) throws JacksonException {
+		JsonNode node = ctxt.readTree(jp);
+		Collection<Object> values = new ArrayList<>();
+		if (node instanceof ArrayNode arrayNode) {
+			for (JsonNode elementNode : arrayNode) {
+				values.add(ctxt.readTreeAsValue(elementNode, Object.class));
+			}
+		}
+		else if (node != null) {
+			values.add(ctxt.readTreeAsValue(node, Object.class));
+		}
+		return createUnmodifiableCollection(values);
+	}
+
+	/**
+	 * Creates an unmodifiable collection from the given JSON node.
+	 * @param values the values to add to the unmodifiable collection
+	 * @return an unmodifiable collection with the deserialized elements.
+	 * @throws JacksonException if an error occurs during deserialization.
+	 */
+	abstract T createUnmodifiableCollection(Collection<Object> values) throws JacksonException;
+
+}

--- a/core/src/main/java/org/springframework/security/jackson/AllowlistTypeResolverBuilder.java
+++ b/core/src/main/java/org/springframework/security/jackson/AllowlistTypeResolverBuilder.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JacksonAnnotation;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import tools.jackson.databind.DatabindContext;
+import tools.jackson.databind.DefaultTyping;
+import tools.jackson.databind.DeserializationConfig;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import tools.jackson.databind.jsontype.NamedType;
+import tools.jackson.databind.jsontype.PolymorphicTypeValidator;
+import tools.jackson.databind.jsontype.TypeIdResolver;
+import tools.jackson.databind.jsontype.impl.DefaultTypeResolverBuilder;
+
+import org.springframework.core.annotation.AnnotationUtils;
+
+/**
+ *
+ * An implementation of {@link DefaultTypeResolverBuilder} that inserts an
+ * {@code allow all} {@link PolymorphicTypeValidator} and overrides the
+ * {@code TypeIdResolver}
+ *
+ * @author Sebastien Deleuze
+ * @author Rob Winch
+ * @since 7.0
+ */
+public class AllowlistTypeResolverBuilder extends DefaultTypeResolverBuilder {
+
+	public AllowlistTypeResolverBuilder() {
+		this(DefaultTyping.NON_FINAL);
+	}
+
+	public AllowlistTypeResolverBuilder(DefaultTyping defaultTyping) {
+		super(// we do explicit validation in the TypeIdResolver
+				BasicPolymorphicTypeValidator.builder().allowIfSubType(Object.class).build(), defaultTyping,
+				JsonTypeInfo.As.PROPERTY);
+	}
+
+	@Override
+	protected TypeIdResolver idResolver(DatabindContext ctxt, JavaType baseType,
+			PolymorphicTypeValidator subtypeValidator, Collection<NamedType> subtypes, boolean forSer,
+			boolean forDeser) {
+		TypeIdResolver result = super.idResolver(ctxt, baseType, subtypeValidator, subtypes, forSer, forDeser);
+		return new AllowlistTypeIdResolver(result);
+	}
+
+	/**
+	 * A {@link TypeIdResolver} that delegates to an existing implementation and throws an
+	 * IllegalStateException if the class being looked up is not in the allowlist, does
+	 * not provide an explicit mixin, and is not annotated with Jackson mappings. See
+	 * https://github.com/spring-projects/spring-security/issues/4370
+	 */
+	static class AllowlistTypeIdResolver implements TypeIdResolver {
+
+		private static final Set<String> ALLOWLIST_CLASS_NAMES;
+		static {
+			Set<String> names = new HashSet<>();
+			names.add("java.util.ArrayList");
+			names.add("java.util.Collections$EmptyList");
+			names.add("java.util.Collections$EmptyMap");
+			names.add("java.util.Collections$UnmodifiableRandomAccessList");
+			names.add("java.util.Collections$SingletonList");
+			names.add("java.util.Date");
+			names.add("java.time.Instant");
+			names.add("java.net.URL");
+			names.add("java.util.TreeMap");
+			names.add("java.util.HashMap");
+			names.add("java.util.LinkedHashMap");
+			names.add("org.springframework.security.core.context.SecurityContextImpl");
+			names.add("java.util.Arrays$ArrayList");
+			ALLOWLIST_CLASS_NAMES = Collections.unmodifiableSet(names);
+		}
+
+		private final TypeIdResolver delegate;
+
+		AllowlistTypeIdResolver(TypeIdResolver delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public void init(JavaType baseType) {
+			this.delegate.init(baseType);
+		}
+
+		@Override
+		public String idFromValue(DatabindContext ctxt, Object value) {
+			return this.delegate.idFromValue(ctxt, value);
+		}
+
+		@Override
+		public String idFromValueAndType(DatabindContext ctxt, Object value, Class<?> suggestedType) {
+			return this.delegate.idFromValueAndType(ctxt, value, suggestedType);
+		}
+
+		@Override
+		public String idFromBaseType(DatabindContext ctxt) {
+			return this.delegate.idFromBaseType(ctxt);
+		}
+
+		@Override
+		public JavaType typeFromId(DatabindContext context, String id) {
+			DeserializationConfig config = (DeserializationConfig) context.getConfig();
+			JavaType result = this.delegate.typeFromId(context, id);
+			String className = result.getRawClass().getName();
+			if (isInAllowlist(className)) {
+				return result;
+			}
+			boolean isExplicitMixin = config.findMixInClassFor(result.getRawClass()) != null;
+			if (isExplicitMixin) {
+				return result;
+			}
+			JacksonAnnotation jacksonAnnotation = AnnotationUtils.findAnnotation(result.getRawClass(),
+					JacksonAnnotation.class);
+			if (jacksonAnnotation != null) {
+				return result;
+			}
+			throw new IllegalArgumentException("The class with " + id + " and name of " + className
+					+ " is not in the allowlist. "
+					+ "If you believe this class is safe to deserialize, please provide an explicit mapping using Jackson annotations or by providing a Mixin. "
+					+ "If the serialization is only done by a trusted source, you can also enable default typing. "
+					+ "See https://github.com/spring-projects/spring-security/issues/4370 for details");
+		}
+
+		private boolean isInAllowlist(String id) {
+			return ALLOWLIST_CLASS_NAMES.contains(id);
+		}
+
+		@Override
+		public String getDescForKnownTypeIds() {
+			return this.delegate.getDescForKnownTypeIds();
+		}
+
+		@Override
+		public JsonTypeInfo.Id getMechanism() {
+			return this.delegate.getMechanism();
+		}
+
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/jackson/AnonymousAuthenticationTokenMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson/AnonymousAuthenticationTokenMixin.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.util.Collection;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.core.GrantedAuthority;
+
+/**
+ * This is a Jackson mixin class helps in serialize/deserialize
+ * {@link org.springframework.security.authentication.AnonymousAuthenticationToken} class.
+ * To use this class you need to register it with
+ * {@link tools.jackson.databind.ObjectMapper} and {@link SimpleGrantedAuthorityMixin}
+ * because AnonymousAuthenticationToken contains SimpleGrantedAuthority.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new CoreJacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * <i>Note: This class will save full class name into a property called @class</i>
+ *
+ * @author Jitendra Singh
+ * @since 4.2
+ * @see CoreJacksonModule
+ * @see SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, isGetterVisibility = JsonAutoDetect.Visibility.NONE,
+		getterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+class AnonymousAuthenticationTokenMixin {
+
+	/**
+	 * Constructor used by Jackson to create object of
+	 * {@link org.springframework.security.authentication.AnonymousAuthenticationToken}.
+	 * @param keyHash hashCode of key provided at the time of token creation by using
+	 * {@link org.springframework.security.authentication.AnonymousAuthenticationToken#AnonymousAuthenticationToken(String, Object, Collection)}
+	 * @param principal the principal (typically a <code>UserDetails</code>)
+	 * @param authorities the authorities granted to the principal
+	 */
+	@JsonCreator
+	AnonymousAuthenticationTokenMixin(@JsonProperty("keyHash") Integer keyHash,
+			@JsonProperty("principal") Object principal,
+			@JsonProperty("authorities") Collection<? extends GrantedAuthority> authorities) {
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/jackson/BadCredentialsExceptionMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson/BadCredentialsExceptionMixin.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * This mixin class helps in serialize/deserialize
+ * {@link org.springframework.security.authentication.BadCredentialsException} class. To
+ * use this class you need to register it with
+ * {@link tools.jackson.databind.ObjectMapper}.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new CoreJacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * <i>Note: This class will save TypeInfo (full class name) into a property
+ * called @class</i> <i>The cause and stackTrace are ignored in the serialization.</i>
+ *
+ * @author Yannick Lombardi
+ * @since 5.0
+ * @see CoreJacksonModule
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
+@JsonIgnoreProperties(ignoreUnknown = true, value = { "cause", "stackTrace", "authenticationRequest" })
+class BadCredentialsExceptionMixin {
+
+	/**
+	 * Constructor used by Jackson to create
+	 * {@link org.springframework.security.authentication.BadCredentialsException} object.
+	 * @param message the detail message
+	 */
+	@JsonCreator
+	BadCredentialsExceptionMixin(@JsonProperty("message") String message) {
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/jackson/CoreJacksonModule.java
+++ b/core/src/main/java/org/springframework/security/jackson/CoreJacksonModule.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.util.Collections;
+
+import tools.jackson.core.Version;
+import tools.jackson.databind.cfg.MapperBuilder;
+import tools.jackson.databind.module.SimpleModule;
+
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.RememberMeAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+/**
+ * Jackson module for spring-security-core. This module register
+ * {@link AnonymousAuthenticationTokenMixin}, {@link RememberMeAuthenticationTokenMixin},
+ * {@link SimpleGrantedAuthorityMixin}, {@link UnmodifiableSetMixin}, {@link UserMixin}
+ * and {@link UsernamePasswordAuthenticationTokenMixin}. If no default typing enabled by
+ * default then it'll enable it because typing info is needed to properly
+ * serialize/deserialize objects. In order to use this module just add this module into
+ * your ObjectMapper configuration.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new CoreJacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * <b>Note: use {@link SecurityJacksonModules#getModules(ClassLoader)} to get list of all
+ * security modules.</b>
+ *
+ * @author Jitendra Singh
+ * @since 4.2
+ * @see SecurityJacksonModules
+ */
+@SuppressWarnings("serial")
+public class CoreJacksonModule extends SimpleModule {
+
+	public CoreJacksonModule() {
+		super(CoreJacksonModule.class.getName(), new Version(1, 0, 0, null, null, null));
+	}
+
+	@Override
+	public void setupModule(SetupContext context) {
+		((MapperBuilder<?, ?>) context.getOwner()).setDefaultTyping(new AllowlistTypeResolverBuilder());
+		context.setMixIn(AnonymousAuthenticationToken.class, AnonymousAuthenticationTokenMixin.class);
+		context.setMixIn(RememberMeAuthenticationToken.class, RememberMeAuthenticationTokenMixin.class);
+		context.setMixIn(SimpleGrantedAuthority.class, SimpleGrantedAuthorityMixin.class);
+		context.setMixIn(Collections.unmodifiableSet(Collections.emptySet()).getClass(), UnmodifiableSetMixin.class);
+		context.setMixIn(Collections.unmodifiableList(Collections.emptyList()).getClass(), UnmodifiableListMixin.class);
+		context.setMixIn(Collections.unmodifiableMap(Collections.emptyMap()).getClass(), UnmodifiableMapMixin.class);
+		context.setMixIn(User.class, UserMixin.class);
+		context.setMixIn(UsernamePasswordAuthenticationToken.class, UsernamePasswordAuthenticationTokenMixin.class);
+		context.setMixIn(BadCredentialsException.class, BadCredentialsExceptionMixin.class);
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/jackson/RememberMeAuthenticationTokenMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson/RememberMeAuthenticationTokenMixin.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.util.Collection;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.core.GrantedAuthority;
+
+/**
+ * This mixin class helps in serialize/deserialize
+ * {@link org.springframework.security.authentication.RememberMeAuthenticationToken}
+ * class. To use this class you need to register it with
+ * {@link tools.jackson.databind.ObjectMapper} and 2 more mixin classes.
+ *
+ * <ol>
+ * <li>{@link SimpleGrantedAuthorityMixin}</li>
+ * <li>{@link UserMixin}</li>
+ * <li>{@link UnmodifiableSetMixin}</li>
+ * </ol>
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new CoreJacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * <i>Note: This class will save TypeInfo (full class name) into a property
+ * called @class</i>
+ *
+ * @author Jitendra Singh
+ * @since 4.2
+ * @see CoreJacksonModule
+ * @see SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+class RememberMeAuthenticationTokenMixin {
+
+	/**
+	 * Constructor used by Jackson to create
+	 * {@link org.springframework.security.authentication.RememberMeAuthenticationToken}
+	 * object.
+	 * @param keyHash hashCode of above given key.
+	 * @param principal the principal (typically a <code>UserDetails</code>)
+	 * @param authorities the authorities granted to the principal
+	 */
+	@JsonCreator
+	RememberMeAuthenticationTokenMixin(@JsonProperty("keyHash") Integer keyHash,
+			@JsonProperty("principal") Object principal,
+			@JsonProperty("authorities") Collection<? extends GrantedAuthority> authorities) {
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/jackson/SecurityJacksonModules.java
+++ b/core/src/main/java/org/springframework/security/jackson/SecurityJacksonModules.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.JacksonModule;
+
+import org.springframework.core.log.LogMessage;
+import org.springframework.util.ClassUtils;
+
+/**
+ * This utility class will find all the SecurityModules in classpath.
+ *
+ * <p>
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new CoreJacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * Above code is equivalent to
+ * <p>
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.setDefaultTyping(new AllowlistTypeResolverBuilder())
+ * 				.addModules(
+ * 						new CoreJacksonModule(),
+ * 						new CasJacksonModule(),
+ * 						new WebJacksonModule(),
+ * 						new WebServletJacksonModule(),
+ * 						new WebServerJackson2Module(),
+ * 						new OAuth2ClientJacksonModule(),
+ * 						new Saml2JacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Jitendra Singh
+ * @since 7.0
+ */
+public final class SecurityJacksonModules {
+
+	private static final Log logger = LogFactory.getLog(SecurityJacksonModules.class);
+
+	private static final List<String> securityJacksonModuleClasses = Arrays.asList(
+			"org.springframework.security.jackson.CoreJacksonModule",
+			"org.springframework.security.web.jackson.WebJacksonModule",
+			"org.springframework.security.web.server.jackson.WebServerJacksonModule");
+
+	private static final String webServletJacksonModuleClass = "org.springframework.security.web.jackson.WebServletJacksonModule";
+
+	private static final String oauth2ClientJacksonModuleClass = "org.springframework.security.oauth2.client.jackson.OAuth2ClientJacksonModule";
+
+	private static final String ldapJacksonModuleClass = "org.springframework.security.ldap.jackson.LdapJacksonModule";
+
+	private static final String saml2JacksonModuleClass = "org.springframework.security.saml2.jackson.Saml2JacksonModule";
+
+	private static final String casJacksonModuleClass = "org.springframework.security.cas.jackson.CasJacksonModule";
+
+	private static final boolean webServletPresent;
+
+	private static final boolean oauth2ClientPresent;
+
+	private static final boolean ldapJacksonPresent;
+
+	private static final boolean saml2JacksonPresent;
+
+	private static final boolean casJacksonPresent;
+
+	static {
+		ClassLoader classLoader = SecurityJacksonModules.class.getClassLoader();
+		webServletPresent = ClassUtils.isPresent("jakarta.servlet.http.Cookie", classLoader);
+		oauth2ClientPresent = ClassUtils.isPresent("org.springframework.security.oauth2.client.OAuth2AuthorizedClient",
+				classLoader);
+		ldapJacksonPresent = ClassUtils.isPresent(ldapJacksonModuleClass, classLoader);
+		saml2JacksonPresent = ClassUtils.isPresent(saml2JacksonModuleClass, classLoader);
+		casJacksonPresent = ClassUtils.isPresent(casJacksonModuleClass, classLoader);
+	}
+
+	private SecurityJacksonModules() {
+	}
+
+	@SuppressWarnings("unchecked")
+	private static @Nullable JacksonModule loadAndGetInstance(String className, ClassLoader loader) {
+		try {
+			Class<? extends JacksonModule> securityModule = (Class<? extends JacksonModule>) ClassUtils
+				.forName(className, loader);
+			logger.debug(LogMessage.format("Loaded module %s, now registering", className));
+			return securityModule.getConstructor().newInstance();
+		}
+		catch (Exception ex) {
+			logger.debug(LogMessage.format("Cannot load module %s", className), ex);
+		}
+		return null;
+	}
+
+	/**
+	 * @param loader the ClassLoader to use
+	 * @return List of available security modules in classpath.
+	 */
+	public static List<JacksonModule> getModules(ClassLoader loader) {
+		List<JacksonModule> modules = new ArrayList<>();
+		for (String className : securityJacksonModuleClasses) {
+			addToModulesList(loader, modules, className);
+		}
+		if (webServletPresent) {
+			addToModulesList(loader, modules, webServletJacksonModuleClass);
+		}
+		if (oauth2ClientPresent) {
+			addToModulesList(loader, modules, oauth2ClientJacksonModuleClass);
+		}
+		if (ldapJacksonPresent) {
+			addToModulesList(loader, modules, ldapJacksonModuleClass);
+		}
+		if (saml2JacksonPresent) {
+			addToModulesList(loader, modules, saml2JacksonModuleClass);
+		}
+		if (casJacksonPresent) {
+			addToModulesList(loader, modules, casJacksonModuleClass);
+		}
+		return modules;
+	}
+
+	/**
+	 * @param loader the ClassLoader to use
+	 * @param modules list of the modules to add
+	 * @param className name of the class to instantiate
+	 */
+	private static void addToModulesList(ClassLoader loader, List<JacksonModule> modules, String className) {
+		JacksonModule module = loadAndGetInstance(className, loader);
+		if (module != null) {
+			modules.add(module);
+		}
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/jackson/SimpleGrantedAuthorityMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson/SimpleGrantedAuthorityMixin.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Jackson Mixin class helps in serialize/deserialize
+ * {@link org.springframework.security.core.authority.SimpleGrantedAuthority}.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new CoreJacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Jitendra Singh
+ * @since 7.0
+ * @see CoreJacksonModule
+ * @see SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE,
+		getterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY, isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class SimpleGrantedAuthorityMixin {
+
+	/**
+	 * Mixin Constructor.
+	 * @param role the role
+	 */
+	@JsonCreator
+	public SimpleGrantedAuthorityMixin(@JsonProperty("authority") String role) {
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/jackson/UnmodifiableListDeserializer.java
+++ b/core/src/main/java/org/springframework/security/jackson/UnmodifiableListDeserializer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Custom deserializer for {@link UnmodifiableListMixin}.
+ *
+ * @author Rob Winch
+ * @author Hyunmin Choi
+ * @since 5.0.2
+ * @see UnmodifiableListMixin
+ */
+class UnmodifiableListDeserializer extends AbstractUnmodifiableCollectionDeserializer<List> {
+
+	@Override
+	List createUnmodifiableCollection(Collection<Object> values) {
+		return Collections.unmodifiableList(new ArrayList<>(values));
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/jackson/UnmodifiableListMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson/UnmodifiableListMixin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import tools.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * This mixin class used to deserialize java.util.Collections$UnmodifiableRandomAccessList
+ * and used with various AuthenticationToken implementation's mixin classes.
+ *
+ * <pre>
+ *     JsonMapper mapper = new JsonMapper();
+ *     mapper.registerModule(new CoreJacksonModule());
+ * </pre>
+ *
+ * @author Rob Winch
+ * @since 5.0.2
+ * @see UnmodifiableListDeserializer
+ * @see CoreJacksonModule
+ * @see SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
+@JsonDeserialize(using = UnmodifiableListDeserializer.class)
+class UnmodifiableListMixin {
+
+	/**
+	 * Mixin Constructor
+	 * @param s the Set
+	 */
+	@JsonCreator
+	UnmodifiableListMixin(Set<?> s) {
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/jackson/UnmodifiableMapDeserializer.java
+++ b/core/src/main/java/org/springframework/security/jackson/UnmodifiableMapDeserializer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+
+/**
+ * Custom deserializer for {@link UnmodifiableMapMixin}.
+ *
+ * @author Ulrich Grave
+ * @since 5.7
+ * @see UnmodifiableMapMixin
+ */
+class UnmodifiableMapDeserializer extends ValueDeserializer<Map<?, ?>> {
+
+	@Override
+	public Map<?, ?> deserialize(JsonParser jp, DeserializationContext ctxt) throws JacksonException {
+		JsonNode node = ctxt.readTree(jp);
+
+		Map<String, Object> result = new LinkedHashMap<>();
+		if (node != null && node.isObject()) {
+			for (Map.Entry<String, JsonNode> field : node.properties()) {
+				result.put(field.getKey(), ctxt.readTreeAsValue(field.getValue(), Object.class));
+			}
+		}
+		return Collections.unmodifiableMap(result);
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/jackson/UnmodifiableMapMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson/UnmodifiableMapMixin.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import tools.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * This mixin class used to deserialize java.util.Collections$UnmodifiableMap and used
+ * with various AuthenticationToken implementation's mixin classes.
+ *
+ * <pre>
+ *     JsonMapper mapper = new JsonMapper();
+ *     mapper.registerModule(new CoreJacksonModule());
+ * </pre>
+ *
+ * @author Ulrich Grave
+ * @since 5.7
+ * @see UnmodifiableMapDeserializer
+ * @see CoreJacksonModule
+ * @see SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonDeserialize(using = UnmodifiableMapDeserializer.class)
+class UnmodifiableMapMixin {
+
+	@JsonCreator
+	UnmodifiableMapMixin(Map<?, ?> map) {
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/jackson/UnmodifiableSetDeserializer.java
+++ b/core/src/main/java/org/springframework/security/jackson/UnmodifiableSetDeserializer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Custom deserializer for {@link UnmodifiableSetMixin}.
+ *
+ * @author Jitendra Singh
+ * @author Hyunmin Choi
+ * @since 4.2
+ * @see UnmodifiableSetMixin
+ */
+class UnmodifiableSetDeserializer extends AbstractUnmodifiableCollectionDeserializer<Set<?>> {
+
+	@Override
+	Set<?> createUnmodifiableCollection(Collection<Object> values) {
+		return Collections.unmodifiableSet(new HashSet<>(values));
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/jackson/UnmodifiableSetMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson/UnmodifiableSetMixin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import tools.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * This mixin class used to deserialize java.util.Collections$UnmodifiableSet and used
+ * with various AuthenticationToken implementation's mixin classes.
+ *
+ * <pre>
+ *     JsonMapper mapper = new JsonMapper();
+ *     mapper.registerModule(new CoreJacksonModule());
+ * </pre>
+ *
+ * @author Jitendra Singh
+ * @since 4.2
+ * @see UnmodifiableSetDeserializer
+ * @see CoreJacksonModule
+ * @see SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
+@JsonDeserialize(using = UnmodifiableSetDeserializer.class)
+class UnmodifiableSetMixin {
+
+	/**
+	 * Mixin Constructor
+	 * @param s the Set
+	 */
+	@JsonCreator
+	UnmodifiableSetMixin(Set<?> s) {
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/jackson/UserDeserializer.java
+++ b/core/src/main/java/org/springframework/security/jackson/UserDeserializer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.util.Set;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.node.MissingNode;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+/**
+ * Custom Deserializer for {@link User} class. This is already registered with
+ * {@link UserMixin}. You can also use it directly with your mixin class.
+ *
+ * @author Jitendra Singh
+ * @since 4.2
+ * @see UserMixin
+ */
+class UserDeserializer extends ValueDeserializer<User> {
+
+	private static final TypeReference<Set<SimpleGrantedAuthority>> SIMPLE_GRANTED_AUTHORITY_SET = new TypeReference<>() {
+	};
+
+	/**
+	 * This method will create {@link User} object. It will ensure successful object
+	 * creation even if password key is null in serialized json, because credentials may
+	 * be removed from the {@link User} by invoking {@link User#eraseCredentials()}. In
+	 * that case there won't be any password key in serialized json.
+	 * @param jp the JsonParser
+	 * @param ctxt the DeserializationContext
+	 * @return the user
+	 * @throws JacksonException if an error during JSON processing occurs
+	 */
+	@Override
+	public User deserialize(JsonParser jp, DeserializationContext ctxt) throws JacksonException {
+		JsonNode jsonNode = ctxt.readTree(jp);
+		Set<? extends GrantedAuthority> authorities = ctxt.readTreeAsValue(jsonNode.get("authorities"),
+				ctxt.getTypeFactory().constructType(SIMPLE_GRANTED_AUTHORITY_SET));
+		JsonNode passwordNode = readJsonNode(jsonNode, "password");
+		String username = readJsonNode(jsonNode, "username").asString();
+		String password = (passwordNode.isNull() || passwordNode.isMissingNode()) ? null : passwordNode.stringValue();
+		boolean enabled = readJsonNode(jsonNode, "enabled").asBoolean();
+		boolean accountNonExpired = readJsonNode(jsonNode, "accountNonExpired").asBoolean();
+		boolean credentialsNonExpired = readJsonNode(jsonNode, "credentialsNonExpired").asBoolean();
+		boolean accountNonLocked = readJsonNode(jsonNode, "accountNonLocked").asBoolean();
+		User result = new User(username, password, enabled, accountNonExpired, credentialsNonExpired, accountNonLocked,
+				authorities);
+		if (passwordNode.asString(null) == null) {
+			result.eraseCredentials();
+		}
+		return result;
+	}
+
+	private JsonNode readJsonNode(JsonNode jsonNode, String field) {
+		return jsonNode.has(field) ? jsonNode.get(field) : MissingNode.getInstance();
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/jackson/UserMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson/UserMixin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import tools.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * This mixin class helps in serialize/deserialize
+ * {@link org.springframework.security.core.userdetails.User}. This class also register a
+ * custom deserializer {@link UserDeserializer} to deserialize User object successfully.
+ * In order to use this mixin you need to register two more mixin classes in your
+ * ObjectMapper configuration.
+ * <ol>
+ * <li>{@link SimpleGrantedAuthorityMixin}</li>
+ * <li>{@link UnmodifiableSetMixin}</li>
+ * </ol>
+ * <pre>
+ *     JsonMapper mapper = new JsonMapper();
+ *     mapper.registerModule(new CoreJacksonModule());
+ * </pre>
+ *
+ * @author Jitendra Singh
+ * @since 4.2
+ * @see UserDeserializer
+ * @see CoreJacksonModule
+ * @see SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
+@JsonDeserialize(using = UserDeserializer.class)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class UserMixin {
+
+}

--- a/core/src/main/java/org/springframework/security/jackson/UsernamePasswordAuthenticationTokenDeserializer.java
+++ b/core/src/main/java/org/springframework/security/jackson/UsernamePasswordAuthenticationTokenDeserializer.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.exc.StreamReadException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.node.MissingNode;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+/**
+ * Custom deserializer for {@link UsernamePasswordAuthenticationToken}. At the time of
+ * deserialization it will invoke suitable constructor depending on the value of
+ * <b>authenticated</b> property. It will ensure that the token's state must not change.
+ * <p>
+ * This deserializer is already registered with
+ * {@link UsernamePasswordAuthenticationTokenMixin} but you can also registered it with
+ * your own mixin class.
+ *
+ * @author Jitendra Singh
+ * @author Greg Turnquist
+ * @author Onur Kagan Ozcan
+ * @since 4.2
+ * @see UsernamePasswordAuthenticationTokenMixin
+ */
+class UsernamePasswordAuthenticationTokenDeserializer extends ValueDeserializer<UsernamePasswordAuthenticationToken> {
+
+	private static final TypeReference<List<GrantedAuthority>> GRANTED_AUTHORITY_LIST = new TypeReference<>() {
+	};
+
+	/**
+	 * This method construct {@link UsernamePasswordAuthenticationToken} object from
+	 * serialized json.
+	 * @param jp the JsonParser
+	 * @param ctxt the DeserializationContext
+	 * @return the user
+	 * @throws JacksonException if an error during JSON processing occurs
+	 */
+	@Override
+	public UsernamePasswordAuthenticationToken deserialize(JsonParser jp, DeserializationContext ctxt)
+			throws JacksonException {
+		JsonNode jsonNode = ctxt.readTree(jp);
+		boolean authenticated = readJsonNode(jsonNode, "authenticated").asBoolean();
+		JsonNode principalNode = readJsonNode(jsonNode, "principal");
+		Object principal = getPrincipal(ctxt, principalNode);
+		JsonNode credentialsNode = readJsonNode(jsonNode, "credentials");
+		Object credentials = getCredentials(credentialsNode);
+		List<GrantedAuthority> authorities = ctxt.readTreeAsValue(readJsonNode(jsonNode, "authorities"),
+				ctxt.getTypeFactory().constructType(GRANTED_AUTHORITY_LIST));
+		UsernamePasswordAuthenticationToken token = (!authenticated)
+				? UsernamePasswordAuthenticationToken.unauthenticated(principal, credentials)
+				: UsernamePasswordAuthenticationToken.authenticated(principal, credentials, authorities);
+		JsonNode detailsNode = readJsonNode(jsonNode, "details");
+		if (detailsNode.isNull() || detailsNode.isMissingNode()) {
+			token.setDetails(null);
+		}
+		else {
+			Object details = ctxt.readTreeAsValue(detailsNode, Object.class);
+			token.setDetails(details);
+		}
+		return token;
+	}
+
+	private @Nullable Object getCredentials(JsonNode credentialsNode) {
+		if (credentialsNode.isNull() || credentialsNode.isMissingNode()) {
+			return null;
+		}
+		return credentialsNode.asString();
+	}
+
+	private Object getPrincipal(DeserializationContext ctxt, JsonNode principalNode)
+			throws StreamReadException, DatabindException {
+		if (principalNode.isObject()) {
+			return ctxt.readTreeAsValue(principalNode, Object.class);
+		}
+		return principalNode.asString();
+	}
+
+	private JsonNode readJsonNode(JsonNode jsonNode, String field) {
+		return jsonNode.has(field) ? jsonNode.get(field) : MissingNode.getInstance();
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/jackson/UsernamePasswordAuthenticationTokenMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson/UsernamePasswordAuthenticationTokenMixin.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import tools.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * This mixin class is used to serialize / deserialize
+ * {@link org.springframework.security.authentication.UsernamePasswordAuthenticationToken}.
+ * This class register a custom deserializer
+ * {@link UsernamePasswordAuthenticationTokenDeserializer}.
+ *
+ * In order to use this mixin you'll need to add 3 more mixin classes.
+ * <ol>
+ * <li>{@link UnmodifiableSetMixin}</li>
+ * <li>{@link SimpleGrantedAuthorityMixin}</li>
+ * <li>{@link UserMixin}</li>
+ * </ol>
+ *
+ * <pre>
+ *     JsonMapper mapper = new JsonMapper();
+ *     mapper.registerModule(new CoreJacksonModule());
+ * </pre>
+ *
+ * @author Jitendra Singh
+ * @author Sebastien Deleuze
+ * @since 4.2
+ * @see CoreJacksonModule
+ * @see SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonDeserialize(using = UsernamePasswordAuthenticationTokenDeserializer.class)
+abstract class UsernamePasswordAuthenticationTokenMixin {
+
+}

--- a/core/src/main/java/org/springframework/security/jackson/package-info.java
+++ b/core/src/main/java/org/springframework/security/jackson/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Jackson 3+ serialization support.
+ */
+@NullMarked
+package org.springframework.security.jackson;
+
+import org.jspecify.annotations.NullMarked;

--- a/core/src/main/java/org/springframework/security/jackson2/AbstractUnmodifiableCollectionDeserializer.java
+++ b/core/src/main/java/org/springframework/security/jackson2/AbstractUnmodifiableCollectionDeserializer.java
@@ -38,7 +38,11 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
  * @param <T> the type of the unmodifiable collection, such as {@link List} or
  * {@link Set}.
  * @author Hyunmin Choi
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.jackson.AbstractUnmodifiableCollectionDeserializer}
+ * based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 abstract class AbstractUnmodifiableCollectionDeserializer<T> extends JsonDeserializer<T> {
 
 	@Override

--- a/core/src/main/java/org/springframework/security/jackson2/AnonymousAuthenticationTokenMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson2/AnonymousAuthenticationTokenMixin.java
@@ -43,11 +43,15 @@ import org.springframework.security.core.GrantedAuthority;
  * @since 4.2
  * @see CoreJackson2Module
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.jackson.AnonymousAuthenticationTokenMixin} based on
+ * Jackson 3
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, isGetterVisibility = JsonAutoDetect.Visibility.NONE,
 		getterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Deprecated(forRemoval = true)
 class AnonymousAuthenticationTokenMixin {
 
 	/**

--- a/core/src/main/java/org/springframework/security/jackson2/BadCredentialsExceptionMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson2/BadCredentialsExceptionMixin.java
@@ -38,9 +38,13 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  * @author Yannick Lombardi
  * @since 5.0
  * @see CoreJackson2Module
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.jackson.BadCredentialsExceptionMixin} based on
+ * Jackson 3
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
 @JsonIgnoreProperties(ignoreUnknown = true, value = { "cause", "stackTrace", "authenticationRequest" })
+@Deprecated(forRemoval = true)
 class BadCredentialsExceptionMixin {
 
 	/**

--- a/core/src/main/java/org/springframework/security/jackson2/CoreJackson2Module.java
+++ b/core/src/main/java/org/springframework/security/jackson2/CoreJackson2Module.java
@@ -43,11 +43,14 @@ import org.springframework.security.core.userdetails.User;
  * </pre> <b>Note: use {@link SecurityJackson2Modules#getModules(ClassLoader)} to get list
  * of all security modules.</b>
  *
- * @author Jitendra Singh.
+ * @author Jitendra Singh
  * @since 4.2
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@link org.springframework.security.jackson.CoreJacksonModule} based on Jackson 3
  */
-@SuppressWarnings("serial")
+@SuppressWarnings({ "serial", "removal" })
+@Deprecated(forRemoval = true)
 public class CoreJackson2Module extends SimpleModule {
 
 	public CoreJackson2Module() {

--- a/core/src/main/java/org/springframework/security/jackson2/RememberMeAuthenticationTokenMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson2/RememberMeAuthenticationTokenMixin.java
@@ -50,11 +50,15 @@ import org.springframework.security.core.GrantedAuthority;
  * @since 4.2
  * @see CoreJackson2Module
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.jackson.RememberMeAuthenticationTokenMixin} based
+ * on Jackson 3
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Deprecated(forRemoval = true)
 class RememberMeAuthenticationTokenMixin {
 
 	/**

--- a/core/src/main/java/org/springframework/security/jackson2/SecurityJackson2Modules.java
+++ b/core/src/main/java/org/springframework/security/jackson2/SecurityJackson2Modules.java
@@ -67,9 +67,12 @@ import org.springframework.util.ClassUtils;
  *     mapper.registerModule(new Saml2Jackson2Module());
  * </pre>
  *
- * @author Jitendra Singh.
+ * @author Jitendra Singh
  * @since 4.2
+ * @deprecated as of 7.0 in favor of
+ * {@link org.springframework.security.jackson.SecurityJacksonModules} based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 public final class SecurityJackson2Modules {
 
 	private static final Log logger = LogFactory.getLog(SecurityJackson2Modules.class);

--- a/core/src/main/java/org/springframework/security/jackson2/SimpleGrantedAuthorityMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson2/SimpleGrantedAuthorityMixin.java
@@ -35,11 +35,15 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  * @since 4.2
  * @see CoreJackson2Module
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.jackson.SimpleGrantedAuthorityMixin} based on
+ * Jackson 3
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE,
 		getterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY, isGetterVisibility = JsonAutoDetect.Visibility.NONE)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Deprecated(forRemoval = true)
 public abstract class SimpleGrantedAuthorityMixin {
 
 	/**

--- a/core/src/main/java/org/springframework/security/jackson2/UnmodifiableListDeserializer.java
+++ b/core/src/main/java/org/springframework/security/jackson2/UnmodifiableListDeserializer.java
@@ -28,7 +28,12 @@ import java.util.List;
  * @author Hyunmin Choi
  * @since 5.0.2
  * @see UnmodifiableListMixin
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.jackson.AbstractUnmodifiableCollectionDeserializer}
+ * based on Jackson 3
  */
+@SuppressWarnings("removal")
+@Deprecated(forRemoval = true)
 class UnmodifiableListDeserializer extends AbstractUnmodifiableCollectionDeserializer<List> {
 
 	@Override

--- a/core/src/main/java/org/springframework/security/jackson2/UnmodifiableListMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson2/UnmodifiableListMixin.java
@@ -36,9 +36,13 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * @see UnmodifiableListDeserializer
  * @see CoreJackson2Module
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.jackson.UnmodifiableListMixin} based on Jackson 3
  */
+@SuppressWarnings("removal")
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
 @JsonDeserialize(using = UnmodifiableListDeserializer.class)
+@Deprecated(forRemoval = true)
 class UnmodifiableListMixin {
 
 	/**

--- a/core/src/main/java/org/springframework/security/jackson2/UnmodifiableMapDeserializer.java
+++ b/core/src/main/java/org/springframework/security/jackson2/UnmodifiableMapDeserializer.java
@@ -33,7 +33,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Ulrich Grave
  * @since 5.7
  * @see UnmodifiableMapMixin
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.jackson.UnmodifiableMapDeserializer} based on
+ * Jackson 3
  */
+@Deprecated(forRemoval = true)
 class UnmodifiableMapDeserializer extends JsonDeserializer<Map<?, ?>> {
 
 	@Override

--- a/core/src/main/java/org/springframework/security/jackson2/UnmodifiableMapMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson2/UnmodifiableMapMixin.java
@@ -36,9 +36,13 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * @see UnmodifiableMapDeserializer
  * @see CoreJackson2Module
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.jackson.UnmodifiableMapMixin} based on Jackson 3
  */
+@SuppressWarnings("removal")
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonDeserialize(using = UnmodifiableMapDeserializer.class)
+@Deprecated(forRemoval = true)
 class UnmodifiableMapMixin {
 
 	@JsonCreator

--- a/core/src/main/java/org/springframework/security/jackson2/UnmodifiableSetDeserializer.java
+++ b/core/src/main/java/org/springframework/security/jackson2/UnmodifiableSetDeserializer.java
@@ -28,7 +28,12 @@ import java.util.Set;
  * @author Hyunmin Choi
  * @since 4.2
  * @see UnmodifiableSetMixin
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.jackson.UnmodifiableSetDeserializer} based on
+ * Jackson 3
  */
+@SuppressWarnings("removal")
+@Deprecated(forRemoval = true)
 class UnmodifiableSetDeserializer extends AbstractUnmodifiableCollectionDeserializer<Set> {
 
 	@Override

--- a/core/src/main/java/org/springframework/security/jackson2/UnmodifiableSetMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson2/UnmodifiableSetMixin.java
@@ -36,9 +36,13 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * @see UnmodifiableSetDeserializer
  * @see CoreJackson2Module
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.jackson.UnmodifiableSetMixin} based on Jackson 3
  */
+@SuppressWarnings("removal")
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
 @JsonDeserialize(using = UnmodifiableSetDeserializer.class)
+@Deprecated(forRemoval = true)
 class UnmodifiableSetMixin {
 
 	/**

--- a/core/src/main/java/org/springframework/security/jackson2/UserDeserializer.java
+++ b/core/src/main/java/org/springframework/security/jackson2/UserDeserializer.java
@@ -39,7 +39,10 @@ import org.springframework.security.core.userdetails.User;
  * @author Jitendra Singh
  * @since 4.2
  * @see UserMixin
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.jackson.UserDeserializer} based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 class UserDeserializer extends JsonDeserializer<User> {
 
 	private static final TypeReference<Set<SimpleGrantedAuthority>> SIMPLE_GRANTED_AUTHORITY_SET = new TypeReference<>() {

--- a/core/src/main/java/org/springframework/security/jackson2/UserMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson2/UserMixin.java
@@ -41,12 +41,16 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * @see UserDeserializer
  * @see CoreJackson2Module
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.jackson.UserMixin} based on Jackson 3
  */
+@SuppressWarnings("removal")
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
 @JsonDeserialize(using = UserDeserializer.class)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Deprecated(forRemoval = true)
 abstract class UserMixin {
 
 }

--- a/core/src/main/java/org/springframework/security/jackson2/UsernamePasswordAuthenticationTokenDeserializer.java
+++ b/core/src/main/java/org/springframework/security/jackson2/UsernamePasswordAuthenticationTokenDeserializer.java
@@ -48,7 +48,11 @@ import org.springframework.security.core.GrantedAuthority;
  * @author Onur Kagan Ozcan
  * @since 4.2
  * @see UsernamePasswordAuthenticationTokenMixin
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.jackson.UsernamePasswordAuthenticationTokenDeserializer}
+ * based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 class UsernamePasswordAuthenticationTokenDeserializer extends JsonDeserializer<UsernamePasswordAuthenticationToken> {
 
 	private static final TypeReference<List<GrantedAuthority>> GRANTED_AUTHORITY_LIST = new TypeReference<>() {

--- a/core/src/main/java/org/springframework/security/jackson2/UsernamePasswordAuthenticationTokenMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson2/UsernamePasswordAuthenticationTokenMixin.java
@@ -42,11 +42,16 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * @since 4.2
  * @see CoreJackson2Module
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.jackson.UsernamePasswordAuthenticationTokenDeserializer}
+ * based on Jackson 3
  */
+@SuppressWarnings("removal")
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
 @JsonDeserialize(using = UsernamePasswordAuthenticationTokenDeserializer.class)
+@Deprecated(forRemoval = true)
 abstract class UsernamePasswordAuthenticationTokenMixin {
 
 }

--- a/core/src/main/java/org/springframework/security/jackson2/package-info.java
+++ b/core/src/main/java/org/springframework/security/jackson2/package-info.java
@@ -15,10 +15,7 @@
  */
 
 /**
- * Mix-in classes to add Jackson serialization support.
- *
- * @author Jitendra Singh
- * @since 4.2
+ * Jackson 2 serialization support.
  */
 @NullMarked
 package org.springframework.security.jackson2;

--- a/core/src/test/java/org/springframework/security/jackson/AbstractMixinTests.java
+++ b/core/src/test/java/org/springframework/security/jackson/AbstractMixinTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import org.junit.jupiter.api.BeforeEach;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.User;
+
+/**
+ * @author Jitenra Singh
+ * @since 4.2
+ */
+public abstract class AbstractMixinTests {
+
+	protected JsonMapper mapper;
+
+	@BeforeEach
+	public void setup() {
+		ClassLoader loader = getClass().getClassLoader();
+		this.mapper = JsonMapper.builder().addModules(SecurityJacksonModules.getModules(loader)).build();
+
+	}
+
+	User createDefaultUser() {
+		return createUser("admin", "1234", "ROLE_USER");
+	}
+
+	User createUser(String username, String password, String authority) {
+		return new User(username, password, AuthorityUtils.createAuthorityList(authority));
+	}
+
+}

--- a/core/src/test/java/org/springframework/security/jackson/AnonymousAuthenticationTokenMixinTests.java
+++ b/core/src/test/java/org/springframework/security/jackson/AnonymousAuthenticationTokenMixinTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.databind.exc.ValueInstantiationException;
+
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * @author Jitendra Singh
+ * @since 4.2
+ */
+public class AnonymousAuthenticationTokenMixinTests extends AbstractMixinTests {
+
+	private static final String HASH_KEY = "key";
+
+	// @formatter:off
+	private static final String ANONYMOUS_JSON = "{"
+		+ "\"@class\": \"org.springframework.security.authentication.AnonymousAuthenticationToken\", "
+		+ "\"details\": null,"
+		+ "\"principal\": " + UserDeserializerTests.USER_JSON + ","
+		+ "\"authenticated\": true, "
+		+ "\"keyHash\": " + HASH_KEY.hashCode() + ","
+		+ "\"authorities\": " + SimpleGrantedAuthorityMixinTests.AUTHORITIES_ARRAYLIST_JSON
+	+ "}";
+	// @formatter:on
+	@Test
+	public void serializeAnonymousAuthenticationTokenTest() throws JSONException {
+		User user = createDefaultUser();
+		AnonymousAuthenticationToken token = new AnonymousAuthenticationToken(HASH_KEY, user, user.getAuthorities());
+		String actualJson = this.mapper.writeValueAsString(token);
+		JSONAssert.assertEquals(ANONYMOUS_JSON, actualJson, true);
+	}
+
+	@Test
+	public void deserializeAnonymousAuthenticationTokenTest() {
+		AnonymousAuthenticationToken token = this.mapper.readValue(ANONYMOUS_JSON, AnonymousAuthenticationToken.class);
+		assertThat(token).isNotNull();
+		assertThat(token.getKeyHash()).isEqualTo(HASH_KEY.hashCode());
+		assertThat(token.getAuthorities()).isNotNull().hasSize(1).contains(new SimpleGrantedAuthority("ROLE_USER"));
+	}
+
+	@Test
+	public void deserializeAnonymousAuthenticationTokenWithoutAuthoritiesTest() {
+		String jsonString = "{\"@class\": \"org.springframework.security.authentication.AnonymousAuthenticationToken\", \"details\": null,"
+				+ "\"principal\": \"user\", \"authenticated\": true, \"keyHash\": " + HASH_KEY.hashCode() + ","
+				+ "\"authorities\": [\"java.util.ArrayList\", []]}";
+		assertThatExceptionOfType(ValueInstantiationException.class)
+			.isThrownBy(() -> this.mapper.readValue(jsonString, AnonymousAuthenticationToken.class));
+	}
+
+	@Test
+	public void serializeAnonymousAuthenticationTokenMixinAfterEraseCredentialTest() throws JSONException {
+		User user = createDefaultUser();
+		AnonymousAuthenticationToken token = new AnonymousAuthenticationToken(HASH_KEY, user, user.getAuthorities());
+		token.eraseCredentials();
+		String actualJson = this.mapper.writeValueAsString(token);
+		JSONAssert.assertEquals(ANONYMOUS_JSON.replace(UserDeserializerTests.USER_PASSWORD, "null"), actualJson, true);
+	}
+
+}

--- a/core/src/test/java/org/springframework/security/jackson/BadCredentialsExceptionMixinTests.java
+++ b/core/src/test/java/org/springframework/security/jackson/BadCredentialsExceptionMixinTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import org.springframework.security.authentication.BadCredentialsException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Yannick Lombardi
+ * @since 5.0
+ */
+public class BadCredentialsExceptionMixinTests extends AbstractMixinTests {
+
+	// @formatter:off
+	private static final String EXCEPTION_JSON = "{"
+		+ "\"@class\": \"org.springframework.security.authentication.BadCredentialsException\","
+		+ "\"localizedMessage\": \"message\", "
+		+ "\"message\": \"message\", "
+		+ "\"suppressed\": [\"[Ljava.lang.Throwable;\",[]]"
+		+ "}";
+	// @formatter:on
+	@Test
+	public void serializeBadCredentialsExceptionMixinTest() throws JsonProcessingException, JSONException {
+		BadCredentialsException exception = new BadCredentialsException("message");
+		String serializedJson = this.mapper.writeValueAsString(exception);
+		JSONAssert.assertEquals(EXCEPTION_JSON, serializedJson, true);
+	}
+
+	@Test
+	public void deserializeBadCredentialsExceptionMixinTest() throws IOException {
+		BadCredentialsException exception = this.mapper.readValue(EXCEPTION_JSON, BadCredentialsException.class);
+		assertThat(exception).isNotNull();
+		assertThat(exception.getCause()).isNull();
+		assertThat(exception.getMessage()).isEqualTo("message");
+		assertThat(exception.getLocalizedMessage()).isEqualTo("message");
+	}
+
+}

--- a/core/src/test/java/org/springframework/security/jackson/RememberMeAuthenticationTokenMixinTests.java
+++ b/core/src/test/java/org/springframework/security/jackson/RememberMeAuthenticationTokenMixinTests.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import org.springframework.security.authentication.RememberMeAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * @author Jitendra Singh
+ * @since 4.2
+ */
+public class RememberMeAuthenticationTokenMixinTests extends AbstractMixinTests {
+
+	private static final String REMEMBERME_KEY = "rememberMe";
+
+	// @formatter:off
+	private static final String REMEMBERME_AUTH_JSON = "{"
+		+ "\"@class\": \"org.springframework.security.authentication.RememberMeAuthenticationToken\", "
+		+ "\"keyHash\": " + REMEMBERME_KEY.hashCode() + ", "
+		+ "\"authenticated\": true, \"details\": null" + ", "
+		+ "\"principal\": " + UserDeserializerTests.USER_JSON + ", "
+		+ "\"authorities\": " + SimpleGrantedAuthorityMixinTests.AUTHORITIES_ARRAYLIST_JSON
+	+ "}";
+	// @formatter:on
+
+	// @formatter:off
+	private static final String REMEMBERME_AUTH_STRINGPRINCIPAL_JSON = "{"
+		+ "\"@class\": \"org.springframework.security.authentication.RememberMeAuthenticationToken\","
+		+ "\"keyHash\": " + REMEMBERME_KEY.hashCode() + ", "
+		+ "\"authenticated\": true, "
+		+ "\"details\": null,"
+		+ "\"principal\": \"admin\", "
+		+ "\"authorities\": " + SimpleGrantedAuthorityMixinTests.AUTHORITIES_ARRAYLIST_JSON
+	+ "}";
+	// @formatter:on
+
+	@Test
+	public void testWithNullPrincipal() {
+		assertThatIllegalArgumentException().isThrownBy(
+				() -> new RememberMeAuthenticationToken("key", null, Collections.<GrantedAuthority>emptyList()));
+	}
+
+	@Test
+	public void testWithNullKey() {
+		assertThatIllegalArgumentException().isThrownBy(
+				() -> new RememberMeAuthenticationToken(null, "principal", Collections.<GrantedAuthority>emptyList()));
+	}
+
+	@Test
+	public void serializeRememberMeAuthenticationToken() throws JsonProcessingException, JSONException {
+		RememberMeAuthenticationToken token = new RememberMeAuthenticationToken(REMEMBERME_KEY, "admin",
+				Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")));
+		String actualJson = this.mapper.writeValueAsString(token);
+		JSONAssert.assertEquals(REMEMBERME_AUTH_STRINGPRINCIPAL_JSON, actualJson, true);
+	}
+
+	@Test
+	public void serializeRememberMeAuthenticationWithUserToken() throws JsonProcessingException, JSONException {
+		User user = createDefaultUser();
+		RememberMeAuthenticationToken token = new RememberMeAuthenticationToken(REMEMBERME_KEY, user,
+				user.getAuthorities());
+		String actualJson = this.mapper.writeValueAsString(token);
+		JSONAssert.assertEquals(String.format(REMEMBERME_AUTH_JSON, "\"password\""), actualJson, true);
+	}
+
+	@Test
+	public void serializeRememberMeAuthenticationWithUserTokenAfterEraseCredential()
+			throws JsonProcessingException, JSONException {
+		User user = createDefaultUser();
+		RememberMeAuthenticationToken token = new RememberMeAuthenticationToken(REMEMBERME_KEY, user,
+				user.getAuthorities());
+		token.eraseCredentials();
+		String actualJson = this.mapper.writeValueAsString(token);
+		JSONAssert.assertEquals(REMEMBERME_AUTH_JSON.replace(UserDeserializerTests.USER_PASSWORD, "null"), actualJson,
+				true);
+	}
+
+	@Test
+	public void deserializeRememberMeAuthenticationToken() throws IOException {
+		RememberMeAuthenticationToken token = this.mapper.readValue(REMEMBERME_AUTH_STRINGPRINCIPAL_JSON,
+				RememberMeAuthenticationToken.class);
+		assertThat(token).isNotNull();
+		assertThat(token.getPrincipal()).isNotNull().isEqualTo("admin").isEqualTo(token.getName());
+		assertThat(token.getAuthorities()).hasSize(1).contains(new SimpleGrantedAuthority("ROLE_USER"));
+	}
+
+	@Test
+	public void deserializeRememberMeAuthenticationTokenWithUserTest() throws IOException {
+		RememberMeAuthenticationToken token = this.mapper.readValue(String.format(REMEMBERME_AUTH_JSON, "\"password\""),
+				RememberMeAuthenticationToken.class);
+		assertThat(token).isNotNull();
+		assertThat(token.getPrincipal()).isNotNull().isInstanceOf(User.class);
+		assertThat(((User) token.getPrincipal()).getUsername()).isEqualTo("admin");
+		assertThat(((User) token.getPrincipal()).getPassword()).isEqualTo("1234");
+		assertThat(((User) token.getPrincipal()).getAuthorities()).hasSize(1)
+			.contains(new SimpleGrantedAuthority("ROLE_USER"));
+		assertThat(token.getAuthorities()).hasSize(1).contains(new SimpleGrantedAuthority("ROLE_USER"));
+		assertThat(((User) token.getPrincipal()).isEnabled()).isEqualTo(true);
+	}
+
+}

--- a/core/src/test/java/org/springframework/security/jackson/SecurityContextMixinTests.java
+++ b/core/src/test/java/org/springframework/security/jackson/SecurityContextMixinTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextImpl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Jitendra Singh
+ * @since 4.2
+ */
+public class SecurityContextMixinTests extends AbstractMixinTests {
+
+	// @formatter:off
+	public static final String SECURITY_CONTEXT_JSON = "{"
+		+ "\"@class\": \"org.springframework.security.core.context.SecurityContextImpl\", "
+		+ "\"authentication\": " + UsernamePasswordAuthenticationTokenMixinTests.AUTHENTICATED_STRINGPRINCIPAL_JSON
+	+ "}";
+	// @formatter:on
+	@Test
+	public void securityContextSerializeTest() throws JsonProcessingException, JSONException {
+		SecurityContext context = new SecurityContextImpl();
+		context.setAuthentication(UsernamePasswordAuthenticationToken.authenticated("admin", "1234",
+				Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"))));
+		String actualJson = this.mapper.writeValueAsString(context);
+		JSONAssert.assertEquals(SECURITY_CONTEXT_JSON, actualJson, true);
+	}
+
+	@Test
+	public void securityContextDeserializeTest() throws IOException {
+		SecurityContext context = this.mapper.readValue(SECURITY_CONTEXT_JSON, SecurityContextImpl.class);
+		assertThat(context).isNotNull();
+		assertThat(context.getAuthentication()).isNotNull().isInstanceOf(UsernamePasswordAuthenticationToken.class);
+		assertThat(context.getAuthentication().getPrincipal()).isEqualTo("admin");
+		assertThat(context.getAuthentication().getCredentials()).isEqualTo("1234");
+		assertThat(context.getAuthentication().isAuthenticated()).isTrue();
+		Collection authorities = context.getAuthentication().getAuthorities();
+		assertThat(authorities).hasSize(1);
+		assertThat(authorities).contains(new SimpleGrantedAuthority("ROLE_USER"));
+	}
+
+}

--- a/core/src/test/java/org/springframework/security/jackson/SecurityJacksonModulesTests.java
+++ b/core/src/test/java/org/springframework/security/jackson/SecurityJacksonModulesTests.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.HashMap;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * @author Rob Winch
+ * @since 5.0
+ */
+public class SecurityJacksonModulesTests {
+
+	private JsonMapper mapper;
+
+	@BeforeEach
+	public void setup() {
+		this.mapper = JsonMapper.builder().setDefaultTyping(new AllowlistTypeResolverBuilder()).build();
+	}
+
+	@Test
+	public void readValueWhenNotAllowedOrMappedThenThrowsException() {
+		String content = "{\"@class\":\"org.springframework.security.jackson.SecurityJacksonModulesTests$NotAllowlisted\",\"property\":\"bar\"}";
+		// @formatter:off
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> this.mapper.readValue(content, Object.class))
+				.withStackTraceContaining("allowlist");
+		// @formatter:on
+	}
+
+	@Test
+	@Disabled("Jackson 3 immutable ObjectMapper/JsonMapper does not allow this use case anymore")
+	public void readValueWhenExplicitDefaultTypingAfterSecuritySetupThenReadsAsSpecificType() throws Exception {
+		// this.mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL,
+		// JsonTypeInfo.As.PROPERTY);
+		String content = "{\"@class\":\"org.springframework.security.jackson.SecurityJacksonModulesTests$NotAllowlisted\",\"property\":\"bar\"}";
+		assertThat(this.mapper.readValue(content, Object.class))
+			.isInstanceOf(SecurityJacksonModulesTests.NotAllowlisted.class);
+	}
+
+	@Test
+	@Disabled("Jackson 3 immutable ObjectMapper/JsonMapper does not allow this use case anymore")
+	public void readValueWhenExplicitDefaultTypingBeforeSecuritySetupThenReadsAsSpecificType() throws Exception {
+		// this.mapper = new ObjectMapper();
+		// this.mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL,
+		// JsonTypeInfo.As.PROPERTY);
+		// SecurityJackson2Modules.enableDefaultTyping(this.mapper);
+		String content = "{\"@class\":\"org.springframework.security.jackson.SecurityJacksonModulesTests$NotAllowlisted\",\"property\":\"bar\"}";
+		assertThat(this.mapper.readValue(content, Object.class))
+			.isInstanceOf(SecurityJacksonModulesTests.NotAllowlisted.class);
+	}
+
+	@Test
+	public void readValueWhenAnnotatedThenReadsAsSpecificType() throws Exception {
+		String content = "{\"@class\":\"org.springframework.security.jackson.SecurityJacksonModulesTests$NotAllowlistedButAnnotated\",\"property\":\"bar\"}";
+		assertThat(this.mapper.readValue(content, Object.class)).isInstanceOf(NotAllowlistedButAnnotated.class);
+	}
+
+	@Test
+	public void readValueWhenMixinProvidedThenReadsAsSpecificType() throws Exception {
+		JsonMapper customizedMapper = this.mapper.rebuild()
+			.addMixIn(NotAllowlisted.class, NotAllowlistedMixin.class)
+			.build();
+		String content = "{\"@class\":\"org.springframework.security.jackson.SecurityJacksonModulesTests$NotAllowlisted\",\"property\":\"bar\"}";
+		assertThat(customizedMapper.readValue(content, Object.class)).isInstanceOf(NotAllowlisted.class);
+	}
+
+	@Test
+	public void readValueWhenHashMapThenReadsAsSpecificType() throws Exception {
+		JsonMapper customizedMapper = this.mapper.rebuild()
+			.addMixIn(NotAllowlisted.class, NotAllowlistedMixin.class)
+			.build();
+		String content = "{\"@class\":\"java.util.HashMap\"}";
+		assertThat(customizedMapper.readValue(content, Object.class)).isInstanceOf(HashMap.class);
+	}
+
+	@Target({ ElementType.TYPE, ElementType.ANNOTATION_TYPE })
+	@Retention(RetentionPolicy.RUNTIME)
+	@Documented
+	public @interface NotJacksonAnnotation {
+
+	}
+
+	@NotJacksonAnnotation
+	static class NotAllowlisted {
+
+		private String property = "bar";
+
+		String getProperty() {
+			return this.property;
+		}
+
+		void setProperty(String property) {
+		}
+
+	}
+
+	@JsonIgnoreType(false)
+	static class NotAllowlistedButAnnotated {
+
+		private String property = "bar";
+
+		String getProperty() {
+			return this.property;
+		}
+
+		void setProperty(String property) {
+		}
+
+	}
+
+	@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
+	@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+			isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	abstract class NotAllowlistedMixin {
+
+	}
+
+}

--- a/core/src/test/java/org/springframework/security/jackson/SimpleGrantedAuthorityMixinTests.java
+++ b/core/src/test/java/org/springframework/security/jackson/SimpleGrantedAuthorityMixinTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.databind.exc.ValueInstantiationException;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * @author Jitendra Singh
+ * @since 4.2
+ */
+public class SimpleGrantedAuthorityMixinTests extends AbstractMixinTests {
+
+	// @formatter:off
+	public static final String AUTHORITY_JSON = "{\"@class\": \"org.springframework.security.core.authority.SimpleGrantedAuthority\", \"authority\": \"ROLE_USER\"}";
+	public static final String AUTHORITIES_ARRAYLIST_JSON = "[\"java.util.Collections$UnmodifiableRandomAccessList\", [" + AUTHORITY_JSON + "]]";
+	public static final String AUTHORITIES_SET_JSON = "[\"java.util.Collections$UnmodifiableSet\", [" + AUTHORITY_JSON + "]]";
+	public static final String NO_AUTHORITIES_ARRAYLIST_JSON = "[\"java.util.Collections$UnmodifiableRandomAccessList\", []]";
+	public static final String EMPTY_AUTHORITIES_ARRAYLIST_JSON = "[\"java.util.Collections$EmptyList\", []]";
+	public static final String NO_AUTHORITIES_SET_JSON = "[\"java.util.Collections$UnmodifiableSet\", []]";
+	// @formatter:on
+	@Test
+	public void serializeSimpleGrantedAuthorityTest() throws JsonProcessingException, JSONException {
+		SimpleGrantedAuthority authority = new SimpleGrantedAuthority("ROLE_USER");
+		String serializeJson = this.mapper.writeValueAsString(authority);
+		JSONAssert.assertEquals(AUTHORITY_JSON, serializeJson, true);
+	}
+
+	@Test
+	public void deserializeGrantedAuthorityTest() throws IOException {
+		SimpleGrantedAuthority authority = this.mapper.readValue(AUTHORITY_JSON, SimpleGrantedAuthority.class);
+		assertThat(authority).isNotNull();
+		assertThat(authority.getAuthority()).isNotNull().isEqualTo("ROLE_USER");
+	}
+
+	@Test
+	public void deserializeGrantedAuthorityWithoutRoleTest() throws IOException {
+		String json = "{\"@class\": \"org.springframework.security.core.authority.SimpleGrantedAuthority\"}";
+		assertThatExceptionOfType(ValueInstantiationException.class)
+			.isThrownBy(() -> this.mapper.readValue(json, SimpleGrantedAuthority.class));
+	}
+
+}

--- a/core/src/test/java/org/springframework/security/jackson/UnmodifiableMapDeserializerTests.java
+++ b/core/src/test/java/org/springframework/security/jackson/UnmodifiableMapDeserializerTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UnmodifiableMapDeserializerTests extends AbstractMixinTests {
+
+	// @formatter:off
+	private static final String DEFAULT_MAP_JSON = "{"
+			+ "\"@class\": \"java.util.Collections$UnmodifiableMap\","
+			+ "\"Key\": \"Value\""
+			+ "}";
+	// @formatter:on
+
+	@Test
+	void shouldSerialize() throws Exception {
+		String mapJson = mapper
+			.writeValueAsString(Collections.unmodifiableMap(Collections.singletonMap("Key", "Value")));
+
+		JSONAssert.assertEquals(DEFAULT_MAP_JSON, mapJson, true);
+	}
+
+	@Test
+	void shouldDeserialize() throws Exception {
+		Map<String, String> map = mapper.readValue(DEFAULT_MAP_JSON,
+				Collections.unmodifiableMap(Collections.emptyMap()).getClass());
+
+		assertThat(map).isNotNull()
+			.isInstanceOf(Collections.unmodifiableMap(Collections.emptyMap()).getClass())
+			.containsAllEntriesOf(Collections.singletonMap("Key", "Value"));
+	}
+
+}

--- a/core/src/test/java/org/springframework/security/jackson/UserDeserializerTests.java
+++ b/core/src/test/java/org/springframework/security/jackson/UserDeserializerTests.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.databind.exc.MismatchedInputException;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * @author Jitendra Singh
+ * @since 4.2
+ */
+public class UserDeserializerTests extends AbstractMixinTests {
+
+	public static final String USER_PASSWORD = "\"1234\"";
+
+	// @formatter:off
+	public static final String USER_JSON = "{"
+		+ "\"@class\": \"org.springframework.security.core.userdetails.User\", "
+		+ "\"username\": \"admin\","
+		+ " \"password\": " + USER_PASSWORD + ", "
+		+ "\"accountNonExpired\": true, "
+		+ "\"accountNonLocked\": true, "
+		+ "\"credentialsNonExpired\": true, "
+		+ "\"enabled\": true, "
+		+ "\"authorities\": " + SimpleGrantedAuthorityMixinTests.AUTHORITIES_SET_JSON
+	+ "}";
+	// @formatter:on
+	@Test
+	public void serializeUserTest() throws JsonProcessingException, JSONException {
+		User user = createDefaultUser();
+		String userJson = this.mapper.writeValueAsString(user);
+		JSONAssert.assertEquals(userWithPasswordJson(user.getPassword()), userJson, true);
+	}
+
+	@Test
+	public void serializeUserWithoutAuthority() throws JsonProcessingException, JSONException {
+		User user = new User("admin", "1234", Collections.<GrantedAuthority>emptyList());
+		String userJson = this.mapper.writeValueAsString(user);
+		JSONAssert.assertEquals(userWithNoAuthoritiesJson(), userJson, true);
+	}
+
+	@Test
+	public void deserializeUserWithNullPasswordEmptyAuthorityTest() throws IOException {
+		String userJsonWithoutPasswordString = USER_JSON.replace(SimpleGrantedAuthorityMixinTests.AUTHORITIES_SET_JSON,
+				"[]");
+		assertThatExceptionOfType(MismatchedInputException.class)
+			.isThrownBy(() -> this.mapper.readValue(userJsonWithoutPasswordString, User.class));
+	}
+
+	@Test
+	public void deserializeUserWithNullPasswordNoAuthorityTest() throws Exception {
+		String userJsonWithoutPasswordString = removeNode(userWithNoAuthoritiesJson(), this.mapper, "password");
+		User user = this.mapper.readValue(userJsonWithoutPasswordString, User.class);
+		assertThat(user).isNotNull();
+		assertThat(user.getUsername()).isEqualTo("admin");
+		assertThat(user.getPassword()).isNull();
+		assertThat(user.getAuthorities()).isEmpty();
+		assertThat(user.isEnabled()).isEqualTo(true);
+	}
+
+	@Test
+	public void deserializeUserWithNoClassIdInAuthoritiesTest() throws Exception {
+		String userJson = USER_JSON.replace(SimpleGrantedAuthorityMixinTests.AUTHORITIES_SET_JSON,
+				"[{\"authority\": \"ROLE_USER\"}]");
+		assertThatExceptionOfType(MismatchedInputException.class)
+			.isThrownBy(() -> this.mapper.readValue(userJson, User.class));
+	}
+
+	@Test
+	public void deserializeUserWithClassIdInAuthoritiesTest() {
+		User user = this.mapper.readValue(userJson(), User.class);
+		assertThat(user).isNotNull();
+		assertThat(user.getUsername()).isEqualTo("admin");
+		assertThat(user.getPassword()).isEqualTo("1234");
+		assertThat(user.getAuthorities()).hasSize(1).contains(new SimpleGrantedAuthority("ROLE_USER"));
+	}
+
+	private String removeNode(String json, JsonMapper mapper, String toRemove) throws Exception {
+		ObjectNode node = mapper.createParser(json).readValueAsTree();
+		node.remove(toRemove);
+		String result = mapper.writeValueAsString(node);
+		JSONAssert.assertNotEquals(json, result, false);
+		return result;
+	}
+
+	public static String userJson() {
+		return USER_JSON;
+	}
+
+	public static String userWithPasswordJson(String password) {
+		return userJson().replaceAll(Pattern.quote(USER_PASSWORD), "\"" + password + "\"");
+	}
+
+	public static String userWithNoAuthoritiesJson() {
+		return userJson().replace(SimpleGrantedAuthorityMixinTests.AUTHORITIES_SET_JSON,
+				SimpleGrantedAuthorityMixinTests.NO_AUTHORITIES_SET_JSON);
+	}
+
+}

--- a/core/src/test/java/org/springframework/security/jackson/UsernamePasswordAuthenticationTokenMixinTests.java
+++ b/core/src/test/java/org/springframework/security/jackson/UsernamePasswordAuthenticationTokenMixinTests.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.jackson;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonInclude.Value;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Jitendra Singh
+ * @author Greg Turnquist
+ * @author Onur Kagan Ozcan
+ * @since 4.2
+ */
+public class UsernamePasswordAuthenticationTokenMixinTests extends AbstractMixinTests {
+
+	private static final String AUTHENTICATED_JSON = "{"
+			+ "\"@class\": \"org.springframework.security.authentication.UsernamePasswordAuthenticationToken\","
+			+ "\"principal\": " + UserDeserializerTests.USER_JSON + ", " + "\"credentials\": \"1234\", "
+			+ "\"authenticated\": true, " + "\"details\": null, " + "\"authorities\": "
+			+ SimpleGrantedAuthorityMixinTests.AUTHORITIES_ARRAYLIST_JSON + "}";
+
+	public static final String AUTHENTICATED_STRINGPRINCIPAL_JSON = AUTHENTICATED_JSON
+		.replace(UserDeserializerTests.USER_JSON, "\"admin\"");
+
+	private static final String NON_USER_PRINCIPAL_JSON = "{"
+			+ "\"@class\": \"org.springframework.security.jackson.UsernamePasswordAuthenticationTokenMixinTests$NonUserPrincipal\", "
+			+ "\"username\": \"admin\"" + "}";
+
+	private static final String AUTHENTICATED_STRINGDETAILS_JSON = AUTHENTICATED_JSON.replace("\"details\": null, ",
+			"\"details\": \"details\", ");
+
+	private static final String AUTHENTICATED_NON_USER_PRINCIPAL_JSON = AUTHENTICATED_JSON
+		.replace(UserDeserializerTests.USER_JSON, NON_USER_PRINCIPAL_JSON)
+		.replaceAll(UserDeserializerTests.USER_PASSWORD, "null")
+		.replace(SimpleGrantedAuthorityMixinTests.AUTHORITIES_ARRAYLIST_JSON,
+				SimpleGrantedAuthorityMixinTests.NO_AUTHORITIES_ARRAYLIST_JSON);
+
+	private static final String UNAUTHENTICATED_STRINGPRINCIPAL_JSON = AUTHENTICATED_STRINGPRINCIPAL_JSON
+		.replace("\"authenticated\": true, ", "\"authenticated\": false, ")
+		.replace(SimpleGrantedAuthorityMixinTests.AUTHORITIES_ARRAYLIST_JSON,
+				SimpleGrantedAuthorityMixinTests.EMPTY_AUTHORITIES_ARRAYLIST_JSON);
+
+	@Test
+	public void serializeUnauthenticatedUsernamePasswordAuthenticationTokenMixinTest()
+			throws JsonProcessingException, JSONException {
+		UsernamePasswordAuthenticationToken token = UsernamePasswordAuthenticationToken.unauthenticated("admin",
+				"1234");
+		String serializedJson = this.mapper.writeValueAsString(token);
+		JSONAssert.assertEquals(UNAUTHENTICATED_STRINGPRINCIPAL_JSON, serializedJson, true);
+	}
+
+	@Test
+	public void serializeAuthenticatedUsernamePasswordAuthenticationTokenMixinTest()
+			throws JsonProcessingException, JSONException {
+		User user = createDefaultUser();
+		UsernamePasswordAuthenticationToken token = UsernamePasswordAuthenticationToken
+			.authenticated(user.getUsername(), user.getPassword(), user.getAuthorities());
+		String serializedJson = this.mapper.writeValueAsString(token);
+		JSONAssert.assertEquals(AUTHENTICATED_STRINGPRINCIPAL_JSON, serializedJson, true);
+	}
+
+	@Test
+	public void deserializeUnauthenticatedUsernamePasswordAuthenticationTokenMixinTest() {
+		UsernamePasswordAuthenticationToken token = this.mapper.readValue(UNAUTHENTICATED_STRINGPRINCIPAL_JSON,
+				UsernamePasswordAuthenticationToken.class);
+		assertThat(token).isNotNull();
+		assertThat(token.isAuthenticated()).isEqualTo(false);
+		assertThat(token.getAuthorities()).isNotNull().hasSize(0);
+	}
+
+	@Test
+	public void deserializeAuthenticatedUsernamePasswordAuthenticationTokenMixinTest() {
+		UsernamePasswordAuthenticationToken expectedToken = createToken();
+		UsernamePasswordAuthenticationToken token = this.mapper.readValue(AUTHENTICATED_STRINGPRINCIPAL_JSON,
+				UsernamePasswordAuthenticationToken.class);
+		assertThat(token).isNotNull();
+		assertThat(token.isAuthenticated()).isTrue();
+		assertThat(token.getAuthorities()).isEqualTo(expectedToken.getAuthorities());
+	}
+
+	@Test
+	public void serializeAuthenticatedUsernamePasswordAuthenticationTokenMixinWithUserTest()
+			throws JsonProcessingException, JSONException {
+		UsernamePasswordAuthenticationToken token = createToken();
+		String actualJson = this.mapper.writeValueAsString(token);
+		JSONAssert.assertEquals(AUTHENTICATED_JSON, actualJson, true);
+	}
+
+	@Test
+	public void deserializeAuthenticatedUsernamePasswordAuthenticationTokenWithUserTest() throws IOException {
+		UsernamePasswordAuthenticationToken token = this.mapper.readValue(AUTHENTICATED_JSON,
+				UsernamePasswordAuthenticationToken.class);
+		assertThat(token).isNotNull();
+		assertThat(token.getPrincipal()).isNotNull().isInstanceOf(User.class);
+		assertThat(((User) token.getPrincipal()).getAuthorities()).isNotNull()
+			.hasSize(1)
+			.contains(new SimpleGrantedAuthority("ROLE_USER"));
+		assertThat(token.isAuthenticated()).isEqualTo(true);
+		assertThat(token.getAuthorities()).hasSize(1).contains(new SimpleGrantedAuthority("ROLE_USER"));
+	}
+
+	@Test
+	public void serializeAuthenticatedUsernamePasswordAuthenticationTokenMixinAfterEraseCredentialInvoked()
+			throws JsonProcessingException, JSONException {
+		UsernamePasswordAuthenticationToken token = createToken();
+		token.eraseCredentials();
+		String actualJson = this.mapper.writeValueAsString(token);
+		JSONAssert.assertEquals(AUTHENTICATED_JSON.replaceAll(UserDeserializerTests.USER_PASSWORD, "null"), actualJson,
+				true);
+	}
+
+	@Test
+	public void serializeAuthenticatedUsernamePasswordAuthenticationTokenMixinWithNonUserPrincipalTest()
+			throws JsonProcessingException, JSONException {
+		NonUserPrincipal principal = new NonUserPrincipal();
+		principal.setUsername("admin");
+		UsernamePasswordAuthenticationToken token = UsernamePasswordAuthenticationToken.authenticated(principal, null,
+				new ArrayList<>());
+		String actualJson = this.mapper.writeValueAsString(token);
+		JSONAssert.assertEquals(AUTHENTICATED_NON_USER_PRINCIPAL_JSON, actualJson, true);
+	}
+
+	@Test
+	public void deserializeAuthenticatedUsernamePasswordAuthenticationTokenWithNonUserPrincipalTest()
+			throws IOException {
+		UsernamePasswordAuthenticationToken token = this.mapper.readValue(AUTHENTICATED_NON_USER_PRINCIPAL_JSON,
+				UsernamePasswordAuthenticationToken.class);
+		assertThat(token).isNotNull();
+		assertThat(token.getPrincipal()).isNotNull().isInstanceOf(NonUserPrincipal.class);
+	}
+
+	@Test
+	public void deserializeAuthenticatedUsernamePasswordAuthenticationTokenWithDetailsTest() {
+		UsernamePasswordAuthenticationToken token = this.mapper.readValue(AUTHENTICATED_STRINGDETAILS_JSON,
+				UsernamePasswordAuthenticationToken.class);
+		assertThat(token).isNotNull();
+		assertThat(token.getPrincipal()).isNotNull().isInstanceOf(User.class);
+		assertThat(((User) token.getPrincipal()).getAuthorities()).isNotNull()
+			.hasSize(1)
+			.contains(new SimpleGrantedAuthority("ROLE_USER"));
+		assertThat(token.isAuthenticated()).isEqualTo(true);
+		assertThat(token.getAuthorities()).hasSize(1).contains(new SimpleGrantedAuthority("ROLE_USER"));
+		assertThat(token.getDetails()).isExactlyInstanceOf(String.class).isEqualTo("details");
+	}
+
+	@Test
+	public void serializingThenDeserializingWithNoCredentialsOrDetailsShouldWork() {
+		UsernamePasswordAuthenticationToken original = UsernamePasswordAuthenticationToken.unauthenticated("Frodo",
+				null);
+		String serialized = this.mapper.writeValueAsString(original);
+		UsernamePasswordAuthenticationToken deserialized = this.mapper.readValue(serialized,
+				UsernamePasswordAuthenticationToken.class);
+		assertThat(deserialized).isEqualTo(original);
+	}
+
+	@Test
+	public void serializingThenDeserializingWithConfiguredObjectMapperShouldWork() {
+		JsonMapper jsonMapper = this.mapper.rebuild()
+			.changeDefaultPropertyInclusion((p) -> Value.construct(Include.NON_ABSENT, Include.NON_ABSENT))
+			.build();
+
+		UsernamePasswordAuthenticationToken original = UsernamePasswordAuthenticationToken.unauthenticated("Frodo",
+				null);
+		String serialized = jsonMapper.writeValueAsString(original);
+		UsernamePasswordAuthenticationToken deserialized = jsonMapper.readValue(serialized,
+				UsernamePasswordAuthenticationToken.class);
+		assertThat(deserialized).isEqualTo(original);
+	}
+
+	private UsernamePasswordAuthenticationToken createToken() {
+		User user = createDefaultUser();
+		UsernamePasswordAuthenticationToken token = UsernamePasswordAuthenticationToken.authenticated(user,
+				user.getPassword(), user.getAuthorities());
+		return token;
+	}
+
+	@JsonClassDescription
+	public static class NonUserPrincipal {
+
+		private String username;
+
+		public String getUsername() {
+			return this.username;
+		}
+
+		public void setUsername(String username) {
+			this.username = username;
+		}
+
+	}
+
+}

--- a/core/src/test/java/org/springframework/security/jackson2/SecurityJackson2ModulesTests.java
+++ b/core/src/test/java/org/springframework/security/jackson2/SecurityJackson2ModulesTests.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Rob Winch
  * @since 5.0
  */
+@SuppressWarnings("removal")
 public class SecurityJackson2ModulesTests {
 
 	private ObjectMapper mapper;

--- a/dependencies/spring-security-dependencies.gradle
+++ b/dependencies/spring-security-dependencies.gradle
@@ -25,6 +25,7 @@ dependencies {
 	api platform(libs.org.jetbrains.kotlin.kotlin.bom)
 	api platform(libs.org.jetbrains.kotlinx.kotlinx.coroutines.bom)
 	api platform(libs.com.fasterxml.jackson.jackson.bom)
+	api platform(libs.tools.jackson.jackson.bom)
 	constraints {
 		api libs.ch.qos.logback.logback.classic
 		api libs.com.google.inject.guice

--- a/docs/modules/ROOT/pages/features/integrations/jackson.adoc
+++ b/docs/modules/ROOT/pages/features/integrations/jackson.adoc
@@ -4,7 +4,7 @@
 Spring Security provides Jackson support for persisting Spring Security related classes.
 This can improve the performance of serializing Spring Security related classes when working with distributed sessions (i.e. session replication, Spring Session, etc).
 
-To use it, register the `SecurityJackson2Modules.getModules(ClassLoader)` with `ObjectMapper` (https://github.com/FasterXML/jackson-databind[jackson-databind]):
+To use it, register the `SecurityJacksonModules.getModules(ClassLoader)` with `JsonMapper.Builder` (https://github.com/FasterXML/jackson-databind[jackson-databind]):
 
 [tabs]
 ======
@@ -12,12 +12,12 @@ Java::
 +
 [source,java,role="primary"]
 ----
-ObjectMapper mapper = new ObjectMapper();
 ClassLoader loader = getClass().getClassLoader();
-List<Module> modules = SecurityJackson2Modules.getModules(loader);
-mapper.registerModules(modules);
+JsonMapper mapper = JsonMapper.builder()
+        .addModules(SecurityJacksonModules.getModules(loader))
+        .build();
 
-// ... use ObjectMapper as normally ...
+// ... use JsonMapper as normally ...
 SecurityContext context = new SecurityContextImpl();
 // ...
 String json = mapper.writeValueAsString(context);
@@ -27,12 +27,12 @@ Kotlin::
 +
 [source,kotlin,role="secondary"]
 ----
-val mapper = ObjectMapper()
 val loader = javaClass.classLoader
-val modules: MutableList<Module> = SecurityJackson2Modules.getModules(loader)
-mapper.registerModules(modules)
+val mapper = JsonMapper.builder()
+    .addModules(SecurityJacksonModules.getModules(loader))
+    .build()
 
-// ... use ObjectMapper as normally ...
+// ... use JsonMapper as normally ...
 val context: SecurityContext = SecurityContextImpl()
 // ...
 val json: String = mapper.writeValueAsString(context)
@@ -43,8 +43,8 @@ val json: String = mapper.writeValueAsString(context)
 ====
 The following Spring Security modules provide Jackson support:
 
-- spring-security-core (`CoreJackson2Module`)
-- spring-security-web (`WebJackson2Module`, `WebServletJackson2Module`, `WebServerJackson2Module`)
-- xref:servlet/oauth2/client/index.adoc#oauth2client[ spring-security-oauth2-client] (`OAuth2ClientJackson2Module`)
-- spring-security-cas (`CasJackson2Module`)
+- spring-security-core (`CoreJacksonModule`)
+- spring-security-web (`WebJacksonModule`, `WebServletJacksonModule`, `WebServerJacksonModule`)
+- xref:servlet/oauth2/client/index.adoc#oauth2client[ spring-security-oauth2-client] (`OAuth2ClientJacksonModule`)
+- spring-security-cas (`CasJacksonModule`)
 ====

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ org-springframework = "7.0.0-M8"
 
 [libraries]
 ch-qos-logback-logback-classic = "ch.qos.logback:logback-classic:1.5.18"
-com-fasterxml-jackson-jackson-bom = "com.fasterxml.jackson:jackson-bom:2.19.2"
+com-fasterxml-jackson-jackson-bom = "com.fasterxml.jackson:jackson-bom:2.20.0-rc1"
 com-google-inject-guice = "com.google.inject:guice:3.0"
 com-netflix-nebula-nebula-project-plugin = "com.netflix.nebula:nebula-project-plugin:8.2.0"
 com-nimbusds-nimbus-jose-jwt = "com.nimbusds:nimbus-jose-jwt:10.4"
@@ -82,6 +82,7 @@ org-springframework-data-spring-data-bom = "org.springframework.data:spring-data
 org-springframework-ldap-spring-ldap-core = "org.springframework.ldap:spring-ldap-core:3.2.13"
 org-springframework-spring-framework-bom = { module = "org.springframework:spring-framework-bom", version.ref = "org-springframework" }
 org-synchronoss-cloud-nio-multipart-parser = "org.synchronoss.cloud:nio-multipart-parser:1.1.0"
+tools-jackson-jackson-bom = "tools.jackson:jackson-bom:3.0.0-rc8"
 
 com-google-code-gson-gson = "com.google.code.gson:gson:2.13.1"
 com-thaiopensource-trag = "com.thaiopensource:trang:20091111"

--- a/ldap/spring-security-ldap.gradle
+++ b/ldap/spring-security-ldap.gradle
@@ -11,6 +11,7 @@ dependencies {
 	optional 'com.fasterxml.jackson.core:jackson-databind'
 	optional 'ldapsdk:ldapsdk'
 	optional "com.unboundid:unboundid-ldapsdk"
+	optional 'tools.jackson.core:jackson-databind'
 	api ('org.springframework.ldap:spring-ldap-core') {
 		exclude(group: 'commons-logging', module: 'commons-logging')
 		exclude(group: 'org.springframework', module: 'spring-beans')

--- a/ldap/src/main/java/org/springframework/security/ldap/jackson/InetOrgPersonMixin.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/jackson/InetOrgPersonMixin.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.ldap.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.ldap.userdetails.InetOrgPerson;
+
+/**
+ * This Jackson mixin is used to serialize/deserialize {@link InetOrgPerson}.
+ *
+ * @author Sebastien Deleuze
+ * @since 7.0
+ * @see LdapJacksonModule
+ * @see SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class InetOrgPersonMixin {
+
+}

--- a/ldap/src/main/java/org/springframework/security/ldap/jackson/LdapAuthorityMixin.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/jackson/LdapAuthorityMixin.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.ldap.jackson;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.ldap.userdetails.LdapAuthority;
+
+/**
+ * This Jackson mixin is used to serialize/deserialize {@link LdapAuthority}.
+ *
+ * @author Sebastien Deleuze
+ * @since 7.0
+ * @see LdapJacksonModule
+ * @see SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class LdapAuthorityMixin {
+
+	@JsonCreator
+	LdapAuthorityMixin(@JsonProperty("role") String role, @JsonProperty("dn") String dn,
+			@JsonProperty("attributes") Map<String, List<String>> attributes) {
+	}
+
+}

--- a/ldap/src/main/java/org/springframework/security/ldap/jackson/LdapJacksonModule.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/jackson/LdapJacksonModule.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.ldap.jackson;
+
+import tools.jackson.core.Version;
+import tools.jackson.databind.cfg.MapperBuilder;
+import tools.jackson.databind.module.SimpleModule;
+
+import org.springframework.security.jackson.AllowlistTypeResolverBuilder;
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.ldap.userdetails.InetOrgPerson;
+import org.springframework.security.ldap.userdetails.LdapAuthority;
+import org.springframework.security.ldap.userdetails.LdapUserDetailsImpl;
+import org.springframework.security.ldap.userdetails.Person;
+
+/**
+ * Jackson module for {@code spring-security-ldap}. This module registers
+ * {@link LdapAuthorityMixin}, {@link LdapUserDetailsImplMixin}, {@link PersonMixin},
+ * {@link InetOrgPersonMixin}.
+ *
+ * <p>
+ * If not already enabled, default typing will be automatically enabled as type info is
+ * required to properly serialize/deserialize objects. In order to use this module just
+ * add it to your {@code ObjectMapper} configuration.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new LdapJacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * <b>Note: use {@link SecurityJacksonModules#getModules(ClassLoader)} to get list of all
+ * security modules.</b>
+ *
+ * @author Sebastien Deleuze
+ * @since 7.0
+ * @see SecurityJacksonModules
+ */
+@SuppressWarnings("serial")
+public class LdapJacksonModule extends SimpleModule {
+
+	public LdapJacksonModule() {
+		super(LdapJacksonModule.class.getName(), new Version(1, 0, 0, null, null, null));
+	}
+
+	@Override
+	public void setupModule(SetupContext context) {
+		((MapperBuilder<?, ?>) context.getOwner()).setDefaultTyping(new AllowlistTypeResolverBuilder());
+		context.setMixIn(LdapAuthority.class, LdapAuthorityMixin.class);
+		context.setMixIn(LdapUserDetailsImpl.class, LdapUserDetailsImplMixin.class);
+		context.setMixIn(Person.class, PersonMixin.class);
+		context.setMixIn(InetOrgPerson.class, InetOrgPersonMixin.class);
+	}
+
+}

--- a/ldap/src/main/java/org/springframework/security/ldap/jackson/LdapUserDetailsImplMixin.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/jackson/LdapUserDetailsImplMixin.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.ldap.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.ldap.userdetails.LdapUserDetailsImpl;
+
+/**
+ * This Jackson mixin is used to serialize/deserialize {@link LdapUserDetailsImpl}.
+ *
+ * @author Sebastien Deleuze
+ * @since 7.0
+ * @see LdapJacksonModule
+ * @see SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class LdapUserDetailsImplMixin {
+
+}

--- a/ldap/src/main/java/org/springframework/security/ldap/jackson/PersonMixin.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/jackson/PersonMixin.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.ldap.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.ldap.userdetails.Person;
+
+/**
+ * This Jackson mixin is used to serialize/deserialize {@link Person}.
+ *
+ * @author Sebastien Deleuze
+ * @since 7.0
+ * @see LdapJacksonModule
+ * @see SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class PersonMixin {
+
+}

--- a/ldap/src/main/java/org/springframework/security/ldap/jackson/package-info.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/jackson/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Jackson 3+ serialization support for LDAP.
+ */
+package org.springframework.security.ldap.jackson;

--- a/ldap/src/main/java/org/springframework/security/ldap/jackson2/InetOrgPersonMixin.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/jackson2/InetOrgPersonMixin.java
@@ -29,7 +29,10 @@ import org.springframework.security.ldap.userdetails.InetOrgPerson;
  * @since 5.7
  * @see LdapJackson2Module
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.ldap.jackson.InetOrgPersonMixin} based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/ldap/src/main/java/org/springframework/security/ldap/jackson2/LdapAuthorityMixin.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/jackson2/LdapAuthorityMixin.java
@@ -34,7 +34,10 @@ import org.springframework.security.ldap.userdetails.LdapAuthority;
  * @since 5.7
  * @see LdapJackson2Module
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.ldap.jackson.LdapAuthorityMixin} based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/ldap/src/main/java/org/springframework/security/ldap/jackson2/LdapJackson2Module.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/jackson2/LdapJackson2Module.java
@@ -45,8 +45,11 @@ import org.springframework.security.ldap.userdetails.Person;
  *
  * @since 5.7
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@link org.springframework.security.ldap.jackson.LdapJacksonModule} based on Jackson 3
  */
-@SuppressWarnings("serial")
+@Deprecated(forRemoval = true)
+@SuppressWarnings({ "serial", "removal" })
 public class LdapJackson2Module extends SimpleModule {
 
 	public LdapJackson2Module() {

--- a/ldap/src/main/java/org/springframework/security/ldap/jackson2/LdapUserDetailsImplMixin.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/jackson2/LdapUserDetailsImplMixin.java
@@ -29,7 +29,11 @@ import org.springframework.security.ldap.userdetails.LdapUserDetailsImpl;
  * @since 5.7
  * @see LdapJackson2Module
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.ldap.jackson.LdapUserDetailsImplMixin} based on
+ * Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/ldap/src/main/java/org/springframework/security/ldap/jackson2/PersonMixin.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/jackson2/PersonMixin.java
@@ -29,7 +29,10 @@ import org.springframework.security.ldap.userdetails.Person;
  * @since 5.7
  * @see LdapJackson2Module
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.ldap.jackson.PersonMixin} based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/ldap/src/main/java/org/springframework/security/ldap/jackson2/package-info.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/jackson2/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Jackson 2 serialization support for LDAP.
+ */
+package org.springframework.security.ldap.jackson2;

--- a/ldap/src/test/java/org/springframework/security/ldap/jackson/InetOrgPersonMixinTests.java
+++ b/ldap/src/test/java/org/springframework/security/ldap/jackson/InetOrgPersonMixinTests.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.ldap.jackson;
+
+import org.json.JSONException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.ldap.core.DirContextAdapter;
+import org.springframework.ldap.support.LdapNameBuilder;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.ldap.userdetails.InetOrgPerson;
+import org.springframework.security.ldap.userdetails.InetOrgPersonContextMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Tests for {@link org.springframework.security.ldap.jackson.InetOrgPersonMixin}.
+ */
+public class InetOrgPersonMixinTests {
+
+	private static final String USER_PASSWORD = "Password1234";
+
+	private static final String AUTHORITIES_ARRAYLIST_JSON = "[\"java.util.Collections$UnmodifiableRandomAccessList\", []]";
+
+	// @formatter:off
+	private static final String INET_ORG_PERSON_JSON = "{\n"
+			+ "\"@class\": \"org.springframework.security.ldap.userdetails.InetOrgPerson\","
+			+ "\"dn\": \"ignored=ignored\","
+			+ "\"uid\": \"ghengis\","
+			+ "\"username\": \"ghengis\","
+			+ "\"password\": \"" + USER_PASSWORD + "\","
+			+ "\"carLicense\": \"HORS1\","
+			+ "\"givenName\": \"Ghengis\","
+			+ "\"destinationIndicator\": \"West\","
+			+ "\"displayName\": \"Ghengis McCann\","
+			+ "\"givenName\": \"Ghengis\","
+			+ "\"homePhone\": \"+467575436521\","
+			+ "\"initials\": \"G\","
+			+ "\"employeeNumber\": \"00001\","
+			+ "\"homePostalAddress\": \"Steppes\","
+			+ "\"mail\": \"ghengis@mongolia\","
+			+ "\"mobile\": \"always\","
+			+ "\"o\": \"Hordes\","
+			+ "\"ou\": \"Horde1\","
+			+ "\"postalAddress\": \"On the Move\","
+			+ "\"postalCode\": \"Changes Frequently\","
+			+ "\"roomNumber\": \"Yurt 1\","
+			+ "\"sn\": \"Khan\","
+			+ "\"street\": \"Westward Avenue\","
+			+ "\"telephoneNumber\": \"+442075436521\","
+			+ "\"departmentNumber\": \"5679\","
+			+ "\"title\": \"T\","
+			+ "\"cn\": [\"java.util.Arrays$ArrayList\",[\"Ghengis Khan\"]],"
+			+ "\"description\": \"Scary\","
+			+ "\"accountNonExpired\": true, "
+			+ "\"accountNonLocked\": true, "
+			+ "\"credentialsNonExpired\": true, "
+			+ "\"enabled\": true, "
+			+ "\"authorities\": " + AUTHORITIES_ARRAYLIST_JSON + ","
+			+ "\"graceLoginsRemaining\": " + Integer.MAX_VALUE + ","
+			+ "\"timeBeforeExpiration\": " + Integer.MAX_VALUE
+			+ "}";
+	// @formatter:on
+
+	private JsonMapper mapper;
+
+	@BeforeEach
+	public void setup() {
+		ClassLoader loader = getClass().getClassLoader();
+		this.mapper = JsonMapper.builder().addModules(SecurityJacksonModules.getModules(loader)).build();
+	}
+
+	@Test
+	public void serializeWhenMixinRegisteredThenSerializes() throws Exception {
+		InetOrgPersonContextMapper mapper = new InetOrgPersonContextMapper();
+		InetOrgPerson p = (InetOrgPerson) mapper.mapUserFromContext(createUserContext(), "ghengis",
+				AuthorityUtils.NO_AUTHORITIES);
+
+		String json = this.mapper.writeValueAsString(p);
+		JSONAssert.assertEquals(INET_ORG_PERSON_JSON, json, true);
+	}
+
+	@Test
+	public void serializeWhenEraseCredentialInvokedThenUserPasswordIsNull() throws JacksonException, JSONException {
+		InetOrgPersonContextMapper mapper = new InetOrgPersonContextMapper();
+		InetOrgPerson p = (InetOrgPerson) mapper.mapUserFromContext(createUserContext(), "ghengis",
+				AuthorityUtils.NO_AUTHORITIES);
+		p.eraseCredentials();
+		String actualJson = this.mapper.writeValueAsString(p);
+		JSONAssert.assertEquals(INET_ORG_PERSON_JSON.replaceAll("\"" + USER_PASSWORD + "\"", "null"), actualJson, true);
+	}
+
+	@Test
+	public void deserializeWhenMixinNotRegisteredThenThrowJsonProcessingException() {
+		assertThatExceptionOfType(JacksonException.class)
+			.isThrownBy(() -> new JsonMapper().readValue(INET_ORG_PERSON_JSON, InetOrgPerson.class));
+	}
+
+	@Test
+	public void deserializeWhenMixinRegisteredThenDeserializes() throws Exception {
+		InetOrgPersonContextMapper mapper = new InetOrgPersonContextMapper();
+		InetOrgPerson expectedAuthentication = (InetOrgPerson) mapper.mapUserFromContext(createUserContext(), "ghengis",
+				AuthorityUtils.NO_AUTHORITIES);
+
+		InetOrgPerson authentication = this.mapper.readValue(INET_ORG_PERSON_JSON, InetOrgPerson.class);
+		assertThat(authentication.getAuthorities()).containsExactlyElementsOf(expectedAuthentication.getAuthorities());
+		assertThat(authentication.getCarLicense()).isEqualTo(expectedAuthentication.getCarLicense());
+		assertThat(authentication.getDepartmentNumber()).isEqualTo(expectedAuthentication.getDepartmentNumber());
+		assertThat(authentication.getDestinationIndicator())
+			.isEqualTo(expectedAuthentication.getDestinationIndicator());
+		assertThat(authentication.getDn()).isEqualTo(expectedAuthentication.getDn());
+		assertThat(authentication.getDescription()).isEqualTo(expectedAuthentication.getDescription());
+		assertThat(authentication.getDisplayName()).isEqualTo(expectedAuthentication.getDisplayName());
+		assertThat(authentication.getUid()).isEqualTo(expectedAuthentication.getUid());
+		assertThat(authentication.getUsername()).isEqualTo(expectedAuthentication.getUsername());
+		assertThat(authentication.getPassword()).isEqualTo(expectedAuthentication.getPassword());
+		assertThat(authentication.getHomePhone()).isEqualTo(expectedAuthentication.getHomePhone());
+		assertThat(authentication.getEmployeeNumber()).isEqualTo(expectedAuthentication.getEmployeeNumber());
+		assertThat(authentication.getHomePostalAddress()).isEqualTo(expectedAuthentication.getHomePostalAddress());
+		assertThat(authentication.getInitials()).isEqualTo(expectedAuthentication.getInitials());
+		assertThat(authentication.getMail()).isEqualTo(expectedAuthentication.getMail());
+		assertThat(authentication.getMobile()).isEqualTo(expectedAuthentication.getMobile());
+		assertThat(authentication.getO()).isEqualTo(expectedAuthentication.getO());
+		assertThat(authentication.getOu()).isEqualTo(expectedAuthentication.getOu());
+		assertThat(authentication.getPostalAddress()).isEqualTo(expectedAuthentication.getPostalAddress());
+		assertThat(authentication.getPostalCode()).isEqualTo(expectedAuthentication.getPostalCode());
+		assertThat(authentication.getRoomNumber()).isEqualTo(expectedAuthentication.getRoomNumber());
+		assertThat(authentication.getStreet()).isEqualTo(expectedAuthentication.getStreet());
+		assertThat(authentication.getSn()).isEqualTo(expectedAuthentication.getSn());
+		assertThat(authentication.getTitle()).isEqualTo(expectedAuthentication.getTitle());
+		assertThat(authentication.getGivenName()).isEqualTo(expectedAuthentication.getGivenName());
+		assertThat(authentication.getTelephoneNumber()).isEqualTo(expectedAuthentication.getTelephoneNumber());
+		assertThat(authentication.getGraceLoginsRemaining())
+			.isEqualTo(expectedAuthentication.getGraceLoginsRemaining());
+		assertThat(authentication.getTimeBeforeExpiration())
+			.isEqualTo(expectedAuthentication.getTimeBeforeExpiration());
+		assertThat(authentication.isAccountNonExpired()).isEqualTo(expectedAuthentication.isAccountNonExpired());
+		assertThat(authentication.isAccountNonLocked()).isEqualTo(expectedAuthentication.isAccountNonLocked());
+		assertThat(authentication.isEnabled()).isEqualTo(expectedAuthentication.isEnabled());
+		assertThat(authentication.isCredentialsNonExpired())
+			.isEqualTo(expectedAuthentication.isCredentialsNonExpired());
+	}
+
+	private DirContextAdapter createUserContext() {
+		DirContextAdapter ctx = new DirContextAdapter();
+		ctx.setDn(LdapNameBuilder.newInstance("ignored=ignored").build());
+		ctx.setAttributeValue("uid", "ghengis");
+		ctx.setAttributeValue("userPassword", USER_PASSWORD);
+		ctx.setAttributeValue("carLicense", "HORS1");
+		ctx.setAttributeValue("cn", "Ghengis Khan");
+		ctx.setAttributeValue("description", "Scary");
+		ctx.setAttributeValue("destinationIndicator", "West");
+		ctx.setAttributeValue("displayName", "Ghengis McCann");
+		ctx.setAttributeValue("givenName", "Ghengis");
+		ctx.setAttributeValue("homePhone", "+467575436521");
+		ctx.setAttributeValue("initials", "G");
+		ctx.setAttributeValue("employeeNumber", "00001");
+		ctx.setAttributeValue("homePostalAddress", "Steppes");
+		ctx.setAttributeValue("mail", "ghengis@mongolia");
+		ctx.setAttributeValue("mobile", "always");
+		ctx.setAttributeValue("o", "Hordes");
+		ctx.setAttributeValue("ou", "Horde1");
+		ctx.setAttributeValue("postalAddress", "On the Move");
+		ctx.setAttributeValue("postalCode", "Changes Frequently");
+		ctx.setAttributeValue("roomNumber", "Yurt 1");
+		ctx.setAttributeValue("sn", "Khan");
+		ctx.setAttributeValue("street", "Westward Avenue");
+		ctx.setAttributeValue("telephoneNumber", "+442075436521");
+		ctx.setAttributeValue("departmentNumber", "5679");
+		ctx.setAttributeValue("title", "T");
+		return ctx;
+	}
+
+}

--- a/ldap/src/test/java/org/springframework/security/ldap/jackson/LdapUserDetailsImplMixinTests.java
+++ b/ldap/src/test/java/org/springframework/security/ldap/jackson/LdapUserDetailsImplMixinTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.ldap.jackson;
+
+import org.json.JSONException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.ldap.core.DirContextAdapter;
+import org.springframework.ldap.support.LdapNameBuilder;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.ldap.userdetails.LdapUserDetailsImpl;
+import org.springframework.security.ldap.userdetails.LdapUserDetailsMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Tests for {@link org.springframework.security.ldap.jackson.LdapUserDetailsImplMixin}.
+ */
+public class LdapUserDetailsImplMixinTests {
+
+	private static final String USER_PASSWORD = "Password1234";
+
+	private static final String AUTHORITIES_ARRAYLIST_JSON = "[\"java.util.Collections$UnmodifiableRandomAccessList\", []]";
+
+	// @formatter:off
+	private static final String USER_JSON = "{"
+			+ "\"@class\": \"org.springframework.security.ldap.userdetails.LdapUserDetailsImpl\", "
+			+ "\"dn\": \"ignored=ignored\","
+			+ "\"username\": \"ghengis\","
+			+ "\"password\": \"" + USER_PASSWORD + "\","
+			+ "\"accountNonExpired\": true, "
+			+ "\"accountNonLocked\": true, "
+			+ "\"credentialsNonExpired\": true, "
+			+ "\"enabled\": true, "
+			+ "\"authorities\": " + AUTHORITIES_ARRAYLIST_JSON + ","
+			+ "\"graceLoginsRemaining\": " + Integer.MAX_VALUE + ","
+			+ "\"timeBeforeExpiration\": " + Integer.MAX_VALUE
+			+ "}";
+	// @formatter:on
+
+	private JsonMapper mapper;
+
+	@BeforeEach
+	public void setup() {
+		ClassLoader loader = getClass().getClassLoader();
+		this.mapper = JsonMapper.builder().addModules(SecurityJacksonModules.getModules(loader)).build();
+	}
+
+	@Test
+	public void serializeWhenMixinRegisteredThenSerializes() throws Exception {
+		LdapUserDetailsMapper mapper = new LdapUserDetailsMapper();
+		LdapUserDetailsImpl p = (LdapUserDetailsImpl) mapper.mapUserFromContext(createUserContext(), "ghengis",
+				AuthorityUtils.NO_AUTHORITIES);
+
+		String json = this.mapper.writeValueAsString(p);
+		JSONAssert.assertEquals(USER_JSON, json, true);
+	}
+
+	@Test
+	public void serializeWhenEraseCredentialInvokedThenUserPasswordIsNull() throws JacksonException, JSONException {
+		LdapUserDetailsMapper mapper = new LdapUserDetailsMapper();
+		LdapUserDetailsImpl p = (LdapUserDetailsImpl) mapper.mapUserFromContext(createUserContext(), "ghengis",
+				AuthorityUtils.NO_AUTHORITIES);
+		p.eraseCredentials();
+		String actualJson = this.mapper.writeValueAsString(p);
+		JSONAssert.assertEquals(USER_JSON.replaceAll("\"" + USER_PASSWORD + "\"", "null"), actualJson, true);
+	}
+
+	@Test
+	public void deserializeWhenMixinNotRegisteredThenThrowJsonProcessingException() {
+		assertThatExceptionOfType(JacksonException.class)
+			.isThrownBy(() -> new JsonMapper().readValue(USER_JSON, LdapUserDetailsImpl.class));
+	}
+
+	@Test
+	public void deserializeWhenMixinRegisteredThenDeserializes() throws Exception {
+		LdapUserDetailsMapper mapper = new LdapUserDetailsMapper();
+		LdapUserDetailsImpl expectedAuthentication = (LdapUserDetailsImpl) mapper
+			.mapUserFromContext(createUserContext(), "ghengis", AuthorityUtils.NO_AUTHORITIES);
+
+		LdapUserDetailsImpl authentication = this.mapper.readValue(USER_JSON, LdapUserDetailsImpl.class);
+		assertThat(authentication.getAuthorities()).containsExactlyElementsOf(expectedAuthentication.getAuthorities());
+		assertThat(authentication.getDn()).isEqualTo(expectedAuthentication.getDn());
+		assertThat(authentication.getUsername()).isEqualTo(expectedAuthentication.getUsername());
+		assertThat(authentication.getPassword()).isEqualTo(expectedAuthentication.getPassword());
+		assertThat(authentication.getGraceLoginsRemaining())
+			.isEqualTo(expectedAuthentication.getGraceLoginsRemaining());
+		assertThat(authentication.getTimeBeforeExpiration())
+			.isEqualTo(expectedAuthentication.getTimeBeforeExpiration());
+		assertThat(authentication.isAccountNonExpired()).isEqualTo(expectedAuthentication.isAccountNonExpired());
+		assertThat(authentication.isAccountNonLocked()).isEqualTo(expectedAuthentication.isAccountNonLocked());
+		assertThat(authentication.isEnabled()).isEqualTo(expectedAuthentication.isEnabled());
+		assertThat(authentication.isCredentialsNonExpired())
+			.isEqualTo(expectedAuthentication.isCredentialsNonExpired());
+	}
+
+	private DirContextAdapter createUserContext() {
+		DirContextAdapter ctx = new DirContextAdapter();
+		ctx.setDn(LdapNameBuilder.newInstance("ignored=ignored").build());
+		ctx.setAttributeValue("userPassword", USER_PASSWORD);
+		return ctx;
+	}
+
+}

--- a/ldap/src/test/java/org/springframework/security/ldap/jackson/PersonMixinTests.java
+++ b/ldap/src/test/java/org/springframework/security/ldap/jackson/PersonMixinTests.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.ldap.jackson;
+
+import org.json.JSONException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.ldap.core.DirContextAdapter;
+import org.springframework.ldap.support.LdapNameBuilder;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.ldap.userdetails.Person;
+import org.springframework.security.ldap.userdetails.PersonContextMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Tests for {@link org.springframework.security.ldap.jackson.PersonMixin}.
+ */
+@SuppressWarnings("removal")
+public class PersonMixinTests {
+
+	private static final String USER_PASSWORD = "Password1234";
+
+	private static final String AUTHORITIES_ARRAYLIST_JSON = "[\"java.util.Collections$UnmodifiableRandomAccessList\", []]";
+
+	// @formatter:off
+	private static final String PERSON_JSON = "{"
+			+ "\"@class\": \"org.springframework.security.ldap.userdetails.Person\", "
+			+ "\"dn\": \"ignored=ignored\","
+			+ "\"username\": \"ghengis\","
+			+ "\"password\": \"" + USER_PASSWORD + "\","
+			+ "\"givenName\": \"Ghengis\","
+			+ "\"sn\": \"Khan\","
+			+ "\"cn\": [\"java.util.Arrays$ArrayList\",[\"Ghengis Khan\"]],"
+			+ "\"description\": \"Scary\","
+			+ "\"telephoneNumber\": \"+442075436521\","
+			+ "\"accountNonExpired\": true, "
+			+ "\"accountNonLocked\": true, "
+			+ "\"credentialsNonExpired\": true, "
+			+ "\"enabled\": true, "
+			+ "\"authorities\": " + AUTHORITIES_ARRAYLIST_JSON + ","
+			+ "\"graceLoginsRemaining\": " + Integer.MAX_VALUE + ","
+			+ "\"timeBeforeExpiration\": " + Integer.MAX_VALUE
+			+ "}";
+	// @formatter:on
+
+	private JsonMapper mapper;
+
+	@BeforeEach
+	public void setup() {
+		ClassLoader loader = getClass().getClassLoader();
+		this.mapper = JsonMapper.builder().addModules(SecurityJacksonModules.getModules(loader)).build();
+	}
+
+	@Test
+	public void serializeWhenMixinRegisteredThenSerializes() throws Exception {
+		PersonContextMapper mapper = new PersonContextMapper();
+		Person p = (Person) mapper.mapUserFromContext(createUserContext(), "ghengis", AuthorityUtils.NO_AUTHORITIES);
+
+		String json = this.mapper.writeValueAsString(p);
+		JSONAssert.assertEquals(PERSON_JSON, json, true);
+	}
+
+	@Test
+	public void serializeWhenEraseCredentialInvokedThenUserPasswordIsNull() throws JacksonException, JSONException {
+		PersonContextMapper mapper = new PersonContextMapper();
+		Person p = (Person) mapper.mapUserFromContext(createUserContext(), "ghengis", AuthorityUtils.NO_AUTHORITIES);
+		p.eraseCredentials();
+		String actualJson = this.mapper.writeValueAsString(p);
+		JSONAssert.assertEquals(PERSON_JSON.replaceAll("\"" + USER_PASSWORD + "\"", "null"), actualJson, true);
+	}
+
+	@Test
+	public void deserializeWhenMixinNotRegisteredThenThrowJsonProcessingException() {
+		assertThatExceptionOfType(JacksonException.class)
+			.isThrownBy(() -> new JsonMapper().readValue(PERSON_JSON, Person.class));
+	}
+
+	@Test
+	public void deserializeWhenMixinRegisteredThenDeserializes() throws Exception {
+		PersonContextMapper mapper = new PersonContextMapper();
+		Person expectedAuthentication = (Person) mapper.mapUserFromContext(createUserContext(), "ghengis",
+				AuthorityUtils.NO_AUTHORITIES);
+
+		Person authentication = this.mapper.readValue(PERSON_JSON, Person.class);
+		assertThat(authentication.getAuthorities()).containsExactlyElementsOf(expectedAuthentication.getAuthorities());
+		assertThat(authentication.getDn()).isEqualTo(expectedAuthentication.getDn());
+		assertThat(authentication.getDescription()).isEqualTo(expectedAuthentication.getDescription());
+		assertThat(authentication.getUsername()).isEqualTo(expectedAuthentication.getUsername());
+		assertThat(authentication.getPassword()).isEqualTo(expectedAuthentication.getPassword());
+		assertThat(authentication.getSn()).isEqualTo(expectedAuthentication.getSn());
+		assertThat(authentication.getGivenName()).isEqualTo(expectedAuthentication.getGivenName());
+		assertThat(authentication.getTelephoneNumber()).isEqualTo(expectedAuthentication.getTelephoneNumber());
+		assertThat(authentication.getGraceLoginsRemaining())
+			.isEqualTo(expectedAuthentication.getGraceLoginsRemaining());
+		assertThat(authentication.getTimeBeforeExpiration())
+			.isEqualTo(expectedAuthentication.getTimeBeforeExpiration());
+		assertThat(authentication.isAccountNonExpired()).isEqualTo(expectedAuthentication.isAccountNonExpired());
+		assertThat(authentication.isAccountNonLocked()).isEqualTo(expectedAuthentication.isAccountNonLocked());
+		assertThat(authentication.isEnabled()).isEqualTo(expectedAuthentication.isEnabled());
+		assertThat(authentication.isCredentialsNonExpired())
+			.isEqualTo(expectedAuthentication.isCredentialsNonExpired());
+	}
+
+	private DirContextAdapter createUserContext() {
+		DirContextAdapter ctx = new DirContextAdapter();
+		ctx.setDn(LdapNameBuilder.newInstance("ignored=ignored").build());
+		ctx.setAttributeValue("userPassword", USER_PASSWORD);
+		ctx.setAttributeValue("cn", "Ghengis Khan");
+		ctx.setAttributeValue("description", "Scary");
+		ctx.setAttributeValue("givenName", "Ghengis");
+		ctx.setAttributeValue("sn", "Khan");
+		ctx.setAttributeValue("telephoneNumber", "+442075436521");
+		return ctx;
+	}
+
+}

--- a/ldap/src/test/java/org/springframework/security/ldap/jackson2/InetOrgPersonMixinTests.java
+++ b/ldap/src/test/java/org/springframework/security/ldap/jackson2/InetOrgPersonMixinTests.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 /**
  * Tests for {@link InetOrgPersonMixin}.
  */
+@SuppressWarnings("removal")
 public class InetOrgPersonMixinTests {
 
 	private static final String USER_PASSWORD = "Password1234";

--- a/ldap/src/test/java/org/springframework/security/ldap/jackson2/LdapUserDetailsImplMixinTests.java
+++ b/ldap/src/test/java/org/springframework/security/ldap/jackson2/LdapUserDetailsImplMixinTests.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 /**
  * Tests for {@link LdapUserDetailsImplMixin}.
  */
+@SuppressWarnings("removal")
 public class LdapUserDetailsImplMixinTests {
 
 	private static final String USER_PASSWORD = "Password1234";

--- a/ldap/src/test/java/org/springframework/security/ldap/jackson2/PersonMixinTests.java
+++ b/ldap/src/test/java/org/springframework/security/ldap/jackson2/PersonMixinTests.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 /**
  * Tests for {@link PersonMixin}.
  */
+@SuppressWarnings("removal")
 public class PersonMixinTests {
 
 	private static final String USER_PASSWORD = "Password1234";

--- a/oauth2/oauth2-client/spring-security-oauth2-client.gradle
+++ b/oauth2/oauth2-client/spring-security-oauth2-client.gradle
@@ -15,6 +15,7 @@ dependencies {
 	optional 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 	optional 'org.springframework:spring-jdbc'
 	optional 'org.springframework:spring-r2dbc'
+	optional 'tools.jackson.core:jackson-databind'
 
 	testImplementation project(path: ':spring-security-oauth2-core', configuration: 'tests')
 	testImplementation project(path: ':spring-security-oauth2-jose', configuration: 'tests')

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/ClientRegistrationDeserializer.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/ClientRegistrationDeserializer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.util.StdConverter;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthenticationMethod;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+
+/**
+ * A {@code JsonDeserializer} for {@link ClientRegistration}.
+ *
+ * @author Sebastien Deleuze
+ * @author Joe Grandja
+ * @since 7.0
+ * @see ClientRegistration
+ * @see ClientRegistrationMixin
+ */
+final class ClientRegistrationDeserializer extends ValueDeserializer<ClientRegistration> {
+
+	private static final StdConverter<JsonNode, ClientAuthenticationMethod> CLIENT_AUTHENTICATION_METHOD_CONVERTER = new StdConverters.ClientAuthenticationMethodConverter();
+
+	private static final StdConverter<JsonNode, AuthorizationGrantType> AUTHORIZATION_GRANT_TYPE_CONVERTER = new StdConverters.AuthorizationGrantTypeConverter();
+
+	private static final StdConverter<JsonNode, AuthenticationMethod> AUTHENTICATION_METHOD_CONVERTER = new StdConverters.AuthenticationMethodConverter();
+
+	@Override
+	public ClientRegistration deserialize(JsonParser parser, DeserializationContext context) {
+		JsonNode clientRegistrationNode = context.readTree(parser);
+		JsonNode providerDetailsNode = JsonNodeUtils.findObjectNode(clientRegistrationNode, "providerDetails");
+		JsonNode userInfoEndpointNode = JsonNodeUtils.findObjectNode(providerDetailsNode, "userInfoEndpoint");
+		return ClientRegistration
+			.withRegistrationId(JsonNodeUtils.findStringValue(clientRegistrationNode, "registrationId"))
+			.clientId(JsonNodeUtils.findStringValue(clientRegistrationNode, "clientId"))
+			.clientSecret(JsonNodeUtils.findStringValue(clientRegistrationNode, "clientSecret"))
+			.clientAuthenticationMethod(CLIENT_AUTHENTICATION_METHOD_CONVERTER
+				.convert(JsonNodeUtils.findObjectNode(clientRegistrationNode, "clientAuthenticationMethod")))
+			.authorizationGrantType(AUTHORIZATION_GRANT_TYPE_CONVERTER
+				.convert(JsonNodeUtils.findObjectNode(clientRegistrationNode, "authorizationGrantType")))
+			.redirectUri(JsonNodeUtils.findStringValue(clientRegistrationNode, "redirectUri"))
+			.scope(JsonNodeUtils.findValue(clientRegistrationNode, "scopes", JsonNodeUtils.STRING_SET, context))
+			.clientName(JsonNodeUtils.findStringValue(clientRegistrationNode, "clientName"))
+			.authorizationUri(JsonNodeUtils.findStringValue(providerDetailsNode, "authorizationUri"))
+			.tokenUri(JsonNodeUtils.findStringValue(providerDetailsNode, "tokenUri"))
+			.userInfoUri(JsonNodeUtils.findStringValue(userInfoEndpointNode, "uri"))
+			.userInfoAuthenticationMethod(AUTHENTICATION_METHOD_CONVERTER
+				.convert(JsonNodeUtils.findObjectNode(userInfoEndpointNode, "authenticationMethod")))
+			.userNameAttributeName(JsonNodeUtils.findStringValue(userInfoEndpointNode, "userNameAttributeName"))
+			.jwkSetUri(JsonNodeUtils.findStringValue(providerDetailsNode, "jwkSetUri"))
+			.issuerUri(JsonNodeUtils.findStringValue(providerDetailsNode, "issuerUri"))
+			.providerConfigurationMetadata(JsonNodeUtils.findValue(providerDetailsNode, "configurationMetadata",
+					JsonNodeUtils.STRING_OBJECT_MAP, context))
+			.build();
+	}
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/ClientRegistrationMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/ClientRegistrationMixin.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import tools.jackson.databind.annotation.JsonDeserialize;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+
+/**
+ * This mixin class is used to serialize/deserialize {@link ClientRegistration}. It also
+ * registers a custom deserializer {@link ClientRegistrationDeserializer}.
+ *
+ * @author Sebastien Deleuze
+ * @author Joe Grandja
+ * @since 7.0
+ * @see ClientRegistration
+ * @see ClientRegistrationDeserializer
+ * @see OAuth2ClientJacksonModule
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonDeserialize(using = ClientRegistrationDeserializer.class)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class ClientRegistrationMixin {
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/DefaultOAuth2UserMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/DefaultOAuth2UserMixin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+/**
+ * This mixin class is used to serialize/deserialize {@link DefaultOAuth2User}.
+ *
+ * @author Sebastien Deleuze
+ * @author Joe Grandja
+ * @since 7.0
+ * @see DefaultOAuth2User
+ * @see OAuth2ClientJacksonModule
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class DefaultOAuth2UserMixin {
+
+	@JsonCreator
+	DefaultOAuth2UserMixin(@JsonProperty("authorities") Collection<? extends GrantedAuthority> authorities,
+			@JsonProperty("attributes") Map<String, Object> attributes,
+			@JsonProperty("nameAttributeKey") String nameAttributeKey) {
+	}
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/DefaultOidcUserMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/DefaultOidcUserMixin.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import java.util.Collection;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+
+/**
+ * This mixin class is used to serialize/deserialize {@link DefaultOidcUser}.
+ *
+ * @author Sebastien Deleuze
+ * @author Joe Grandja
+ * @since 7.0
+ * @see DefaultOidcUser
+ * @see OAuth2ClientJacksonModule
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(value = { "attributes" }, ignoreUnknown = true)
+abstract class DefaultOidcUserMixin {
+
+	@JsonCreator
+	DefaultOidcUserMixin(@JsonProperty("authorities") Collection<? extends GrantedAuthority> authorities,
+			@JsonProperty("idToken") OidcIdToken idToken, @JsonProperty("userInfo") OidcUserInfo userInfo,
+			@JsonProperty("nameAttributeKey") String nameAttributeKey) {
+	}
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/JsonNodeUtils.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/JsonNodeUtils.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import java.util.Map;
+import java.util.Set;
+
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * Utility class for {@code JsonNode}.
+ *
+ * @author Sebastien Deleuze
+ * @author Joe Grandja
+ * @since 7.0
+ */
+abstract class JsonNodeUtils {
+
+	static final TypeReference<Set<String>> STRING_SET = new TypeReference<>() {
+	};
+
+	static final TypeReference<Map<String, Object>> STRING_OBJECT_MAP = new TypeReference<>() {
+	};
+
+	static String findStringValue(JsonNode jsonNode, String fieldName) {
+		if (jsonNode == null) {
+			return null;
+		}
+		JsonNode value = jsonNode.findValue(fieldName);
+		return (value != null && value.isString()) ? value.stringValue() : null;
+	}
+
+	static <T> T findValue(JsonNode jsonNode, String fieldName, TypeReference<T> valueTypeReference,
+			DeserializationContext context) {
+		if (jsonNode == null) {
+			return null;
+		}
+		JsonNode value = jsonNode.findValue(fieldName);
+		return (value != null && value.isContainer())
+				? context.readTreeAsValue(value, context.getTypeFactory().constructType(valueTypeReference)) : null;
+	}
+
+	static JsonNode findObjectNode(JsonNode jsonNode, String fieldName) {
+		if (jsonNode == null) {
+			return null;
+		}
+		JsonNode value = jsonNode.findValue(fieldName);
+		return (value != null && value.isObject()) ? value : null;
+	}
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2AccessTokenMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2AccessTokenMixin.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import java.time.Instant;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import tools.jackson.databind.annotation.JsonDeserialize;
+
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+
+/**
+ * This mixin class is used to serialize/deserialize {@link OAuth2AccessToken}.
+ *
+ * @author Sebastien Deleuze
+ * @author Joe Grandja
+ * @since 7.0
+ * @see OAuth2AccessToken
+ * @see OAuth2ClientJacksonModule
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class OAuth2AccessTokenMixin {
+
+	@JsonCreator
+	OAuth2AccessTokenMixin(
+			@JsonProperty("tokenType") @JsonDeserialize(
+					converter = StdConverters.AccessTokenTypeConverter.class) OAuth2AccessToken.TokenType tokenType,
+			@JsonProperty("tokenValue") String tokenValue, @JsonProperty("issuedAt") Instant issuedAt,
+			@JsonProperty("expiresAt") Instant expiresAt, @JsonProperty("scopes") Set<String> scopes) {
+	}
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthenticationExceptionMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthenticationExceptionMixin.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+/**
+ * This mixin class is used to serialize/deserialize
+ * {@link OAuth2AuthenticationException}.
+ *
+ * @author Sebastien Deleuze
+ * @author Dennis Neufeld
+ * @author Steve Riesenberg
+ * @since 7.0
+ * @see OAuth2AuthenticationException
+ * @see OAuth2ClientJacksonModule
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true, value = { "cause", "stackTrace", "suppressedExceptions" })
+abstract class OAuth2AuthenticationExceptionMixin {
+
+	@JsonProperty("error")
+	abstract OAuth2Error getError();
+
+	@JsonProperty("detailMessage")
+	abstract String getMessage();
+
+	@JsonCreator
+	OAuth2AuthenticationExceptionMixin(@JsonProperty("error") OAuth2Error error,
+			@JsonProperty("detailMessage") String message) {
+	}
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthenticationTokenMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthenticationTokenMixin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import java.util.Collection;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+/**
+ * This mixin class is used to serialize/deserialize {@link OAuth2AuthenticationToken}.
+ *
+ * @author Sebastien Deleuze
+ * @author Joe Grandja
+ * @since 7.0O
+ * @see OAuth2AuthenticationToken
+ * @see OAuth2ClientJacksonModule
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(value = { "authenticated" }, ignoreUnknown = true)
+abstract class OAuth2AuthenticationTokenMixin {
+
+	@JsonCreator
+	OAuth2AuthenticationTokenMixin(@JsonProperty("principal") OAuth2User principal,
+			@JsonProperty("authorities") Collection<? extends GrantedAuthority> authorities,
+			@JsonProperty("authorizedClientRegistrationId") String authorizedClientRegistrationId) {
+	}
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthorizationRequestDeserializer.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthorizationRequestDeserializer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.exc.StreamReadException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.util.StdConverter;
+
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest.Builder;
+
+/**
+ * A {@code JsonDeserializer} for {@link OAuth2AuthorizationRequest}.
+ *
+ * @author Sebastien Deleuze
+ * @author Joe Grandja
+ * @since 7.0
+ * @see OAuth2AuthorizationRequest
+ * @see OAuth2AuthorizationRequestMixin
+ */
+final class OAuth2AuthorizationRequestDeserializer extends ValueDeserializer<OAuth2AuthorizationRequest> {
+
+	private static final StdConverter<JsonNode, AuthorizationGrantType> AUTHORIZATION_GRANT_TYPE_CONVERTER = new StdConverters.AuthorizationGrantTypeConverter();
+
+	@Override
+	public OAuth2AuthorizationRequest deserialize(JsonParser parser, DeserializationContext context) {
+		JsonNode root = context.readTree(parser);
+		return deserialize(parser, context, root);
+	}
+
+	private OAuth2AuthorizationRequest deserialize(JsonParser parser, DeserializationContext context, JsonNode root) {
+		AuthorizationGrantType authorizationGrantType = AUTHORIZATION_GRANT_TYPE_CONVERTER
+			.convert(JsonNodeUtils.findObjectNode(root, "authorizationGrantType"));
+		Builder builder = getBuilder(parser, authorizationGrantType);
+		builder.authorizationUri(JsonNodeUtils.findStringValue(root, "authorizationUri"));
+		builder.clientId(JsonNodeUtils.findStringValue(root, "clientId"));
+		builder.redirectUri(JsonNodeUtils.findStringValue(root, "redirectUri"));
+		builder.scopes(JsonNodeUtils.findValue(root, "scopes", JsonNodeUtils.STRING_SET, context));
+		builder.state(JsonNodeUtils.findStringValue(root, "state"));
+		builder.additionalParameters(
+				JsonNodeUtils.findValue(root, "additionalParameters", JsonNodeUtils.STRING_OBJECT_MAP, context));
+		builder.authorizationRequestUri(JsonNodeUtils.findStringValue(root, "authorizationRequestUri"));
+		builder.attributes(JsonNodeUtils.findValue(root, "attributes", JsonNodeUtils.STRING_OBJECT_MAP, context));
+		return builder.build();
+	}
+
+	private Builder getBuilder(JsonParser parser, AuthorizationGrantType authorizationGrantType) {
+		if (AuthorizationGrantType.AUTHORIZATION_CODE.equals(authorizationGrantType)) {
+			return OAuth2AuthorizationRequest.authorizationCode();
+		}
+		throw new StreamReadException(parser, "Invalid authorizationGrantType");
+	}
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthorizationRequestMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthorizationRequestMixin.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import tools.jackson.databind.annotation.JsonDeserialize;
+
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+/**
+ * This mixin class is used to serialize/deserialize {@link OAuth2AuthorizationRequest}.
+ * It also registers a custom deserializer {@link OAuth2AuthorizationRequestDeserializer}.
+ *
+ * @author Sebastien Deleuze
+ * @author Joe Grandja
+ * @since 7.0
+ * @see OAuth2AuthorizationRequest
+ * @see OAuth2AuthorizationRequestDeserializer
+ * @see OAuth2ClientJacksonModule
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonDeserialize(using = OAuth2AuthorizationRequestDeserializer.class)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class OAuth2AuthorizationRequestMixin {
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthorizedClientMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthorizedClientMixin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+
+/**
+ * This mixin class is used to serialize/deserialize {@link OAuth2AuthorizedClient}.
+ *
+ * @author Sebastien Deleuze
+ * @author Joe Grandja
+ * @since 7.0
+ * @see OAuth2AuthorizedClient
+ * @see OAuth2ClientJacksonModule
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class OAuth2AuthorizedClientMixin {
+
+	@JsonCreator
+	OAuth2AuthorizedClientMixin(@JsonProperty("clientRegistration") ClientRegistration clientRegistration,
+			@JsonProperty("principalName") String principalName,
+			@JsonProperty("accessToken") OAuth2AccessToken accessToken,
+			@JsonProperty("refreshToken") OAuth2RefreshToken refreshToken) {
+	}
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2ClientJacksonModule.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2ClientJacksonModule.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import tools.jackson.core.Version;
+import tools.jackson.databind.cfg.MapperBuilder;
+import tools.jackson.databind.module.SimpleModule;
+
+import org.springframework.security.jackson.AllowlistTypeResolverBuilder;
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
+
+/**
+ * Jackson {@code Module} for {@code spring-security-oauth2-client}, that registers the
+ * following mix-in annotations:
+ *
+ * <ul>
+ * <li>{@link OAuth2AuthorizationRequestMixin}</li>
+ * <li>{@link ClientRegistrationMixin}</li>
+ * <li>{@link OAuth2AccessTokenMixin}</li>
+ * <li>{@link OAuth2RefreshTokenMixin}</li>
+ * <li>{@link OAuth2AuthorizedClientMixin}</li>
+ * <li>{@link OAuth2UserAuthorityMixin}</li>
+ * <li>{@link DefaultOAuth2UserMixin}</li>
+ * <li>{@link OidcIdTokenMixin}</li>
+ * <li>{@link OidcUserInfoMixin}</li>
+ * <li>{@link OidcUserAuthorityMixin}</li>
+ * <li>{@link DefaultOidcUserMixin}</li>
+ * <li>{@link OAuth2AuthenticationTokenMixin}</li>
+ * <li>{@link OAuth2AuthenticationExceptionMixin}</li>
+ * <li>{@link OAuth2ErrorMixin}</li>
+ * </ul>
+ *
+ * If not already enabled, default typing will be automatically enabled as type info is
+ * required to properly serialize/deserialize objects. In order to use this module just
+ * add it to your {@code ObjectMapper} configuration.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new OAuth2ClientJacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * <b>NOTE:</b> Use {@link SecurityJacksonModules#getModules(ClassLoader)} to get a list
+ * of all security modules.
+ *
+ * @author Sebastien Deleuze
+ * @author Joe Grandja
+ * @since 7.0
+ * @see SecurityJacksonModules
+ * @see OAuth2AuthorizationRequestMixin
+ * @see ClientRegistrationMixin
+ * @see OAuth2AccessTokenMixin
+ * @see OAuth2RefreshTokenMixin
+ * @see OAuth2AuthorizedClientMixin
+ * @see OAuth2UserAuthorityMixin
+ * @see DefaultOAuth2UserMixin
+ * @see OidcIdTokenMixin
+ * @see OidcUserInfoMixin
+ * @see OidcUserAuthorityMixin
+ * @see DefaultOidcUserMixin
+ * @see OAuth2AuthenticationTokenMixin
+ * @see OAuth2AuthenticationExceptionMixin
+ * @see OAuth2ErrorMixin
+ */
+@SuppressWarnings("serial")
+public class OAuth2ClientJacksonModule extends SimpleModule {
+
+	public OAuth2ClientJacksonModule() {
+		super(OAuth2ClientJacksonModule.class.getName(), new Version(1, 0, 0, null, null, null));
+	}
+
+	@Override
+	public void setupModule(SetupContext context) {
+		((MapperBuilder<?, ?>) context.getOwner()).setDefaultTyping(new AllowlistTypeResolverBuilder());
+		context.setMixIn(OAuth2AuthorizationRequest.class, OAuth2AuthorizationRequestMixin.class);
+		context.setMixIn(ClientRegistration.class, ClientRegistrationMixin.class);
+		context.setMixIn(OAuth2AccessToken.class, OAuth2AccessTokenMixin.class);
+		context.setMixIn(OAuth2RefreshToken.class, OAuth2RefreshTokenMixin.class);
+		context.setMixIn(OAuth2AuthorizedClient.class, OAuth2AuthorizedClientMixin.class);
+		context.setMixIn(OAuth2UserAuthority.class, OAuth2UserAuthorityMixin.class);
+		context.setMixIn(DefaultOAuth2User.class, DefaultOAuth2UserMixin.class);
+		context.setMixIn(OidcIdToken.class, OidcIdTokenMixin.class);
+		context.setMixIn(OidcUserInfo.class, OidcUserInfoMixin.class);
+		context.setMixIn(OidcUserAuthority.class, OidcUserAuthorityMixin.class);
+		context.setMixIn(DefaultOidcUser.class, DefaultOidcUserMixin.class);
+		context.setMixIn(OAuth2AuthenticationToken.class, OAuth2AuthenticationTokenMixin.class);
+		context.setMixIn(OAuth2AuthenticationException.class, OAuth2AuthenticationExceptionMixin.class);
+		context.setMixIn(OAuth2Error.class, OAuth2ErrorMixin.class);
+	}
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2ErrorMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2ErrorMixin.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+/**
+ * This mixin class is used to serialize/deserialize {@link OAuth2Error} as part of
+ * {@link org.springframework.security.oauth2.core.OAuth2AuthenticationException}.
+ *
+ * @author Sebastien Deleuze
+ * @author Dennis Neufeld
+ * @since 7.0
+ * @see OAuth2Error
+ * @see OAuth2AuthenticationExceptionMixin
+ * @see OAuth2ClientJacksonModule
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class OAuth2ErrorMixin {
+
+	@JsonCreator
+	OAuth2ErrorMixin(@JsonProperty("errorCode") String errorCode, @JsonProperty("description") String description,
+			@JsonProperty("uri") String uri) {
+	}
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2RefreshTokenMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2RefreshTokenMixin.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import java.time.Instant;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+
+/**
+ * This mixin class is used to serialize/deserialize {@link OAuth2RefreshToken}.
+ *
+ * @author Sebastien Deleuze
+ * @author Joe Grandja
+ * @since 7.0
+ * @see OAuth2RefreshToken
+ * @see OAuth2ClientJacksonModule
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class OAuth2RefreshTokenMixin {
+
+	@JsonCreator
+	OAuth2RefreshTokenMixin(@JsonProperty("tokenValue") String tokenValue, @JsonProperty("issuedAt") Instant issuedAt) {
+	}
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2UserAuthorityMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2UserAuthorityMixin.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
+
+/**
+ * This mixin class is used to serialize/deserialize {@link OAuth2UserAuthority}.
+ *
+ * @author Sebastien Deleuze
+ * @author Joe Grandja
+ * @since 7.0
+ * @see OAuth2UserAuthority
+ * @see OAuth2ClientJacksonModule
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class OAuth2UserAuthorityMixin {
+
+	@JsonCreator
+	OAuth2UserAuthorityMixin(@JsonProperty("authority") String authority,
+			@JsonProperty("attributes") Map<String, Object> attributes) {
+	}
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OidcIdTokenMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OidcIdTokenMixin.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import java.time.Instant;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+
+/**
+ * This mixin class is used to serialize/deserialize {@link OidcIdToken}.
+ *
+ * @author Sebastien Deleuze
+ * @author Joe Grandja
+ * @since 7.0
+ * @see OidcIdToken
+ * @see OAuth2ClientJacksonModule
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class OidcIdTokenMixin {
+
+	@JsonCreator
+	OidcIdTokenMixin(@JsonProperty("tokenValue") String tokenValue, @JsonProperty("issuedAt") Instant issuedAt,
+			@JsonProperty("expiresAt") Instant expiresAt, @JsonProperty("claims") Map<String, Object> claims) {
+	}
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OidcUserAuthorityMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OidcUserAuthorityMixin.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
+
+/**
+ * This mixin class is used to serialize/deserialize {@link OidcUserAuthority}.
+ *
+ * @author Sebastien Deleuze
+ * @author Joe Grandja
+ * @since 7.0
+ * @see OidcUserAuthority
+ * @see OAuth2ClientJacksonModule
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(value = { "attributes" }, ignoreUnknown = true)
+abstract class OidcUserAuthorityMixin {
+
+	@JsonCreator
+	OidcUserAuthorityMixin(@JsonProperty("authority") String authority, @JsonProperty("idToken") OidcIdToken idToken,
+			@JsonProperty("userInfo") OidcUserInfo userInfo) {
+	}
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OidcUserInfoMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OidcUserInfoMixin.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+
+/**
+ * This mixin class is used to serialize/deserialize {@link OidcUserInfo}.
+ *
+ * @author Sebastien Deleuze
+ * @author Joe Grandja
+ * @since 7.0
+ * @see OidcUserInfo
+ * @see OAuth2ClientJacksonModule
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class OidcUserInfoMixin {
+
+	@JsonCreator
+	OidcUserInfoMixin(@JsonProperty("claims") Map<String, Object> claims) {
+	}
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/StdConverters.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/StdConverters.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.util.StdConverter;
+
+import org.springframework.security.oauth2.core.AuthenticationMethod;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+
+/**
+ * {@code StdConverter} implementations.
+ *
+ * @author Sebastien Deleuze
+ * @author Joe Grandja
+ * @since 7.0
+ */
+abstract class StdConverters {
+
+	static final class AccessTokenTypeConverter extends StdConverter<JsonNode, OAuth2AccessToken.TokenType> {
+
+		@Override
+		public OAuth2AccessToken.TokenType convert(JsonNode jsonNode) {
+			String value = JsonNodeUtils.findStringValue(jsonNode, "value");
+			if (OAuth2AccessToken.TokenType.BEARER.getValue().equalsIgnoreCase(value)) {
+				return OAuth2AccessToken.TokenType.BEARER;
+			}
+			return null;
+		}
+
+	}
+
+	static final class ClientAuthenticationMethodConverter extends StdConverter<JsonNode, ClientAuthenticationMethod> {
+
+		@Override
+		public ClientAuthenticationMethod convert(JsonNode jsonNode) {
+			String value = JsonNodeUtils.findStringValue(jsonNode, "value");
+			return ClientAuthenticationMethod.valueOf(value);
+		}
+
+	}
+
+	static final class AuthorizationGrantTypeConverter extends StdConverter<JsonNode, AuthorizationGrantType> {
+
+		@Override
+		public AuthorizationGrantType convert(JsonNode jsonNode) {
+			String value = JsonNodeUtils.findStringValue(jsonNode, "value");
+			if (AuthorizationGrantType.AUTHORIZATION_CODE.getValue().equalsIgnoreCase(value)) {
+				return AuthorizationGrantType.AUTHORIZATION_CODE;
+			}
+			if (AuthorizationGrantType.CLIENT_CREDENTIALS.getValue().equalsIgnoreCase(value)) {
+				return AuthorizationGrantType.CLIENT_CREDENTIALS;
+			}
+			return new AuthorizationGrantType(value);
+		}
+
+	}
+
+	static final class AuthenticationMethodConverter extends StdConverter<JsonNode, AuthenticationMethod> {
+
+		@Override
+		public AuthenticationMethod convert(JsonNode jsonNode) {
+			String value = JsonNodeUtils.findStringValue(jsonNode, "value");
+			if (AuthenticationMethod.HEADER.getValue().equalsIgnoreCase(value)) {
+				return AuthenticationMethod.HEADER;
+			}
+			if (AuthenticationMethod.FORM.getValue().equalsIgnoreCase(value)) {
+				return AuthenticationMethod.FORM;
+			}
+			if (AuthenticationMethod.QUERY.getValue().equalsIgnoreCase(value)) {
+				return AuthenticationMethod.QUERY;
+			}
+			return null;
+		}
+
+	}
+
+}

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/package-info.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Jackson 3+ serialization support for OAuth2 client.
+ */
+package org.springframework.security.oauth2.client.jackson;

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/ClientRegistrationDeserializer.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/ClientRegistrationDeserializer.java
@@ -37,7 +37,11 @@ import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
  * @since 5.3
  * @see ClientRegistration
  * @see ClientRegistrationMixin
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.oauth2.client.jackson.ClientRegistrationDeserializer}
+ * based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 final class ClientRegistrationDeserializer extends JsonDeserializer<ClientRegistration> {
 
 	private static final StdConverter<JsonNode, ClientAuthenticationMethod> CLIENT_AUTHENTICATION_METHOD_CONVERTER = new StdConverters.ClientAuthenticationMethodConverter();

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/ClientRegistrationMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/ClientRegistrationMixin.java
@@ -32,7 +32,11 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
  * @see ClientRegistration
  * @see ClientRegistrationDeserializer
  * @see OAuth2ClientJackson2Module
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.oauth2.client.jackson.ClientRegistrationMixin}
+ * based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonDeserialize(using = ClientRegistrationDeserializer.class)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/DefaultOAuth2UserMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/DefaultOAuth2UserMixin.java
@@ -35,7 +35,11 @@ import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
  * @since 5.3
  * @see DefaultOAuth2User
  * @see OAuth2ClientJackson2Module
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.oauth2.client.jackson.DefaultOAuth2UserMixin} based
+ * on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/DefaultOidcUserMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/DefaultOidcUserMixin.java
@@ -36,7 +36,11 @@ import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
  * @since 5.3
  * @see DefaultOidcUser
  * @see OAuth2ClientJackson2Module
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.oauth2.client.jackson.DefaultOidcUserMixin} based
+ * on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/JsonNodeUtils.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/JsonNodeUtils.java
@@ -28,7 +28,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  *
  * @author Joe Grandja
  * @since 5.3
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.oauth2.client.jackson.JsonNodeUtils} based on
+ * Jackson 3
  */
+@Deprecated(forRemoval = true)
 abstract class JsonNodeUtils {
 
 	static final TypeReference<Set<String>> STRING_SET = new TypeReference<>() {

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2AccessTokenMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2AccessTokenMixin.java
@@ -35,7 +35,11 @@ import org.springframework.security.oauth2.core.OAuth2AccessToken;
  * @since 5.3
  * @see OAuth2AccessToken
  * @see OAuth2ClientJackson2Module
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.oauth2.client.jackson.OAuth2AccessTokenMixin} based
+ * on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthenticationExceptionMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthenticationExceptionMixin.java
@@ -34,7 +34,11 @@ import org.springframework.security.oauth2.core.OAuth2Error;
  * @since 5.3.4
  * @see OAuth2AuthenticationException
  * @see OAuth2ClientJackson2Module
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.oauth2.client.jackson.OAuth2AuthenticationExceptionMixin}
+ * based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthenticationTokenMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthenticationTokenMixin.java
@@ -35,7 +35,11 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
  * @since 5.3
  * @see OAuth2AuthenticationToken
  * @see OAuth2ClientJackson2Module
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.oauth2.client.jackson.OAuth2AuthenticationTokenMixin}
+ * based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthorizationRequestDeserializer.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthorizationRequestDeserializer.java
@@ -37,7 +37,11 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequ
  * @since 5.3
  * @see OAuth2AuthorizationRequest
  * @see OAuth2AuthorizationRequestMixin
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.oauth2.client.jackson.OAuth2AuthorizationRequestDeserializer}
+ * based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 final class OAuth2AuthorizationRequestDeserializer extends JsonDeserializer<OAuth2AuthorizationRequest> {
 
 	private static final StdConverter<JsonNode, AuthorizationGrantType> AUTHORIZATION_GRANT_TYPE_CONVERTER = new StdConverters.AuthorizationGrantTypeConverter();

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthorizationRequestMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthorizationRequestMixin.java
@@ -32,7 +32,11 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequ
  * @see OAuth2AuthorizationRequest
  * @see OAuth2AuthorizationRequestDeserializer
  * @see OAuth2ClientJackson2Module
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.oauth2.client.jackson.OAuth2AuthorizationRequestMixin}
+ * based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonDeserialize(using = OAuth2AuthorizationRequestDeserializer.class)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthorizedClientMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthorizedClientMixin.java
@@ -34,7 +34,11 @@ import org.springframework.security.oauth2.core.OAuth2RefreshToken;
  * @since 5.3
  * @see OAuth2AuthorizedClient
  * @see OAuth2ClientJackson2Module
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.oauth2.client.jackson.OAuth2AuthorizedClientMixin}
+ * based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2ClientJackson2Module.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2ClientJackson2Module.java
@@ -85,8 +85,12 @@ import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
  * @see OAuth2AuthenticationTokenMixin
  * @see OAuth2AuthenticationExceptionMixin
  * @see OAuth2ErrorMixin
+ * @deprecated as of 7.0 in favor of
+ * {@link org.springframework.security.oauth2.client.jackson.OAuth2ClientJacksonModule}
+ * based on Jackson 3
  */
-@SuppressWarnings("serial")
+@Deprecated(forRemoval = true)
+@SuppressWarnings({ "serial", "removal" })
 public class OAuth2ClientJackson2Module extends SimpleModule {
 
 	public OAuth2ClientJackson2Module() {

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2ErrorMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2ErrorMixin.java
@@ -33,7 +33,11 @@ import org.springframework.security.oauth2.core.OAuth2Error;
  * @see OAuth2Error
  * @see OAuth2AuthenticationExceptionMixin
  * @see OAuth2ClientJackson2Module
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.oauth2.client.jackson.OAuth2ErrorMixin} based on
+ * Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2RefreshTokenMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2RefreshTokenMixin.java
@@ -33,7 +33,11 @@ import org.springframework.security.oauth2.core.OAuth2RefreshToken;
  * @since 5.3
  * @see OAuth2RefreshToken
  * @see OAuth2ClientJackson2Module
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.oauth2.client.jackson.OAuth2RefreshTokenMixin}
+ * based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2UserAuthorityMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OAuth2UserAuthorityMixin.java
@@ -33,7 +33,11 @@ import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
  * @since 5.3
  * @see OAuth2UserAuthority
  * @see OAuth2ClientJackson2Module
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.oauth2.client.jackson.OAuth2UserAuthorityMixin}
+ * based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OidcIdTokenMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OidcIdTokenMixin.java
@@ -34,7 +34,11 @@ import org.springframework.security.oauth2.core.oidc.OidcIdToken;
  * @since 5.3
  * @see OidcIdToken
  * @see OAuth2ClientJackson2Module
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.oauth2.client.jackson.OidcIdTokenMixin} based on
+ * Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OidcUserAuthorityMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OidcUserAuthorityMixin.java
@@ -33,7 +33,11 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
  * @since 5.3
  * @see OidcUserAuthority
  * @see OAuth2ClientJackson2Module
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.oauth2.client.jackson.OidcUserAuthorityMixin} based
+ * on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OidcUserInfoMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/OidcUserInfoMixin.java
@@ -33,7 +33,11 @@ import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
  * @since 5.3
  * @see OidcUserInfo
  * @see OAuth2ClientJackson2Module
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.oauth2.client.jackson.OidcUserInfoMixin} based on
+ * Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/StdConverters.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/StdConverters.java
@@ -29,7 +29,11 @@ import org.springframework.security.oauth2.core.OAuth2AccessToken;
  *
  * @author Joe Grandja
  * @since 5.3
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.oauth2.client.jackson.StdConverters} based on
+ * Jackson 3
  */
+@Deprecated(forRemoval = true)
 abstract class StdConverters {
 
 	static final class AccessTokenTypeConverter extends StdConverter<JsonNode, OAuth2AccessToken.TokenType> {

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/package-info.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson2/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Jackson 2 serialization support for OAuth2 client.
+ */
+package org.springframework.security.oauth2.client.jackson2;

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthenticationExceptionMixinTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthenticationExceptionMixinTests.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.databind.exc.ValueInstantiationException;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Tests for
+ * {@link org.springframework.security.oauth2.client.jackson.OAuth2AuthenticationExceptionMixin}.
+ *
+ * @author Dennis Neufeld
+ * @since 5.3.4
+ */
+public class OAuth2AuthenticationExceptionMixinTests {
+
+	private JsonMapper mapper;
+
+	@BeforeEach
+	public void setup() {
+		ClassLoader loader = getClass().getClassLoader();
+		this.mapper = JsonMapper.builder().addModules(SecurityJacksonModules.getModules(loader)).build();
+	}
+
+	@Test
+	public void serializeWhenMixinRegisteredThenSerializes() throws Exception {
+		OAuth2AuthenticationException exception = new OAuth2AuthenticationException(
+				new OAuth2Error("[authorization_request_not_found]", "Authorization Request Not Found", "/foo/bar"),
+				"Authorization Request Not Found");
+		String serializedJson = this.mapper.writeValueAsString(exception);
+		String expected = asJson(exception);
+		JSONAssert.assertEquals(expected, serializedJson, true);
+	}
+
+	@Test
+	public void serializeWhenRequiredAttributesOnlyThenSerializes() throws Exception {
+		OAuth2AuthenticationException exception = new OAuth2AuthenticationException(
+				new OAuth2Error("[authorization_request_not_found]"));
+		String serializedJson = this.mapper.writeValueAsString(exception);
+		String expected = asJson(exception);
+		JSONAssert.assertEquals(expected, serializedJson, true);
+	}
+
+	@Test
+	public void deserializeWhenMixinNotRegisteredThenThrowJsonProcessingException() {
+		String json = asJson(new OAuth2AuthenticationException(new OAuth2Error("[authorization_request_not_found]")));
+		assertThatExceptionOfType(ValueInstantiationException.class)
+			.isThrownBy(() -> new JsonMapper().readValue(json, OAuth2AuthenticationException.class));
+	}
+
+	@Test
+	public void deserializeWhenMixinRegisteredThenDeserializes() throws Exception {
+		OAuth2AuthenticationException expected = new OAuth2AuthenticationException(
+				new OAuth2Error("[authorization_request_not_found]", "Authorization Request Not Found", "/foo/bar"),
+				"Authorization Request Not Found");
+		OAuth2AuthenticationException exception = this.mapper.readValue(asJson(expected),
+				OAuth2AuthenticationException.class);
+		assertThat(exception).isNotNull();
+		assertThat(exception.getCause()).isNull();
+		assertThat(exception.getMessage()).isEqualTo(expected.getMessage());
+		OAuth2Error oauth2Error = exception.getError();
+		assertThat(oauth2Error).isNotNull();
+		assertThat(oauth2Error.getErrorCode()).isEqualTo(expected.getError().getErrorCode());
+		assertThat(oauth2Error.getDescription()).isEqualTo(expected.getError().getDescription());
+		assertThat(oauth2Error.getUri()).isEqualTo(expected.getError().getUri());
+	}
+
+	@Test
+	public void deserializeWhenRequiredAttributesOnlyThenDeserializes() throws Exception {
+		OAuth2AuthenticationException expected = new OAuth2AuthenticationException(
+				new OAuth2Error("[authorization_request_not_found]"));
+		OAuth2AuthenticationException exception = this.mapper.readValue(asJson(expected),
+				OAuth2AuthenticationException.class);
+		assertThat(exception).isNotNull();
+		assertThat(exception.getCause()).isNull();
+		assertThat(exception.getMessage()).isNull();
+		OAuth2Error oauth2Error = exception.getError();
+		assertThat(oauth2Error).isNotNull();
+		assertThat(oauth2Error.getErrorCode()).isEqualTo(expected.getError().getErrorCode());
+		assertThat(oauth2Error.getDescription()).isNull();
+		assertThat(oauth2Error.getUri()).isNull();
+	}
+
+	private String asJson(OAuth2AuthenticationException exception) {
+		OAuth2Error error = exception.getError();
+		// @formatter:off
+		return "\n{"
+				+ "\n  \"@class\": \"org.springframework.security.oauth2.core.OAuth2AuthenticationException\","
+				+ "\n  \"error\":"
+				+ "\n  {"
+				+ "\n    \"@class\":\"org.springframework.security.oauth2.core.OAuth2Error\","
+				+ "\n    \"errorCode\":\"" + error.getErrorCode() + "\","
+				+ "\n    \"description\":" + jsonStringOrNull(error.getDescription()) + ","
+				+ "\n    \"uri\":" + jsonStringOrNull(error.getUri())
+				+ "\n  },"
+				+ "\n  \"detailMessage\":" + jsonStringOrNull(exception.getMessage())
+				+ "\n}";
+		// @formatter:on
+	}
+
+	private String jsonStringOrNull(String input) {
+		return (input != null) ? "\"" + input + "\"" : "null";
+	}
+
+}

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthenticationTokenMixinTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthenticationTokenMixinTests.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.authentication.TestOAuth2AuthenticationTokens;
+import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
+import org.springframework.security.oauth2.core.oidc.user.TestOidcUsers;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Tests for
+ * {@link org.springframework.security.oauth2.client.jackson.OAuth2AuthenticationTokenMixin}.
+ *
+ * @author Joe Grandja
+ */
+public class OAuth2AuthenticationTokenMixinTests {
+
+	private JsonMapper mapper;
+
+	@BeforeEach
+	public void setup() {
+		ClassLoader loader = getClass().getClassLoader();
+		this.mapper = JsonMapper.builder()
+			.addModules(SecurityJacksonModules.getModules(loader))
+			// see https://github.com/FasterXML/jackson-databind/issues/3052 for details
+			.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+			.build();
+	}
+
+	@Test
+	public void serializeWhenMixinRegisteredThenSerializes() throws Exception {
+		// OidcUser
+		OAuth2AuthenticationToken authentication = TestOAuth2AuthenticationTokens.oidcAuthenticated();
+		String expectedJson = asJson(authentication);
+		String json = this.mapper.writeValueAsString(authentication);
+		JSONAssert.assertEquals(expectedJson, json, true);
+		// OAuth2User
+		authentication = TestOAuth2AuthenticationTokens.authenticated();
+		expectedJson = asJson(authentication);
+		json = this.mapper.writeValueAsString(authentication);
+		JSONAssert.assertEquals(expectedJson, json, true);
+	}
+
+	@Test
+	public void serializeWhenRequiredAttributesOnlyThenSerializes() throws Exception {
+		DefaultOidcUser principal = TestOidcUsers.create();
+		principal = new DefaultOidcUser(principal.getAuthorities(), principal.getIdToken());
+		OAuth2AuthenticationToken authentication = new OAuth2AuthenticationToken(principal, Collections.emptyList(),
+				"registration-id");
+		String expectedJson = asJson(authentication);
+		String json = this.mapper.writeValueAsString(authentication);
+		JSONAssert.assertEquals(expectedJson, json, true);
+	}
+
+	@Test
+	public void deserializeWhenMixinNotRegisteredThenThrowJsonProcessingException() {
+		OAuth2AuthenticationToken authentication = TestOAuth2AuthenticationTokens.oidcAuthenticated();
+		String json = asJson(authentication);
+		assertThatExceptionOfType(JacksonException.class)
+			.isThrownBy(() -> new JsonMapper().readValue(json, OAuth2AuthenticationToken.class));
+	}
+
+	@Test
+	public void deserializeWhenMixinRegisteredThenDeserializes() throws Exception {
+		// OidcUser
+		OAuth2AuthenticationToken expectedAuthentication = TestOAuth2AuthenticationTokens.oidcAuthenticated();
+		String json = asJson(expectedAuthentication);
+		OAuth2AuthenticationToken authentication = this.mapper.readValue(json, OAuth2AuthenticationToken.class);
+		assertThat(authentication.getAuthorities()).containsExactlyElementsOf(expectedAuthentication.getAuthorities());
+		assertThat(authentication.getDetails()).isEqualTo(expectedAuthentication.getDetails());
+		assertThat(authentication.isAuthenticated()).isEqualTo(expectedAuthentication.isAuthenticated());
+		assertThat(authentication.getAuthorizedClientRegistrationId())
+			.isEqualTo(expectedAuthentication.getAuthorizedClientRegistrationId());
+		DefaultOidcUser expectedOidcUser = (DefaultOidcUser) expectedAuthentication.getPrincipal();
+		DefaultOidcUser oidcUser = (DefaultOidcUser) authentication.getPrincipal();
+		assertThat(oidcUser.getAuthorities().containsAll(expectedOidcUser.getAuthorities())).isTrue();
+		assertThat(oidcUser.getAttributes()).containsExactlyEntriesOf(expectedOidcUser.getAttributes());
+		assertThat(oidcUser.getName()).isEqualTo(expectedOidcUser.getName());
+		OidcIdToken expectedIdToken = expectedOidcUser.getIdToken();
+		OidcIdToken idToken = oidcUser.getIdToken();
+		assertThat(idToken.getTokenValue()).isEqualTo(expectedIdToken.getTokenValue());
+		assertThat(idToken.getIssuedAt()).isEqualTo(expectedIdToken.getIssuedAt());
+		assertThat(idToken.getExpiresAt()).isEqualTo(expectedIdToken.getExpiresAt());
+		assertThat(idToken.getClaims()).containsExactlyEntriesOf(expectedIdToken.getClaims());
+		OidcUserInfo expectedUserInfo = expectedOidcUser.getUserInfo();
+		OidcUserInfo userInfo = oidcUser.getUserInfo();
+		assertThat(userInfo.getClaims()).containsExactlyEntriesOf(expectedUserInfo.getClaims());
+		// OAuth2User
+		expectedAuthentication = TestOAuth2AuthenticationTokens.authenticated();
+		json = asJson(expectedAuthentication);
+		authentication = this.mapper.readValue(json, OAuth2AuthenticationToken.class);
+		assertThat(authentication.getAuthorities()).containsExactlyElementsOf(expectedAuthentication.getAuthorities());
+		assertThat(authentication.getDetails()).isEqualTo(expectedAuthentication.getDetails());
+		assertThat(authentication.isAuthenticated()).isEqualTo(expectedAuthentication.isAuthenticated());
+		assertThat(authentication.getAuthorizedClientRegistrationId())
+			.isEqualTo(expectedAuthentication.getAuthorizedClientRegistrationId());
+		DefaultOAuth2User expectedOauth2User = (DefaultOAuth2User) expectedAuthentication.getPrincipal();
+		DefaultOAuth2User oauth2User = (DefaultOAuth2User) authentication.getPrincipal();
+		assertThat(oauth2User.getAuthorities().containsAll(expectedOauth2User.getAuthorities())).isTrue();
+		assertThat(oauth2User.getAttributes()).containsExactlyEntriesOf(expectedOauth2User.getAttributes());
+		assertThat(oauth2User.getName()).isEqualTo(expectedOauth2User.getName());
+	}
+
+	@Test
+	public void deserializeWhenRequiredAttributesOnlyThenDeserializes() throws Exception {
+		DefaultOidcUser expectedPrincipal = TestOidcUsers.create();
+		expectedPrincipal = new DefaultOidcUser(expectedPrincipal.getAuthorities(), expectedPrincipal.getIdToken());
+		OAuth2AuthenticationToken expectedAuthentication = new OAuth2AuthenticationToken(expectedPrincipal,
+				Collections.emptyList(), "registration-id");
+		String json = asJson(expectedAuthentication);
+		OAuth2AuthenticationToken authentication = this.mapper.readValue(json, OAuth2AuthenticationToken.class);
+		assertThat(authentication.getAuthorities()).isEmpty();
+		assertThat(authentication.getDetails()).isEqualTo(expectedAuthentication.getDetails());
+		assertThat(authentication.isAuthenticated()).isEqualTo(expectedAuthentication.isAuthenticated());
+		assertThat(authentication.getAuthorizedClientRegistrationId())
+			.isEqualTo(expectedAuthentication.getAuthorizedClientRegistrationId());
+		DefaultOidcUser principal = (DefaultOidcUser) authentication.getPrincipal();
+		assertThat(principal.getAuthorities().containsAll(expectedPrincipal.getAuthorities())).isTrue();
+		assertThat(principal.getAttributes()).containsExactlyEntriesOf(expectedPrincipal.getAttributes());
+		assertThat(principal.getName()).isEqualTo(expectedPrincipal.getName());
+		OidcIdToken expectedIdToken = expectedPrincipal.getIdToken();
+		OidcIdToken idToken = principal.getIdToken();
+		assertThat(idToken.getTokenValue()).isEqualTo(expectedIdToken.getTokenValue());
+		assertThat(idToken.getIssuedAt()).isEqualTo(expectedIdToken.getIssuedAt());
+		assertThat(idToken.getExpiresAt()).isEqualTo(expectedIdToken.getExpiresAt());
+		assertThat(idToken.getClaims()).containsExactlyEntriesOf(expectedIdToken.getClaims());
+		assertThat(principal.getUserInfo()).isNull();
+	}
+
+	private static String asJson(OAuth2AuthenticationToken authentication) {
+		String principalJson = (authentication.getPrincipal() instanceof DefaultOidcUser)
+				? asJson((DefaultOidcUser) authentication.getPrincipal())
+				: asJson((DefaultOAuth2User) authentication.getPrincipal());
+		// @formatter:off
+		return "{\n" +
+				"  \"@class\": \"org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken\",\n" +
+				"  \"principal\": " + principalJson + ",\n" +
+				"  \"authorities\": " + asJson(authentication.getAuthorities(), "java.util.Collections$UnmodifiableRandomAccessList") + ",\n" +
+				"  \"authorizedClientRegistrationId\": \"" + authentication.getAuthorizedClientRegistrationId() + "\",\n" +
+				"  \"details\": null\n" +
+				"}";
+		// @formatter:on
+	}
+
+	private static String asJson(DefaultOAuth2User oauth2User) {
+		// @formatter:off
+		return "{\n" +
+				"    \"@class\": \"org.springframework.security.oauth2.core.user.DefaultOAuth2User\",\n" +
+				"    \"authorities\": " + asJson(oauth2User.getAuthorities(), "java.util.Collections$UnmodifiableSet") + ",\n" +
+				"    \"attributes\": {\n" +
+				"      \"@class\": \"java.util.Collections$UnmodifiableMap\",\n" +
+				"      \"username\": \"user\"\n" +
+				"    },\n" +
+				"    \"nameAttributeKey\": \"username\"\n" +
+				"  }";
+		// @formatter:on
+	}
+
+	private static String asJson(DefaultOidcUser oidcUser) {
+		// @formatter:off
+		return "{\n" +
+				"    \"@class\": \"org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser\",\n" +
+				"    \"authorities\": " + asJson(oidcUser.getAuthorities(), "java.util.Collections$UnmodifiableSet") + ",\n" +
+				"    \"idToken\": " + asJson(oidcUser.getIdToken()) + ",\n" +
+				"    \"userInfo\": " + asJson(oidcUser.getUserInfo()) + ",\n" +
+				"    \"nameAttributeKey\": \"" + IdTokenClaimNames.SUB + "\"\n" +
+				"  }";
+		// @formatter:on
+	}
+
+	private static String asJson(Collection<? extends GrantedAuthority> authorities, String classTypeInfo) {
+		OAuth2UserAuthority oauth2UserAuthority = null;
+		OidcUserAuthority oidcUserAuthority = null;
+		List<SimpleGrantedAuthority> simpleAuthorities = new ArrayList<>();
+		for (GrantedAuthority authority : authorities) {
+			if (authority instanceof OidcUserAuthority) {
+				oidcUserAuthority = (OidcUserAuthority) authority;
+			}
+			else if (authority instanceof OAuth2UserAuthority) {
+				oauth2UserAuthority = (OAuth2UserAuthority) authority;
+			}
+			else if (authority instanceof SimpleGrantedAuthority) {
+				simpleAuthorities.add((SimpleGrantedAuthority) authority);
+			}
+		}
+		String authoritiesJson = (oidcUserAuthority != null) ? asJson(oidcUserAuthority)
+				: (oauth2UserAuthority != null) ? asJson(oauth2UserAuthority) : "";
+		if (!simpleAuthorities.isEmpty()) {
+			if (StringUtils.hasLength(authoritiesJson)) {
+				authoritiesJson += ",";
+			}
+			authoritiesJson += asJson(simpleAuthorities);
+		}
+		// @formatter:off
+		return "[\n" +
+				"      \"" + classTypeInfo + "\",\n" +
+				"      [" + authoritiesJson + "]\n" +
+				"    ]";
+		// @formatter:on
+	}
+
+	private static String asJson(OAuth2UserAuthority oauth2UserAuthority) {
+		// @formatter:off
+		return "{\n" +
+				"          \"@class\": \"org.springframework.security.oauth2.core.user.OAuth2UserAuthority\",\n" +
+				"          \"authority\": \"" + oauth2UserAuthority.getAuthority() + "\",\n" +
+				"          \"userNameAttributeName\": \"username\",\n" +
+				"          \"attributes\": {\n" +
+				"            \"@class\": \"java.util.Collections$UnmodifiableMap\",\n" +
+				"            \"username\": \"user\"\n" +
+				"          }\n" +
+				"        }";
+		// @formatter:on
+	}
+
+	private static String asJson(OidcUserAuthority oidcUserAuthority) {
+		// @formatter:off
+		return "{\n" +
+				"          \"@class\": \"org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority\",\n" +
+				"          \"authority\": \"" + oidcUserAuthority.getAuthority() + "\",\n" +
+				"          \"userNameAttributeName\": \"" + oidcUserAuthority.getUserNameAttributeName() + "\",\n" +
+				"          \"idToken\": " + asJson(oidcUserAuthority.getIdToken()) + ",\n" +
+				"          \"userInfo\": " + asJson(oidcUserAuthority.getUserInfo()) + "\n" +
+				"        }";
+		// @formatter:on
+	}
+
+	private static String asJson(List<SimpleGrantedAuthority> simpleAuthorities) {
+		// @formatter:off
+		return simpleAuthorities.stream()
+				.map((authority) -> "{\n" +
+						"        \"@class\": \"org.springframework.security.core.authority.SimpleGrantedAuthority\",\n" +
+						"        \"authority\": \"" + authority.getAuthority() + "\"\n" +
+						"      }")
+				.collect(Collectors.joining(","));
+		// @formatter:on
+	}
+
+	private static String asJson(OidcIdToken idToken) {
+		String aud = "";
+		if (!CollectionUtils.isEmpty(idToken.getAudience())) {
+			aud = StringUtils.collectionToDelimitedString(idToken.getAudience(), ",", "\"", "\"");
+		}
+		// @formatter:off
+		return "{\n" +
+				"      \"@class\": \"org.springframework.security.oauth2.core.oidc.OidcIdToken\",\n" +
+				"      \"tokenValue\": \"" + idToken.getTokenValue() + "\",\n" +
+				"      \"issuedAt\": " + toString(idToken.getIssuedAt()) + ",\n" +
+				"      \"expiresAt\": " + toString(idToken.getExpiresAt()) + ",\n" +
+				"      \"claims\": {\n" +
+				"        \"@class\": \"java.util.Collections$UnmodifiableMap\",\n" +
+				"        \"iat\": [\n" +
+				"          \"java.time.Instant\",\n" +
+				"          " + toString(idToken.getIssuedAt()) + "\n" +
+				"        ],\n" +
+				"        \"exp\": [\n" +
+				"          \"java.time.Instant\",\n" +
+				"          " + toString(idToken.getExpiresAt()) + "\n" +
+				"        ],\n" +
+				"        \"sub\": \"" + idToken.getSubject() + "\",\n" +
+				"        \"iss\": \"" + idToken.getIssuer() + "\",\n" +
+				"        \"aud\": [\n" +
+				"          \"java.util.Collections$UnmodifiableSet\",\n" +
+				"          [" + aud + "]\n" +
+				"        ],\n" +
+				"        \"azp\": \"" + idToken.getAuthorizedParty() + "\"\n" +
+				"      }\n" +
+				"    }";
+		// @formatter:on
+	}
+
+	private static String asJson(OidcUserInfo userInfo) {
+		if (userInfo == null) {
+			return null;
+		}
+		// @formatter:off
+		return "{\n" +
+				"      \"@class\": \"org.springframework.security.oauth2.core.oidc.OidcUserInfo\",\n" +
+				"      \"claims\": {\n" +
+				"        \"@class\": \"java.util.Collections$UnmodifiableMap\",\n" +
+				"        \"sub\": \"" + userInfo.getSubject() + "\",\n" +
+				"        \"name\": \"" + userInfo.getClaim(StandardClaimNames.NAME) + "\"\n" +
+				"      }\n" +
+				"    }";
+		// @formatter:on
+	}
+
+	private static String toString(Instant instant) {
+		if (instant == null) {
+			return null;
+		}
+		return "\"" + DateTimeFormatter.ISO_INSTANT.format(instant) + "\"";
+	}
+
+}

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthorizationRequestMixinTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthorizationRequestMixinTests.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.exc.StreamReadException;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.TestOAuth2AuthorizationRequests;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Tests for
+ * {@link org.springframework.security.oauth2.client.jackson.OAuth2AuthorizationRequestMixin}.
+ *
+ * @author Joe Grandja
+ */
+public class OAuth2AuthorizationRequestMixinTests {
+
+	private JsonMapper mapper;
+
+	private OAuth2AuthorizationRequest.Builder authorizationRequestBuilder;
+
+	@BeforeEach
+	public void setup() {
+		ClassLoader loader = getClass().getClassLoader();
+		this.mapper = JsonMapper.builder().addModules(SecurityJacksonModules.getModules(loader)).build();
+		Map<String, Object> additionalParameters = new LinkedHashMap<>();
+		additionalParameters.put("param1", "value1");
+		additionalParameters.put("param2", "value2");
+		// @formatter:off
+		this.authorizationRequestBuilder = TestOAuth2AuthorizationRequests.request()
+				.scope("read", "write")
+				.additionalParameters(additionalParameters);
+		// @formatter:on
+	}
+
+	@Test
+	public void serializeWhenMixinRegisteredThenSerializes() throws Exception {
+		OAuth2AuthorizationRequest authorizationRequest = this.authorizationRequestBuilder.build();
+		String expectedJson = asJson(authorizationRequest);
+		String json = this.mapper.writeValueAsString(authorizationRequest);
+		JSONAssert.assertEquals(expectedJson, json, true);
+	}
+
+	@Test
+	public void serializeWhenRequiredAttributesOnlyThenSerializes() throws Exception {
+		// @formatter:off
+		OAuth2AuthorizationRequest authorizationRequest = this.authorizationRequestBuilder
+				.scopes(null)
+				.state(null)
+				.additionalParameters(Map::clear)
+				.attributes(Map::clear)
+				.build();
+		// @formatter:on
+		String expectedJson = asJson(authorizationRequest);
+		String json = this.mapper.writeValueAsString(authorizationRequest);
+		JSONAssert.assertEquals(expectedJson, json, true);
+	}
+
+	@Test
+	public void deserializeWhenMixinNotRegisteredThenThrowJsonProcessingException() {
+		String json = asJson(this.authorizationRequestBuilder.build());
+		assertThatExceptionOfType(JacksonException.class)
+			.isThrownBy(() -> new JsonMapper().readValue(json, OAuth2AuthorizationRequest.class));
+	}
+
+	@Test
+	public void deserializeWhenMixinRegisteredThenDeserializes() throws Exception {
+		OAuth2AuthorizationRequest expectedAuthorizationRequest = this.authorizationRequestBuilder.build();
+		String json = asJson(expectedAuthorizationRequest);
+		OAuth2AuthorizationRequest authorizationRequest = this.mapper.readValue(json, OAuth2AuthorizationRequest.class);
+		assertThat(authorizationRequest.getAuthorizationUri())
+			.isEqualTo(expectedAuthorizationRequest.getAuthorizationUri());
+		assertThat(authorizationRequest.getGrantType()).isEqualTo(expectedAuthorizationRequest.getGrantType());
+		assertThat(authorizationRequest.getResponseType()).isEqualTo(expectedAuthorizationRequest.getResponseType());
+		assertThat(authorizationRequest.getClientId()).isEqualTo(expectedAuthorizationRequest.getClientId());
+		assertThat(authorizationRequest.getRedirectUri()).isEqualTo(expectedAuthorizationRequest.getRedirectUri());
+		assertThat(authorizationRequest.getScopes()).isEqualTo(expectedAuthorizationRequest.getScopes());
+		assertThat(authorizationRequest.getState()).isEqualTo(expectedAuthorizationRequest.getState());
+		assertThat(authorizationRequest.getAdditionalParameters())
+			.containsExactlyEntriesOf(expectedAuthorizationRequest.getAdditionalParameters());
+		assertThat(authorizationRequest.getAuthorizationRequestUri())
+			.isEqualTo(expectedAuthorizationRequest.getAuthorizationRequestUri());
+		assertThat(authorizationRequest.getAttributes())
+			.containsExactlyEntriesOf(expectedAuthorizationRequest.getAttributes());
+	}
+
+	@Test
+	public void deserializeWhenRequiredAttributesOnlyThenDeserializes() throws Exception {
+		// @formatter:off
+		OAuth2AuthorizationRequest expectedAuthorizationRequest = this.authorizationRequestBuilder.scopes(null)
+				.state(null)
+				.additionalParameters(Map::clear)
+				.attributes(Map::clear)
+				.build();
+		// @formatter:on
+		String json = asJson(expectedAuthorizationRequest);
+		OAuth2AuthorizationRequest authorizationRequest = this.mapper.readValue(json, OAuth2AuthorizationRequest.class);
+		assertThat(authorizationRequest.getAuthorizationUri())
+			.isEqualTo(expectedAuthorizationRequest.getAuthorizationUri());
+		assertThat(authorizationRequest.getGrantType()).isEqualTo(expectedAuthorizationRequest.getGrantType());
+		assertThat(authorizationRequest.getResponseType()).isEqualTo(expectedAuthorizationRequest.getResponseType());
+		assertThat(authorizationRequest.getClientId()).isEqualTo(expectedAuthorizationRequest.getClientId());
+		assertThat(authorizationRequest.getRedirectUri()).isEqualTo(expectedAuthorizationRequest.getRedirectUri());
+		assertThat(authorizationRequest.getScopes()).isEmpty();
+		assertThat(authorizationRequest.getState()).isNull();
+		assertThat(authorizationRequest.getAdditionalParameters()).isEmpty();
+		assertThat(authorizationRequest.getAuthorizationRequestUri())
+			.isEqualTo(expectedAuthorizationRequest.getAuthorizationRequestUri());
+		assertThat(authorizationRequest.getAttributes()).isEmpty();
+	}
+
+	@Test
+	public void deserializeWhenInvalidAuthorizationGrantTypeThenThrowJsonParseException() {
+		OAuth2AuthorizationRequest authorizationRequest = this.authorizationRequestBuilder.build();
+		String json = asJson(authorizationRequest).replace("authorization_code", "client_credentials");
+		assertThatExceptionOfType(StreamReadException.class)
+			.isThrownBy(() -> this.mapper.readValue(json, OAuth2AuthorizationRequest.class))
+			.withMessageContaining("Invalid authorizationGrantType");
+	}
+
+	private static String asJson(OAuth2AuthorizationRequest authorizationRequest) {
+		String scopes = "";
+		if (!CollectionUtils.isEmpty(authorizationRequest.getScopes())) {
+			scopes = StringUtils.collectionToDelimitedString(authorizationRequest.getScopes(), ",", "\"", "\"");
+		}
+		String additionalParameters = "\"@class\": \"java.util.Collections$UnmodifiableMap\"";
+		if (!CollectionUtils.isEmpty(authorizationRequest.getAdditionalParameters())) {
+			additionalParameters += "," + authorizationRequest.getAdditionalParameters()
+				.keySet()
+				.stream()
+				.map((key) -> "\"" + key + "\": \"" + authorizationRequest.getAdditionalParameters().get(key) + "\"")
+				.collect(Collectors.joining(","));
+		}
+		String attributes = "\"@class\": \"java.util.Collections$UnmodifiableMap\"";
+		if (!CollectionUtils.isEmpty(authorizationRequest.getAttributes())) {
+			attributes += "," + authorizationRequest.getAttributes()
+				.keySet()
+				.stream()
+				.map((key) -> "\"" + key + "\": \"" + authorizationRequest.getAttributes().get(key) + "\"")
+				.collect(Collectors.joining(","));
+		}
+		// @formatter:off
+		return "{\n" +
+				"  \"@class\": \"org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest\",\n" +
+				"  \"authorizationUri\": \"" + authorizationRequest.getAuthorizationUri() + "\",\n" +
+				"  \"authorizationGrantType\": {\n" +
+				"    \"value\": \"" + authorizationRequest.getGrantType().getValue() + "\"\n" +
+				"  },\n" +
+				"  \"responseType\": {\n" +
+				"    \"value\": \"" + authorizationRequest.getResponseType().getValue() + "\"\n" +
+				"  },\n" +
+				"  \"clientId\": \"" + authorizationRequest.getClientId() + "\",\n" +
+				"  \"redirectUri\": \"" + authorizationRequest.getRedirectUri() + "\",\n" +
+				"  \"scopes\": [\n" +
+				"    \"java.util.Collections$UnmodifiableSet\",\n" +
+				"    [" + scopes + "]\n" +
+				"  ],\n" +
+				"  \"state\": " + ((authorizationRequest.getState() != null) ? "\"" + authorizationRequest.getState() + "\"" : "null") + ",\n" +
+				"  \"additionalParameters\": {\n" +
+				"    " + additionalParameters + "\n" +
+				"  },\n" +
+				"  \"authorizationRequestUri\": \"" + authorizationRequest.getAuthorizationRequestUri() + "\",\n" +
+				"  \"attributes\": {\n" +
+				"    " + attributes + "\n" +
+				"  }\n" +
+				"}";
+		// @formatter:on
+	}
+
+}

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthorizedClientMixinTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthorizedClientMixinTests.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.TestClientRegistrations;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.TestOAuth2AccessTokens;
+import org.springframework.security.oauth2.core.TestOAuth2RefreshTokens;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Tests for
+ * {@link org.springframework.security.oauth2.client.jackson.OAuth2AuthorizedClientMixin}.
+ *
+ * @author Joe Grandja
+ */
+public class OAuth2AuthorizedClientMixinTests {
+
+	private JsonMapper mapper;
+
+	private ClientRegistration.Builder clientRegistrationBuilder;
+
+	private OAuth2AccessToken accessToken;
+
+	private OAuth2RefreshToken refreshToken;
+
+	private String principalName;
+
+	@BeforeEach
+	public void setup() {
+		ClassLoader loader = getClass().getClassLoader();
+		this.mapper = JsonMapper.builder().addModules(SecurityJacksonModules.getModules(loader)).build();
+		Map<String, Object> providerConfigurationMetadata = new LinkedHashMap<>();
+		providerConfigurationMetadata.put("config1", "value1");
+		providerConfigurationMetadata.put("config2", "value2");
+		// @formatter:off
+		this.clientRegistrationBuilder = TestClientRegistrations.clientRegistration()
+				.authorizationGrantType(new AuthorizationGrantType("custom-grant"))
+				.scope("read", "write")
+				.providerConfigurationMetadata(providerConfigurationMetadata);
+		// @formatter:on
+		this.accessToken = TestOAuth2AccessTokens.scopes("read", "write");
+		this.refreshToken = TestOAuth2RefreshTokens.refreshToken();
+		this.principalName = "principal-name";
+	}
+
+	@Test
+	public void serializeWhenMixinRegisteredThenSerializes() throws Exception {
+		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.clientRegistrationBuilder.build(),
+				this.principalName, this.accessToken, this.refreshToken);
+		String expectedJson = asJson(authorizedClient);
+		String json = this.mapper.writeValueAsString(authorizedClient);
+		JSONAssert.assertEquals(expectedJson, json, true);
+	}
+
+	@Test
+	public void serializeWhenRequiredAttributesOnlyThenSerializes() throws Exception {
+		// @formatter:off
+		ClientRegistration clientRegistration = TestClientRegistrations.clientRegistration()
+				.clientSecret(null)
+				.clientName(null)
+				.userInfoUri(null)
+				.userNameAttributeName(null)
+				.jwkSetUri(null)
+				.issuerUri(null)
+				.build();
+		// @formatter:on
+		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(clientRegistration, this.principalName,
+				TestOAuth2AccessTokens.noScopes());
+		String expectedJson = asJson(authorizedClient);
+		String json = this.mapper.writeValueAsString(authorizedClient);
+		JSONAssert.assertEquals(expectedJson, json, true);
+	}
+
+	@Test
+	public void deserializeWhenMixinNotRegisteredThenThrowJsonProcessingException() {
+		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.clientRegistrationBuilder.build(),
+				this.principalName, this.accessToken);
+		String json = asJson(authorizedClient);
+		assertThatExceptionOfType(JacksonException.class)
+			.isThrownBy(() -> new JsonMapper().readValue(json, OAuth2AuthorizedClient.class));
+	}
+
+	@Test
+	public void deserializeWhenMixinRegisteredThenDeserializes() throws Exception {
+		ClientRegistration expectedClientRegistration = this.clientRegistrationBuilder.build();
+		OAuth2AccessToken expectedAccessToken = this.accessToken;
+		OAuth2RefreshToken expectedRefreshToken = this.refreshToken;
+		OAuth2AuthorizedClient expectedAuthorizedClient = new OAuth2AuthorizedClient(expectedClientRegistration,
+				this.principalName, expectedAccessToken, expectedRefreshToken);
+		String json = asJson(expectedAuthorizedClient);
+		OAuth2AuthorizedClient authorizedClient = this.mapper.readValue(json, OAuth2AuthorizedClient.class);
+		ClientRegistration clientRegistration = authorizedClient.getClientRegistration();
+		assertThat(clientRegistration.getRegistrationId()).isEqualTo(expectedClientRegistration.getRegistrationId());
+		assertThat(clientRegistration.getClientId()).isEqualTo(expectedClientRegistration.getClientId());
+		assertThat(clientRegistration.getClientSecret()).isEqualTo(expectedClientRegistration.getClientSecret());
+		assertThat(clientRegistration.getClientAuthenticationMethod())
+			.isEqualTo(expectedClientRegistration.getClientAuthenticationMethod());
+		assertThat(clientRegistration.getAuthorizationGrantType())
+			.isEqualTo(expectedClientRegistration.getAuthorizationGrantType());
+		assertThat(clientRegistration.getRedirectUri()).isEqualTo(expectedClientRegistration.getRedirectUri());
+		assertThat(clientRegistration.getScopes()).isEqualTo(expectedClientRegistration.getScopes());
+		assertThat(clientRegistration.getProviderDetails().getAuthorizationUri())
+			.isEqualTo(expectedClientRegistration.getProviderDetails().getAuthorizationUri());
+		assertThat(clientRegistration.getProviderDetails().getTokenUri())
+			.isEqualTo(expectedClientRegistration.getProviderDetails().getTokenUri());
+		assertThat(clientRegistration.getProviderDetails().getUserInfoEndpoint().getUri())
+			.isEqualTo(expectedClientRegistration.getProviderDetails().getUserInfoEndpoint().getUri());
+		assertThat(clientRegistration.getProviderDetails().getUserInfoEndpoint().getAuthenticationMethod())
+			.isEqualTo(expectedClientRegistration.getProviderDetails().getUserInfoEndpoint().getAuthenticationMethod());
+		assertThat(clientRegistration.getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName()).isEqualTo(
+				expectedClientRegistration.getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName());
+		assertThat(clientRegistration.getProviderDetails().getJwkSetUri())
+			.isEqualTo(expectedClientRegistration.getProviderDetails().getJwkSetUri());
+		assertThat(clientRegistration.getProviderDetails().getIssuerUri())
+			.isEqualTo(expectedClientRegistration.getProviderDetails().getIssuerUri());
+		assertThat(clientRegistration.getProviderDetails().getConfigurationMetadata())
+			.containsExactlyEntriesOf(clientRegistration.getProviderDetails().getConfigurationMetadata());
+		assertThat(clientRegistration.getClientName()).isEqualTo(expectedClientRegistration.getClientName());
+		assertThat(authorizedClient.getPrincipalName()).isEqualTo(expectedAuthorizedClient.getPrincipalName());
+		OAuth2AccessToken accessToken = authorizedClient.getAccessToken();
+		assertThat(accessToken.getTokenType()).isEqualTo(expectedAccessToken.getTokenType());
+		assertThat(accessToken.getScopes()).isEqualTo(expectedAccessToken.getScopes());
+		assertThat(accessToken.getTokenValue()).isEqualTo(expectedAccessToken.getTokenValue());
+		assertThat(accessToken.getIssuedAt()).isEqualTo(expectedAccessToken.getIssuedAt());
+		assertThat(accessToken.getExpiresAt()).isEqualTo(expectedAccessToken.getExpiresAt());
+		OAuth2RefreshToken refreshToken = authorizedClient.getRefreshToken();
+		assertThat(refreshToken.getTokenValue()).isEqualTo(expectedRefreshToken.getTokenValue());
+		assertThat(refreshToken.getIssuedAt()).isEqualTo(expectedRefreshToken.getIssuedAt());
+		assertThat(refreshToken.getExpiresAt()).isEqualTo(expectedRefreshToken.getExpiresAt());
+	}
+
+	@Test
+	public void deserializeWhenRequiredAttributesOnlyThenDeserializes() throws Exception {
+		// @formatter:off
+		ClientRegistration expectedClientRegistration = TestClientRegistrations.clientRegistration()
+				.clientSecret(null)
+				.clientName(null)
+				.userInfoUri(null)
+				.userNameAttributeName(null)
+				.jwkSetUri(null)
+				.issuerUri(null)
+				.build();
+		// @formatter:on
+		OAuth2AccessToken expectedAccessToken = TestOAuth2AccessTokens.noScopes();
+		OAuth2AuthorizedClient expectedAuthorizedClient = new OAuth2AuthorizedClient(expectedClientRegistration,
+				this.principalName, expectedAccessToken);
+		String json = asJson(expectedAuthorizedClient);
+		OAuth2AuthorizedClient authorizedClient = this.mapper.readValue(json, OAuth2AuthorizedClient.class);
+		ClientRegistration clientRegistration = authorizedClient.getClientRegistration();
+		assertThat(clientRegistration.getRegistrationId()).isEqualTo(expectedClientRegistration.getRegistrationId());
+		assertThat(clientRegistration.getClientId()).isEqualTo(expectedClientRegistration.getClientId());
+		assertThat(clientRegistration.getClientSecret()).isEmpty();
+		assertThat(clientRegistration.getClientAuthenticationMethod())
+			.isEqualTo(expectedClientRegistration.getClientAuthenticationMethod());
+		assertThat(clientRegistration.getAuthorizationGrantType())
+			.isEqualTo(expectedClientRegistration.getAuthorizationGrantType());
+		assertThat(clientRegistration.getRedirectUri()).isEqualTo(expectedClientRegistration.getRedirectUri());
+		assertThat(clientRegistration.getScopes()).isEqualTo(expectedClientRegistration.getScopes());
+		assertThat(clientRegistration.getProviderDetails().getAuthorizationUri())
+			.isEqualTo(expectedClientRegistration.getProviderDetails().getAuthorizationUri());
+		assertThat(clientRegistration.getProviderDetails().getTokenUri())
+			.isEqualTo(expectedClientRegistration.getProviderDetails().getTokenUri());
+		assertThat(clientRegistration.getProviderDetails().getUserInfoEndpoint().getUri()).isNull();
+		assertThat(clientRegistration.getProviderDetails().getUserInfoEndpoint().getAuthenticationMethod())
+			.isEqualTo(expectedClientRegistration.getProviderDetails().getUserInfoEndpoint().getAuthenticationMethod());
+		assertThat(clientRegistration.getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName()).isNull();
+		assertThat(clientRegistration.getProviderDetails().getJwkSetUri()).isNull();
+		assertThat(clientRegistration.getProviderDetails().getIssuerUri()).isNull();
+		assertThat(clientRegistration.getProviderDetails().getConfigurationMetadata()).isEmpty();
+		assertThat(clientRegistration.getClientName()).isEqualTo(clientRegistration.getRegistrationId());
+		assertThat(authorizedClient.getPrincipalName()).isEqualTo(expectedAuthorizedClient.getPrincipalName());
+		OAuth2AccessToken accessToken = authorizedClient.getAccessToken();
+		assertThat(accessToken.getTokenType()).isEqualTo(expectedAccessToken.getTokenType());
+		assertThat(accessToken.getScopes()).isEmpty();
+		assertThat(accessToken.getTokenValue()).isEqualTo(expectedAccessToken.getTokenValue());
+		assertThat(accessToken.getIssuedAt()).isEqualTo(expectedAccessToken.getIssuedAt());
+		assertThat(accessToken.getExpiresAt()).isEqualTo(expectedAccessToken.getExpiresAt());
+		assertThat(authorizedClient.getRefreshToken()).isNull();
+	}
+
+	@Test
+	void deserializeWhenClientSettingsPropertyDoesNotExistThenDefaulted() throws JacksonException {
+		// ClientRegistration.clientSettings was added later, so old values will be
+		// serialized without that property
+		// this test checks for passivity
+		ClientRegistration clientRegistration = this.clientRegistrationBuilder.build();
+		ClientRegistration.ProviderDetails providerDetails = clientRegistration.getProviderDetails();
+		ClientRegistration.ProviderDetails.UserInfoEndpoint userInfoEndpoint = providerDetails.getUserInfoEndpoint();
+		String scopes = "";
+		if (!CollectionUtils.isEmpty(clientRegistration.getScopes())) {
+			scopes = StringUtils.collectionToDelimitedString(clientRegistration.getScopes(), ",", "\"", "\"");
+		}
+		String configurationMetadata = "\"@class\": \"java.util.Collections$UnmodifiableMap\"";
+		if (!CollectionUtils.isEmpty(providerDetails.getConfigurationMetadata())) {
+			configurationMetadata += "," + providerDetails.getConfigurationMetadata()
+				.keySet()
+				.stream()
+				.map((key) -> "\"" + key + "\": \"" + providerDetails.getConfigurationMetadata().get(key) + "\"")
+				.collect(Collectors.joining(","));
+		}
+		// @formatter:off
+		String json = "{\n" +
+				"    \"@class\": \"org.springframework.security.oauth2.client.registration.ClientRegistration\",\n" +
+				"    \"registrationId\": \"" + clientRegistration.getRegistrationId() + "\",\n" +
+				"    \"clientId\": \"" + clientRegistration.getClientId() + "\",\n" +
+				"    \"clientSecret\": \"" + clientRegistration.getClientSecret() + "\",\n" +
+				"    \"clientAuthenticationMethod\": {\n" +
+				"      \"value\": \"" + clientRegistration.getClientAuthenticationMethod().getValue() + "\"\n" +
+				"    },\n" +
+				"    \"authorizationGrantType\": {\n" +
+				"      \"value\": \"" + clientRegistration.getAuthorizationGrantType().getValue() + "\"\n" +
+				"    },\n" +
+				"    \"redirectUri\": \"" + clientRegistration.getRedirectUri() + "\",\n" +
+				"    \"scopes\": [\n" +
+				"      \"java.util.Collections$UnmodifiableSet\",\n" +
+				"      [" + scopes + "]\n" +
+				"    ],\n" +
+				"    \"providerDetails\": {\n" +
+				"      \"@class\": \"org.springframework.security.oauth2.client.registration.ClientRegistration$ProviderDetails\",\n" +
+				"      \"authorizationUri\": \"" + providerDetails.getAuthorizationUri() + "\",\n" +
+				"      \"tokenUri\": \"" + providerDetails.getTokenUri() + "\",\n" +
+				"      \"userInfoEndpoint\": {\n" +
+				"        \"@class\": \"org.springframework.security.oauth2.client.registration.ClientRegistration$ProviderDetails$UserInfoEndpoint\",\n" +
+				"        \"uri\": " + ((userInfoEndpoint.getUri() != null) ? "\"" + userInfoEndpoint.getUri() + "\"" : null) + ",\n" +
+				"        \"authenticationMethod\": {\n" +
+				"          \"value\": \"" + userInfoEndpoint.getAuthenticationMethod().getValue() + "\"\n" +
+				"        },\n" +
+				"        \"userNameAttributeName\": " + ((userInfoEndpoint.getUserNameAttributeName() != null) ? "\"" + userInfoEndpoint.getUserNameAttributeName() + "\"" : null) + "\n" +
+				"      },\n" +
+				"      \"jwkSetUri\": " + ((providerDetails.getJwkSetUri() != null) ? "\"" + providerDetails.getJwkSetUri() + "\"" : null) + ",\n" +
+				"      \"issuerUri\": " + ((providerDetails.getIssuerUri() != null) ? "\"" + providerDetails.getIssuerUri() + "\"" : null) + ",\n" +
+				"      \"configurationMetadata\": {\n" +
+				"        " + configurationMetadata + "\n" +
+				"      }\n" +
+				"    },\n" +
+				"    \"clientName\": \"" + clientRegistration.getClientName() + "\"\n" +
+				"}";
+		// @formatter:on
+		// validate the test input
+		assertThat(json).doesNotContain("clientSettings");
+		ClientRegistration registration = this.mapper.readValue(json, ClientRegistration.class);
+		// the default value of requireProofKey is false
+		assertThat(registration.getClientSettings().isRequireProofKey()).isFalse();
+	}
+
+	private static String asJson(OAuth2AuthorizedClient authorizedClient) {
+		// @formatter:off
+		return "{\n" +
+				"  \"@class\": \"org.springframework.security.oauth2.client.OAuth2AuthorizedClient\",\n" +
+				"  \"clientRegistration\": " + asJson(authorizedClient.getClientRegistration()) + ",\n" +
+				"  \"principalName\": \"" + authorizedClient.getPrincipalName() + "\",\n" +
+				"  \"accessToken\": " + asJson(authorizedClient.getAccessToken()) + ",\n" +
+				"  \"refreshToken\": " + asJson(authorizedClient.getRefreshToken()) + "\n" +
+				"}";
+		// @formatter:on
+	}
+
+	private static String asJson(ClientRegistration clientRegistration) {
+		ClientRegistration.ProviderDetails providerDetails = clientRegistration.getProviderDetails();
+		ClientRegistration.ProviderDetails.UserInfoEndpoint userInfoEndpoint = providerDetails.getUserInfoEndpoint();
+		String scopes = "";
+		if (!CollectionUtils.isEmpty(clientRegistration.getScopes())) {
+			scopes = StringUtils.collectionToDelimitedString(clientRegistration.getScopes(), ",", "\"", "\"");
+		}
+		String configurationMetadata = "\"@class\": \"java.util.Collections$UnmodifiableMap\"";
+		if (!CollectionUtils.isEmpty(providerDetails.getConfigurationMetadata())) {
+			configurationMetadata += "," + providerDetails.getConfigurationMetadata()
+				.keySet()
+				.stream()
+				.map((key) -> "\"" + key + "\": \"" + providerDetails.getConfigurationMetadata().get(key) + "\"")
+				.collect(Collectors.joining(","));
+		}
+		// @formatter:off
+		return "{\n" +
+				"    \"@class\": \"org.springframework.security.oauth2.client.registration.ClientRegistration\",\n" +
+				"    \"registrationId\": \"" + clientRegistration.getRegistrationId() + "\",\n" +
+				"    \"clientId\": \"" + clientRegistration.getClientId() + "\",\n" +
+				"    \"clientSecret\": \"" + clientRegistration.getClientSecret() + "\",\n" +
+				"    \"clientAuthenticationMethod\": {\n" +
+				"      \"value\": \"" + clientRegistration.getClientAuthenticationMethod().getValue() + "\"\n" +
+				"    },\n" +
+				"    \"authorizationGrantType\": {\n" +
+				"      \"value\": \"" + clientRegistration.getAuthorizationGrantType().getValue() + "\"\n" +
+				"    },\n" +
+				"    \"redirectUri\": \"" + clientRegistration.getRedirectUri() + "\",\n" +
+				"    \"scopes\": [\n" +
+				"      \"java.util.Collections$UnmodifiableSet\",\n" +
+				"      [" + scopes + "]\n" +
+				"    ],\n" +
+				"    \"providerDetails\": {\n" +
+				"      \"@class\": \"org.springframework.security.oauth2.client.registration.ClientRegistration$ProviderDetails\",\n" +
+				"      \"authorizationUri\": \"" + providerDetails.getAuthorizationUri() + "\",\n" +
+				"      \"tokenUri\": \"" + providerDetails.getTokenUri() + "\",\n" +
+				"      \"userInfoEndpoint\": {\n" +
+				"        \"@class\": \"org.springframework.security.oauth2.client.registration.ClientRegistration$ProviderDetails$UserInfoEndpoint\",\n" +
+				"        \"uri\": " + ((userInfoEndpoint.getUri() != null) ? "\"" + userInfoEndpoint.getUri() + "\"" : null) + ",\n" +
+				"        \"authenticationMethod\": {\n" +
+				"          \"value\": \"" + userInfoEndpoint.getAuthenticationMethod().getValue() + "\"\n" +
+				"        },\n" +
+				"        \"userNameAttributeName\": " + ((userInfoEndpoint.getUserNameAttributeName() != null) ? "\"" + userInfoEndpoint.getUserNameAttributeName() + "\"" : null) + "\n" +
+				"      },\n" +
+				"      \"jwkSetUri\": " + ((providerDetails.getJwkSetUri() != null) ? "\"" + providerDetails.getJwkSetUri() + "\"" : null) + ",\n" +
+				"      \"issuerUri\": " + ((providerDetails.getIssuerUri() != null) ? "\"" + providerDetails.getIssuerUri() + "\"" : null) + ",\n" +
+				"      \"configurationMetadata\": {\n" +
+				"        " + configurationMetadata + "\n" +
+				"      }\n" +
+				"    },\n" +
+				"    \"clientName\": \"" + clientRegistration.getClientName() + "\",\n" +
+				"    \"clientSettings\": {\n" +
+				"      \"requireProofKey\": " + clientRegistration.getClientSettings().isRequireProofKey() + "\n" +
+				"    }\n" +
+				"}";
+		// @formatter:on
+	}
+
+	private static String asJson(OAuth2AccessToken accessToken) {
+		String scopes = "";
+		if (!CollectionUtils.isEmpty(accessToken.getScopes())) {
+			scopes = StringUtils.collectionToDelimitedString(accessToken.getScopes(), ",", "\"", "\"");
+		}
+		// @formatter:off
+		return "{\n" +
+				"    \"@class\": \"org.springframework.security.oauth2.core.OAuth2AccessToken\",\n" +
+				"    \"tokenType\": {\n" +
+				"      \"value\": \"" + accessToken.getTokenType().getValue() + "\"\n" +
+				"    },\n" +
+				"    \"tokenValue\": \"" + accessToken.getTokenValue() + "\",\n" +
+				"    \"issuedAt\": " + toString(accessToken.getIssuedAt()) + ",\n" +
+				"    \"expiresAt\": " + toString(accessToken.getExpiresAt()) + ",\n" +
+				"    \"scopes\": [\n" +
+				"      \"java.util.Collections$UnmodifiableSet\",\n" +
+				"      [" + scopes + "]\n" +
+				"    ]\n" +
+				"}";
+		// @formatter:on
+	}
+
+	private static String asJson(OAuth2RefreshToken refreshToken) {
+		if (refreshToken == null) {
+			return null;
+		}
+		// @formatter:off
+		return "{\n" +
+				"    \"@class\": \"org.springframework.security.oauth2.core.OAuth2RefreshToken\",\n" +
+				"    \"tokenValue\": \"" + refreshToken.getTokenValue() + "\",\n" +
+				"    \"issuedAt\": " + toString(refreshToken.getIssuedAt()) + ",\n" +
+				"    \"expiresAt\": " + toString(refreshToken.getExpiresAt()) + "\n" +
+				"}";
+		// @formatter:on
+	}
+
+	private static String toString(Instant instant) {
+		if (instant == null) {
+			return null;
+		}
+		return "\"" + DateTimeFormatter.ISO_INSTANT.format(instant) + "\"";
+	}
+
+}

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson/StdConvertersTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson/StdConvertersTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.client.jackson;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.util.StdConverter;
+
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StdConvertersTests {
+
+	private final StdConverter<JsonNode, ClientAuthenticationMethod> clientAuthenticationMethodConverter = new org.springframework.security.oauth2.client.jackson.StdConverters.ClientAuthenticationMethodConverter();
+
+	@ParameterizedTest
+	@MethodSource("convertWhenClientAuthenticationMethodConvertedThenDeserializes")
+	void convertWhenClientAuthenticationMethodConvertedThenDeserializes(String clientAuthenticationMethod) {
+		ObjectNode jsonNode = JsonNodeFactory.instance.objectNode();
+		jsonNode.put("value", clientAuthenticationMethod);
+		ClientAuthenticationMethod actual = this.clientAuthenticationMethodConverter.convert(jsonNode);
+		assertThat(actual.getValue()).isEqualTo(clientAuthenticationMethod);
+	}
+
+	static Stream<Arguments> convertWhenClientAuthenticationMethodConvertedThenDeserializes() {
+		return Stream.of(Arguments.of(ClientAuthenticationMethod.CLIENT_SECRET_BASIC.getValue()),
+				Arguments.of(ClientAuthenticationMethod.CLIENT_SECRET_POST.getValue()),
+				Arguments.of(ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue()),
+				Arguments.of(ClientAuthenticationMethod.NONE.getValue()), Arguments.of("custom_method"));
+	}
+
+}

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthenticationExceptionMixinTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthenticationExceptionMixinTests.java
@@ -35,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Dennis Neufeld
  * @since 5.3.4
  */
+@SuppressWarnings("removal")
 public class OAuth2AuthenticationExceptionMixinTests {
 
 	private ObjectMapper mapper;

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthenticationTokenMixinTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthenticationTokenMixinTests.java
@@ -56,6 +56,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  *
  * @author Joe Grandja
  */
+@SuppressWarnings("removal")
 public class OAuth2AuthenticationTokenMixinTests {
 
 	private ObjectMapper mapper;

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthorizationRequestMixinTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthorizationRequestMixinTests.java
@@ -41,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  *
  * @author Joe Grandja
  */
+@SuppressWarnings("removal")
 public class OAuth2AuthorizationRequestMixinTests {
 
 	private ObjectMapper mapper;

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthorizedClientMixinTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson2/OAuth2AuthorizedClientMixinTests.java
@@ -48,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  *
  * @author Joe Grandja
  */
+@SuppressWarnings("removal")
 public class OAuth2AuthorizedClientMixinTests {
 
 	private ObjectMapper mapper;

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson2/StdConvertersTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson2/StdConvertersTests.java
@@ -30,6 +30,7 @@ import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("removal")
 public class StdConvertersTests {
 
 	private final StdConverter<JsonNode, ClientAuthenticationMethod> clientAuthenticationMethodConverter = new StdConverters.ClientAuthenticationMethodConverter();

--- a/saml2/saml2-service-provider/spring-security-saml2-service-provider.gradle
+++ b/saml2/saml2-service-provider/spring-security-saml2-service-provider.gradle
@@ -94,6 +94,7 @@ dependencies {
 
 	optional 'com.fasterxml.jackson.core:jackson-databind'
 	optional 'org.springframework:spring-jdbc'
+	optional 'tools.jackson.core:jackson-databind'
 
 	testImplementation project(path: ':spring-security-web', configuration: 'tests')
 	testImplementation 'com.squareup.okhttp3:mockwebserver'

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/DefaultSaml2AuthenticatedPrincipalMixin.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/DefaultSaml2AuthenticatedPrincipalMixin.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.jackson;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.saml2.provider.service.authentication.DefaultSaml2AuthenticatedPrincipal;
+
+/**
+ * Jackson Mixin class helps in serialize/deserialize
+ * {@link DefaultSaml2AuthenticatedPrincipal}.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new Saml2JacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Ulrich Grave
+ * @since 7.0
+ * @see Saml2JacksonModule
+ * @see SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+class DefaultSaml2AuthenticatedPrincipalMixin {
+
+	@JsonProperty("registrationId")
+	String registrationId;
+
+	DefaultSaml2AuthenticatedPrincipalMixin(@JsonProperty("name") String name,
+			@JsonProperty("attributes") Map<String, List<Object>> attributes,
+			@JsonProperty("sessionIndexes") List<String> sessionIndexes) {
+
+	}
+
+}

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/Saml2AssertionAuthenticationMixin.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/Saml2AssertionAuthenticationMixin.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.jackson;
+
+import java.util.Collection;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.saml2.provider.service.authentication.Saml2AssertionAuthentication;
+import org.springframework.security.saml2.provider.service.authentication.Saml2ResponseAssertionAccessor;
+
+/**
+ * Jackson Mixin class helps in serialize/deserialize
+ * {@link Saml2AssertionAuthentication}.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new Saml2JacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Josh Cummings
+ * @since 7.0
+ * @see Saml2JacksonModule
+ * @see SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(value = { "authenticated" }, ignoreUnknown = true)
+class Saml2AssertionAuthenticationMixin {
+
+	@JsonCreator
+	Saml2AssertionAuthenticationMixin(@JsonProperty("principal") Object principal,
+			@JsonProperty("assertion") Saml2ResponseAssertionAccessor assertion,
+			@JsonProperty("authorities") Collection<? extends GrantedAuthority> authorities,
+			@JsonProperty("relyingPartyRegistrationId") String relyingPartyRegistrationId) {
+	}
+
+}

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/Saml2AuthenticationExceptionMixin.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/Saml2AuthenticationExceptionMixin.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.saml2.core.Saml2Error;
+import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticationException;
+
+/**
+ * This mixin class is used to serialize/deserialize {@link Saml2AuthenticationException}.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new Saml2JacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Ulrich Grave
+ * @since 7.0
+ * @see Saml2AuthenticationException
+ * @see Saml2JacksonModule
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true, value = { "cause", "stackTrace", "suppressedExceptions" })
+abstract class Saml2AuthenticationExceptionMixin {
+
+	@JsonProperty("error")
+	abstract Saml2Error getSaml2Error();
+
+	@JsonProperty("detailMessage")
+	abstract String getMessage();
+
+	@JsonCreator
+	Saml2AuthenticationExceptionMixin(@JsonProperty("error") Saml2Error error,
+			@JsonProperty("detailMessage") String message) {
+	}
+
+}

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/Saml2AuthenticationMixin.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/Saml2AuthenticationMixin.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.jackson;
+
+import java.util.Collection;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.core.AuthenticatedPrincipal;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication;
+
+/**
+ * Jackson Mixin class helps in serialize/deserialize {@link Saml2Authentication}.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new Saml2JacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @since 7.0
+ * @see Saml2JacksonModule
+ * @see SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(value = { "authenticated" }, ignoreUnknown = true)
+class Saml2AuthenticationMixin {
+
+	@JsonCreator
+	Saml2AuthenticationMixin(@JsonProperty("principal") AuthenticatedPrincipal principal,
+			@JsonProperty("saml2Response") String saml2Response,
+			@JsonProperty("authorities") Collection<? extends GrantedAuthority> authorities) {
+	}
+
+}

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/Saml2ErrorMixin.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/Saml2ErrorMixin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.saml2.core.Saml2Error;
+
+/**
+ * This mixin class is used to serialize/deserialize {@link Saml2Error}.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new Saml2JacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Ulrich Grave
+ * @since 7.0
+ * @see Saml2Error
+ * @see Saml2JacksonModule
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+class Saml2ErrorMixin {
+
+	@JsonCreator
+	Saml2ErrorMixin(@JsonProperty("errorCode") String errorCode, @JsonProperty("description") String description) {
+	}
+
+}

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/Saml2JacksonModule.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/Saml2JacksonModule.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.jackson;
+
+import tools.jackson.core.Version;
+import tools.jackson.databind.module.SimpleModule;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.saml2.core.Saml2Error;
+import org.springframework.security.saml2.provider.service.authentication.DefaultSaml2AuthenticatedPrincipal;
+import org.springframework.security.saml2.provider.service.authentication.Saml2AssertionAuthentication;
+import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication;
+import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticationException;
+import org.springframework.security.saml2.provider.service.authentication.Saml2PostAuthenticationRequest;
+import org.springframework.security.saml2.provider.service.authentication.Saml2RedirectAuthenticationRequest;
+import org.springframework.security.saml2.provider.service.authentication.Saml2ResponseAssertion;
+import org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutRequest;
+
+/**
+ * Jackson module for saml2-service-provider. This module register
+ * {@link Saml2AuthenticationMixin}, {@link DefaultSaml2AuthenticatedPrincipalMixin},
+ * {@link Saml2LogoutRequestMixin}, {@link Saml2RedirectAuthenticationRequestMixin},
+ * {@link Saml2PostAuthenticationRequestMixin}, {@link Saml2ErrorMixin} and
+ * {@link Saml2AuthenticationExceptionMixin}.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new Saml2JacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @since 7.0
+ * @see SecurityJacksonModules
+ */
+@SuppressWarnings("serial")
+public class Saml2JacksonModule extends SimpleModule {
+
+	public Saml2JacksonModule() {
+		super(Saml2JacksonModule.class.getName(), new Version(1, 0, 0, null, null, null));
+	}
+
+	@Override
+	public void setupModule(SetupContext context) {
+		// TODO Is it expected that default typing in not configured in the Jackson 2
+		// module?
+		context.setMixIn(Saml2Authentication.class, Saml2AuthenticationMixin.class);
+		context.setMixIn(Saml2AssertionAuthentication.class, Saml2AssertionAuthenticationMixin.class);
+		context.setMixIn(Saml2ResponseAssertion.class, SimpleSaml2ResponseAssertionAccessorMixin.class);
+		context.setMixIn(DefaultSaml2AuthenticatedPrincipal.class, DefaultSaml2AuthenticatedPrincipalMixin.class);
+		context.setMixIn(Saml2LogoutRequest.class, Saml2LogoutRequestMixin.class);
+		context.setMixIn(Saml2RedirectAuthenticationRequest.class, Saml2RedirectAuthenticationRequestMixin.class);
+		context.setMixIn(Saml2PostAuthenticationRequest.class, Saml2PostAuthenticationRequestMixin.class);
+		context.setMixIn(Saml2Error.class, Saml2ErrorMixin.class);
+		context.setMixIn(Saml2AuthenticationException.class, Saml2AuthenticationExceptionMixin.class);
+	}
+
+}

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/Saml2LogoutRequestMixin.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/Saml2LogoutRequestMixin.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.jackson;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutRequest;
+import org.springframework.security.saml2.provider.service.registration.Saml2MessageBinding;
+
+/**
+ * Jackson Mixin class helps in serialize/deserialize {@link Saml2LogoutRequest}.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new Saml2JacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Ulrich Grave
+ * @since 7.0
+ * @see Saml2JacksonModule
+ * @see SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+class Saml2LogoutRequestMixin {
+
+	@JsonIgnore
+	Function<Map<String, String>, String> encoder;
+
+	@JsonCreator
+	Saml2LogoutRequestMixin(@JsonProperty("location") String location,
+			@JsonProperty("binding") Saml2MessageBinding binding,
+			@JsonProperty("parameters") Map<String, String> parameters, @JsonProperty("id") String id,
+			@JsonProperty("relyingPartyRegistrationId") String relyingPartyRegistrationId) {
+	}
+
+}

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/Saml2PostAuthenticationRequestMixin.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/Saml2PostAuthenticationRequestMixin.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.saml2.provider.service.authentication.Saml2PostAuthenticationRequest;
+
+/**
+ * Jackson Mixin class helps in serialize/deserialize
+ * {@link Saml2PostAuthenticationRequest}.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new Saml2JacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Ulrich Grave
+ * @since 7.0
+ * @see Saml2JacksonModule
+ * @see SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+class Saml2PostAuthenticationRequestMixin {
+
+	@JsonCreator
+	Saml2PostAuthenticationRequestMixin(@JsonProperty("samlRequest") String samlRequest,
+			@JsonProperty("relayState") String relayState,
+			@JsonProperty("authenticationRequestUri") String authenticationRequestUri,
+			@JsonProperty("relyingPartyRegistrationId") String relyingPartyRegistrationId,
+			@JsonProperty("id") String id) {
+	}
+
+}

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/Saml2RedirectAuthenticationRequestMixin.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/Saml2RedirectAuthenticationRequestMixin.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.saml2.provider.service.authentication.Saml2RedirectAuthenticationRequest;
+
+/**
+ * Jackson Mixin class helps in serialize/deserialize
+ * {@link Saml2RedirectAuthenticationRequest}.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new Saml2JacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Ulrich Grave
+ * @since 7.0
+ * @see Saml2JacksonModule
+ * @see SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+class Saml2RedirectAuthenticationRequestMixin {
+
+	@JsonCreator
+	Saml2RedirectAuthenticationRequestMixin(@JsonProperty("samlRequest") String samlRequest,
+			@JsonProperty("sigAlg") String sigAlg, @JsonProperty("signature") String signature,
+			@JsonProperty("relayState") String relayState,
+			@JsonProperty("authenticationRequestUri") String authenticationRequestUri,
+			@JsonProperty("relyingPartyRegistrationId") String relyingPartyRegistrationId,
+			@JsonProperty("id") String id) {
+	}
+
+}

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/SimpleSaml2ResponseAssertionAccessorMixin.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/SimpleSaml2ResponseAssertionAccessorMixin.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.jackson;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.saml2.provider.service.authentication.Saml2ResponseAssertion;
+
+/**
+ * Jackson Mixin class helps in serialize/deserialize {@link Saml2ResponseAssertion}.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new Saml2JacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Josh Cummings
+ * @since 7.0
+ * @see Saml2JacksonModule
+ * @see SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(value = { "authenticated" }, ignoreUnknown = true)
+class SimpleSaml2ResponseAssertionAccessorMixin {
+
+	@JsonCreator
+	SimpleSaml2ResponseAssertionAccessorMixin(@JsonProperty("responseValue") String responseValue,
+			@JsonProperty("nameId") String nameId, @JsonProperty("sessionIndexes") List<String> sessionIndexes,
+			@JsonProperty("attributes") Map<String, List<Object>> attributes) {
+	}
+
+}

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/package-info.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Jackson 3+ serialization support for SAML2.
+ */
+package org.springframework.security.saml2.jackson;

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/DefaultSaml2AuthenticatedPrincipalMixin.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/DefaultSaml2AuthenticatedPrincipalMixin.java
@@ -40,7 +40,11 @@ import org.springframework.security.saml2.provider.service.authentication.Defaul
  * @since 5.7
  * @see Saml2Jackson2Module
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.saml2.jackson.DefaultSaml2AuthenticatedPrincipalMixin}
+ * based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/Saml2AssertionAuthenticationMixin.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/Saml2AssertionAuthenticationMixin.java
@@ -42,7 +42,11 @@ import org.springframework.security.saml2.provider.service.authentication.Saml2R
  * @since 7.0
  * @see Saml2Jackson2Module
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.saml2.jackson.Saml2AssertionAuthenticationMixin}
+ * based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/Saml2AuthenticationExceptionMixin.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/Saml2AuthenticationExceptionMixin.java
@@ -32,7 +32,11 @@ import org.springframework.security.saml2.provider.service.authentication.Saml2A
  * @since 5.7
  * @see Saml2AuthenticationException
  * @see Saml2Jackson2Module
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.saml2.jackson.Saml2AuthenticationExceptionMixin}
+ * based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/Saml2AuthenticationMixin.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/Saml2AuthenticationMixin.java
@@ -41,7 +41,11 @@ import org.springframework.security.saml2.provider.service.authentication.Saml2A
  * @since 5.7
  * @see Saml2Jackson2Module
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.saml2.jackson.Saml2AuthenticationMixin} based on
+ * Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/Saml2ErrorMixin.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/Saml2ErrorMixin.java
@@ -31,7 +31,10 @@ import org.springframework.security.saml2.core.Saml2Error;
  * @since 5.7
  * @see Saml2Error
  * @see Saml2Jackson2Module
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.saml2.jackson.Saml2ErrorMixin} based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/Saml2Jackson2Module.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/Saml2Jackson2Module.java
@@ -40,7 +40,11 @@ import org.springframework.security.saml2.provider.service.authentication.logout
  * @author Ulrich Grave
  * @since 5.7
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@link org.springframework.security.saml2.jackson.Saml2JacksonModule} based on Jackson
+ * 3
  */
+@Deprecated(forRemoval = true)
 @SuppressWarnings("serial")
 public class Saml2Jackson2Module extends SimpleModule {
 
@@ -50,6 +54,7 @@ public class Saml2Jackson2Module extends SimpleModule {
 
 	@Override
 	public void setupModule(SetupContext context) {
+		// TODO Is it expected that default typing in not configured here?
 		context.setMixInAnnotations(Saml2Authentication.class, Saml2AuthenticationMixin.class);
 		context.setMixInAnnotations(Saml2AssertionAuthentication.class, Saml2AssertionAuthenticationMixin.class);
 		context.setMixInAnnotations(Saml2ResponseAssertion.class, SimpleSaml2ResponseAssertionAccessorMixin.class);

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/Saml2LogoutRequestMixin.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/Saml2LogoutRequestMixin.java
@@ -42,7 +42,11 @@ import org.springframework.security.saml2.provider.service.registration.Saml2Mes
  * @since 5.7
  * @see Saml2Jackson2Module
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.saml2.jackson.Saml2LogoutRequestMixin} based on
+ * Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/Saml2PostAuthenticationRequestMixin.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/Saml2PostAuthenticationRequestMixin.java
@@ -38,7 +38,11 @@ import org.springframework.security.saml2.provider.service.authentication.Saml2P
  * @since 5.7
  * @see Saml2Jackson2Module
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.saml2.jackson.Saml2PostAuthenticationRequestMixin}
+ * based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/Saml2RedirectAuthenticationRequestMixin.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/Saml2RedirectAuthenticationRequestMixin.java
@@ -38,7 +38,11 @@ import org.springframework.security.saml2.provider.service.authentication.Saml2R
  * @since 5.7
  * @see Saml2Jackson2Module
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.saml2.jackson.Saml2RedirectAuthenticationRequestMixin}
+ * based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/SimpleSaml2ResponseAssertionAccessorMixin.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/SimpleSaml2ResponseAssertionAccessorMixin.java
@@ -40,7 +40,11 @@ import org.springframework.security.saml2.provider.service.authentication.Saml2R
  * @since 7.0
  * @see Saml2Jackson2Module
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.saml2.jackson.SimpleSaml2ResponseAssertionAccessorMixin}
+ * based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/package-info.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/jackson2/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Jackson 2 serialization support for SAML2.
+ */
+package org.springframework.security.saml2.jackson2;

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson/DefaultSaml2AuthenticatedPrincipalMixinTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson/DefaultSaml2AuthenticatedPrincipalMixinTests.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.jackson;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.saml2.provider.service.authentication.DefaultSaml2AuthenticatedPrincipal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("removal")
+class DefaultSaml2AuthenticatedPrincipalMixinTests {
+
+	private JsonMapper mapper;
+
+	@BeforeEach
+	void setUp() {
+		ClassLoader loader = getClass().getClassLoader();
+		this.mapper = JsonMapper.builder().addModules(SecurityJacksonModules.getModules(loader)).build();
+	}
+
+	@Test
+	void shouldSerialize() throws Exception {
+		DefaultSaml2AuthenticatedPrincipal principal = TestSaml2JsonPayloads.createDefaultPrincipal();
+
+		String principalJson = this.mapper.writeValueAsString(principal);
+
+		JSONAssert.assertEquals(TestSaml2JsonPayloads.DEFAULT_AUTHENTICATED_PRINCIPAL_JSON, principalJson, true);
+	}
+
+	@Test
+	void shouldSerializeWithoutRegistrationId() throws Exception {
+		DefaultSaml2AuthenticatedPrincipal principal = new DefaultSaml2AuthenticatedPrincipal(
+				TestSaml2JsonPayloads.PRINCIPAL_NAME, TestSaml2JsonPayloads.ATTRIBUTES,
+				TestSaml2JsonPayloads.SESSION_INDEXES);
+
+		String principalJson = this.mapper.writeValueAsString(principal);
+
+		JSONAssert.assertEquals(principalWithoutRegId(), principalJson, true);
+	}
+
+	@Test
+	void shouldSerializeWithoutIndices() throws Exception {
+		DefaultSaml2AuthenticatedPrincipal principal = new DefaultSaml2AuthenticatedPrincipal(
+				TestSaml2JsonPayloads.PRINCIPAL_NAME, TestSaml2JsonPayloads.ATTRIBUTES);
+		principal.setRelyingPartyRegistrationId(TestSaml2JsonPayloads.REG_ID);
+
+		String principalJson = this.mapper.writeValueAsString(principal);
+
+		JSONAssert.assertEquals(principalWithoutIndices(), principalJson, true);
+	}
+
+	@Test
+	void shouldDeserialize() throws Exception {
+		DefaultSaml2AuthenticatedPrincipal principal = this.mapper.readValue(
+				TestSaml2JsonPayloads.DEFAULT_AUTHENTICATED_PRINCIPAL_JSON, DefaultSaml2AuthenticatedPrincipal.class);
+
+		assertThat(principal).isNotNull();
+		assertThat(principal.getName()).isEqualTo(TestSaml2JsonPayloads.PRINCIPAL_NAME);
+		assertThat(principal.getRelyingPartyRegistrationId()).isEqualTo(TestSaml2JsonPayloads.REG_ID);
+		assertThat(principal.getAttributes()).isEqualTo(TestSaml2JsonPayloads.ATTRIBUTES);
+		assertThat(principal.getSessionIndexes()).isEqualTo(TestSaml2JsonPayloads.SESSION_INDEXES);
+	}
+
+	@Test
+	void shouldDeserializeWithoutRegistrationId() throws Exception {
+		DefaultSaml2AuthenticatedPrincipal principal = this.mapper.readValue(principalWithoutRegId(),
+				DefaultSaml2AuthenticatedPrincipal.class);
+
+		assertThat(principal).isNotNull();
+		assertThat(principal.getName()).isEqualTo(TestSaml2JsonPayloads.PRINCIPAL_NAME);
+		assertThat(principal.getRelyingPartyRegistrationId()).isNull();
+		assertThat(principal.getAttributes()).isEqualTo(TestSaml2JsonPayloads.ATTRIBUTES);
+		assertThat(principal.getSessionIndexes()).isEqualTo(TestSaml2JsonPayloads.SESSION_INDEXES);
+	}
+
+	private static String principalWithoutRegId() {
+		return TestSaml2JsonPayloads.DEFAULT_AUTHENTICATED_PRINCIPAL_JSON.replace(TestSaml2JsonPayloads.REG_ID_JSON,
+				"null");
+	}
+
+	private static String principalWithoutIndices() {
+		return TestSaml2JsonPayloads.DEFAULT_AUTHENTICATED_PRINCIPAL_JSON
+			.replace(TestSaml2JsonPayloads.SESSION_INDEXES_JSON, "[\"java.util.Collections$EmptyList\", []]");
+	}
+
+}

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson/Saml2AuthenticationExceptionMixinTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson/Saml2AuthenticationExceptionMixinTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.jackson;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.saml2.core.Saml2Error;
+import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("removal")
+class Saml2AuthenticationExceptionMixinTests {
+
+	private JsonMapper mapper;
+
+	@BeforeEach
+	void setUp() {
+		ClassLoader loader = getClass().getClassLoader();
+		this.mapper = JsonMapper.builder().addModules(SecurityJacksonModules.getModules(loader)).build();
+	}
+
+	@Test
+	void shouldSerialize() throws Exception {
+		Saml2AuthenticationException exception = TestSaml2JsonPayloads.createDefaultSaml2AuthenticationException();
+
+		String exceptionJson = this.mapper.writeValueAsString(exception);
+
+		JSONAssert.assertEquals(TestSaml2JsonPayloads.DEFAULT_SAML_AUTH_EXCEPTION_JSON, exceptionJson, true);
+	}
+
+	@Test
+	void shouldDeserialize() throws Exception {
+		Saml2AuthenticationException exception = this.mapper
+			.readValue(TestSaml2JsonPayloads.DEFAULT_SAML_AUTH_EXCEPTION_JSON, Saml2AuthenticationException.class);
+
+		assertThat(exception).isNotNull();
+		assertThat(exception.getMessage()).isEqualTo("exceptionMessage");
+		assertThat(exception.getSaml2Error()).extracting(Saml2Error::getErrorCode, Saml2Error::getDescription)
+			.contains("errorCode", "errorDescription");
+	}
+
+}

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson/Saml2AuthenticationMixinTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson/Saml2AuthenticationMixinTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.jackson;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("removal")
+class Saml2AuthenticationMixinTests {
+
+	private JsonMapper mapper;
+
+	@BeforeEach
+	void setUp() {
+		ClassLoader loader = getClass().getClassLoader();
+		this.mapper = JsonMapper.builder().addModules(SecurityJacksonModules.getModules(loader)).build();
+	}
+
+	@Test
+	void shouldSerialize() throws Exception {
+		Saml2Authentication authentication = TestSaml2JsonPayloads.createDefaultAuthentication();
+
+		String authenticationJson = this.mapper.writeValueAsString(authentication);
+
+		JSONAssert.assertEquals(TestSaml2JsonPayloads.DEFAULT_SAML2AUTHENTICATION_JSON, authenticationJson, true);
+	}
+
+	@Test
+	void shouldDeserialize() throws Exception {
+		Saml2Authentication authentication = this.mapper
+			.readValue(TestSaml2JsonPayloads.DEFAULT_SAML2AUTHENTICATION_JSON, Saml2Authentication.class);
+
+		assertThat(authentication).isNotNull();
+		assertThat(authentication.getDetails()).isEqualTo(TestSaml2JsonPayloads.DETAILS);
+		assertThat(authentication.getCredentials()).isEqualTo(TestSaml2JsonPayloads.SAML_RESPONSE);
+		assertThat(authentication.getSaml2Response()).isEqualTo(TestSaml2JsonPayloads.SAML_RESPONSE);
+		assertThat(authentication.getAuthorities()).isEqualTo(TestSaml2JsonPayloads.AUTHORITIES);
+		assertThat(authentication.getPrincipal()).usingRecursiveComparison()
+			.isEqualTo(TestSaml2JsonPayloads.createDefaultPrincipal());
+		assertThat(authentication.getDetails()).usingRecursiveComparison().isEqualTo(TestSaml2JsonPayloads.DETAILS);
+	}
+
+}

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson/Saml2LogoutRequestMixinTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson/Saml2LogoutRequestMixinTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.jackson;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutRequest;
+import org.springframework.security.saml2.provider.service.registration.Saml2MessageBinding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("removal")
+class Saml2LogoutRequestMixinTests {
+
+	private JsonMapper mapper;
+
+	@BeforeEach
+	void setUp() {
+		ClassLoader loader = getClass().getClassLoader();
+		this.mapper = JsonMapper.builder().addModules(SecurityJacksonModules.getModules(loader)).build();
+	}
+
+	@Test
+	void shouldSerialize() throws Exception {
+		Saml2LogoutRequest request = TestSaml2JsonPayloads.createDefaultSaml2LogoutRequest();
+
+		String requestJson = this.mapper.writeValueAsString(request);
+
+		JSONAssert.assertEquals(TestSaml2JsonPayloads.DEFAULT_LOGOUT_REQUEST_JSON, requestJson, true);
+	}
+
+	@Test
+	void shouldDeserialize() {
+		deserializeAndAssertRequest();
+	}
+
+	// gh-12539
+	@Test
+	void shouldDeserializeWhenFailOnMissingCreatorPropertiesEnabled() {
+		// Jackson will use reflection to initialize the binding property if this is not
+		// enabled
+		JsonMapper customizedMapper = this.mapper.rebuild()
+			.enable(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES)
+			.build();
+		deserializeAndAssertRequest();
+	}
+
+	private void deserializeAndAssertRequest() throws JacksonException {
+		Saml2LogoutRequest logoutRequest = this.mapper.readValue(TestSaml2JsonPayloads.DEFAULT_LOGOUT_REQUEST_JSON,
+				Saml2LogoutRequest.class);
+
+		assertThat(logoutRequest).isNotNull();
+		assertThat(logoutRequest.getId()).isEqualTo(TestSaml2JsonPayloads.ID);
+		assertThat(logoutRequest.getRelyingPartyRegistrationId())
+			.isEqualTo(TestSaml2JsonPayloads.RELYINGPARTY_REGISTRATION_ID);
+		assertThat(logoutRequest.getSamlRequest()).isEqualTo(TestSaml2JsonPayloads.SAML_REQUEST);
+		assertThat(logoutRequest.getRelayState()).isEqualTo(TestSaml2JsonPayloads.RELAY_STATE);
+		assertThat(logoutRequest.getLocation()).isEqualTo(TestSaml2JsonPayloads.LOCATION);
+		assertThat(logoutRequest.getBinding()).isEqualTo(Saml2MessageBinding.REDIRECT);
+		Map<String, String> expectedParams = new HashMap<>();
+		expectedParams.put("SAMLRequest", TestSaml2JsonPayloads.SAML_REQUEST);
+		expectedParams.put("RelayState", TestSaml2JsonPayloads.RELAY_STATE);
+		expectedParams.put("AdditionalParam", TestSaml2JsonPayloads.ADDITIONAL_PARAM);
+		assertThat(logoutRequest.getParameters()).containsAllEntriesOf(expectedParams);
+	}
+
+}

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson/Saml2PostAuthenticationRequestMixinTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson/Saml2PostAuthenticationRequestMixinTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.jackson;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.saml2.provider.service.authentication.Saml2PostAuthenticationRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("removal")
+class Saml2PostAuthenticationRequestMixinTests {
+
+	private JsonMapper mapper;
+
+	@BeforeEach
+	void setUp() {
+		ClassLoader loader = getClass().getClassLoader();
+		this.mapper = JsonMapper.builder().addModules(SecurityJacksonModules.getModules(loader)).build();
+	}
+
+	@Test
+	void shouldSerialize() throws Exception {
+		Saml2PostAuthenticationRequest request = TestSaml2JsonPayloads.createDefaultSaml2PostAuthenticationRequest();
+
+		String requestJson = this.mapper.writeValueAsString(request);
+
+		JSONAssert.assertEquals(TestSaml2JsonPayloads.DEFAULT_POST_AUTH_REQUEST_JSON, requestJson, true);
+	}
+
+	@Test
+	void shouldDeserialize() {
+		Saml2PostAuthenticationRequest authRequest = this.mapper
+			.readValue(TestSaml2JsonPayloads.DEFAULT_POST_AUTH_REQUEST_JSON, Saml2PostAuthenticationRequest.class);
+
+		assertThat(authRequest).isNotNull();
+		assertThat(authRequest.getSamlRequest()).isEqualTo(TestSaml2JsonPayloads.SAML_REQUEST);
+		assertThat(authRequest.getRelayState()).isEqualTo(TestSaml2JsonPayloads.RELAY_STATE);
+		assertThat(authRequest.getAuthenticationRequestUri())
+			.isEqualTo(TestSaml2JsonPayloads.AUTHENTICATION_REQUEST_URI);
+		assertThat(authRequest.getRelyingPartyRegistrationId())
+			.isEqualTo(TestSaml2JsonPayloads.RELYINGPARTY_REGISTRATION_ID);
+		assertThat(authRequest.getId()).isEqualTo(TestSaml2JsonPayloads.ID);
+	}
+
+	@Test
+	void shouldDeserializeWithNoRegistrationId() {
+		String json = TestSaml2JsonPayloads.DEFAULT_POST_AUTH_REQUEST_JSON.replace(
+				"\"relyingPartyRegistrationId\": \"" + TestSaml2JsonPayloads.RELYINGPARTY_REGISTRATION_ID + "\",", "");
+
+		Saml2PostAuthenticationRequest authRequest = this.mapper.readValue(json, Saml2PostAuthenticationRequest.class);
+
+		assertThat(authRequest).isNotNull();
+		assertThat(authRequest.getSamlRequest()).isEqualTo(TestSaml2JsonPayloads.SAML_REQUEST);
+		assertThat(authRequest.getRelayState()).isEqualTo(TestSaml2JsonPayloads.RELAY_STATE);
+		assertThat(authRequest.getAuthenticationRequestUri())
+			.isEqualTo(TestSaml2JsonPayloads.AUTHENTICATION_REQUEST_URI);
+		assertThat(authRequest.getRelyingPartyRegistrationId()).isNull();
+		assertThat(authRequest.getId()).isEqualTo(TestSaml2JsonPayloads.ID);
+	}
+
+	@Test
+	void shouldDeserializeWithNoId() {
+		String json = TestSaml2JsonPayloads.DEFAULT_POST_AUTH_REQUEST_JSON
+			.replace(", \"id\": \"" + TestSaml2JsonPayloads.ID + "\"", "");
+
+		Saml2PostAuthenticationRequest authRequest = this.mapper.readValue(json, Saml2PostAuthenticationRequest.class);
+
+		assertThat(authRequest).isNotNull();
+		assertThat(authRequest.getSamlRequest()).isEqualTo(TestSaml2JsonPayloads.SAML_REQUEST);
+		assertThat(authRequest.getRelayState()).isEqualTo(TestSaml2JsonPayloads.RELAY_STATE);
+		assertThat(authRequest.getAuthenticationRequestUri())
+			.isEqualTo(TestSaml2JsonPayloads.AUTHENTICATION_REQUEST_URI);
+		assertThat(authRequest.getRelyingPartyRegistrationId())
+			.isEqualTo(TestSaml2JsonPayloads.RELYINGPARTY_REGISTRATION_ID);
+		assertThat(authRequest.getId()).isNull();
+	}
+
+}

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson/Saml2RedirectAuthenticationRequestMixinTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson/Saml2RedirectAuthenticationRequestMixinTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.jackson;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.saml2.provider.service.authentication.Saml2RedirectAuthenticationRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("removal")
+class Saml2RedirectAuthenticationRequestMixinTests {
+
+	private JsonMapper mapper;
+
+	@BeforeEach
+	void setUp() {
+		ClassLoader loader = getClass().getClassLoader();
+		this.mapper = JsonMapper.builder().addModules(SecurityJacksonModules.getModules(loader)).build();
+	}
+
+	@Test
+	void shouldSerialize() throws Exception {
+		Saml2RedirectAuthenticationRequest request = TestSaml2JsonPayloads
+			.createDefaultSaml2RedirectAuthenticationRequest();
+
+		String requestJson = this.mapper.writeValueAsString(request);
+
+		JSONAssert.assertEquals(TestSaml2JsonPayloads.DEFAULT_REDIRECT_AUTH_REQUEST_JSON, requestJson, true);
+	}
+
+	@Test
+	void shouldDeserialize() throws Exception {
+		Saml2RedirectAuthenticationRequest authRequest = this.mapper.readValue(
+				TestSaml2JsonPayloads.DEFAULT_REDIRECT_AUTH_REQUEST_JSON, Saml2RedirectAuthenticationRequest.class);
+
+		assertThat(authRequest).isNotNull();
+		assertThat(authRequest.getSamlRequest()).isEqualTo(TestSaml2JsonPayloads.SAML_REQUEST);
+		assertThat(authRequest.getRelayState()).isEqualTo(TestSaml2JsonPayloads.RELAY_STATE);
+		assertThat(authRequest.getAuthenticationRequestUri())
+			.isEqualTo(TestSaml2JsonPayloads.AUTHENTICATION_REQUEST_URI);
+		assertThat(authRequest.getSigAlg()).isEqualTo(TestSaml2JsonPayloads.SIG_ALG);
+		assertThat(authRequest.getSignature()).isEqualTo(TestSaml2JsonPayloads.SIGNATURE);
+		assertThat(authRequest.getRelyingPartyRegistrationId())
+			.isEqualTo(TestSaml2JsonPayloads.RELYINGPARTY_REGISTRATION_ID);
+	}
+
+	@Test
+	void shouldDeserializeWithNoRegistrationId() throws Exception {
+		String json = TestSaml2JsonPayloads.DEFAULT_REDIRECT_AUTH_REQUEST_JSON.replace(
+				"\"relyingPartyRegistrationId\": \"" + TestSaml2JsonPayloads.RELYINGPARTY_REGISTRATION_ID + "\",", "");
+
+		Saml2RedirectAuthenticationRequest authRequest = this.mapper.readValue(json,
+				Saml2RedirectAuthenticationRequest.class);
+
+		assertThat(authRequest).isNotNull();
+		assertThat(authRequest.getSamlRequest()).isEqualTo(TestSaml2JsonPayloads.SAML_REQUEST);
+		assertThat(authRequest.getRelayState()).isEqualTo(TestSaml2JsonPayloads.RELAY_STATE);
+		assertThat(authRequest.getAuthenticationRequestUri())
+			.isEqualTo(TestSaml2JsonPayloads.AUTHENTICATION_REQUEST_URI);
+		assertThat(authRequest.getSigAlg()).isEqualTo(TestSaml2JsonPayloads.SIG_ALG);
+		assertThat(authRequest.getSignature()).isEqualTo(TestSaml2JsonPayloads.SIGNATURE);
+		assertThat(authRequest.getRelyingPartyRegistrationId()).isNull();
+	}
+
+}

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson/TestSaml2JsonPayloads.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson/TestSaml2JsonPayloads.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.saml2.jackson;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.saml2.core.Saml2Error;
+import org.springframework.security.saml2.provider.service.authentication.DefaultSaml2AuthenticatedPrincipal;
+import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication;
+import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticationException;
+import org.springframework.security.saml2.provider.service.authentication.Saml2PostAuthenticationRequest;
+import org.springframework.security.saml2.provider.service.authentication.Saml2RedirectAuthenticationRequest;
+import org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutRequest;
+import org.springframework.security.saml2.provider.service.registration.Saml2MessageBinding;
+import org.springframework.security.saml2.provider.service.registration.TestRelyingPartyRegistrations;
+
+@SuppressWarnings("removal")
+final class TestSaml2JsonPayloads {
+
+	private TestSaml2JsonPayloads() {
+	}
+
+	static final Map<String, List<Object>> ATTRIBUTES;
+
+	static {
+		Map<String, List<Object>> tmpAttributes = new HashMap<>();
+		tmpAttributes.put("name", Collections.singletonList("attr_name"));
+		tmpAttributes.put("email", Collections.singletonList("attr_email"));
+		tmpAttributes.put("listOf", Collections.unmodifiableList(Arrays.asList("Element1", "Element2", 4, true)));
+		ATTRIBUTES = Collections.unmodifiableMap(tmpAttributes);
+	}
+
+	static final String REG_ID = "REG_ID_TEST";
+	static final String REG_ID_JSON = "\"" + REG_ID + "\"";
+
+	static final String SESSION_INDEXES_JSON = "[" + "  \"java.util.Collections$UnmodifiableRandomAccessList\","
+			+ "  [ \"Index 1\", \"Index 2\" ]" + "]";
+	static final List<String> SESSION_INDEXES = Collections.unmodifiableList(Arrays.asList("Index 1", "Index 2"));
+
+	static final String PRINCIPAL_NAME = "principalName";
+
+	// @formatter:off
+	static final String DEFAULT_AUTHENTICATED_PRINCIPAL_JSON = "{"
+			+ "  \"@class\": \"org.springframework.security.saml2.provider.service.authentication.DefaultSaml2AuthenticatedPrincipal\","
+			+ "  \"name\": \"" + PRINCIPAL_NAME + "\","
+			+ "  \"attributes\": {"
+			+ "    \"@class\": \"java.util.Collections$UnmodifiableMap\","
+			+ "    \"listOf\": ["
+			+ "      \"java.util.Collections$UnmodifiableRandomAccessList\","
+			+ "      [ \"Element1\", \"Element2\", 4, true ]"
+			+ "    ],"
+			+ "    \"email\": ["
+			+ "      \"java.util.Collections$SingletonList\","
+			+ "      [ \"attr_email\" ]"
+			+ "    ],"
+			+ "    \"name\": ["
+			+ "      \"java.util.Collections$SingletonList\","
+			+ "      [ \"attr_name\" ]"
+			+ "    ]"
+			+ "  },"
+			+ "  \"sessionIndexes\": " + SESSION_INDEXES_JSON + ","
+			+ "  \"registrationId\": " + REG_ID_JSON + ""
+			+ "}";
+	// @formatter:on
+
+	static DefaultSaml2AuthenticatedPrincipal createDefaultPrincipal() {
+		DefaultSaml2AuthenticatedPrincipal principal = new DefaultSaml2AuthenticatedPrincipal(PRINCIPAL_NAME,
+				ATTRIBUTES, SESSION_INDEXES);
+		principal.setRelyingPartyRegistrationId(REG_ID);
+		return principal;
+	}
+
+	static final String SAML_REQUEST = "samlRequestValue";
+	static final String RELAY_STATE = "relayStateValue";
+	static final String AUTHENTICATION_REQUEST_URI = "authenticationRequestUriValue";
+	static final String RELYINGPARTY_REGISTRATION_ID = "registrationIdValue";
+	static final String SIG_ALG = "sigAlgValue";
+	static final String SIGNATURE = "signatureValue";
+	static final String ID = "idValue";
+
+	// @formatter:off
+	static final String DEFAULT_REDIRECT_AUTH_REQUEST_JSON = "{"
+			+ " \"@class\": \"org.springframework.security.saml2.provider.service.authentication.Saml2RedirectAuthenticationRequest\","
+			+ " \"samlRequest\": \"" + SAML_REQUEST + "\","
+			+ " \"relayState\": \"" + RELAY_STATE + "\","
+			+ " \"authenticationRequestUri\": \"" + AUTHENTICATION_REQUEST_URI + "\","
+			+ " \"relyingPartyRegistrationId\": \"" + RELYINGPARTY_REGISTRATION_ID + "\","
+			+ " \"sigAlg\": \"" + SIG_ALG + "\","
+			+ " \"signature\": \"" + SIGNATURE + "\","
+			+ " \"id\": \"" + ID + "\""
+			+ "}";
+	// @formatter:on
+
+	// @formatter:off
+	static final String DEFAULT_POST_AUTH_REQUEST_JSON = "{"
+			+ " \"@class\": \"org.springframework.security.saml2.provider.service.authentication.Saml2PostAuthenticationRequest\","
+			+ " \"samlRequest\": \"" + SAML_REQUEST + "\","
+			+ " \"relayState\": \"" + RELAY_STATE + "\","
+			+ " \"relyingPartyRegistrationId\": \"" + RELYINGPARTY_REGISTRATION_ID + "\","
+			+ " \"authenticationRequestUri\": \"" + AUTHENTICATION_REQUEST_URI + "\","
+			+ " \"id\": \"" + ID + "\""
+			+ "}";
+	// @formatter:on
+
+	static final String LOCATION = "locationValue";
+	static final String BINDNG = "REDIRECT";
+	static final String ADDITIONAL_PARAM = "additionalParamValue";
+
+	// @formatter:off
+	static final String DEFAULT_LOGOUT_REQUEST_JSON = "{"
+			+ "  \"@class\": \"org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutRequest\","
+			+ "  \"id\": \"" + ID + "\","
+			+ "  \"location\": \"" + LOCATION + "\","
+			+ "  \"binding\": \"" + BINDNG + "\","
+			+ "  \"relyingPartyRegistrationId\": \"" + RELYINGPARTY_REGISTRATION_ID + "\","
+			+ "  \"parameters\": { "
+			+ "     \"@class\": \"java.util.Collections$UnmodifiableMap\","
+			+ "     \"SAMLRequest\": \"" + SAML_REQUEST + "\","
+			+ "     \"RelayState\": \"" + RELAY_STATE + "\","
+			+ "     \"AdditionalParam\": \"" + ADDITIONAL_PARAM + "\""
+			+ "  }"
+			+ "}";
+	// @formatter:on
+
+	static Saml2PostAuthenticationRequest createDefaultSaml2PostAuthenticationRequest() {
+		return Saml2PostAuthenticationRequest
+			.withRelyingPartyRegistration(TestRelyingPartyRegistrations.full()
+				.registrationId(RELYINGPARTY_REGISTRATION_ID)
+				.assertingPartyMetadata((party) -> party.singleSignOnServiceLocation(AUTHENTICATION_REQUEST_URI))
+				.build())
+			.samlRequest(SAML_REQUEST)
+			.relayState(RELAY_STATE)
+			.id(ID)
+			.build();
+	}
+
+	static Saml2RedirectAuthenticationRequest createDefaultSaml2RedirectAuthenticationRequest() {
+		return Saml2RedirectAuthenticationRequest
+			.withRelyingPartyRegistration(TestRelyingPartyRegistrations.full()
+				.registrationId(RELYINGPARTY_REGISTRATION_ID)
+				.assertingPartyMetadata((party) -> party.singleSignOnServiceLocation(AUTHENTICATION_REQUEST_URI))
+				.build())
+			.samlRequest(SAML_REQUEST)
+			.relayState(RELAY_STATE)
+			.sigAlg(SIG_ALG)
+			.signature(SIGNATURE)
+			.id(ID)
+			.build();
+	}
+
+	static Saml2LogoutRequest createDefaultSaml2LogoutRequest() {
+		return Saml2LogoutRequest
+			.withRelyingPartyRegistration(TestRelyingPartyRegistrations.full()
+				.registrationId(RELYINGPARTY_REGISTRATION_ID)
+				.assertingPartyMetadata((party) -> party.singleLogoutServiceLocation(LOCATION)
+					.singleLogoutServiceBinding(Saml2MessageBinding.REDIRECT))
+				.build())
+			.id(ID)
+			.samlRequest(SAML_REQUEST)
+			.relayState(RELAY_STATE)
+			.parameters((params) -> params.put("AdditionalParam", ADDITIONAL_PARAM))
+			.build();
+	}
+
+	static final Collection<GrantedAuthority> AUTHORITIES = Collections
+		.unmodifiableList(Arrays.asList(new SimpleGrantedAuthority("Role1"), new SimpleGrantedAuthority("Role2")));
+
+	static final Object DETAILS = User.withUsername("username").password("empty").authorities("A", "B").build();
+	static final String SAML_RESPONSE = "samlResponseValue";
+
+	// @formatter:off
+	static final String DEFAULT_SAML2AUTHENTICATION_JSON = "{"
+			+ "	\"@class\": \"org.springframework.security.saml2.provider.service.authentication.Saml2Authentication\","
+			+ "	\"authorities\": ["
+			+ "		\"java.util.Collections$UnmodifiableRandomAccessList\","
+			+ "		["
+			+ "			{"
+			+ "				\"@class\": \"org.springframework.security.core.authority.SimpleGrantedAuthority\","
+			+ "				\"authority\": \"Role1\""
+			+ "			},"
+			+ "			{"
+			+ "				\"@class\": \"org.springframework.security.core.authority.SimpleGrantedAuthority\","
+			+ "				\"authority\": \"Role2\""
+			+ "			}"
+			+ "		]"
+			+ " ],"
+			+ "	\"details\": {"
+			+ "		\"@class\": \"org.springframework.security.core.userdetails.User\","
+			+ "		\"password\": \"empty\","
+			+ "		\"username\": \"username\","
+			+ "		\"authorities\": ["
+			+ "			\"java.util.Collections$UnmodifiableSet\", ["
+			+ "				{"
+			+ "					\"@class\":\"org.springframework.security.core.authority.SimpleGrantedAuthority\","
+			+ "					\"authority\":\"A\""
+			+ "				},"
+			+ "				{"
+			+ "					\"@class\":\"org.springframework.security.core.authority.SimpleGrantedAuthority\","
+			+ "					\"authority\":\"B\""
+			+ "				}"
+			+ "		]],"
+			+ "		\"accountNonExpired\": true,"
+			+ "		\"accountNonLocked\": true,"
+			+ "		\"credentialsNonExpired\": true,"
+			+ "		\"enabled\": true"
+			+ "	},"
+			+ "	\"principal\": " + DEFAULT_AUTHENTICATED_PRINCIPAL_JSON + ","
+			+ "	\"saml2Response\": \"" + SAML_RESPONSE + "\""
+			+ "}";
+	// @formatter:on
+
+	static Saml2Authentication createDefaultAuthentication() {
+		DefaultSaml2AuthenticatedPrincipal principal = createDefaultPrincipal();
+		Saml2Authentication authentication = new Saml2Authentication(principal, SAML_RESPONSE, AUTHORITIES);
+		authentication.setDetails(DETAILS);
+		return authentication;
+	}
+
+	// @formatter:off
+	static final String DEFAULT_SAML_AUTH_EXCEPTION_JSON = "{"
+			+ "  \"@class\": \"org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticationException\","
+			+ "  \"detailMessage\": \"exceptionMessage\","
+			+ "  \"error\": {"
+			+ "    \"@class\": \"org.springframework.security.saml2.core.Saml2Error\","
+			+ "    \"errorCode\": \"errorCode\","
+			+ "    \"description\": \"errorDescription\""
+			+ "  }"
+			+ "}";
+	// @formatter:on
+
+	static Saml2AuthenticationException createDefaultSaml2AuthenticationException() {
+		return new Saml2AuthenticationException(new Saml2Error("errorCode", "errorDescription"), "exceptionMessage");
+	}
+
+}

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson2/DefaultSaml2AuthenticatedPrincipalMixinTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson2/DefaultSaml2AuthenticatedPrincipalMixinTests.java
@@ -26,6 +26,7 @@ import org.springframework.security.saml2.provider.service.authentication.Defaul
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("removal")
 class DefaultSaml2AuthenticatedPrincipalMixinTests {
 
 	private ObjectMapper mapper;

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson2/Saml2AuthenticationExceptionMixinTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson2/Saml2AuthenticationExceptionMixinTests.java
@@ -27,6 +27,7 @@ import org.springframework.security.saml2.provider.service.authentication.Saml2A
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("removal")
 class Saml2AuthenticationExceptionMixinTests {
 
 	private ObjectMapper mapper;

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson2/Saml2AuthenticationMixinTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson2/Saml2AuthenticationMixinTests.java
@@ -26,6 +26,7 @@ import org.springframework.security.saml2.provider.service.authentication.Saml2A
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("removal")
 class Saml2AuthenticationMixinTests {
 
 	private ObjectMapper mapper;

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson2/Saml2LogoutRequestMixinTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson2/Saml2LogoutRequestMixinTests.java
@@ -32,6 +32,7 @@ import org.springframework.security.saml2.provider.service.registration.Saml2Mes
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("removal")
 class Saml2LogoutRequestMixinTests {
 
 	private ObjectMapper mapper;

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson2/Saml2PostAuthenticationRequestMixinTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson2/Saml2PostAuthenticationRequestMixinTests.java
@@ -26,6 +26,7 @@ import org.springframework.security.saml2.provider.service.authentication.Saml2P
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("removal")
 class Saml2PostAuthenticationRequestMixinTests {
 
 	private ObjectMapper mapper;

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson2/Saml2RedirectAuthenticationRequestMixinTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/jackson2/Saml2RedirectAuthenticationRequestMixinTests.java
@@ -26,6 +26,7 @@ import org.springframework.security.saml2.provider.service.authentication.Saml2R
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("removal")
 class Saml2RedirectAuthenticationRequestMixinTests {
 
 	private ObjectMapper mapper;

--- a/web/spring-security-web.gradle
+++ b/web/spring-security-web.gradle
@@ -46,6 +46,7 @@ dependencies {
 	optional 'org.springframework:spring-tx'
 	optional 'org.springframework:spring-webflux'
 	optional 'org.springframework:spring-webmvc'
+	optional 'tools.jackson.core:jackson-databind'
 	optional libs.webauthn4j.core
 
 	provided 'jakarta.servlet:jakarta.servlet-api'

--- a/web/src/main/java/org/springframework/security/web/jackson/CookieDeserializer.java
+++ b/web/src/main/java/org/springframework/security/web/jackson/CookieDeserializer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.jackson;
+
+import jakarta.servlet.http.Cookie;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.node.MissingNode;
+import tools.jackson.databind.node.NullNode;
+
+/**
+ * Jackson deserializer for {@link Cookie}. This is needed because in most cases we don't
+ * set {@link Cookie#getDomain()} property. So when jackson deserialize that json
+ * {@link Cookie#setDomain(String)} throws {@link NullPointerException}. This is
+ * registered with {@link CookieMixin} but you can also use it with your own mixin.
+ *
+ * @author Sebastien Deleuze
+ * @author Jitendra Singh
+ * @since 7.0
+ * @see CookieMixin
+ */
+class CookieDeserializer extends ValueDeserializer<Cookie> {
+
+	@Override
+	public Cookie deserialize(JsonParser jp, DeserializationContext ctxt) throws JacksonException {
+		JsonNode jsonNode = ctxt.readTree(jp);
+		Cookie cookie = new Cookie(readJsonNode(jsonNode, "name").stringValue(),
+				readJsonNode(jsonNode, "value").stringValue());
+		JsonNode domainNode = readJsonNode(jsonNode, "domain");
+		cookie.setDomain((domainNode.isNull() || domainNode.isMissingNode()) ? null : domainNode.stringValue());
+		cookie.setMaxAge(readJsonNode(jsonNode, "maxAge").asInt(-1));
+		cookie.setSecure(readJsonNode(jsonNode, "secure").asBoolean());
+		JsonNode pathNode = readJsonNode(jsonNode, "path");
+		cookie.setPath((pathNode.isNull() || pathNode.isMissingNode()) ? null : pathNode.stringValue());
+		JsonNode attributes = readJsonNode(jsonNode, "attributes");
+		cookie.setHttpOnly(readJsonNode(attributes, "HttpOnly") != null);
+		return cookie;
+	}
+
+	private JsonNode readJsonNode(JsonNode jsonNode, String field) {
+		return hasNonNullField(jsonNode, field) ? jsonNode.get(field) : MissingNode.getInstance();
+	}
+
+	private boolean hasNonNullField(JsonNode jsonNode, String field) {
+		return jsonNode.has(field) && !(jsonNode.get(field) instanceof NullNode);
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/jackson/CookieMixin.java
+++ b/web/src/main/java/org/springframework/security/web/jackson/CookieMixin.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import tools.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * Mixin class to serialize/deserialize {@link jakarta.servlet.http.Cookie}
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new WebServletJacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Jitendra Singh
+ * @since 7.0
+ * @see WebServletJacksonModule
+ * @see org.springframework.security.jackson.SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
+@JsonDeserialize(using = CookieDeserializer.class)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+abstract class CookieMixin {
+
+}

--- a/web/src/main/java/org/springframework/security/web/jackson/DefaultCsrfTokenMixin.java
+++ b/web/src/main/java/org/springframework/security/web/jackson/DefaultCsrfTokenMixin.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.jackson;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Jackson mixin class to serialize/deserialize
+ * {@link org.springframework.security.web.csrf.DefaultCsrfToken} serialization support.
+ *
+ *
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new WebJacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Jitendra Singh
+ * @since 7.0
+ * @see WebJacksonModule
+ * @see org.springframework.security.jackson.SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+@JsonIgnoreProperties(ignoreUnknown = true)
+class DefaultCsrfTokenMixin {
+
+	/**
+	 * JsonCreator constructor needed by Jackson to create
+	 * {@link org.springframework.security.web.csrf.DefaultCsrfToken} object.
+	 * @param headerName the name of the header
+	 * @param parameterName the parameter name
+	 * @param token the CSRF token value
+	 */
+	@JsonCreator
+	DefaultCsrfTokenMixin(@JsonProperty("headerName") String headerName,
+			@JsonProperty("parameterName") String parameterName, @JsonProperty("token") String token) {
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/jackson/DefaultSavedRequestMixin.java
+++ b/web/src/main/java/org/springframework/security/web/jackson/DefaultSavedRequestMixin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import tools.jackson.databind.annotation.JsonDeserialize;
+
+import org.springframework.security.web.savedrequest.DefaultSavedRequest;
+
+/**
+ * Jackson mixin class to serialize/deserialize {@link DefaultSavedRequest}. This mixin
+ * use {@link DefaultSavedRequest.Builder} to deserialized json.In order to use this mixin
+ * class you also need to register {@link CookieMixin}.
+ *
+ * <p>
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new WebServletJacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Jitendra Singh
+ * @since 7.0
+ * @see WebServletJacksonModule
+ * @see org.springframework.security.jackson.SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
+@JsonDeserialize(builder = DefaultSavedRequest.Builder.class)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE)
+abstract class DefaultSavedRequestMixin {
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	String matchingRequestParameterName;
+
+}

--- a/web/src/main/java/org/springframework/security/web/jackson/PreAuthenticatedAuthenticationTokenDeserializer.java
+++ b/web/src/main/java/org/springframework/security/web/jackson/PreAuthenticatedAuthenticationTokenDeserializer.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.jackson;
+
+import java.util.List;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.node.MissingNode;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+/**
+ * Custom deserializer for {@link PreAuthenticatedAuthenticationToken}. At the time of
+ * deserialization it will invoke suitable constructor depending on the value of
+ * <b>authenticated</b> property. It will ensure that the token's state must not change.
+ * <p>
+ * This deserializer is already registered with
+ * {@link PreAuthenticatedAuthenticationTokenMixin} but you can also registered it with
+ * your own mixin class.
+ *
+ * @author Sebastien Deleuze
+ * @author Jitendra Singh
+ * @since 7.0
+ * @see PreAuthenticatedAuthenticationTokenMixin
+ */
+class PreAuthenticatedAuthenticationTokenDeserializer extends ValueDeserializer<PreAuthenticatedAuthenticationToken> {
+
+	private static final TypeReference<List<GrantedAuthority>> GRANTED_AUTHORITY_LIST = new TypeReference<>() {
+	};
+
+	/**
+	 * This method construct {@link PreAuthenticatedAuthenticationToken} object from
+	 * serialized json.
+	 * @param jp the JsonParser
+	 * @param ctxt the DeserializationContext
+	 * @return the user
+	 * @throws tools.jackson.core.JacksonException if an error during JSON processing
+	 * occurs
+	 */
+	@Override
+	public PreAuthenticatedAuthenticationToken deserialize(JsonParser jp, DeserializationContext ctxt)
+			throws JacksonException {
+		JsonNode jsonNode = ctxt.readTree(jp);
+		boolean authenticated = readJsonNode(jsonNode, "authenticated").asBoolean();
+		JsonNode principalNode = readJsonNode(jsonNode, "principal");
+		Object principal = (!principalNode.isObject()) ? principalNode.stringValue()
+				: ctxt.readTreeAsValue(principalNode, Object.class);
+		Object credentials = readJsonNode(jsonNode, "credentials").stringValue();
+		List<GrantedAuthority> authorities = ctxt.readTreeAsValue(readJsonNode(jsonNode, "authorities"),
+				ctxt.getTypeFactory().constructType(GRANTED_AUTHORITY_LIST));
+		PreAuthenticatedAuthenticationToken token = (!authenticated)
+				? new PreAuthenticatedAuthenticationToken(principal, credentials)
+				: new PreAuthenticatedAuthenticationToken(principal, credentials, authorities);
+		token.setDetails(readJsonNode(jsonNode, "details"));
+		return token;
+	}
+
+	private JsonNode readJsonNode(JsonNode jsonNode, String field) {
+		return jsonNode.has(field) ? jsonNode.get(field) : MissingNode.getInstance();
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/jackson/PreAuthenticatedAuthenticationTokenMixin.java
+++ b/web/src/main/java/org/springframework/security/web/jackson/PreAuthenticatedAuthenticationTokenMixin.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import tools.jackson.databind.annotation.JsonDeserialize;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.jackson.SimpleGrantedAuthorityMixin;
+
+/**
+ * This mixin class is used to serialize / deserialize
+ * {@link org.springframework.security.authentication.UsernamePasswordAuthenticationToken}.
+ * This class register a custom deserializer
+ * {@link PreAuthenticatedAuthenticationTokenDeserializer}.
+ *
+ * In order to use this mixin you'll need to add 3 more mixin classes.
+ * <ol>
+ * <li>{@link UnmodifiableSetMixin}</li>
+ * <li>{@link SimpleGrantedAuthorityMixin}</li>
+ * <li>{@link UserMixin}</li>
+ * </ol>
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new WebJacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Jitendra Singh
+ * @since 7.0
+ * @see WebJacksonModule
+ * @see SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonDeserialize(using = PreAuthenticatedAuthenticationTokenDeserializer.class)
+abstract class PreAuthenticatedAuthenticationTokenMixin {
+
+}

--- a/web/src/main/java/org/springframework/security/web/jackson/SavedCookieMixin.java
+++ b/web/src/main/java/org/springframework/security/web/jackson/SavedCookieMixin.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Jackson mixin class to serialize/deserialize
+ * {@link org.springframework.security.web.savedrequest.SavedCookie} serialization
+ * support.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new WebJackson2Module())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Jitendra Singh
+ * @since 7.0
+ * @see WebServletJacksonModule
+ * @see org.springframework.security.jackson.SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class SavedCookieMixin {
+
+	@JsonCreator
+	SavedCookieMixin(@JsonProperty("name") String name, @JsonProperty("value") String value,
+			@JsonProperty("domain") String domain, @JsonProperty("maxAge") int maxAge,
+			@JsonProperty("path") String path, @JsonProperty("secure") boolean secure) {
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/jackson/SwitchUserGrantedAuthorityMixIn.java
+++ b/web/src/main/java/org/springframework/security/web/jackson/SwitchUserGrantedAuthorityMixIn.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.switchuser.SwitchUserGrantedAuthority;
+
+/**
+ * Jackson mixin class to serialize/deserialize {@link SwitchUserGrantedAuthority}.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new WebServletJacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Markus Heiden
+ * @since 7.0
+ * @see WebJacksonModule
+ * @see WebServletJacksonModule
+ * @see org.springframework.security.jackson.SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class SwitchUserGrantedAuthorityMixIn {
+
+	@JsonCreator
+	SwitchUserGrantedAuthorityMixIn(@JsonProperty("role") String role, @JsonProperty("source") Authentication source) {
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/jackson/WebAuthenticationDetailsMixin.java
+++ b/web/src/main/java/org/springframework/security/web/jackson/WebAuthenticationDetailsMixin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Jackson mixin class to serialize/deserialize
+ * {@link org.springframework.security.web.authentication.WebAuthenticationDetails}.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new WebServletJacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Jitendra Singh
+ * @since 7.0
+ * @see WebServletJacksonModule
+ * @see org.springframework.security.jackson.SecurityJacksonModules
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
+		isGetterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.ANY)
+class WebAuthenticationDetailsMixin {
+
+	@JsonCreator
+	WebAuthenticationDetailsMixin(@JsonProperty("remoteAddress") String remoteAddress,
+			@JsonProperty("sessionId") String sessionId) {
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/jackson/WebJacksonModule.java
+++ b/web/src/main/java/org/springframework/security/web/jackson/WebJacksonModule.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.jackson;
+
+import tools.jackson.core.Version;
+import tools.jackson.databind.cfg.MapperBuilder;
+import tools.jackson.databind.module.SimpleModule;
+
+import org.springframework.security.jackson.AllowlistTypeResolverBuilder;
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.security.web.authentication.switchuser.SwitchUserGrantedAuthority;
+import org.springframework.security.web.csrf.DefaultCsrfToken;
+
+/**
+ * Jackson module for spring-security-web. This module register
+ * {@link DefaultCsrfTokenMixin}, {@link PreAuthenticatedAuthenticationTokenMixin} and
+ * {@link SwitchUserGrantedAuthorityMixIn}. If no default typing enabled by default then
+ * it'll enable it because typing info is needed to properly serialize/deserialize
+ * objects. In order to use this module just add this module into your ObjectMapper
+ * configuration.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new WebJackson2Module())
+ * 				.build();
+ * </pre>
+ *
+ *
+ * <b>Note: use {@link SecurityJacksonModules#getModules(ClassLoader)} to get list of all
+ * security modules.</b>
+ *
+ * @author Sebastien Deleuze
+ * @author Jitendra Singh
+ * @since 7.0
+ * @see SecurityJacksonModules
+ */
+@SuppressWarnings("serial")
+public class WebJacksonModule extends SimpleModule {
+
+	public WebJacksonModule() {
+		super(WebJacksonModule.class.getName(), new Version(1, 0, 0, null, null, null));
+	}
+
+	@Override
+	public void setupModule(SetupContext context) {
+		((MapperBuilder<?, ?>) context.getOwner()).setDefaultTyping(new AllowlistTypeResolverBuilder());
+		context.setMixIn(DefaultCsrfToken.class, DefaultCsrfTokenMixin.class);
+		context.setMixIn(PreAuthenticatedAuthenticationToken.class, PreAuthenticatedAuthenticationTokenMixin.class);
+		context.setMixIn(SwitchUserGrantedAuthority.class, SwitchUserGrantedAuthorityMixIn.class);
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/jackson/WebServletJacksonModule.java
+++ b/web/src/main/java/org/springframework/security/web/jackson/WebServletJacksonModule.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.jackson;
+
+import jakarta.servlet.http.Cookie;
+import tools.jackson.core.Version;
+import tools.jackson.databind.cfg.MapperBuilder;
+import tools.jackson.databind.module.SimpleModule;
+
+import org.springframework.security.jackson.AllowlistTypeResolverBuilder;
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.security.web.authentication.switchuser.SwitchUserGrantedAuthority;
+import org.springframework.security.web.savedrequest.DefaultSavedRequest;
+import org.springframework.security.web.savedrequest.SavedCookie;
+
+/**
+ * Jackson module for spring-security-web related to servlet. This module registers
+ * {@link CookieMixin}, {@link SavedCookieMixin}, {@link DefaultSavedRequestMixin},
+ * {@link WebAuthenticationDetailsMixin}, and {@link SwitchUserGrantedAuthorityMixIn}. If
+ * no default typing is enabled by default then it will be enabled, because typing info is
+ * needed to properly serialize/deserialize objects. In order to use this module just add
+ * this module into your ObjectMapper configuration.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new WebServletJacksonModule())
+ * 				.build();
+ * </pre>
+ *
+ * <b>Note: use {@link SecurityJacksonModules#getModules(ClassLoader)} to get list of all
+ * security modules.</b>
+ *
+ * @author Sebastien Deleuze
+ * @author Boris Finkelshteyn
+ * @since 7.0
+ * @see SecurityJacksonModules
+ */
+@SuppressWarnings("serial")
+public class WebServletJacksonModule extends SimpleModule {
+
+	public WebServletJacksonModule() {
+		super(WebServletJacksonModule.class.getName(), new Version(1, 0, 0, null, null, null));
+	}
+
+	@Override
+	public void setupModule(SetupContext context) {
+		((MapperBuilder<?, ?>) context.getOwner()).setDefaultTyping(new AllowlistTypeResolverBuilder());
+		context.setMixIn(Cookie.class, CookieMixin.class);
+		context.setMixIn(SavedCookie.class, SavedCookieMixin.class);
+		context.setMixIn(DefaultSavedRequest.class, DefaultSavedRequestMixin.class);
+		context.setMixIn(WebAuthenticationDetails.class, WebAuthenticationDetailsMixin.class);
+		context.setMixIn(SwitchUserGrantedAuthority.class, SwitchUserGrantedAuthorityMixIn.class);
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/jackson/package-info.java
+++ b/web/src/main/java/org/springframework/security/web/jackson/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Jackson 3+ serialization support for web.
+ */
+package org.springframework.security.web.jackson;

--- a/web/src/main/java/org/springframework/security/web/jackson2/CookieDeserializer.java
+++ b/web/src/main/java/org/springframework/security/web/jackson2/CookieDeserializer.java
@@ -37,7 +37,10 @@ import jakarta.servlet.http.Cookie;
  * @author Jitendra Singh
  * @since 4.2
  * @see CookieMixin
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.web.jackson.CookieDeserializer} based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 class CookieDeserializer extends JsonDeserializer<Cookie> {
 
 	@Override

--- a/web/src/main/java/org/springframework/security/web/jackson2/CookieMixin.java
+++ b/web/src/main/java/org/springframework/security/web/jackson2/CookieMixin.java
@@ -32,7 +32,10 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * @since 4.2
  * @see WebServletJackson2Module
  * @see org.springframework.security.jackson2.SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.web.jackson.CookieMixin} based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
 @JsonDeserialize(using = CookieDeserializer.class)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/web/src/main/java/org/springframework/security/web/jackson2/DefaultCsrfTokenMixin.java
+++ b/web/src/main/java/org/springframework/security/web/jackson2/DefaultCsrfTokenMixin.java
@@ -34,7 +34,11 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  * @since 4.2
  * @see WebJackson2Module
  * @see org.springframework.security.jackson2.SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.web.jackson.DefaultCsrfTokenMixin} based on Jackson
+ * 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 @JsonIgnoreProperties(ignoreUnknown = true)
 class DefaultCsrfTokenMixin {

--- a/web/src/main/java/org/springframework/security/web/jackson2/DefaultSavedRequestMixin.java
+++ b/web/src/main/java/org/springframework/security/web/jackson2/DefaultSavedRequestMixin.java
@@ -39,7 +39,11 @@ import org.springframework.security.web.savedrequest.DefaultSavedRequest;
  * @since 4.2
  * @see WebServletJackson2Module
  * @see org.springframework.security.jackson2.SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.web.jackson.DefaultCsrfTokenMixin} based on Jackson
+ * 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
 @JsonDeserialize(builder = DefaultSavedRequest.Builder.class)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/web/src/main/java/org/springframework/security/web/jackson2/PreAuthenticatedAuthenticationTokenDeserializer.java
+++ b/web/src/main/java/org/springframework/security/web/jackson2/PreAuthenticatedAuthenticationTokenDeserializer.java
@@ -43,7 +43,11 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedA
  * @author Jitendra Singh
  * @since 4.2
  * @see PreAuthenticatedAuthenticationTokenMixin
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.web.jackson.PreAuthenticatedAuthenticationTokenDeserializer}
+ * based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 class PreAuthenticatedAuthenticationTokenDeserializer extends JsonDeserializer<PreAuthenticatedAuthenticationToken> {
 
 	private static final TypeReference<List<GrantedAuthority>> GRANTED_AUTHORITY_LIST = new TypeReference<>() {

--- a/web/src/main/java/org/springframework/security/web/jackson2/PreAuthenticatedAuthenticationTokenMixin.java
+++ b/web/src/main/java/org/springframework/security/web/jackson2/PreAuthenticatedAuthenticationTokenMixin.java
@@ -45,7 +45,11 @@ import org.springframework.security.jackson2.SimpleGrantedAuthorityMixin;
  * @since 4.2
  * @see Webackson2Module
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.web.jackson.PreAuthenticatedAuthenticationTokenMixin}
+ * based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/web/src/main/java/org/springframework/security/web/jackson2/SavedCookieMixin.java
+++ b/web/src/main/java/org/springframework/security/web/jackson2/SavedCookieMixin.java
@@ -32,11 +32,14 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  *		mapper.registerModule(new WebServletJackson2Module());
  * </pre>
  *
- * @author Jitendra Singh.
+ * @author Jitendra Singh
  * @since 4.2
  * @see WebServletJackson2Module
  * @see org.springframework.security.jackson2.SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.web.jackson.SavedCookieMixin} based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/web/src/main/java/org/springframework/security/web/jackson2/SwitchUserGrantedAuthorityMixIn.java
+++ b/web/src/main/java/org/springframework/security/web/jackson2/SwitchUserGrantedAuthorityMixIn.java
@@ -33,7 +33,11 @@ import org.springframework.security.web.authentication.switchuser.SwitchUserGran
  * @see WebJackson2Module
  * @see WebServletJackson2Module
  * @see org.springframework.security.jackson2.SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.web.jackson.SwitchUserGrantedAuthorityMixIn} based
+ * on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,
 		isGetterVisibility = JsonAutoDetect.Visibility.NONE)

--- a/web/src/main/java/org/springframework/security/web/jackson2/WebAuthenticationDetailsMixin.java
+++ b/web/src/main/java/org/springframework/security/web/jackson2/WebAuthenticationDetailsMixin.java
@@ -35,7 +35,11 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  * @since 4.2
  * @see WebServletJackson2Module
  * @see org.springframework.security.jackson2.SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.web.jackson.SwitchUserGrantedAuthorityMixIn} based
+ * on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE,

--- a/web/src/main/java/org/springframework/security/web/jackson2/WebJackson2Module.java
+++ b/web/src/main/java/org/springframework/security/web/jackson2/WebJackson2Module.java
@@ -35,13 +35,18 @@ import org.springframework.security.web.csrf.DefaultCsrfToken;
  * <pre>
  *     ObjectMapper mapper = new ObjectMapper();
  *     mapper.registerModule(new WebJackson2Module());
- * </pre> <b>Note: use {@link SecurityJackson2Modules#getModules(ClassLoader)} to get list
- * of all security modules.</b>
+ * </pre>
+ *
+ * <b>Note: use {@link SecurityJackson2Modules#getModules(ClassLoader)} to get list of all
+ * security modules.</b>
  *
  * @author Jitendra Singh
  * @since 4.2
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@link org.springframework.security.web.jackson.WebJacksonModule} based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @SuppressWarnings("serial")
 public class WebJackson2Module extends SimpleModule {
 

--- a/web/src/main/java/org/springframework/security/web/jackson2/WebServletJackson2Module.java
+++ b/web/src/main/java/org/springframework/security/web/jackson2/WebServletJackson2Module.java
@@ -43,7 +43,11 @@ import org.springframework.security.web.savedrequest.SavedCookie;
  * @author Boris Finkelshteyn
  * @since 5.1
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@link org.springframework.security.web.jackson.WebServletJacksonModule} based on
+ * Jackson 3
  */
+@Deprecated(forRemoval = true)
 @SuppressWarnings("serial")
 public class WebServletJackson2Module extends SimpleModule {
 

--- a/web/src/main/java/org/springframework/security/web/jackson2/package-info.java
+++ b/web/src/main/java/org/springframework/security/web/jackson2/package-info.java
@@ -15,10 +15,7 @@
  */
 
 /**
- * Mix-in classes to provide Jackson serialization support.
- *
- * @author Jitendra Singh
- * @since 4.2
+ * Jackson 2 serialization support for web.
  */
 @NullMarked
 package org.springframework.security.web.jackson2;

--- a/web/src/main/java/org/springframework/security/web/savedrequest/DefaultSavedRequest.java
+++ b/web/src/main/java/org/springframework/security/web/savedrequest/DefaultSavedRequest.java
@@ -27,7 +27,6 @@ import java.util.Objects;
 import java.util.TreeMap;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.logging.Log;
@@ -396,7 +395,8 @@ public class DefaultSavedRequest implements SavedRequest {
 	 * @since 4.2
 	 */
 	@JsonIgnoreProperties(ignoreUnknown = true)
-	@JsonPOJOBuilder(withPrefix = "set")
+	@com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "set")
+	@tools.jackson.databind.annotation.JsonPOJOBuilder(withPrefix = "set")
 	public static class Builder {
 
 		private @Nullable List<SavedCookie> cookies = null;

--- a/web/src/main/java/org/springframework/security/web/server/jackson/DefaultCsrfServerTokenMixin.java
+++ b/web/src/main/java/org/springframework/security/web/server/jackson/DefaultCsrfServerTokenMixin.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.server.jackson;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Jackson mixin class to serialize/deserialize
+ * {@link org.springframework.security.web.server.csrf.DefaultCsrfToken} serialization
+ * support.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new WebServerJackson2Module())
+ * 				.build();
+ * </pre>
+ *
+ * @author Sebastien Deleuze
+ * @author Boris Finkelshteyn
+ * @since 7.0
+ * @see WebServerJacksonModule
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+@JsonIgnoreProperties(ignoreUnknown = true)
+class DefaultCsrfServerTokenMixin {
+
+	/**
+	 * JsonCreator constructor needed by Jackson to create
+	 * {@link org.springframework.security.web.server.csrf.DefaultCsrfToken} object.
+	 * @param headerName the name of the header
+	 * @param parameterName the parameter name
+	 * @param token the CSRF token value
+	 */
+	@JsonCreator
+	DefaultCsrfServerTokenMixin(@JsonProperty("headerName") String headerName,
+			@JsonProperty("parameterName") String parameterName, @JsonProperty("token") String token) {
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/server/jackson/WebServerJacksonModule.java
+++ b/web/src/main/java/org/springframework/security/web/server/jackson/WebServerJacksonModule.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.server.jackson;
+
+import tools.jackson.core.Version;
+import tools.jackson.databind.cfg.MapperBuilder;
+import tools.jackson.databind.module.SimpleModule;
+
+import org.springframework.security.jackson.AllowlistTypeResolverBuilder;
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.web.server.csrf.DefaultCsrfToken;
+
+/**
+ * Jackson module for spring-security-web-flux. This module register
+ * {@link DefaultCsrfServerTokenMixin} If no default typing enabled by default then it'll
+ * enable it because typing info is needed to properly serialize/deserialize objects. In
+ * order to use this module just add this module into your ObjectMapper configuration.
+ *
+ * <pre>
+ *     JsonMapper mapper = JsonMapper.builder()
+ * 				.addModule(new WebServerJackson2Module())
+ * 				.build();
+ * </pre>
+ *
+ * <b>Note: use {@link SecurityJacksonModules#getModules(ClassLoader)} to get list of all
+ * security modules.</b>
+ *
+ * @author Boris Finkelshteyn
+ * @since 5.1
+ * @see SecurityJacksonModules
+ */
+@SuppressWarnings("serial")
+public class WebServerJacksonModule extends SimpleModule {
+
+	private static final String NAME = WebServerJacksonModule.class.getName();
+
+	private static final Version VERSION = new Version(1, 0, 0, null, null, null);
+
+	public WebServerJacksonModule() {
+		super(NAME, VERSION);
+	}
+
+	@Override
+	public void setupModule(SetupContext context) {
+		((MapperBuilder<?, ?>) context.getOwner()).setDefaultTyping(new AllowlistTypeResolverBuilder());
+		context.setMixIn(DefaultCsrfToken.class, DefaultCsrfServerTokenMixin.class);
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/server/jackson/package-info.java
+++ b/web/src/main/java/org/springframework/security/web/server/jackson/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Jackson 3+ serialization support for reactive web server.
+ */
+@NullMarked
+package org.springframework.security.web.server.jackson;
+
+import org.jspecify.annotations.NullMarked;

--- a/web/src/main/java/org/springframework/security/web/server/jackson2/DefaultCsrfServerTokenMixin.java
+++ b/web/src/main/java/org/springframework/security/web/server/jackson2/DefaultCsrfServerTokenMixin.java
@@ -34,7 +34,11 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  * @author Boris Finkelshteyn
  * @since 5.1
  * @see WebServerJackson2Module
+ * @deprecated as of 7.0 in favor of
+ * {@code org.springframework.security.web.server.jackson.DefaultCsrfServerTokenMixin}
+ * based on Jackson 3
  */
+@Deprecated(forRemoval = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 @JsonIgnoreProperties(ignoreUnknown = true)
 class DefaultCsrfServerTokenMixin {

--- a/web/src/main/java/org/springframework/security/web/server/jackson2/WebServerJackson2Module.java
+++ b/web/src/main/java/org/springframework/security/web/server/jackson2/WebServerJackson2Module.java
@@ -37,7 +37,11 @@ import org.springframework.security.web.server.csrf.DefaultCsrfToken;
  * @author Boris Finkelshteyn
  * @since 5.1
  * @see SecurityJackson2Modules
+ * @deprecated as of 7.0 in favor of
+ * {@link org.springframework.security.web.server.jackson.WebServerJacksonModule} based on
+ * Jackson 3
  */
+@Deprecated(forRemoval = true)
 @SuppressWarnings("serial")
 public class WebServerJackson2Module extends SimpleModule {
 

--- a/web/src/main/java/org/springframework/security/web/server/jackson2/package-info.java
+++ b/web/src/main/java/org/springframework/security/web/server/jackson2/package-info.java
@@ -15,7 +15,7 @@
  */
 
 /**
- * Reactive web jackson2 integration.
+ * Jackson 2 serialization support for reactive web server.
  */
 @NullMarked
 package org.springframework.security.web.server.jackson2;

--- a/web/src/test/java/org/springframework/security/web/jackson/AbstractMixinTests.java
+++ b/web/src/test/java/org/springframework/security/web/jackson/AbstractMixinTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.jackson;
+
+import org.junit.jupiter.api.BeforeEach;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.security.jackson.SecurityJacksonModules;
+
+/**
+ * @author Sebastien Deleuze
+ * @author Jitenra Singh
+ */
+public abstract class AbstractMixinTests {
+
+	protected JsonMapper mapper;
+
+	@BeforeEach
+	public void setup() {
+		ClassLoader loader = getClass().getClassLoader();
+		this.mapper = JsonMapper.builder().addModules(SecurityJacksonModules.getModules(loader)).build();
+	}
+
+}

--- a/web/src/test/java/org/springframework/security/web/jackson/CookieMixinTests.java
+++ b/web/src/test/java/org/springframework/security/web/jackson/CookieMixinTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.jackson;
+
+import jakarta.servlet.http.Cookie;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.core.JacksonException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Jitendra Singh
+ * @since 4.2
+ */
+public class CookieMixinTests extends AbstractMixinTests {
+
+	// @formatter:off
+	private static final String COOKIE_JSON = "{" +
+		"	\"@class\": \"jakarta.servlet.http.Cookie\"," +
+		"	\"name\": \"demo\"," +
+		"	\"value\": \"cookie1\"," +
+		"	\"attributes\":{\"@class\":\"java.util.Collections$EmptyMap\"}," +
+		"	\"comment\": null," +
+		"	\"maxAge\": -1," +
+		"	\"path\": null," +
+		"	\"secure\": false," +
+		"	\"version\": 0," +
+		"	\"domain\": null" +
+		"}";
+	// @formatter:on
+
+	// @formatter:off
+	private static final String COOKIE_HTTP_ONLY_JSON = "{" +
+		"	\"@class\": \"jakarta.servlet.http.Cookie\"," +
+		"	\"name\": \"demo\"," +
+		"	\"value\": \"cookie1\"," +
+		"	\"attributes\":{\"@class\":\"java.util.Collections$UnmodifiableMap\", \"HttpOnly\": \"\"}," +
+		"	\"comment\": null," +
+		"	\"maxAge\": -1," +
+		"	\"path\": null," +
+		"	\"secure\": false," +
+		"	\"version\": 0," +
+		"	\"domain\": null" +
+		"}";
+	// @formatter:on
+
+	@Test
+	public void serializeCookie() throws JacksonException, JSONException {
+		Cookie cookie = new Cookie("demo", "cookie1");
+		String actualString = this.mapper.writeValueAsString(cookie);
+		JSONAssert.assertEquals(COOKIE_JSON, actualString, true);
+	}
+
+	@Test
+	public void deserializeCookie() {
+		Cookie cookie = this.mapper.readValue(COOKIE_JSON, Cookie.class);
+		assertThat(cookie).isNotNull();
+		assertThat(cookie.getName()).isEqualTo("demo");
+		assertThat(cookie.getDomain()).isNull();
+	}
+
+	@Test
+	public void serializeCookieWithHttpOnly() throws JacksonException, JSONException {
+		Cookie cookie = new Cookie("demo", "cookie1");
+		cookie.setHttpOnly(true);
+		String actualString = this.mapper.writeValueAsString(cookie);
+		JSONAssert.assertEquals(COOKIE_HTTP_ONLY_JSON, actualString, true);
+	}
+
+	@Test
+	public void deserializeCookieWithHttpOnly() {
+		Cookie cookie = this.mapper.readValue(COOKIE_HTTP_ONLY_JSON, Cookie.class);
+		assertThat(cookie).isNotNull();
+		assertThat(cookie.getName()).isEqualTo("demo");
+		assertThat(cookie.getDomain()).isNull();
+		assertThat(cookie.isHttpOnly()).isEqualTo(true);
+	}
+
+}

--- a/web/src/test/java/org/springframework/security/web/jackson/DefaultCsrfTokenMixinTests.java
+++ b/web/src/test/java/org/springframework/security/web/jackson/DefaultCsrfTokenMixinTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.jackson;
+
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.core.JacksonException;
+
+import org.springframework.security.web.csrf.DefaultCsrfToken;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * @author Jitendra Singh
+ * @since 4.2
+ */
+public class DefaultCsrfTokenMixinTests extends AbstractMixinTests {
+
+	// @formatter:off
+	public static final String CSRF_JSON = "{"
+		+ "\"@class\": \"org.springframework.security.web.csrf.DefaultCsrfToken\", "
+		+ "\"headerName\": \"csrf-header\", "
+		+ "\"parameterName\": \"_csrf\", "
+		+ "\"token\": \"1\""
+	+ "}";
+	// @formatter:on
+	@Test
+	public void defaultCsrfTokenSerializedTest() throws JacksonException, JSONException {
+		DefaultCsrfToken token = new DefaultCsrfToken("csrf-header", "_csrf", "1");
+		String serializedJson = this.mapper.writeValueAsString(token);
+		JSONAssert.assertEquals(CSRF_JSON, serializedJson, true);
+	}
+
+	@Test
+	public void defaultCsrfTokenDeserializeTest() {
+		DefaultCsrfToken token = this.mapper.readValue(CSRF_JSON, DefaultCsrfToken.class);
+		assertThat(token).isNotNull();
+		assertThat(token.getHeaderName()).isEqualTo("csrf-header");
+		assertThat(token.getParameterName()).isEqualTo("_csrf");
+		assertThat(token.getToken()).isEqualTo("1");
+	}
+
+	@Test
+	public void defaultCsrfTokenDeserializeWithoutClassTest() {
+		String tokenJson = "{\"headerName\": \"csrf-header\", \"parameterName\": \"_csrf\", \"token\": \"1\"}";
+		assertThatExceptionOfType(JacksonException.class)
+			.isThrownBy(() -> this.mapper.readValue(tokenJson, DefaultCsrfToken.class));
+	}
+
+	@Test
+	public void defaultCsrfTokenDeserializeNullValuesTest() {
+		String tokenJson = "{\"@class\": \"org.springframework.security.web.csrf.DefaultCsrfToken\", \"headerName\": \"\", \"parameterName\": null, \"token\": \"1\"}";
+		assertThatExceptionOfType(JacksonException.class)
+			.isThrownBy(() -> this.mapper.readValue(tokenJson, DefaultCsrfToken.class));
+	}
+
+}

--- a/web/src/test/java/org/springframework/security/web/jackson/DefaultSavedRequestMixinTests.java
+++ b/web/src/test/java/org/springframework/security/web/jackson/DefaultSavedRequestMixinTests.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.jackson;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Locale;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.web.PortResolverImpl;
+import org.springframework.security.web.savedrequest.DefaultSavedRequest;
+import org.springframework.security.web.savedrequest.SavedCookie;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Jitendra Singh
+ * @since 4.2
+ */
+public class DefaultSavedRequestMixinTests extends AbstractMixinTests {
+
+	// @formatter:off
+	private static final String COOKIES_JSON = "[\"java.util.ArrayList\", [{"
+		+ "\"@class\": \"org.springframework.security.web.savedrequest.SavedCookie\", "
+		+ "\"name\": \"SESSION\", "
+		+ "\"value\": \"123456789\", "
+		+ "\"maxAge\": -1, "
+		+ "\"path\": null, "
+		+ "\"secure\":false, "
+		+ "\"domain\": null"
+	+ "}]]";
+	// @formatter:on
+	// @formatter:off
+	private static final String REQUEST_JSON = "{" +
+			"\"@class\": \"org.springframework.security.web.savedrequest.DefaultSavedRequest\", "
+			+ "\"cookies\": " + COOKIES_JSON + ","
+			+ "\"locales\": [\"java.util.ArrayList\", [\"en\"]], "
+			+ "\"headers\": {\"@class\": \"java.util.TreeMap\", \"x-auth-token\": [\"java.util.ArrayList\", [\"12\"]]}, "
+			+ "\"parameters\": {\"@class\": \"java.util.TreeMap\"},"
+			+ "\"contextPath\": \"\", "
+			+ "\"method\": \"\", "
+			+ "\"pathInfo\": null, "
+			+ "\"queryString\": null, "
+			+ "\"requestURI\": \"\", "
+			+ "\"requestURL\": \"http://localhost\", "
+			+ "\"scheme\": \"http\", "
+			+ "\"serverName\": \"localhost\", "
+			+ "\"servletPath\": \"\", "
+			+ "\"serverPort\": 80"
+			+ "}";
+	// @formatter:on
+	// @formatter:off
+	private static final String REQUEST_WITH_MATCHING_REQUEST_PARAM_NAME_JSON = "{" +
+			"\"@class\": \"org.springframework.security.web.savedrequest.DefaultSavedRequest\", "
+			+ "\"cookies\": " + COOKIES_JSON + ","
+			+ "\"locales\": [\"java.util.ArrayList\", [\"en\"]], "
+			+ "\"headers\": {\"@class\": \"java.util.TreeMap\", \"x-auth-token\": [\"java.util.ArrayList\", [\"12\"]]}, "
+			+ "\"parameters\": {\"@class\": \"java.util.TreeMap\"},"
+			+ "\"contextPath\": \"\", "
+			+ "\"method\": \"\", "
+			+ "\"pathInfo\": null, "
+			+ "\"queryString\": null, "
+			+ "\"requestURI\": \"\", "
+			+ "\"requestURL\": \"http://localhost\", "
+			+ "\"scheme\": \"http\", "
+			+ "\"serverName\": \"localhost\", "
+			+ "\"servletPath\": \"\", "
+			+ "\"serverPort\": 80, "
+			+ "\"matchingRequestParameterName\": \"success\""
+			+ "}";
+	// @formatter:on
+	@Test
+	public void matchRequestBuildWithConstructorAndBuilder() {
+		DefaultSavedRequest request = new DefaultSavedRequest.Builder()
+			.setCookies(Collections.singletonList(new SavedCookie(new Cookie("SESSION", "123456789"))))
+			.setHeaders(Collections.singletonMap("x-auth-token", Collections.singletonList("12")))
+			.setScheme("http")
+			.setRequestURL("http://localhost")
+			.setServerName("localhost")
+			.setRequestURI("")
+			.setLocales(Collections.singletonList(new Locale("en")))
+			.setContextPath("")
+			.setMethod("")
+			.setServletPath("")
+			.build();
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+		mockRequest.setCookies(new Cookie("SESSION", "123456789"));
+		mockRequest.addHeader("x-auth-token", "12");
+		assertThat(request.doesRequestMatch(mockRequest, new PortResolverImpl())).isTrue();
+	}
+
+	@Test
+	public void serializeDefaultRequestBuildWithConstructorTest() throws IOException, JSONException {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("x-auth-token", "12");
+		// Spring 5 MockHttpServletRequest automatically adds a header when the cookies
+		// are set. To get consistency we override the request.
+		HttpServletRequest requestToWrite = new HttpServletRequestWrapper(request) {
+			@Override
+			public Cookie[] getCookies() {
+				return new Cookie[] { new Cookie("SESSION", "123456789") };
+			}
+		};
+		String actualString = this.mapper.writerWithDefaultPrettyPrinter()
+			.writeValueAsString(new DefaultSavedRequest(requestToWrite, new PortResolverImpl()));
+		JSONAssert.assertEquals(REQUEST_JSON, actualString, true);
+	}
+
+	@Test
+	public void serializeDefaultRequestBuildWithBuilderTest() throws IOException, JSONException {
+		DefaultSavedRequest request = new DefaultSavedRequest.Builder()
+			.setCookies(Collections.singletonList(new SavedCookie(new Cookie("SESSION", "123456789"))))
+			.setHeaders(Collections.singletonMap("x-auth-token", Collections.singletonList("12")))
+			.setScheme("http")
+			.setRequestURL("http://localhost")
+			.setServerName("localhost")
+			.setRequestURI("")
+			.setLocales(Collections.singletonList(new Locale("en")))
+			.setContextPath("")
+			.setMethod("")
+			.setServletPath("")
+			.build();
+		String actualString = this.mapper.writerWithDefaultPrettyPrinter().writeValueAsString(request);
+		JSONAssert.assertEquals(REQUEST_JSON, actualString, true);
+	}
+
+	@Test
+	public void deserializeDefaultSavedRequest() {
+		DefaultSavedRequest request = (DefaultSavedRequest) this.mapper.readValue(REQUEST_JSON, Object.class);
+		assertThat(request).isNotNull();
+		assertThat(request.getCookies()).hasSize(1);
+		assertThat(request.getLocales()).hasSize(1).contains(new Locale("en"));
+		assertThat(request.getHeaderNames()).hasSize(1).contains("x-auth-token");
+		assertThat(request.getHeaderValues("x-auth-token")).hasSize(1).contains("12");
+	}
+
+	@Test
+	public void deserializeWhenMatchingRequestParameterNameThenRedirectUrlContainsParam() {
+		DefaultSavedRequest request = (DefaultSavedRequest) this.mapper
+			.readValue(REQUEST_WITH_MATCHING_REQUEST_PARAM_NAME_JSON, Object.class);
+		assertThat(request.getRedirectUrl()).isEqualTo("http://localhost?success");
+	}
+
+	@Test
+	public void deserializeWhenNullMatchingRequestParameterNameThenRedirectUrlDoesNotContainParam() {
+		DefaultSavedRequest request = (DefaultSavedRequest) this.mapper.readValue(REQUEST_JSON, Object.class);
+		assertThat(request.getRedirectUrl()).isEqualTo("http://localhost");
+	}
+
+}

--- a/web/src/test/java/org/springframework/security/web/jackson/PreAuthenticatedAuthenticationTokenMixinTests.java
+++ b/web/src/test/java/org/springframework/security/web/jackson/PreAuthenticatedAuthenticationTokenMixinTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.jackson;
+
+import org.json.JSONException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.core.JacksonException;
+
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.jackson2.SimpleGrantedAuthorityMixinTests;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Rob Winch
+ * @since 4.2
+ */
+public class PreAuthenticatedAuthenticationTokenMixinTests extends AbstractMixinTests {
+
+	// @formatter:off
+	private static final String PREAUTH_JSON = "{"
+		+ "\"@class\": \"org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken\","
+		+ "\"principal\": \"principal\", "
+		+ "\"credentials\": \"credentials\", "
+		+ "\"authenticated\": true, "
+		+ "\"details\": null, "
+		+ "\"authorities\": " + SimpleGrantedAuthorityMixinTests.AUTHORITIES_ARRAYLIST_JSON
+	+ "}";
+	// @formatter:on
+	PreAuthenticatedAuthenticationToken expected;
+
+	@BeforeEach
+	public void setupExpected() {
+		this.expected = new PreAuthenticatedAuthenticationToken("principal", "credentials",
+				AuthorityUtils.createAuthorityList("ROLE_USER"));
+	}
+
+	@Test
+	public void serializeWhenPrincipalCredentialsAuthoritiesThenSuccess() throws JacksonException, JSONException {
+		String serializedJson = this.mapper.writeValueAsString(this.expected);
+		JSONAssert.assertEquals(PREAUTH_JSON, serializedJson, true);
+	}
+
+	@Test
+	public void deserializeAuthenticatedUsernamePasswordAuthenticationTokenMixinTest() {
+		PreAuthenticatedAuthenticationToken deserialized = this.mapper.readValue(PREAUTH_JSON,
+				PreAuthenticatedAuthenticationToken.class);
+		assertThat(deserialized).isNotNull();
+		assertThat(deserialized.isAuthenticated()).isTrue();
+		assertThat(deserialized.getAuthorities()).isEqualTo(this.expected.getAuthorities());
+	}
+
+}

--- a/web/src/test/java/org/springframework/security/web/jackson/SavedCookieMixinTests.java
+++ b/web/src/test/java/org/springframework/security/web/jackson/SavedCookieMixinTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.jackson;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.servlet.http.Cookie;
+import org.json.JSONException;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.core.JacksonException;
+
+import org.springframework.security.web.savedrequest.SavedCookie;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Jitendra Singh
+ */
+public class SavedCookieMixinTests extends AbstractMixinTests {
+
+	// @formatter:off
+	private static final String COOKIE_JSON = "{"
+		+ "\"@class\": \"org.springframework.security.web.savedrequest.SavedCookie\", "
+		+ "\"name\": \"SESSION\", "
+		+ "\"value\": \"123456789\", "
+		+ "\"maxAge\": -1, "
+		+ "\"path\": null, "
+		+ "\"secure\":false, "
+		+ "\"domain\": null"
+	+ "}";
+	// @formatter:on
+	// @formatter:off
+	private static final String COOKIES_JSON = "[\"java.util.ArrayList\", ["
+		+ COOKIE_JSON
+	+ "]]";
+	// @formatter:on
+	@Test
+	public void serializeWithDefaultConfigurationTest() throws JacksonException, JSONException {
+		SavedCookie savedCookie = new SavedCookie(new Cookie("SESSION", "123456789"));
+		String actualJson = this.mapper.writeValueAsString(savedCookie);
+		JSONAssert.assertEquals(COOKIE_JSON, actualJson, true);
+	}
+
+	@Test
+	@Disabled("No supported by Jackson 3 as ObjectMapper/JsonMapper is immutable")
+	public void serializeWithOverrideConfigurationTest() throws JacksonException, JSONException {
+		SavedCookie savedCookie = new SavedCookie(new Cookie("SESSION", "123456789"));
+		// this.mapper.setVisibility(PropertyAccessor.FIELD,
+		// JsonAutoDetect.Visibility.PUBLIC_ONLY)
+		// .setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.ANY);
+		String actualJson = this.mapper.writeValueAsString(savedCookie);
+		JSONAssert.assertEquals(COOKIE_JSON, actualJson, true);
+	}
+
+	@Test
+	public void serializeSavedCookieWithList() throws JacksonException, JSONException {
+		List<SavedCookie> savedCookies = new ArrayList<>();
+		savedCookies.add(new SavedCookie(new Cookie("SESSION", "123456789")));
+		String actualJson = this.mapper.writeValueAsString(savedCookies);
+		JSONAssert.assertEquals(COOKIES_JSON, actualJson, true);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void deserializeSavedCookieWithList() {
+		List<SavedCookie> savedCookies = (List<SavedCookie>) this.mapper.readValue(COOKIES_JSON, Object.class);
+		assertThat(savedCookies).isNotNull().hasSize(1);
+		assertThat(savedCookies.get(0).getName()).isEqualTo("SESSION");
+		assertThat(savedCookies.get(0).getValue()).isEqualTo("123456789");
+	}
+
+	@Test
+	public void deserializeSavedCookieJsonTest() {
+		SavedCookie savedCookie = (SavedCookie) this.mapper.readValue(COOKIE_JSON, Object.class);
+		assertThat(savedCookie).isNotNull();
+		assertThat(savedCookie.getName()).isEqualTo("SESSION");
+		assertThat(savedCookie.getValue()).isEqualTo("123456789");
+		assertThat(savedCookie.isSecure()).isEqualTo(false);
+	}
+
+}

--- a/web/src/test/java/org/springframework/security/web/jackson/SwitchUserGrantedAuthorityMixInTests.java
+++ b/web/src/test/java/org/springframework/security/web/jackson/SwitchUserGrantedAuthorityMixInTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.jackson;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.jackson.CoreJacksonModule;
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.jackson.SimpleGrantedAuthorityMixinTests;
+import org.springframework.security.web.authentication.switchuser.SwitchUserGrantedAuthority;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Markus Heiden
+ * @since 6.3
+ */
+public class SwitchUserGrantedAuthorityMixInTests {
+
+	// language=JSON
+	private static final String SWITCH_JSON = """
+			{
+				"@class": "org.springframework.security.web.authentication.switchuser.SwitchUserGrantedAuthority",
+				"role": "switched",
+				"source": {
+					"@class": "org.springframework.security.authentication.UsernamePasswordAuthenticationToken",
+					"principal": "principal",
+					"credentials": "credentials",
+					"authenticated": true,
+					"details": null,
+					"authorities": %s
+				}
+			}
+			""".formatted(SimpleGrantedAuthorityMixinTests.AUTHORITIES_ARRAYLIST_JSON);
+
+	private Authentication source;
+
+	static Stream<Arguments> mappers() {
+		ClassLoader classLoader = SwitchUserGrantedAuthorityMixInTests.class.getClassLoader();
+		JsonMapper securityJackson2ModulesMapper = JsonMapper.builder()
+			.addModules(SecurityJacksonModules.getModules(classLoader))
+			.build();
+
+		JsonMapper webJackson2ModuleMapper = JsonMapper.builder()
+			.addModule(new CoreJacksonModule())
+			.addModule(new WebJacksonModule())
+			.build();
+
+		JsonMapper webServletJackson2ModuleMapper = JsonMapper.builder()
+			.addModule(new CoreJacksonModule())
+			.addModule(new WebServletJacksonModule())
+			.build();
+
+		return Stream.of(Arguments.of(securityJackson2ModulesMapper), Arguments.of(webJackson2ModuleMapper),
+				Arguments.of(webServletJackson2ModuleMapper));
+	}
+
+	@BeforeEach
+	public void setUp() {
+		this.source = new UsernamePasswordAuthenticationToken("principal", "credentials",
+				AuthorityUtils.createAuthorityList("ROLE_USER"));
+	}
+
+	@ParameterizedTest
+	@MethodSource("mappers")
+	public void serializeWhenPrincipalCredentialsAuthoritiesThenSuccess(JsonMapper mapper) throws Exception {
+		SwitchUserGrantedAuthority expected = new SwitchUserGrantedAuthority("switched", this.source);
+		String serializedJson = mapper.writeValueAsString(expected);
+		JSONAssert.assertEquals(SWITCH_JSON, serializedJson, true);
+	}
+
+	@ParameterizedTest
+	@MethodSource("mappers")
+	public void deserializeWhenSourceIsUsernamePasswordAuthenticationTokenThenSuccess(JsonMapper mapper)
+			throws Exception {
+		SwitchUserGrantedAuthority deserialized = mapper.readValue(SWITCH_JSON, SwitchUserGrantedAuthority.class);
+		assertThat(deserialized).isNotNull();
+		assertThat(deserialized.getAuthority()).isEqualTo("switched");
+		assertThat(deserialized.getSource()).isEqualTo(this.source);
+	}
+
+}

--- a/web/src/test/java/org/springframework/security/web/jackson/WebAuthenticationDetailsMixinTests.java
+++ b/web/src/test/java/org/springframework/security/web/jackson/WebAuthenticationDetailsMixinTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.jackson;
+
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.core.JacksonException;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Jitendra Singh
+ * @since 4.2
+ */
+public class WebAuthenticationDetailsMixinTests extends AbstractMixinTests {
+
+	// @formatter:off
+	private static final String AUTHENTICATION_DETAILS_JSON = "{"
+		+ "\"@class\": \"org.springframework.security.web.authentication.WebAuthenticationDetails\","
+		+ "\"sessionId\": \"1\", "
+		+ "\"remoteAddress\": "
+		+ "\"/localhost\""
+	+ "}";
+	// @formatter:on
+	@Test
+	public void buildWebAuthenticationDetailsUsingDifferentConstructors() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setRemoteAddr("localhost");
+		request.setSession(new MockHttpSession(null, "1"));
+		WebAuthenticationDetails details = new WebAuthenticationDetails(request);
+		WebAuthenticationDetails authenticationDetails = this.mapper.readValue(AUTHENTICATION_DETAILS_JSON,
+				WebAuthenticationDetails.class);
+		assertThat(details.equals(authenticationDetails));
+	}
+
+	@Test
+	public void webAuthenticationDetailsSerializeTest() throws JacksonException, JSONException {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setRemoteAddr("/localhost");
+		request.setSession(new MockHttpSession(null, "1"));
+		WebAuthenticationDetails details = new WebAuthenticationDetails(request);
+		String actualJson = this.mapper.writeValueAsString(details);
+		JSONAssert.assertEquals(AUTHENTICATION_DETAILS_JSON, actualJson, true);
+	}
+
+	@Test
+	public void webAuthenticationDetailsJackson2SerializeTest() throws JacksonException, JSONException {
+		WebAuthenticationDetails details = new WebAuthenticationDetails("/localhost", "1");
+		String actualJson = this.mapper.writeValueAsString(details);
+		JSONAssert.assertEquals(AUTHENTICATION_DETAILS_JSON, actualJson, true);
+	}
+
+	@Test
+	public void webAuthenticationDetailsDeserializeTest() {
+		WebAuthenticationDetails details = this.mapper.readValue(AUTHENTICATION_DETAILS_JSON,
+				WebAuthenticationDetails.class);
+		assertThat(details).isNotNull();
+		assertThat(details.getRemoteAddress()).isEqualTo("/localhost");
+		assertThat(details.getSessionId()).isEqualTo("1");
+	}
+
+}

--- a/web/src/test/java/org/springframework/security/web/jackson2/AbstractMixinTests.java
+++ b/web/src/test/java/org/springframework/security/web/jackson2/AbstractMixinTests.java
@@ -25,6 +25,7 @@ import org.springframework.security.jackson2.SecurityJackson2Modules;
  * @author Jitenra Singh
  * @since 4.2
  */
+@SuppressWarnings("removal")
 public abstract class AbstractMixinTests {
 
 	protected ObjectMapper mapper;

--- a/web/src/test/java/org/springframework/security/web/jackson2/SavedCookieMixinTests.java
+++ b/web/src/test/java/org/springframework/security/web/jackson2/SavedCookieMixinTests.java
@@ -33,7 +33,7 @@ import org.springframework.security.web.savedrequest.SavedCookie;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * @author Jitendra Singh.
+ * @author Jitendra Singh
  */
 public class SavedCookieMixinTests extends AbstractMixinTests {
 

--- a/web/src/test/java/org/springframework/security/web/jackson2/SwitchUserGrantedAuthorityMixInTests.java
+++ b/web/src/test/java/org/springframework/security/web/jackson2/SwitchUserGrantedAuthorityMixInTests.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Markus Heiden
  * @since 6.3
  */
+@SuppressWarnings("removal")
 public class SwitchUserGrantedAuthorityMixInTests {
 
 	// language=JSON

--- a/web/src/test/java/org/springframework/security/web/server/jackson/DefaultCsrfServerTokenMixinTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/jackson/DefaultCsrfServerTokenMixinTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.server.jackson;
+
+import java.io.IOException;
+
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.core.JacksonException;
+
+import org.springframework.security.web.jackson.AbstractMixinTests;
+import org.springframework.security.web.server.csrf.DefaultCsrfToken;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * @author Sebastien Deleuze
+ * @author Boris Finkelshteyn
+ */
+public class DefaultCsrfServerTokenMixinTests extends AbstractMixinTests {
+
+	// @formatter:off
+	private static final String CSRF_JSON = "{"
+			+ "\"@class\": \"org.springframework.security.web.server.csrf.DefaultCsrfToken\", "
+			+ "\"headerName\": \"csrf-header\", "
+			+ "\"parameterName\": \"_csrf\", "
+			+ "\"token\": \"1\""
+			+ "}";
+	// @formatter:on
+	@Test
+	public void defaultCsrfTokenSerializedTest() throws JacksonException, JSONException {
+		DefaultCsrfToken token = new DefaultCsrfToken("csrf-header", "_csrf", "1");
+		String serializedJson = this.mapper.writeValueAsString(token);
+		JSONAssert.assertEquals(CSRF_JSON, serializedJson, true);
+	}
+
+	@Test
+	public void defaultCsrfTokenDeserializeTest() throws IOException {
+		DefaultCsrfToken token = this.mapper.readValue(CSRF_JSON, DefaultCsrfToken.class);
+		assertThat(token).isNotNull();
+		assertThat(token.getHeaderName()).isEqualTo("csrf-header");
+		assertThat(token.getParameterName()).isEqualTo("_csrf");
+		assertThat(token.getToken()).isEqualTo("1");
+	}
+
+	@Test
+	public void defaultCsrfTokenDeserializeWithoutClassTest() throws IOException {
+		String tokenJson = "{\"headerName\": \"csrf-header\", \"parameterName\": \"_csrf\", \"token\": \"1\"}";
+		assertThatExceptionOfType(JacksonException.class)
+			.isThrownBy(() -> this.mapper.readValue(tokenJson, DefaultCsrfToken.class));
+	}
+
+	@Test
+	public void defaultCsrfTokenDeserializeNullValuesTest() throws IOException {
+		String tokenJson = "{\"@class\": \"org.springframework.security.web.server.csrf.DefaultCsrfToken\", \"headerName\": \"\", \"parameterName\": null, \"token\": \"1\"}";
+		assertThatExceptionOfType(JacksonException.class)
+			.isThrownBy(() -> this.mapper.readValue(tokenJson, DefaultCsrfToken.class));
+	}
+
+}


### PR DESCRIPTION
This PR adds support for Jackson 3 which has the following major differences with the Jackson 2 one:
 - `jackson` subpackage instead of `jackson2`
 - `Jackson` type prefix instead of `Jackson2`
 - `JsonMapper` instead of `ObjectMapper`
 - For configuration, `JsonMapper.Builder` instead of `ObjectMapper` since the latter is now immutable
 - `AllowlistTypeResolverBuilder` in new a public type in order to be used easily with the `JsonMapper.Builder` API

Jackson 3 changes compared to Jackson 2 are documented on https://github.com/FasterXML/jackson-future-ideas/discussions/72.

It also deprecates Jackson 2 support for removal.