### PR TITLE
Fix OIDC discovery to fallback on text/html responses

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistrations.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistrations.java
@@ -37,6 +37,7 @@ import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
 import org.springframework.util.Assert;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.UnknownContentTypeException;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -278,6 +279,9 @@ public final class ClientRegistrations {
 				}
 				errors.add(ex.getMessage());
 				// else try another endpoint
+			}
+			catch (UnknownContentTypeException ex) {
+				errors.add(ex.getMessage());
 			}
 			catch (IllegalArgumentException | IllegalStateException ex) {
 				throw ex;


### PR DESCRIPTION
## Summary
Some providers return `200 OK` with `text/html` for `/.well-known/openid-configuration`. Previously, discovery stopped at the
first endpoint. This PR makes discovery continue to the next candidate so it can fall back to the OAuth 2.0 Authorization Server metadata endpoint.

## Motivation
- Addresses #17036  
- Improves compatibility with providers that misconfigure content type.

## What Changed
- `oauth2/oauth2-client`
  - `ClientRegistrations#getBuilder`: record `UnknownContentTypeException`
    and try the next discovery endpoint (same treatment as 4xx).
- Tests
  - `issuerWhenOidcHtmlThenFallbackToOAuth2ThenSuccess`
  - `issuerWhenFirstEndpoint5xxThenThrowsIllegalArgumentException`

## Behavior
- Before: Non-JSON at OIDC discovery → exception surfaced, no fallback.
- After: Non-JSON at OIDC discovery → error recorded → try next endpoint →
  succeeds via OAuth 2.0 AS metadata when available.

Closes gh-17036