### PR TITLE
Update BCrypt.java

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCrypt.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCrypt.java
@@ -611,6 +611,10 @@ public class BCrypt {
 		int rounds, off;
 		StringBuilder rs = new StringBuilder();
 
+		if(passwordb.length > 72){
+			throw new IllegalArgumentException("password cannot be more than 72 bytes");
+		}
+
 		if (salt == null) {
 			throw new IllegalArgumentException("salt cannot be null");
 		}


### PR DESCRIPTION
In response to the security vulnerability identified as CVE-2025-22228, a critical safeguard has been implemented within the Bcrypt file to enhance the integrity and security of password handling processes. Specifically, a length check has been added to ensure that the password does not exceed 72 bytes in length.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
