### PR TITLE
Use `SmartHttpMessageConverter` over `GenericHttpMessageConverter` where possible

### DIFF
--- a/config/src/main/java/org/springframework/security/config/web/server/HttpMessageConverters.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/HttpMessageConverters.java
@@ -16,11 +16,13 @@
 
 package org.springframework.security.config.web.server;
 
-import org.springframework.http.converter.GenericHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.SmartHttpMessageConverter;
 import org.springframework.http.converter.json.GsonHttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.http.converter.json.JsonbHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.oauth2.core.SmartGenericHttpMessageConverterAdapter;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -28,9 +30,12 @@ import org.springframework.util.ClassUtils;
  *
  * @author Joe Grandja
  * @author luamas
+ * @author Andrey Litvitski
  * @since 5.1
  */
 final class HttpMessageConverters {
+
+	private static final boolean jackson3Present;
 
 	private static final boolean jackson2Present;
 
@@ -40,6 +45,8 @@ final class HttpMessageConverters {
 
 	static {
 		ClassLoader classLoader = HttpMessageConverters.class.getClassLoader();
+		jackson3Present = ClassUtils.isPresent("tools.jackson.databind.ObjectMapper", classLoader)
+				&& ClassUtils.isPresent("tools.jackson.core.JsonGenerator", classLoader);
 		jackson2Present = ClassUtils.isPresent("com.fasterxml.jackson.databind.ObjectMapper", classLoader)
 				&& ClassUtils.isPresent("com.fasterxml.jackson.core.JsonGenerator", classLoader);
 		gsonPresent = ClassUtils.isPresent("com.google.gson.Gson", classLoader);
@@ -49,15 +56,18 @@ final class HttpMessageConverters {
 	private HttpMessageConverters() {
 	}
 
-	static GenericHttpMessageConverter<Object> getJsonMessageConverter() {
+	static SmartHttpMessageConverter<Object> getJsonMessageConverter() {
+		if (jackson3Present) {
+			return new JacksonJsonHttpMessageConverter();
+		}
 		if (jackson2Present) {
-			return new MappingJackson2HttpMessageConverter();
+			return new SmartGenericHttpMessageConverterAdapter<>(new MappingJackson2HttpMessageConverter());
 		}
 		if (gsonPresent) {
-			return new GsonHttpMessageConverter();
+			return new SmartGenericHttpMessageConverterAdapter<>(new GsonHttpMessageConverter());
 		}
 		if (jsonbPresent) {
-			return new JsonbHttpMessageConverter();
+			return new SmartGenericHttpMessageConverterAdapter<>(new JsonbHttpMessageConverter());
 		}
 		return null;
 	}

--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/http/converter/HttpMessageConverters.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/http/converter/HttpMessageConverters.java
@@ -16,11 +16,13 @@
 
 package org.springframework.security.oauth2.server.authorization.http.converter;
 
-import org.springframework.http.converter.GenericHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.SmartHttpMessageConverter;
 import org.springframework.http.converter.json.GsonHttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.http.converter.json.JsonbHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.oauth2.core.SmartGenericHttpMessageConverterAdapter;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -28,9 +30,12 @@ import org.springframework.util.ClassUtils;
  *
  * @author Joe Grandja
  * @author l uamas
+ * @author Andrey Litvitski
  * @since 7.0
  */
 final class HttpMessageConverters {
+
+	private static final boolean jackson3Present;
 
 	private static final boolean jackson2Present;
 
@@ -40,6 +45,8 @@ final class HttpMessageConverters {
 
 	static {
 		ClassLoader classLoader = HttpMessageConverters.class.getClassLoader();
+		jackson3Present = ClassUtils.isPresent("tools.jackson.databind.ObjectMapper", classLoader)
+				&& ClassUtils.isPresent("tools.jackson.core.JsonGenerator", classLoader);
 		jackson2Present = ClassUtils.isPresent("com.fasterxml.jackson.databind.ObjectMapper", classLoader)
 				&& ClassUtils.isPresent("com.fasterxml.jackson.core.JsonGenerator", classLoader);
 		gsonPresent = ClassUtils.isPresent("com.google.gson.Gson", classLoader);
@@ -49,15 +56,18 @@ final class HttpMessageConverters {
 	private HttpMessageConverters() {
 	}
 
-	static GenericHttpMessageConverter<Object> getJsonMessageConverter() {
+	static SmartHttpMessageConverter<Object> getJsonMessageConverter() {
+		if (jackson3Present) {
+			return new JacksonJsonHttpMessageConverter();
+		}
 		if (jackson2Present) {
-			return new MappingJackson2HttpMessageConverter();
+			return new SmartGenericHttpMessageConverterAdapter<>(new MappingJackson2HttpMessageConverter());
 		}
 		if (gsonPresent) {
-			return new GsonHttpMessageConverter();
+			return new SmartGenericHttpMessageConverterAdapter<>(new GsonHttpMessageConverter());
 		}
 		if (jsonbPresent) {
-			return new JsonbHttpMessageConverter();
+			return new SmartGenericHttpMessageConverterAdapter<>(new JsonbHttpMessageConverter());
 		}
 		return null;
 	}

--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/http/converter/OAuth2AuthorizationServerMetadataHttpMessageConverter.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/http/converter/OAuth2AuthorizationServerMetadataHttpMessageConverter.java
@@ -22,16 +22,17 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.ResolvableType;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.AbstractHttpMessageConverter;
-import org.springframework.http.converter.GenericHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.http.converter.SmartHttpMessageConverter;
 import org.springframework.security.oauth2.core.converter.ClaimConversionService;
 import org.springframework.security.oauth2.core.converter.ClaimTypeConverter;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationServerMetadata;
@@ -43,6 +44,7 @@ import org.springframework.util.Assert;
  * 2.0 Authorization Server Metadata Response}.
  *
  * @author Daniel Garnier-Moiroux
+ * @author Andrey Livtitski
  * @since 7.0
  * @see AbstractHttpMessageConverter
  * @see OAuth2AuthorizationServerMetadata
@@ -53,7 +55,7 @@ public class OAuth2AuthorizationServerMetadataHttpMessageConverter
 	private static final ParameterizedTypeReference<Map<String, Object>> STRING_OBJECT_MAP = new ParameterizedTypeReference<>() {
 	};
 
-	private final GenericHttpMessageConverter<Object> jsonMessageConverter = HttpMessageConverters
+	private final SmartHttpMessageConverter<Object> jsonMessageConverter = HttpMessageConverters
 		.getJsonMessageConverter();
 
 	private Converter<Map<String, Object>, OAuth2AuthorizationServerMetadata> authorizationServerMetadataConverter = new OAuth2AuthorizationServerMetadataConverter();
@@ -75,7 +77,7 @@ public class OAuth2AuthorizationServerMetadataHttpMessageConverter
 			HttpInputMessage inputMessage) throws HttpMessageNotReadableException {
 		try {
 			Map<String, Object> authorizationServerMetadataParameters = (Map<String, Object>) this.jsonMessageConverter
-				.read(STRING_OBJECT_MAP.getType(), null, inputMessage);
+				.read(ResolvableType.forType(STRING_OBJECT_MAP.getType()), inputMessage, null);
 			return this.authorizationServerMetadataConverter.convert(authorizationServerMetadataParameters);
 		}
 		catch (Exception ex) {
@@ -91,8 +93,9 @@ public class OAuth2AuthorizationServerMetadataHttpMessageConverter
 		try {
 			Map<String, Object> authorizationServerMetadataResponseParameters = this.authorizationServerMetadataParametersConverter
 				.convert(authorizationServerMetadata);
-			this.jsonMessageConverter.write(authorizationServerMetadataResponseParameters, STRING_OBJECT_MAP.getType(),
-					MediaType.APPLICATION_JSON, outputMessage);
+			this.jsonMessageConverter.write(authorizationServerMetadataResponseParameters,
+					ResolvableType.forType(STRING_OBJECT_MAP.getType()), MediaType.APPLICATION_JSON, outputMessage,
+					null);
 		}
 		catch (Exception ex) {
 			throw new HttpMessageNotWritableException(

--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/http/converter/OAuth2ClientRegistrationHttpMessageConverter.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/http/converter/OAuth2ClientRegistrationHttpMessageConverter.java
@@ -27,16 +27,17 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.ResolvableType;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.AbstractHttpMessageConverter;
-import org.springframework.http.converter.GenericHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.http.converter.SmartHttpMessageConverter;
 import org.springframework.security.oauth2.core.converter.ClaimConversionService;
 import org.springframework.security.oauth2.core.converter.ClaimTypeConverter;
 import org.springframework.security.oauth2.server.authorization.OAuth2ClientMetadataClaimNames;
@@ -50,6 +51,7 @@ import org.springframework.util.StringUtils;
  * Client Registration Request and Response}.
  *
  * @author Joe Grandja
+ * @author Andrey Litvitski
  * @since 7.0
  * @see AbstractHttpMessageConverter
  * @see OAuth2ClientRegistration
@@ -60,7 +62,7 @@ public class OAuth2ClientRegistrationHttpMessageConverter
 	private static final ParameterizedTypeReference<Map<String, Object>> STRING_OBJECT_MAP = new ParameterizedTypeReference<>() {
 	};
 
-	private final GenericHttpMessageConverter<Object> jsonMessageConverter = HttpMessageConverters
+	private final SmartHttpMessageConverter<Object> jsonMessageConverter = HttpMessageConverters
 		.getJsonMessageConverter();
 
 	private Converter<Map<String, Object>, OAuth2ClientRegistration> clientRegistrationConverter = new MapOAuth2ClientRegistrationConverter();
@@ -82,7 +84,7 @@ public class OAuth2ClientRegistrationHttpMessageConverter
 			HttpInputMessage inputMessage) throws HttpMessageNotReadableException {
 		try {
 			Map<String, Object> clientRegistrationParameters = (Map<String, Object>) this.jsonMessageConverter
-				.read(STRING_OBJECT_MAP.getType(), null, inputMessage);
+				.read(ResolvableType.forType(STRING_OBJECT_MAP.getType()), inputMessage, null);
 			return this.clientRegistrationConverter.convert(clientRegistrationParameters);
 		}
 		catch (Exception ex) {
@@ -98,8 +100,9 @@ public class OAuth2ClientRegistrationHttpMessageConverter
 		try {
 			Map<String, Object> clientRegistrationParameters = this.clientRegistrationParametersConverter
 				.convert(clientRegistration);
-			this.jsonMessageConverter.write(clientRegistrationParameters, STRING_OBJECT_MAP.getType(),
-					MediaType.APPLICATION_JSON, outputMessage);
+			this.jsonMessageConverter.write(clientRegistrationParameters,
+					ResolvableType.forType(STRING_OBJECT_MAP.getType()), MediaType.APPLICATION_JSON, outputMessage,
+					null);
 		}
 		catch (Exception ex) {
 			throw new HttpMessageNotWritableException(

--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/oidc/http/converter/HttpMessageConverters.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/oidc/http/converter/HttpMessageConverters.java
@@ -16,11 +16,13 @@
 
 package org.springframework.security.oauth2.server.authorization.oidc.http.converter;
 
-import org.springframework.http.converter.GenericHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.SmartHttpMessageConverter;
 import org.springframework.http.converter.json.GsonHttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.http.converter.json.JsonbHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.oauth2.core.SmartGenericHttpMessageConverterAdapter;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -28,9 +30,12 @@ import org.springframework.util.ClassUtils;
  *
  * @author Joe Grandja
  * @author l uamas
+ * @author Andrey Litvitski
  * @since 7.0
  */
 final class HttpMessageConverters {
+
+	private static final boolean jackson3Present;
 
 	private static final boolean jackson2Present;
 
@@ -40,6 +45,8 @@ final class HttpMessageConverters {
 
 	static {
 		ClassLoader classLoader = HttpMessageConverters.class.getClassLoader();
+		jackson3Present = ClassUtils.isPresent("tools.jackson.databind.ObjectMapper", classLoader)
+				&& ClassUtils.isPresent("tools.jackson.core.JsonGenerator", classLoader);
 		jackson2Present = ClassUtils.isPresent("com.fasterxml.jackson.databind.ObjectMapper", classLoader)
 				&& ClassUtils.isPresent("com.fasterxml.jackson.core.JsonGenerator", classLoader);
 		gsonPresent = ClassUtils.isPresent("com.google.gson.Gson", classLoader);
@@ -49,15 +56,18 @@ final class HttpMessageConverters {
 	private HttpMessageConverters() {
 	}
 
-	static GenericHttpMessageConverter<Object> getJsonMessageConverter() {
+	static SmartHttpMessageConverter<Object> getJsonMessageConverter() {
+		if (jackson3Present) {
+			return new JacksonJsonHttpMessageConverter();
+		}
 		if (jackson2Present) {
-			return new MappingJackson2HttpMessageConverter();
+			return new SmartGenericHttpMessageConverterAdapter<>(new MappingJackson2HttpMessageConverter());
 		}
 		if (gsonPresent) {
-			return new GsonHttpMessageConverter();
+			return new SmartGenericHttpMessageConverterAdapter<>(new GsonHttpMessageConverter());
 		}
 		if (jsonbPresent) {
-			return new JsonbHttpMessageConverter();
+			return new SmartGenericHttpMessageConverterAdapter<>(new JsonbHttpMessageConverter());
 		}
 		return null;
 	}

--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/oidc/http/converter/OidcProviderConfigurationHttpMessageConverter.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/oidc/http/converter/OidcProviderConfigurationHttpMessageConverter.java
@@ -22,16 +22,17 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.ResolvableType;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.AbstractHttpMessageConverter;
-import org.springframework.http.converter.GenericHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.http.converter.SmartHttpMessageConverter;
 import org.springframework.security.oauth2.core.converter.ClaimConversionService;
 import org.springframework.security.oauth2.core.converter.ClaimTypeConverter;
 import org.springframework.security.oauth2.server.authorization.oidc.OidcProviderConfiguration;
@@ -43,6 +44,7 @@ import org.springframework.util.Assert;
  * Configuration Response}.
  *
  * @author Daniel Garnier-Moiroux
+ * @author Andrey Litvitski
  * @since 7.0
  * @see AbstractHttpMessageConverter
  * @see OidcProviderConfiguration
@@ -53,7 +55,7 @@ public class OidcProviderConfigurationHttpMessageConverter
 	private static final ParameterizedTypeReference<Map<String, Object>> STRING_OBJECT_MAP = new ParameterizedTypeReference<>() {
 	};
 
-	private final GenericHttpMessageConverter<Object> jsonMessageConverter = HttpMessageConverters
+	private final SmartHttpMessageConverter<Object> jsonMessageConverter = HttpMessageConverters
 		.getJsonMessageConverter();
 
 	private Converter<Map<String, Object>, OidcProviderConfiguration> providerConfigurationConverter = new OidcProviderConfigurationConverter();
@@ -75,7 +77,7 @@ public class OidcProviderConfigurationHttpMessageConverter
 			HttpInputMessage inputMessage) throws HttpMessageNotReadableException {
 		try {
 			Map<String, Object> providerConfigurationParameters = (Map<String, Object>) this.jsonMessageConverter
-				.read(STRING_OBJECT_MAP.getType(), null, inputMessage);
+				.read(ResolvableType.forType(STRING_OBJECT_MAP.getType()), inputMessage, null);
 			return this.providerConfigurationConverter.convert(providerConfigurationParameters);
 		}
 		catch (Exception ex) {
@@ -91,8 +93,9 @@ public class OidcProviderConfigurationHttpMessageConverter
 		try {
 			Map<String, Object> providerConfigurationResponseParameters = this.providerConfigurationParametersConverter
 				.convert(providerConfiguration);
-			this.jsonMessageConverter.write(providerConfigurationResponseParameters, STRING_OBJECT_MAP.getType(),
-					MediaType.APPLICATION_JSON, outputMessage);
+			this.jsonMessageConverter.write(providerConfigurationResponseParameters,
+					ResolvableType.forType(STRING_OBJECT_MAP.getType()), MediaType.APPLICATION_JSON, outputMessage,
+					null);
 		}
 		catch (Exception ex) {
 			throw new HttpMessageNotWritableException(

--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/HttpMessageConverters.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/HttpMessageConverters.java
@@ -16,20 +16,25 @@
 
 package org.springframework.security.oauth2.server.authorization.web;
 
-import org.springframework.http.converter.GenericHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.SmartHttpMessageConverter;
 import org.springframework.http.converter.json.GsonHttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.http.converter.json.JsonbHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.oauth2.core.SmartGenericHttpMessageConverterAdapter;
 import org.springframework.util.ClassUtils;
 
 /**
  * Utility methods for {@link HttpMessageConverter}'s.
  *
  * @author Joe Grandja
+ * @author Andrey Litvitski
  * @since 7.0
  */
 final class HttpMessageConverters {
+
+	private static final boolean jackson3Present;
 
 	private static final boolean jackson2Present;
 
@@ -39,6 +44,8 @@ final class HttpMessageConverters {
 
 	static {
 		ClassLoader classLoader = HttpMessageConverters.class.getClassLoader();
+		jackson3Present = ClassUtils.isPresent("tools.jackson.databind.ObjectMapper", classLoader)
+				&& ClassUtils.isPresent("tools.jackson.core.JsonGenerator", classLoader);
 		jackson2Present = ClassUtils.isPresent("com.fasterxml.jackson.databind.ObjectMapper", classLoader)
 				&& ClassUtils.isPresent("com.fasterxml.jackson.core.JsonGenerator", classLoader);
 		gsonPresent = ClassUtils.isPresent("com.google.gson.Gson", classLoader);
@@ -48,15 +55,18 @@ final class HttpMessageConverters {
 	private HttpMessageConverters() {
 	}
 
-	static GenericHttpMessageConverter<Object> getJsonMessageConverter() {
+	static SmartHttpMessageConverter<Object> getJsonMessageConverter() {
+		if (jackson3Present) {
+			return new JacksonJsonHttpMessageConverter();
+		}
 		if (jackson2Present) {
-			return new MappingJackson2HttpMessageConverter();
+			return new SmartGenericHttpMessageConverterAdapter<>(new MappingJackson2HttpMessageConverter());
 		}
 		if (gsonPresent) {
-			return new GsonHttpMessageConverter();
+			return new SmartGenericHttpMessageConverterAdapter<>(new GsonHttpMessageConverter());
 		}
 		if (jsonbPresent) {
-			return new JsonbHttpMessageConverter();
+			return new SmartGenericHttpMessageConverterAdapter<>(new JsonbHttpMessageConverter());
 		}
 		return null;
 	}

--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2PushedAuthorizationRequestEndpointFilter.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/OAuth2PushedAuthorizationRequestEndpointFilter.java
@@ -28,11 +28,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.ResolvableType;
 import org.springframework.core.log.LogMessage;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.converter.GenericHttpMessageConverter;
+import org.springframework.http.converter.SmartHttpMessageConverter;
 import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.AuthenticationDetailsSource;
@@ -59,6 +60,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * the processing of the OAuth 2.0 Pushed Authorization Request.
  *
  * @author Joe Grandja
+ * @author Andrey Litvitski
  * @since 7.0
  * @see AuthenticationManager
  * @see OAuth2PushedAuthorizationRequestAuthenticationProvider
@@ -82,7 +84,7 @@ public final class OAuth2PushedAuthorizationRequestEndpointFilter extends OncePe
 	private static final ParameterizedTypeReference<Map<String, Object>> STRING_OBJECT_MAP = new ParameterizedTypeReference<>() {
 	};
 
-	private static final GenericHttpMessageConverter<Object> JSON_MESSAGE_CONVERTER = HttpMessageConverters
+	private static final SmartHttpMessageConverter<Object> JSON_MESSAGE_CONVERTER = HttpMessageConverters
 		.getJsonMessageConverter();
 
 	private final AuthenticationManager authenticationManager;
@@ -218,8 +220,8 @@ public final class OAuth2PushedAuthorizationRequestEndpointFilter extends OncePe
 		ServletServerHttpResponse httpResponse = new ServletServerHttpResponse(response);
 		httpResponse.setStatusCode(HttpStatus.CREATED);
 
-		JSON_MESSAGE_CONVERTER.write(pushedAuthorizationResponse, STRING_OBJECT_MAP.getType(),
-				MediaType.APPLICATION_JSON, httpResponse);
+		JSON_MESSAGE_CONVERTER.write(pushedAuthorizationResponse, ResolvableType.forType(STRING_OBJECT_MAP.getType()),
+				MediaType.APPLICATION_JSON, httpResponse, null);
 	}
 
 }

--- a/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/OAuth2PushedAuthorizationRequestEndpointFilterTests.java
+++ b/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/OAuth2PushedAuthorizationRequestEndpointFilterTests.java
@@ -30,9 +30,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.ResolvableType;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.converter.GenericHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.SmartHttpMessageConverter;
 import org.springframework.mock.http.client.MockClientHttpResponse;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -74,6 +75,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
  * Tests for {@link OAuth2PushedAuthorizationRequestEndpointFilter}.
  *
  * @author Joe Grandja
+ * @author Andrey Litvitski
  */
 public class OAuth2PushedAuthorizationRequestEndpointFilterTests {
 
@@ -85,7 +87,7 @@ public class OAuth2PushedAuthorizationRequestEndpointFilterTests {
 
 	private final HttpMessageConverter<OAuth2Error> errorHttpResponseConverter = new OAuth2ErrorHttpMessageConverter();
 
-	private final GenericHttpMessageConverter<Object> jsonMessageConverter = HttpMessageConverters
+	private final SmartHttpMessageConverter<Object> jsonMessageConverter = HttpMessageConverters
 		.getJsonMessageConverter();
 
 	private AuthenticationManager authenticationManager;
@@ -486,7 +488,8 @@ public class OAuth2PushedAuthorizationRequestEndpointFilterTests {
 		};
 		MockClientHttpResponse httpResponse = new MockClientHttpResponse(response.getContentAsByteArray(),
 				HttpStatus.valueOf(response.getStatus()));
-		return (Map<String, Object>) this.jsonMessageConverter.read(STRING_OBJECT_MAP.getType(), null, httpResponse);
+		return (Map<String, Object>) this.jsonMessageConverter.read(ResolvableType.forType(STRING_OBJECT_MAP.getType()),
+				httpResponse, null);
 	}
 
 }

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/SmartGenericHttpMessageConverterAdapter.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/SmartGenericHttpMessageConverterAdapter.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.core;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.GenericHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.http.converter.SmartHttpMessageConverter;
+
+/**
+ * Adapter that exposes a {@link GenericHttpMessageConverter} as a
+ * {@link SmartHttpMessageConverter}. Delegates read and write operations with support for
+ * parameterized types.
+ *
+ * @param <T> the type of objects to convert
+ * @author Andrey Litvitski
+ * @since 7.0.0
+ */
+public class SmartGenericHttpMessageConverterAdapter<T> implements SmartHttpMessageConverter<T> {
+
+	private final GenericHttpMessageConverter<T> genericHttpMessageConverter;
+
+	public SmartGenericHttpMessageConverterAdapter(GenericHttpMessageConverter<T> genericHttpMessageConverter) {
+		this.genericHttpMessageConverter = genericHttpMessageConverter;
+	}
+
+	@Override
+	public boolean canRead(ResolvableType type, @Nullable MediaType mediaType) {
+		return this.genericHttpMessageConverter.canRead(Objects.requireNonNull(type.getRawClass()), mediaType);
+	}
+
+	@Override
+	public T read(ResolvableType type, HttpInputMessage inputMessage, @Nullable Map<String, Object> hints)
+			throws IOException, HttpMessageNotReadableException {
+		return this.genericHttpMessageConverter.read(type.getType(), null, inputMessage);
+	}
+
+	@Override
+	public boolean canWrite(ResolvableType targetType, Class<?> valueClass, @Nullable MediaType mediaType) {
+		return this.genericHttpMessageConverter.canWrite(Objects.requireNonNull(targetType.getRawClass()), mediaType);
+	}
+
+	@Override
+	public void write(T t, ResolvableType type, @Nullable MediaType contentType, HttpOutputMessage outputMessage,
+			@Nullable Map<String, Object> hints) throws IOException, HttpMessageNotWritableException {
+		this.genericHttpMessageConverter.write(t, type.getType(), contentType, outputMessage);
+	}
+
+	@Override
+	public List<MediaType> getSupportedMediaTypes() {
+		return this.genericHttpMessageConverter.getSupportedMediaTypes();
+	}
+
+}

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/http/converter/OAuth2DeviceAuthorizationResponseHttpMessageConverter.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/http/converter/OAuth2DeviceAuthorizationResponseHttpMessageConverter.java
@@ -26,15 +26,16 @@ import java.util.Map;
 import java.util.Set;
 
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.ResolvableType;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.AbstractHttpMessageConverter;
-import org.springframework.http.converter.GenericHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.http.converter.SmartHttpMessageConverter;
 import org.springframework.security.oauth2.core.endpoint.OAuth2DeviceAuthorizationResponse;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.util.Assert;
@@ -46,6 +47,7 @@ import org.springframework.util.StringUtils;
  * 2.0 Device Authorization Response}.
  *
  * @author Steve Riesenberg
+ * @author Andrey Litvitski
  * @since 6.1
  * @see AbstractHttpMessageConverter
  * @see OAuth2DeviceAuthorizationResponse
@@ -56,7 +58,7 @@ public class OAuth2DeviceAuthorizationResponseHttpMessageConverter
 	private static final ParameterizedTypeReference<Map<String, Object>> STRING_OBJECT_MAP = new ParameterizedTypeReference<>() {
 	};
 
-	private final GenericHttpMessageConverter<Object> jsonMessageConverter = HttpMessageConverters
+	private final SmartHttpMessageConverter<Object> jsonMessageConverter = HttpMessageConverters
 		.getJsonMessageConverter();
 
 	private Converter<Map<String, Object>, OAuth2DeviceAuthorizationResponse> deviceAuthorizationResponseConverter = new DefaultMapOAuth2DeviceAuthorizationResponseConverter();
@@ -75,7 +77,7 @@ public class OAuth2DeviceAuthorizationResponseHttpMessageConverter
 
 		try {
 			Map<String, Object> deviceAuthorizationResponseParameters = (Map<String, Object>) this.jsonMessageConverter
-				.read(STRING_OBJECT_MAP.getType(), null, inputMessage);
+				.read(ResolvableType.forType(STRING_OBJECT_MAP.getType()), inputMessage, null);
 			return this.deviceAuthorizationResponseConverter.convert(deviceAuthorizationResponseParameters);
 		}
 		catch (Exception ex) {
@@ -92,8 +94,9 @@ public class OAuth2DeviceAuthorizationResponseHttpMessageConverter
 		try {
 			Map<String, Object> deviceAuthorizationResponseParameters = this.deviceAuthorizationResponseParametersConverter
 				.convert(deviceAuthorizationResponse);
-			this.jsonMessageConverter.write(deviceAuthorizationResponseParameters, STRING_OBJECT_MAP.getType(),
-					MediaType.APPLICATION_JSON, outputMessage);
+			this.jsonMessageConverter.write(deviceAuthorizationResponseParameters,
+					ResolvableType.forType(STRING_OBJECT_MAP.getType()), MediaType.APPLICATION_JSON, outputMessage,
+					null);
 		}
 		catch (Exception ex) {
 			throw new HttpMessageNotWritableException(


### PR DESCRIPTION
We want to use `SmartHttpMessageConverter` over `GenericHttpMessageConverter`. 

To get there, we first need to see the classes where `GenericHttpMessageConverter` is still used. These are `HttpConverters` with the methods `static GenericHttpMessageConverter<Object> getJsonMessageConverter()`. If we directly replace the return value with `SmartHttpMessageConverter`, we will see that some classes directly use `GenericHttpMessageConverter` and its methods.

To do this, I decided to create a special adapter `SmartGenericHttpMessageConverterAdapter` into which we can pass `GenericHttpMessageConverter` and use it as `SmartHttpMessageConverter`. We need this for classes that inherit from `GenericHttpMessageConverter`. However, for those who use jackson3, we can directly return `JacksonJsonHttpMessageConverter`, which in turn inherits from `SmartHttpMessageConverter`.

Closes: gh-18073

