### PR TITLE
`typ` values should not be case-sensitive in `JwtTypeValidator`

### DIFF
--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtTypeValidator.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtTypeValidator.java
@@ -72,8 +72,10 @@ public final class JwtTypeValidator implements OAuth2TokenValidator<Jwt> {
 		if (this.allowEmpty && !StringUtils.hasText(typ)) {
 			return OAuth2TokenValidatorResult.success();
 		}
-		if (this.validTypes.contains(typ)) {
-			return OAuth2TokenValidatorResult.success();
+		for (String validType : this.validTypes) {
+			if (validType.equalsIgnoreCase(typ)) {
+				return OAuth2TokenValidatorResult.success();
+			}
 		}
 		return OAuth2TokenValidatorResult.failure(new OAuth2Error(OAuth2ErrorCodes.INVALID_TOKEN,
 				"the given typ value needs to be one of " + this.validTypes,

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtTypeValidatorTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtTypeValidatorTests.java
@@ -44,4 +44,12 @@ class JwtTypeValidatorTests {
 		assertThat(validator.validate(jwt.build()).hasErrors()).isFalse();
 	}
 
+	@Test
+	void validateWhenTypHeaderHasDifferentCaseThenSuccess() {
+		Jwt.Builder jwt = TestJwts.jwt();
+		JwtTypeValidator validator = new JwtTypeValidator("at+jwt");
+		jwt.header(JoseHeaderNames.TYP, "AT+JWT");
+		assertThat(validator.validate(jwt.build()).hasErrors()).isFalse();
+	}
+
 }


### PR DESCRIPTION
Fixed: #18092

The JwtTypeValidator was performing a case-sensitive check for the JWT typ header, which was a change from the behavior of the previous Nimbus JOSEObjectTypeVerifier.

This commit updates the JwtTypeValidator to be case-insensitive.
New test cases have been added to verify this change.



<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
