### PR TITLE
Default WebAuthnConfigurer#rpName to rpId

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
@@ -3701,7 +3701,6 @@ public final class HttpSecurity extends AbstractConfiguredSecurityBuilder<Defaul
 	 * 		http
 	 * 			// ...
 	 * 			.webAuthn((webAuthn) -&gt; webAuthn
-	 * 				.rpName("Spring Security Relying Party")
 	 * 				.rpId("example.com")
 	 * 				.allowedOrigins("https://example.com")
 	 * 			);

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/WebAuthnConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/WebAuthnConfigurer.java
@@ -192,9 +192,9 @@ public class WebAuthnConfigurer<H extends HttpSecurityBuilder<H>>
 		if (webauthnOperationsBean.isPresent()) {
 			return webauthnOperationsBean.get();
 		}
-		Webauthn4JRelyingPartyOperations result = new Webauthn4JRelyingPartyOperations(userEntities, userCredentials,
-				PublicKeyCredentialRpEntity.builder().id(this.rpId).name(this.rpName).build(), this.allowedOrigins);
-		return result;
+		String rpName = (this.rpName != null) ? this.rpName : this.rpId;
+		return new Webauthn4JRelyingPartyOperations(userEntities, userCredentials,
+				PublicKeyCredentialRpEntity.builder().id(this.rpId).name(rpName).build(), this.allowedOrigins);
 	}
 
 }

--- a/docs/modules/ROOT/pages/servlet/authentication/passkeys.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/passkeys.adoc
@@ -64,7 +64,6 @@ SecurityFilterChain filterChain(HttpSecurity http) {
 		// ...
 		.formLogin(withDefaults())
 		.webAuthn((webAuthn) -> webAuthn
-			.rpName("Spring Security Relying Party")
 			.rpId("example.com")
 			.allowedOrigins("https://example.com")
 		);
@@ -91,7 +90,6 @@ Kotlin::
 open fun filterChain(http: HttpSecurity): SecurityFilterChain {
 	http {
 		webAuthn {
-			rpName = "Spring Security Relying Party"
 			rpId = "example.com"
 			allowedOrigins = setOf("https://example.com")
 		}


### PR DESCRIPTION
In WebAuthn L3 spec, PublicKeyCredentialEntity.name is deprecated:

> This member is deprecated because many clients do not display it,
> but it remains a required dictionary member for backwards compatibility.
> Relying Parties MAY, as a safe default, set this equal to the RP ID.

Source: https://www.w3.org/TR/webauthn-3/#dictdef-publickeycredentialentity