### PR TITLE
Add `logoutRequestMatcher` to `Saml2LogoutConfigurer` for custom matching

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurer.java
@@ -105,6 +105,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
  *
  * @author Josh Cummings
  * @author Ngoc Nhan
+ * @author Andrey Litvitski
  * @since 5.6
  * @see Saml2LogoutConfigurer
  */
@@ -126,6 +127,8 @@ public final class Saml2LogoutConfigurer<H extends HttpSecurityBuilder<H>>
 	private LogoutRequestConfigurer logoutRequestConfigurer;
 
 	private LogoutResponseConfigurer logoutResponseConfigurer;
+
+	private RequestMatcher logoutRequestMatcher;
 
 	/**
 	 * Creates a new instance
@@ -192,6 +195,16 @@ public final class Saml2LogoutConfigurer<H extends HttpSecurityBuilder<H>>
 	public Saml2LogoutConfigurer<H> logoutResponse(
 			Customizer<LogoutResponseConfigurer> logoutResponseConfigurerCustomizer) {
 		logoutResponseConfigurerCustomizer.customize(this.logoutResponseConfigurer);
+		return this;
+	}
+
+	/**
+	 * Sets a custom {@link RequestMatcher} to use for SAML logout requests.
+	 * @param logoutRequestMatcher the matcher to use
+	 * @return the {@link Saml2LogoutConfigurer} for further customization
+	 */
+	public Saml2LogoutConfigurer<H> logoutRequestMatcher(RequestMatcher logoutRequestMatcher) {
+		this.logoutRequestMatcher = logoutRequestMatcher;
 		return this;
 	}
 
@@ -271,6 +284,9 @@ public final class Saml2LogoutConfigurer<H extends HttpSecurityBuilder<H>>
 	}
 
 	private RequestMatcher createLogoutMatcher() {
+		if (this.logoutRequestMatcher != null) {
+			return this.logoutRequestMatcher;
+		}
 		RequestMatcher logout = getRequestMatcherBuilder().matcher(HttpMethod.POST, this.logoutUrl);
 		RequestMatcher saml2 = new Saml2RequestMatcher(getSecurityContextHolderStrategy());
 		return new AndRequestMatcher(logout, saml2);

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurerTests.java
@@ -543,6 +543,18 @@ public class Saml2LogoutConfigurerTests {
 
 	}
 
+	// gh-10821
+	@Test
+	public void saml2LogoutWhenCustomLogoutRequestMatcherThenUsed() throws Exception {
+		this.spring.register(Saml2LogoutCustomMatcherConfig.class).autowire();
+		MvcResult result = this.mvc.perform(post("/saml/custom-logout").with(authentication(this.user)).with(csrf()))
+			.andExpect(status().isFound())
+			.andReturn();
+		assertThat(result.getResponse().getHeader("Location"))
+			.startsWith("https://ap.example.org/logout/saml2/request");
+		verify(getBean(LogoutHandler.class)).logout(any(), any(), any());
+	}
+
 	private <T> T getBean(Class<T> clazz) {
 		return this.spring.getContext().getBean(clazz);
 	}
@@ -566,6 +578,34 @@ public class Saml2LogoutConfigurerTests {
 				.logout((logout) -> logout.addLogoutHandler(this.mockLogoutHandler))
 				.saml2Login(withDefaults())
 				.saml2Logout(withDefaults());
+			return http.build();
+			// @formatter:on
+		}
+
+		@Bean
+		LogoutHandler logoutHandler() {
+			return this.mockLogoutHandler;
+		}
+
+	}
+
+	@Configuration
+	@EnableWebSecurity
+	@Import(Saml2LoginConfigBeans.class)
+	static class Saml2LogoutCustomMatcherConfig {
+
+		LogoutHandler mockLogoutHandler = mock(LogoutHandler.class);
+
+		@Bean
+		SecurityFilterChain web(HttpSecurity http) throws Exception {
+			// @formatter:off
+			http
+					.authorizeHttpRequests((authorize) -> authorize.anyRequest().authenticated())
+					.logout((logout) -> logout.addLogoutHandler(this.mockLogoutHandler))
+					.saml2Login(withDefaults())
+					.saml2Logout((saml2) -> saml2
+							.logoutRequestMatcher(pathPattern(HttpMethod.POST, "/saml/custom-logout"))
+					);
 			return http.build();
 			// @formatter:on
 		}


### PR DESCRIPTION
This solves the problem that previously SAML2 logout could only be triggered from the default POST /logout. Now you can configure any endpoint/method for SAML2 logout using the DSL.

Closes: gh-10821

