### PR TITLE
Fix docs typo X-Requested-By -> X-Requested-With

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/passwords/basic.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/passwords/basic.adoc
@@ -24,7 +24,7 @@ The `RequestCache` is typically a `NullRequestCache` that does not save the requ
 
 [NOTE]
 ====
-The default HTTP Basic Auth Provider will suppress both Response body and `WWW-Authenticate` header in the 401 response when the request was made with a `X-Requested-By: XMLHttpRequest` header.
+The default HTTP Basic Auth Provider will suppress both Response body and `WWW-Authenticate` header in the 401 response when the request was made with a `X-Requested-With: XMLHttpRequest` header.
 This allows frontends to implement their own authentication code, instead of triggering the browser login dialog.
 To override, implement your own javadoc:org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint[].
 ====


### PR DESCRIPTION
## Simple documentation typo fix

The documentation states that setting the header `X-Requested-By` will remove the `WWW-Authenticate` header from the response. 

However, after testing this and reading the library code it looks like the header to set should be `X-Requested-With` (X-Requested-By is mentioned nowhere except in this documentation file), so I propose this simple PR to fix this.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
