### PR TITLE
fix: Allow OidcAuthorizedClientRefreshedEventListener refreshing if authentication subclasses OAuth2AuthenticationToken

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/authentication/OidcAuthorizedClientRefreshedEventListener.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/authentication/OidcAuthorizedClientRefreshedEventListener.java
@@ -106,11 +106,10 @@ public final class OidcAuthorizedClientRefreshedEventListener
 
 		// The current authentication must be an OAuth2AuthenticationToken
 		Authentication authentication = this.securityContextHolderStrategy.getContext().getAuthentication();
-		if (!(authentication instanceof OAuth2AuthenticationToken authenticationToken)
-				|| authenticationToken.getClass() != OAuth2AuthenticationToken.class) {
+		if (!(authentication instanceof OAuth2AuthenticationToken authenticationToken)) {
 			// This event listener only handles the default authentication result. If the
-			// application customizes the authentication result, then a custom event
-			// handler should be provided.
+			// application customizes the authentication result by not subclassing
+			// OAuth2AuthenticationToken, then a custom event handler should be provided.
 			return;
 		}
 

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/authentication/OidcAuthorizedClientRefreshedEventListenerTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/authentication/OidcAuthorizedClientRefreshedEventListenerTests.java
@@ -239,19 +239,20 @@ public class OidcAuthorizedClientRefreshedEventListenerTests {
 	}
 
 	@Test
-	public void onApplicationEventWhenAuthenticationIsCustomThenOidcUserRefreshedEventNotPublished() {
+	public void onApplicationEventWhenAuthenticationIsSubclassedThenOidcUserRefreshedEventPublished() {
 		OAuth2AuthenticationToken authentication = new CustomOAuth2AuthenticationToken(this.oidcUser,
 				this.oidcUser.getAuthorities(), this.clientRegistration.getRegistrationId());
 		SecurityContextImpl securityContext = new SecurityContextImpl(authentication);
 		given(this.securityContextHolderStrategy.getContext()).willReturn(securityContext);
+		given(this.jwtDecoder.decode(anyString())).willReturn(this.jwt);
+		given(this.userService.loadUser(any(OidcUserRequest.class))).willReturn(this.oidcUser);
 
 		OAuth2AuthorizedClientRefreshedEvent authorizedClientRefreshedEvent = new OAuth2AuthorizedClientRefreshedEvent(
 				this.accessTokenResponse, this.authorizedClient);
 		this.eventListener.onApplicationEvent(authorizedClientRefreshedEvent);
 
-		verify(this.securityContextHolderStrategy).getContext();
-		verifyNoMoreInteractions(this.securityContextHolderStrategy);
-		verifyNoInteractions(this.jwtDecoder, this.userService, this.applicationEventPublisher);
+		verify(this.applicationEventPublisher).publishEvent(any(OidcUserRefreshedEvent.class));
+		verifyNoMoreInteractions(this.applicationEventPublisher);
 	}
 
 	@Test


### PR DESCRIPTION
hi,

This PR considers relaxing the check that is done is `OidcAuthorizedClientRefreshedEventListener`. If for some reason, you want/need to subclass `OAuth2AuthenticationToken` to add custom data to `Principal`, you lose the ability of `OidcAuthorizedClientRefreshedEventListener` to refresh expiration dates.

The doc states that _If the application customizes the authentication result, then a custom event handler should be provided._  **But**

- This class is final
- Not exposed as a @Bean
- Its full instance configuration is handled by `OAuth2LoginConfigurer` and is quite rough to replicate manually.

This PR relaxes this check. Hope this may be reconsidered.

Thanks