### PR TITLE
Fix typo in AnnotationTemplateExpressionDefaults documentation 

### DIFF
--- a/docs/modules/ROOT/pages/servlet/integrations/mvc.adoc
+++ b/docs/modules/ROOT/pages/servlet/integrations/mvc.adoc
@@ -375,7 +375,7 @@ Java::
 ----
 @Bean
 public AnnotationTemplateExpressionDefaults templateDefaults() {
-	return new AnnotationTemplateExpressionDeafults();
+	return new AnnotationTemplateExpressionDefaults();
 }
 ----
 
@@ -385,7 +385,7 @@ Kotlin::
 ----
 @Bean
 fun templateDefaults(): AnnotationTemplateExpressionDefaults {
-	return AnnotationTemplateExpressionDeafults()
+	return AnnotationTemplateExpressionDefaults()
 }
 ----
 


### PR DESCRIPTION
There is a typo in the [documention](https://docs.spring.io/spring-security/reference/servlet/integrations/mvc.html#mvc-authentication-principal) that misspells `AnnotationTemplateExpressionDefaults`

Forward port of gh-18254