### PR TITLE
Remove throws from MyCustomDsl in docs

### DIFF
--- a/docs/modules/ROOT/pages/servlet/configuration/java.adoc
+++ b/docs/modules/ROOT/pages/servlet/configuration/java.adoc
@@ -493,14 +493,14 @@ public class MyCustomDsl extends AbstractHttpConfigurer<MyCustomDsl, HttpSecurit
 	private boolean flag;
 
 	@Override
-	public void init(HttpSecurity http) throws Exception {
+	public void init(HttpSecurity http) {
 		// any method that adds another configurer
 		// must be done in the init method
 		http.csrf().disable();
 	}
 
 	@Override
-	public void configure(HttpSecurity http) throws Exception {
+	public void configure(HttpSecurity http) {
 		ApplicationContext context = http.getSharedObject(ApplicationContext.class);
 
 		// here we lookup from the ApplicationContext. You can also just create a new instance.


### PR DESCRIPTION
In `init` and `configure`, throws Exception has been removed in the super interface `SecurityConfigurer`, since Spring Security 7.0. This change is the consequence of https://github.com/spring-projects/spring-security/issues/17957
