### PR TITLE
Update password4j docs to use BcryptPassword4jPasswordEncoder

### DIFF
--- a/docs/src/test/java/org/springframework/security/docs/features/authentication/password4jbcrypt/BcryptUsageTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/features/authentication/password4jbcrypt/BcryptUsageTests.java
@@ -19,7 +19,6 @@ package org.springframework.security.docs.features.authentication.password4jbcry
 import com.password4j.BcryptFunction;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.crypto.password4j.BcryptPassword4jPasswordEncoder;
 
@@ -33,7 +32,7 @@ public class BcryptUsageTests {
 	@Test
 	void defaultParams() {
 		// tag::default-params[]
-		PasswordEncoder encoder = new BCryptPasswordEncoder();
+		PasswordEncoder encoder = new BcryptPassword4jPasswordEncoder();
 		String result = encoder.encode("myPassword");
 		assertThat(encoder.matches("myPassword", result)).isTrue();
 		// end::default-params[]

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/features/authentication/password4jbcrypt/BcryptUsageTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/features/authentication/password4jbcrypt/BcryptUsageTests.kt
@@ -3,7 +3,6 @@ package org.springframework.security.kt.docs.features.authentication.password4jb
 import com.password4j.BcryptFunction
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.crypto.password4j.BcryptPassword4jPasswordEncoder
 
@@ -14,7 +13,7 @@ class BcryptUsageTests {
     @Test
     fun defaultParams() {
         // tag::default-params[]
-        val encoder: PasswordEncoder = BCryptPasswordEncoder()
+        val encoder: PasswordEncoder = BcryptPassword4jPasswordEncoder()
         val result = encoder.encode("myPassword")
         Assertions.assertThat(encoder.matches("myPassword", result)).isTrue()
         // end::default-params[]


### PR DESCRIPTION
Fix: Corrected class name inconsistency in password-storage.adoc example