### PR TITLE
Fix broken link to Spring Boot docs

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authorization/authorize-http-requests.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/authorize-http-requests.adoc
@@ -639,7 +639,7 @@ This is because Spring Security requires all URIs to be absolute (minus the cont
 
 [TIP]
 =====
-There are several other components that create request matchers for you like {spring-boot-api-url}org/springframework/boot/autoconfigure/security/servlet/PathRequest.html[`PathRequest#toStaticResources#atCommonLocations`]
+There are several other components that create request matchers for you like {spring-boot-api-url}org/springframework/boot/security/autoconfigure/web/servlet/PathRequest.html[`PathRequest#toStaticResources#atCommonLocations`]
 =====
 
 [[match-by-custom]]

--- a/docs/modules/ROOT/pages/servlet/getting-started.adoc
+++ b/docs/modules/ROOT/pages/servlet/getting-started.adoc
@@ -118,7 +118,7 @@ The default arrangement of Spring Boot and Spring Security affords the following
 * Publishes xref:servlet/authentication/events.adoc[authentication success and failure events]
 
 It can be helpful to understand how Spring Boot is coordinating with Spring Security to achieve this.
-Taking a look at {spring-boot-api-url}org/springframework/boot/autoconfigure/security/servlet/SecurityAutoConfiguration.html[Boot's security auto configuration], it does the following (simplified for illustration):
+Taking a look at {spring-boot-api-url}org/springframework/boot/security/autoconfigure/SecurityAutoConfiguration.html[Boot's security auto configuration], it does the following (simplified for illustration):
 
 .Spring Boot Security Auto Configuration
 [source,java]


### PR DESCRIPTION
Link to Spring Boot docs is broken.

Reference
https://docs.spring.io/spring-security/reference/servlet/authorization/authorize-http-requests.html#match-by-mvc
<img width="2008" height="168" alt="image" src="https://github.com/user-attachments/assets/6247c5ac-100c-4785-b8eb-e6ffa8baaa75" />

https://docs.spring.io/spring-security/reference/servlet/getting-started.html#servlet-hello-auto-configuration
<img width="2339" height="129" alt="image" src="https://github.com/user-attachments/assets/f17c6ca6-d4a6-4674-8b8f-8c641f02007d" />
