### PR TITLE
Fix typo in AnnotationTemplateExpressionDefaults

### DIFF
--- a/docs/modules/ROOT/pages/servlet/integrations/mvc.adoc
+++ b/docs/modules/ROOT/pages/servlet/integrations/mvc.adoc
@@ -546,7 +546,7 @@ Java::
 ----
 @Bean
 public AnnotationTemplateExpressionDefaults templateDefaults() {
-	return new AnnotationTemplateExpressionDeafults();
+	return new AnnotationTemplateExpressionDefaults();
 }
 ----
 
@@ -556,7 +556,7 @@ Kotlin::
 ----
 @Bean
 fun templateDefaults(): AnnotationTemplateExpressionDefaults {
-	return AnnotationTemplateExpressionDeafults()
+	return AnnotationTemplateExpressionDefaults()
 }
 ----
 


### PR DESCRIPTION
The AnnotationTemplateExpressionDeafults was wrong，and right is  AnnotationTemplateExpressionDefaults

Signed-off-by: kucoll <kucoll@163.com>