### PR TITLE
Mark `targetDomainObject` as `@Nullable` in `PermissionEvaluator`

### DIFF
--- a/core/src/main/java/org/springframework/security/access/PermissionEvaluator.java
+++ b/core/src/main/java/org/springframework/security/access/PermissionEvaluator.java
@@ -18,6 +18,8 @@ package org.springframework.security.access;
 
 import java.io.Serializable;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.aop.framework.AopInfrastructureBean;
 import org.springframework.security.core.Authentication;
 
@@ -39,7 +41,7 @@ public interface PermissionEvaluator extends AopInfrastructureBean {
 	 * expression system. Not null.
 	 * @return true if the permission is granted, false otherwise
 	 */
-	boolean hasPermission(Authentication authentication, Object targetDomainObject, Object permission);
+	boolean hasPermission(Authentication authentication, @Nullable Object targetDomainObject, Object permission);
 
 	/**
 	 * Alternative method for evaluating a permission where only the identifier of the

--- a/core/src/main/java/org/springframework/security/access/expression/DenyAllPermissionEvaluator.java
+++ b/core/src/main/java/org/springframework/security/access/expression/DenyAllPermissionEvaluator.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.core.log.LogMessage;
 import org.springframework.security.access.PermissionEvaluator;
@@ -40,7 +41,7 @@ public class DenyAllPermissionEvaluator implements PermissionEvaluator {
 	 * @return false always
 	 */
 	@Override
-	public boolean hasPermission(Authentication authentication, Object target, Object permission) {
+	public boolean hasPermission(Authentication authentication, @Nullable Object target, Object permission) {
 		this.logger.warn(LogMessage.format("Denying user %s permission '%s' on object %s", authentication.getName(),
 				permission, target));
 		return false;


### PR DESCRIPTION
Currently, there are other places where `PermissionEvaluator` is inherited and methods are overridden. However, these places aren't yet covered by jspecify. I expect that in the future, when these places are covered by jspecify, we'll ensure that `@Nullable` is used (the build simply won't pass).

Closes: gh-18259
