### PR TITLE
KerberosRestClient should rethrow original RestClientException

### DIFF
--- a/kerberos/kerberos-client/src/main/java/org/springframework/security/kerberos/client/KerberosRestTemplate.java
+++ b/kerberos/kerberos-client/src/main/java/org/springframework/security/kerberos/client/KerberosRestTemplate.java
@@ -248,6 +248,9 @@ public class KerberosRestTemplate extends RestTemplate {
 			});
 
 		}
+		catch (RestClientException ex) {
+			throw ex;
+		}
 		catch (Exception ex) {
 			throw new RestClientException("Error running rest call", ex);
 		}

--- a/kerberos/kerberos-client/src/test/java/org/springframework/security/kerberos/client/KerberosRestTemplateTests.java
+++ b/kerberos/kerberos-client/src/test/java/org/springframework/security/kerberos/client/KerberosRestTemplateTests.java
@@ -38,7 +38,7 @@ import org.springframework.security.kerberos.test.MiniKdc;
 import org.springframework.web.client.HttpClientErrorException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class KerberosRestTemplateTests extends KerberosSecurityTestcase {
 
@@ -93,14 +93,15 @@ class KerberosRestTemplateTests extends KerberosSecurityTestcase {
 
 	@Test
 	void throwsOriginalException() {
-		assertThatThrownBy(() -> restTemplate.getForObject(this.baseUrl + "/notfound", String.class))
-				.isInstanceOf(HttpClientErrorException.NotFound.class);
+		assertThatExceptionOfType(HttpClientErrorException.NotFound.class)
+			.isThrownBy(() -> this.restTemplate.getForObject(this.baseUrl + "/notfound", String.class));
 	}
 
 	private void setUpClient() {
 		Map<String, Object> loginOptions = new HashMap<>();
 		loginOptions.put("refreshKrb5Config", "true");
-		this.restTemplate = new KerberosRestTemplate(this.clientKeytab.getAbsolutePath(), this.clientPrincipal, loginOptions);
+		this.restTemplate = new KerberosRestTemplate(this.clientKeytab.getAbsolutePath(), this.clientPrincipal,
+				loginOptions);
 	}
 
 	private MockResponse getRequest(RecordedRequest request, byte[] body, String contentType) {


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
Currently, the doExecute method in spring−security−kerberos−client always wraps exceptions in a RestClientException. This unnecessarily complicates exception handling for HTTP status errors and other exceptions.

This change modifies the behavior to avoid wrapping an exception if it is already an instance of RestClientException.

This aligns the exception handling with other RestTemplate implementations, making it more consistent and easier to manage.