### PR TITLE
ServerHttpSecurityConfiguration should not set userDetailsPasswordService to a null value

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/reactive/ServerHttpSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/reactive/ServerHttpSecurityConfiguration.java
@@ -255,7 +255,9 @@ class ServerHttpSecurityConfiguration {
 			if (this.passwordEncoder != null) {
 				manager.setPasswordEncoder(this.passwordEncoder);
 			}
-			manager.setUserDetailsPasswordService(this.userDetailsPasswordService);
+			if (this.userDetailsPasswordService != null) {
+				manager.setUserDetailsPasswordService(this.userDetailsPasswordService);
+			}
 			manager.setCompromisedPasswordChecker(this.compromisedPasswordChecker);
 			return this.postProcessor.postProcess(manager);
 		}

--- a/config/src/test/java/org/springframework/security/config/annotation/web/reactive/ServerHttpSecurityConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/reactive/ServerHttpSecurityConfigurationTests.java
@@ -107,9 +107,19 @@ public class ServerHttpSecurityConfigurationTests {
 	}
 
 	@Test
-	public void loadConfigWhenReactiveUserDetailsServiceConfiguredThenServerHttpSecurityExists() {
+	public void loadConfigWhenReactiveUserAuthenticationServiceConfiguredThenServerHttpSecurityExists() {
 		this.spring
 			.register(ServerHttpSecurityConfiguration.class, ReactiveAuthenticationTestConfiguration.class,
+					WebFluxSecurityConfiguration.class)
+			.autowire();
+		ServerHttpSecurity serverHttpSecurity = this.spring.getContext().getBean(ServerHttpSecurity.class);
+		assertThat(serverHttpSecurity).isNotNull();
+	}
+
+	@Test
+	public void loadConfigWhenOnlyReactiveUserDetailsServiceConfiguredThenServerHttpSecurityExists() {
+		this.spring
+			.register(ServerHttpSecurityConfiguration.class, ReactiveUserDetailsServiceOnlyTestConfiguration.class,
 					WebFluxSecurityConfiguration.class)
 			.autowire();
 		ServerHttpSecurity serverHttpSecurity = this.spring.getContext().getBean(ServerHttpSecurity.class);
@@ -577,6 +587,16 @@ public class ServerHttpSecurityConfigurationTests {
 		@Order(Ordered.HIGHEST_PRECEDENCE)
 		static Customizer<ServerHttpSecurity> httpSecurityCustomizer0() {
 			return mock(Customizer.class);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class ReactiveUserDetailsServiceOnlyTestConfiguration {
+
+		@Bean
+		static ReactiveUserDetailsService userDetailsService() {
+			return (username) -> Mono.just(PasswordEncodedUser.user());
 		}
 
 	}


### PR DESCRIPTION
... when using `ReactiveUserDetailsService` without `ReactiveUserDetailsPasswordService`.

The existing test uses a `MapReactiveUserDetailsService` that implements `ReactiveUserDetailsPasswordService`, which does not trigger the error.

fixes gh-17986
