### PR TITLE
Document Client PKCE settings

### DIFF
--- a/docs/modules/ROOT/pages/reactive/oauth2/client/authorization-grants.adoc
+++ b/docs/modules/ROOT/pages/reactive/oauth2/client/authorization-grants.adoc
@@ -77,15 +77,16 @@ Public Clients are supported using https://tools.ietf.org/html/rfc7636[Proof Key
 If the client is running in an untrusted environment (e.g. native application or web browser-based application) and therefore incapable of maintaining the confidentiality of its credentials, PKCE will automatically be used when the following conditions are true:
 
 . `client-secret` is omitted (or empty)
-. `client-authentication-method` is set to "none" (`ClientAuthenticationMethod.NONE`)
+. `client-authentication-method` is set to `none` (`ClientAuthenticationMethod.NONE`)
 
 or
 
 . When `ClientRegistration.clientSettings.requireProofKey` is `true` (in this case `ClientRegistration.authorizationGrantType` must be `authorization_code`)
 
+
 [TIP]
 ====
-If the OAuth 2.0 Provider supports PKCE for https://tools.ietf.org/html/rfc6749#section-2.1[Confidential Clients], you may (optionally) configure it using `DefaultServerOAuth2AuthorizationRequestResolver.setAuthorizationRequestCustomizer(OAuth2AuthorizationRequestCustomizers.withPkce())`.
+If the OAuth 2.0 Provider doesn't support PKCE for https://tools.ietf.org/html/rfc6749#section-2.1[Confidential Clients], you need to disable it by setting  `ClientRegistration.clientSettings.requireProofKey` to `false`.
 ====
 
 [[oauth2-client-authorization-code-redirect-uri]]

--- a/docs/modules/ROOT/pages/reactive/oauth2/client/core.adoc
+++ b/docs/modules/ROOT/pages/reactive/oauth2/client/core.adoc
@@ -68,7 +68,7 @@ The name may be used in certain scenarios, such as when displaying the name of t
 <15> `(userInfoEndpoint)authenticationMethod`: The authentication method used when sending the access token to the UserInfo Endpoint.
 The supported values are *header*, *form* and *query*.
 <16> `userNameAttributeName`: The name of the attribute returned in the UserInfo Response that references the Name or Identifier of the end-user.
-<17> [[oauth2Client-client-registration-requireProofKey]]`requireProofKey`: If `true` or if `authorizationGrantType` is `none`, then PKCE will be enabled by default.
+<17> [[oauth2Client-client-registration-requireProofKey]]`requireProofKey`: If `true` or if `clientAuthenticationMethod` is `none`, then PKCE will be enabled. Defaults to `true` for `authorization_code` grant type and `false` for other grant types.
 
 A `ClientRegistration` can be initially configured using discovery of an OpenID Connect Provider's https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig[Configuration endpoint] or an Authorization Server's https://tools.ietf.org/html/rfc8414#section-3[Metadata endpoint].
 

--- a/docs/modules/ROOT/pages/servlet/oauth2/client/authorization-grants.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/client/authorization-grants.adoc
@@ -77,7 +77,7 @@ spring:
 Public Clients are supported by using https://tools.ietf.org/html/rfc7636[Proof Key for Code Exchange] (PKCE).
 If the client is running in an untrusted environment (such as a native application or web browser-based application) and is therefore incapable of maintaining the confidentiality of its credentials, PKCE is automatically used when the following conditions are true:
 
-. `client-secret` is omitted (or empty) and
+. `client-secret` is omitted (or empty)
 . `client-authentication-method` is set to `none` (`ClientAuthenticationMethod.NONE`)
 
 or
@@ -87,7 +87,7 @@ or
 
 [TIP]
 ====
-If the OAuth 2.0 Provider supports PKCE for https://tools.ietf.org/html/rfc6749#section-2.1[Confidential Clients], you may (optionally) configure it using `DefaultOAuth2AuthorizationRequestResolver.setAuthorizationRequestCustomizer(OAuth2AuthorizationRequestCustomizers.withPkce())`.
+If the OAuth 2.0 Provider doesn't support PKCE for https://tools.ietf.org/html/rfc6749#section-2.1[Confidential Clients], you need to disable it by setting  `ClientRegistration.clientSettings.requireProofKey` to `false`.
 ====
 
 [[oauth2-client-authorization-code-redirect-uri]]

--- a/docs/modules/ROOT/pages/servlet/oauth2/client/core.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/client/core.adoc
@@ -69,7 +69,7 @@ This information is available only if the Spring Boot property `spring.security.
 <15> `(userInfoEndpoint)authenticationMethod`: The authentication method used when sending the access token to the UserInfo Endpoint.
 The supported values are *header*, *form*, and *query*.
 <16> `userNameAttributeName`: The name of the attribute returned in the UserInfo Response that references the Name or Identifier of the end-user.
-<17> [[oauth2Client-client-registration-requireProofKey]]`requireProofKey`: If `true` or if `clientAuthenticationMethod` is `none`, then PKCE will be enabled.
+<17> [[oauth2Client-client-registration-requireProofKey]]`requireProofKey`: If `true` or if `clientAuthenticationMethod` is `none`, then PKCE will be enabled. Defaults to `true` for `authorization_code` grant type and `false` for other grant types.
 
 You can initially configure a `ClientRegistration` by using discovery of an OpenID Connect Provider's https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig[Configuration endpoint] or an Authorization Server's https://tools.ietf.org/html/rfc8414#section-3[Metadata endpoint].
 


### PR DESCRIPTION
Updates documentation to reflect that PKCE is now enabled by default for `authorization_code` flows in both authorization server and client.

Changes include:
- Documenting the default PKCE behavior for authorization code flows
- Adding instructions for disabling PKCE when not supported

The documented changes were introduced by:
- gh-16391
- gh-17507