### PR TITLE
Clarify AuthenticationManagerBuilder.authenticationProvider JavaDoc

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/builders/AuthenticationManagerBuilder.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/builders/AuthenticationManagerBuilder.java
@@ -200,17 +200,20 @@ public class AuthenticationManagerBuilder
 	}
 
 	/**
-	 * Add authentication based upon the custom {@link AuthenticationProvider} that is
-	 * passed in. Since the {@link AuthenticationProvider} implementation is unknown, all
+	 * Adds the custom {@link AuthenticationProvider} to the list of providers. This
+	 * method does not replace existing providers. it appends the new provider to the
+	 * internal collection.
+	 * <p>
+	 * Since the {@link AuthenticationProvider} implementation is unknown, all
 	 * customizations must be done externally and the {@link AuthenticationManagerBuilder}
 	 * is returned immediately.
-	 *
 	 * <p>
 	 * This method <b>does NOT</b> ensure that the {@link UserDetailsService} is available
 	 * for the {@link #getDefaultUserDetailsService()} method.
-	 *
+	 * <p>
 	 * Note that an {@link Exception} might be thrown if an error occurs when adding the
 	 * {@link AuthenticationProvider}.
+	 * @param authenticationProvider the {@link AuthenticationProvider} to add
 	 * @return a {@link AuthenticationManagerBuilder} to allow further authentication to
 	 * be provided to the {@link AuthenticationManagerBuilder}
 	 */


### PR DESCRIPTION
## Summary
- Clarifies that the `authenticationProvider()` method adds a provider to the existing list rather than replacing it
- Documents that the provider is appended to the internal collection
- Adds missing `@param` tag for the `authenticationProvider` parameter

## Context
The original JavaDoc for `AuthenticationManagerBuilder.authenticationProvider()` could be misinterpreted as setting a single provider.

This change makes it explicit that the method appends the provider to the internal collection, which is important for users configuring multiple authentication providers.