### PR TITLE
Add nullability contract to `PasswordEncoder#encode`

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/password/PasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password/PasswordEncoder.java
@@ -17,6 +17,7 @@
 package org.springframework.security.crypto.password;
 
 import org.jspecify.annotations.Nullable;
+
 import org.springframework.lang.Contract;
 
 /**


### PR DESCRIPTION
Originally reported at https://github.com/uber/NullAway/issues/1273#issuecomment-3252976051:

> It's [PasswordEncoder.encode](https://github.com/spring-projects/spring-security/blob/main/crypto/src/main/java/org/springframework/security/crypto/password/PasswordEncoder.java#L39) from Spring Security. The JSpecify annotations were [recently added throughout Spring Security](https://github.com/spring-projects/spring-security/commit/7c887d2da1b201f15815e180365f7cf7955e9fb5), but are currently only released as milestones of v7. If you have a suggestion for how they can improve their usage of these annotations, now would be an ideal time to let them know.

This PR should solve the use case reported in the NullAway issue.

I don't know whether there should be a test for this change or how to compose it... in case there should be one, please let me know and I'll think about something 🙂 