### PR TITLE
Add @FunctionalInterface to RequestMatcher

### DIFF
--- a/web/src/main/java/org/springframework/security/web/util/matcher/RequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/RequestMatcher.java
@@ -28,6 +28,7 @@ import jakarta.servlet.http.HttpServletRequest;
  * @author Eddú Meléndez
  * @since 3.0.2
  */
+@FunctionalInterface
 public interface RequestMatcher {
 
 	/**


### PR DESCRIPTION
Add `@FunctionalInterface` to `RequestMatcher`.

According to the documentation, it is a FunctionalInterface.

See: https://docs.spring.io/spring-security/reference/6.5/servlet/authorization/authorize-http-requests.html#match-by-custom

