### PR TITLE
Prevent execution of scheduled GitHub Actions on forks

### DIFF
--- a/.github/workflows/gradle-wrapper-upgrade-execution.yml
+++ b/.github/workflows/gradle-wrapper-upgrade-execution.yml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   upgrade_wrapper:
     name: Execution
+    if: ${{ github.repository == 'spring-projects/spring-security' }}
     runs-on: ubuntu-latest
     steps:
       - name: Set up Git configuration

--- a/.github/workflows/update-antora-ui-spring.yml
+++ b/.github/workflows/update-antora-ui-spring.yml
@@ -12,8 +12,9 @@ permissions:
 
 jobs:
   update-antora-ui-spring:
-    runs-on: ubuntu-latest
     name: Update on Supported Branches
+    if: ${{ github.repository == 'spring-projects/spring-security' }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         branch: [ '6.5.x', '7.0.x', 'main' ]
@@ -25,8 +26,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           antora-file-path: 'docs/antora-playbook.yml'
   update-antora-ui-spring-docs-build:
-    runs-on: ubuntu-latest
     name: Update on docs-build
+    if: ${{ github.repository == 'spring-projects/spring-security' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: spring-io/spring-doc-actions/update-antora-spring-ui@415e2b11a766ba64799fffb5c97a4f7e17f677cf
         name: Update


### PR DESCRIPTION
Prior to this commit, any fork that copied the `main` branch only experienced daily failures at 10am UTC due to the scheduled execution of the `update-antora-ui-spring` workflow:

https://github.com/spring-projects/spring-security/blob/6d6552a602b5b57fdceb8188797b55154542ed40/.github/workflows/update-antora-ui-spring.yml#L4-L5

or at 2am UTC due to `gradle-wrapper-upgrade-execution`:

https://github.com/spring-projects/spring-security/blob/6d6552a602b5b57fdceb8188797b55154542ed40/.github/workflows/gradle-wrapper-upgrade-execution.yml#L5

With this change, scheduled workflow jobs are executed only when under `spring-projects/spring-security`.

The failures of my fork: [`update-antora-ui-spring`](https://github.com/scordio/spring-security/actions/workflows/update-antora-ui-spring.yml) and [`gradle-wrapper-upgrade-execution`](https://github.com/scordio/spring-security/actions/workflows/gradle-wrapper-upgrade-execution.yml)

Relates to:
* spring-projects/spring-framework#34077