### PR TITLE
Clarify Session Management Persistence Documentation

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/session-management.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/session-management.adoc
@@ -3,7 +3,8 @@
 
 Once you have got an application that is xref:servlet/authentication/index.adoc[authenticating requests], it is important to consider how that resulting authentication will be persisted and restored on future requests.
 
-This is done automatically by default. If you have a custom filter or controller that is setting the security context, you will need to use a `SecurityContextRepository` to persist it across requests.
+This is done automatically by default.
+If you have a custom filter or controller that is setting the security context, you will need to use a `SecurityContextRepository` to persist it across requests.
 
 If you are upgrading from an older version, you may be interested in the `requireExplicitSave` setting that preserves Spring Security 5's default, though note that this is primarily for migration purposes.
 


### PR DESCRIPTION
Corrected that starting from Spring Security 6 security context is not automatically saved by default.
