### PR TITLE
Fix documentation for Custom Authorization Manager

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
@@ -1384,7 +1384,7 @@ Java::
 @Component
 public class MyPreAuthorizeAuthorizationManager implements AuthorizationManager<MethodInvocation> {
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authentication, MethodInvocation invocation) {
+    public AuthorizationResult authorize(Supplier<Authentication> authentication, MethodInvocation invocation) {
         // ... authorization logic
     }
 }
@@ -1392,7 +1392,7 @@ public class MyPreAuthorizeAuthorizationManager implements AuthorizationManager<
 @Component
 public class MyPostAuthorizeAuthorizationManager implements AuthorizationManager<MethodInvocationResult> {
     @Override
-    public AuthorizationDecision check(Supplier<Authentication> authentication, MethodInvocationResult invocation) {
+    public AuthorizationResult authorize(Supplier<Authentication> authentication, MethodInvocationResult invocation) {
         // ... authorization logic
     }
 }
@@ -1404,14 +1404,14 @@ Kotlin::
 ----
 @Component
 class MyPreAuthorizeAuthorizationManager : AuthorizationManager<MethodInvocation> {
-    override fun check(authentication: Supplier<Authentication>, invocation: MethodInvocation): AuthorizationDecision {
+    override fun authorize(authentication: Supplier<Authentication>, invocation: MethodInvocation): AuthorizationResult {
         // ... authorization logic
     }
 }
 
 @Component
 class MyPostAuthorizeAuthorizationManager : AuthorizationManager<MethodInvocationResult> {
-    override fun check(authentication: Supplier<Authentication>, invocation: MethodInvocationResult): AuthorizationDecision {
+    override fun authorize(authentication: Supplier<Authentication>, invocation: MethodInvocationResult): AuthorizationResult {
         // ... authorization logic
     }
 }


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->
Fixes https://github.com/spring-projects/spring-security/issues/13967

Updates method security documentation to align with Spring 7 Security’s current authorization model by separating PreAuthorize and PostAuthorize logic into dedicated AuthorizationManager implementations, which was not possible in current example, throwing compilation error https://github.com/spring-projects/spring-security/issues/13967#issuecomment-1954644960. 

Also clarifies optional customization of exceptions via MethodAuthorizationDeniedHandler.

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
