### PR TITLE
Update Ont-Time-Token Login Docs

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/onetimetoken.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/onetimetoken.adoc
@@ -89,7 +89,7 @@ public class MagicLinkOneTimeTokenGenerationSuccessHandler implements OneTimeTok
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, OneTimeToken oneTimeToken) throws IOException, ServletException {
-        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(UrlUtils.buildFullRequestUrl(request))
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(request.getRequestURL().toString())
                 .replacePath(request.getContextPath())
                 .replaceQuery(null)
                 .fragment(null)
@@ -147,7 +147,7 @@ class MagicLinkOneTimeTokenGenerationSuccessHandler(
 ) : OneTimeTokenGenerationSuccessHandler {
 
     override fun handle(request: HttpServletRequest, response: HttpServletResponse, oneTimeToken: OneTimeToken) {
-        val builder = UriComponentsBuilder.fromHttpUrl(UrlUtils.buildFullRequestUrl(request))
+        val builder = UriComponentsBuilder.fromUriString(request.getRequestURL().toString())
             .replacePath(request.contextPath)
             .replaceQuery(null)
             .fragment(null)


### PR DESCRIPTION
Update UriComponentsBuilder method implementation in the given example


## Description
This pull request updates the `One-Time Token Login` documentation to correct an outdated method call. The current documentation suggests using `UriComponentsBuilder.fromHttpUrl()`, which is no longer available in the Spring Framework 7.0.x API. 

The example has been updated to use `UriComponentsBuilder.fromUriString(request.getRequestURL().toString())`, which is the correct and supported implementation for capturing the absolute request URL in modern Spring Security environments.

## Motivation
Following the current documentation leads to compilation errors (`Cannot resolve method 'fromHttpUrl'`) for users attempting to implement the new One-Time Token (OTT) feature. Correcting this ensures a smooth onboarding experience for passwordless authentication.

## Related Issue
Closes gh-18367


email: hardikkumarpro0005@gmail.com
Signed-off-by: Hardik Kumar 