### PR TITLE
Polish SecurityAnnotationScanner

### DIFF
--- a/core/src/main/java/org/springframework/security/core/annotation/ExpressionTemplateSecurityAnnotationScanner.java
+++ b/core/src/main/java/org/springframework/security/core/annotation/ExpressionTemplateSecurityAnnotationScanner.java
@@ -99,26 +99,15 @@ final class ExpressionTemplateSecurityAnnotationScanner<A extends Annotation>
 	@Override
 	@Nullable MergedAnnotation<A> merge(AnnotatedElement element, @Nullable Class<?> targetClass) {
 		if (element instanceof Parameter parameter) {
-			MergedAnnotation<A> annotation = this.unique.merge(parameter, targetClass);
-			if (annotation == null) {
-				return null;
-			}
-			return resolvePlaceholders(annotation);
+			return resolvePlaceholders(this.unique.merge(parameter, targetClass));
 		}
 		if (element instanceof Method method) {
-			MergedAnnotation<A> annotation = this.unique.merge(method, targetClass);
-			if (annotation == null) {
-				return null;
-			}
-			return resolvePlaceholders(annotation);
+			return resolvePlaceholders(this.unique.merge(method, targetClass));
 		}
 		throw new IllegalArgumentException("Unsupported element of type " + element.getClass());
 	}
 
 	private MergedAnnotation<A> resolvePlaceholders(MergedAnnotation<A> mergedAnnotation) {
-		if (this.templateDefaults == null) {
-			return mergedAnnotation;
-		}
 		if (mergedAnnotation.getMetaSource() == null) {
 			return mergedAnnotation;
 		}

--- a/core/src/main/java/org/springframework/security/core/annotation/UniqueSecurityAnnotationScanner.java
+++ b/core/src/main/java/org/springframework/security/core/annotation/UniqueSecurityAnnotationScanner.java
@@ -163,7 +163,7 @@ final class UniqueSecurityAnnotationScanner<A extends Annotation> extends Abstra
 
 	private List<MergedAnnotation<A>> findClosestParameterAnnotations(Method method, Class<?> clazz, Parameter current,
 			Set<Class<?>> visited) {
-		if (clazz == null || clazz == Object.class || !visited.add(clazz)) {
+		if (clazz == Object.class || !visited.add(clazz)) {
 			return Collections.emptyList();
 		}
 		List<MergedAnnotation<A>> directAnnotations = findDirectParameterAnnotations(method, clazz, current);
@@ -224,7 +224,7 @@ final class UniqueSecurityAnnotationScanner<A extends Annotation> extends Abstra
 
 	private List<MergedAnnotation<A>> findClosestMethodAnnotations(Method method, Class<?> targetClass,
 			Set<Class<?>> classesToSkip) {
-		if (targetClass == null || classesToSkip.contains(targetClass) || targetClass == Object.class) {
+		if (classesToSkip.contains(targetClass) || targetClass == Object.class) {
 			return Collections.emptyList();
 		}
 		classesToSkip.add(targetClass);
@@ -244,7 +244,7 @@ final class UniqueSecurityAnnotationScanner<A extends Annotation> extends Abstra
 	}
 
 	private List<MergedAnnotation<A>> findClosestClassAnnotations(Class<?> targetClass, Set<Class<?>> classesToSkip) {
-		if (targetClass == null || classesToSkip.contains(targetClass) || targetClass == Object.class) {
+		if (classesToSkip.contains(targetClass) || targetClass == Object.class) {
 			return Collections.emptyList();
 		}
 		classesToSkip.add(targetClass);


### PR DESCRIPTION
Remove redundant code in `ExpressionTemplateSecurityAnnotationScanner `and `UniqueSecurityAnnotationScanner`.