### PR TITLE
Replace method call with 'Builder.configureMessageConverters()'

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractRestClientOAuth2AccessTokenResponseClient.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/AbstractRestClientOAuth2AccessTokenResponseClient.java
@@ -63,10 +63,9 @@ public abstract class AbstractRestClientOAuth2AccessTokenResponseClient<T extend
 
 	// @formatter:off
 	private RestClient restClient = RestClient.builder()
-			.messageConverters((messageConverters) -> {
-				messageConverters.clear();
-				messageConverters.add(new FormHttpMessageConverter());
-				messageConverters.add(new OAuth2AccessTokenResponseHttpMessageConverter());
+			.configureMessageConverters((messageConverters) -> {
+				messageConverters.addCustomConverter(new FormHttpMessageConverter());
+				messageConverters.addCustomConverter(new OAuth2AccessTokenResponseHttpMessageConverter());
 			})
 			.defaultStatusHandler(new OAuth2ErrorResponseErrorHandler())
 			.build();


### PR DESCRIPTION
Deprecated
since 7.0 in favor of configureMessageConverters(Consumer)

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
