### PR TITLE
Fix duplicated use-authorization-manager in docs

### DIFF
--- a/docs/modules/ROOT/pages/servlet/appendix/namespace/http.adoc
+++ b/docs/modules/ROOT/pages/servlet/appendix/namespace/http.adoc
@@ -34,7 +34,7 @@ The attributes on the `<http>` element control some of the properties on the cor
 Use AuthorizationManager API instead of SecurityMetadataSource (defaults to true)
 
 [[nsa-http-authorization-manager-ref]]
-* **use-authorization-manager**
+* **authorization-manager-ref**
 Use this AuthorizationManager instead of deriving one from <intercept-url> elements
 
 [[nsa-http-access-decision-manager-ref]]


### PR DESCRIPTION
The <http> namespace appendix listed use-authorization-manager twice; the second entry corresponds to authorization-manager-ref. This PR fixes the attribute name.