### PR TITLE
Improve And/Or-RequestMatcher/ServerWebExchangeMatcher API

### DIFF
--- a/web/src/main/java/org/springframework/security/web/server/util/matcher/AndServerWebExchangeMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/server/util/matcher/AndServerWebExchangeMatcher.java
@@ -42,9 +42,9 @@ public class AndServerWebExchangeMatcher implements ServerWebExchangeMatcher {
 
 	private static final Log logger = LogFactory.getLog(AndServerWebExchangeMatcher.class);
 
-	private final List<ServerWebExchangeMatcher> matchers;
+	private final List<? extends ServerWebExchangeMatcher> matchers;
 
-	public AndServerWebExchangeMatcher(List<ServerWebExchangeMatcher> matchers) {
+	public AndServerWebExchangeMatcher(List<? extends ServerWebExchangeMatcher> matchers) {
 		Assert.notEmpty(matchers, "matchers cannot be empty");
 		this.matchers = matchers;
 	}

--- a/web/src/main/java/org/springframework/security/web/server/util/matcher/OrServerWebExchangeMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/server/util/matcher/OrServerWebExchangeMatcher.java
@@ -40,9 +40,9 @@ public class OrServerWebExchangeMatcher implements ServerWebExchangeMatcher {
 
 	private static final Log logger = LogFactory.getLog(OrServerWebExchangeMatcher.class);
 
-	private final List<ServerWebExchangeMatcher> matchers;
+	private final List<? extends ServerWebExchangeMatcher> matchers;
 
-	public OrServerWebExchangeMatcher(List<ServerWebExchangeMatcher> matchers) {
+	public OrServerWebExchangeMatcher(List<? extends ServerWebExchangeMatcher> matchers) {
 		Assert.notEmpty(matchers, "matchers cannot be empty");
 		this.matchers = matchers;
 	}

--- a/web/src/main/java/org/springframework/security/web/util/matcher/AndRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/AndRequestMatcher.java
@@ -35,13 +35,13 @@ import org.springframework.util.Assert;
  */
 public final class AndRequestMatcher implements RequestMatcher {
 
-	private final List<RequestMatcher> requestMatchers;
+	private final List<? extends RequestMatcher> requestMatchers;
 
 	/**
 	 * Creates a new instance
 	 * @param requestMatchers the {@link RequestMatcher} instances to try
 	 */
-	public AndRequestMatcher(List<RequestMatcher> requestMatchers) {
+	public AndRequestMatcher(List<? extends RequestMatcher> requestMatchers) {
 		Assert.notEmpty(requestMatchers, "requestMatchers must contain a value");
 		Assert.noNullElements(requestMatchers, "requestMatchers cannot contain null values");
 		this.requestMatchers = requestMatchers;

--- a/web/src/main/java/org/springframework/security/web/util/matcher/OrRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/OrRequestMatcher.java
@@ -33,13 +33,13 @@ import org.springframework.util.Assert;
  */
 public final class OrRequestMatcher implements RequestMatcher {
 
-	private final List<RequestMatcher> requestMatchers;
+	private final List<? extends RequestMatcher> requestMatchers;
 
 	/**
 	 * Creates a new instance
 	 * @param requestMatchers the {@link RequestMatcher} instances to try
 	 */
-	public OrRequestMatcher(List<RequestMatcher> requestMatchers) {
+	public OrRequestMatcher(List<? extends RequestMatcher> requestMatchers) {
 		Assert.notEmpty(requestMatchers, "requestMatchers must contain a value");
 		Assert.noNullElements(requestMatchers, "requestMatchers cannot contain null values");
 		this.requestMatchers = requestMatchers;


### PR DESCRIPTION
Currently, the List-receiving constructors of `AndRequestMatcher`, `OrRequestMatcher`, `AndServerWebExchangeMatcher`, and `OrServerWebExchangeMatcher` don't support covariance, which adds obstacles to users of these APIs.  For example, one cannot pass a `List<PathPatternRequestMatcher>` to `OrRequestMatcher(List<RequestMatcher>)`.

This PR resolves the aforementioned problem.  It should not break existing code.
