### PR TITLE
Make the reactive OAuth2 stack more reactive 

### DIFF
--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ReactiveOAuth2TokenValidator.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ReactiveOAuth2TokenValidator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.core;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Implementations of this interface are responsible for &quot;verifying&quot; the
+ * validity and/or constraints of the attributes contained in an OAuth 2.0 Token.
+ *
+ * @author Iain Henderson
+ */
+@FunctionalInterface
+public interface ReactiveOAuth2TokenValidator<T extends OAuth2Token> {
+
+	/**
+	 * Verify the validity and/or constraints of the provided OAuth 2.0 Token.
+	 * @param token an OAuth 2.0 token
+	 * @return Mono<OAuth2TokenValidationResult> the success or failure detail of the validation
+	 */
+	Mono<OAuth2TokenValidatorResult> validate(T token);
+
+}

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ReactiveWrappingOAuth2TokenValidator.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/ReactiveWrappingOAuth2TokenValidator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.core;
+
+import org.springframework.util.Assert;
+import reactor.core.publisher.Mono;
+
+/**
+ * A reactive wrapper for synchronous validators
+ *
+ * @param <T> the type of {@link OAuth2Token} this validator validates
+ * @author Iain Henderson
+ */
+public final class ReactiveWrappingOAuth2TokenValidator<T extends OAuth2Token> implements ReactiveOAuth2TokenValidator<T> {
+
+	private final OAuth2TokenValidator<T> tokenValidator;
+
+	/**
+	 * Constructs a {@code ReactiveWrappingOAuth2TokenValidator} using the provided validator.
+	 * @param tokenValidator the {@link OAuth2TokenValidator}s to use
+	 */
+	public ReactiveWrappingOAuth2TokenValidator(OAuth2TokenValidator<T> tokenValidator) {
+		Assert.notNull(tokenValidator, "tokenValidator cannot be null");
+		this.tokenValidator = tokenValidator;
+	}
+
+	@Override
+	public Mono<OAuth2TokenValidatorResult> validate(T token) {
+		return Mono.just(tokenValidator.validate(token))
+				.map(OAuth2TokenValidatorResult::getErrors)
+				.map(OAuth2TokenValidatorResult::failure);
+	}
+}

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/ReactiveDelegatingOAuth2TokenValidatorTests.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/ReactiveDelegatingOAuth2TokenValidatorTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.core;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for verifying {@link ReactiveDelegatingOAuth2TokenValidator}
+ *
+ * @author Josh Cummings
+ * @author Iain Henderson
+ */
+public class ReactiveDelegatingOAuth2TokenValidatorTests {
+
+	private static final OAuth2Error DETAIL = new OAuth2Error("error", "description", "uri");
+
+	@Test
+	public void validateWhenNoValidatorsConfiguredThenReturnsSuccessfulResult() {
+		ReactiveDelegatingOAuth2TokenValidator<OAuth2Token> tokenValidator =
+				new ReactiveDelegatingOAuth2TokenValidator<>(emptyList());
+		OAuth2Token token = mock(OAuth2Token.class);
+		assertThat(tokenValidator.validate(token).block().hasErrors()).isFalse();
+	}
+
+	@Test
+	public void validateWhenAnyValidatorFailsThenReturnsFailureResultContainingDetailFromFailingValidator() {
+		OAuth2TokenValidator<OAuth2Token> success = mock(OAuth2TokenValidator.class);
+		OAuth2TokenValidator<OAuth2Token> failure = mock(OAuth2TokenValidator.class);
+		given(success.validate(any(OAuth2Token.class))).willReturn(OAuth2TokenValidatorResult.success());
+		given(failure.validate(any(OAuth2Token.class))).willReturn(OAuth2TokenValidatorResult.failure(DETAIL));
+		ReactiveDelegatingOAuth2TokenValidator<OAuth2Token> tokenValidator = new ReactiveDelegatingOAuth2TokenValidator<>(
+				success, failure);
+		OAuth2Token token = mock(OAuth2Token.class);
+		OAuth2TokenValidatorResult result = tokenValidator.validate(token).block();
+		assertThat(result).isNotNull();
+		assertThat(result.hasErrors()).isTrue();
+		assertThat(result.getErrors()).containsExactly(DETAIL);
+	}
+
+	@Test
+	public void validateWhenMultipleValidatorsFailThenReturnsFailureResultContainingAllDetails() {
+		OAuth2TokenValidator<OAuth2Token> firstFailure = mock(OAuth2TokenValidator.class);
+		OAuth2TokenValidator<OAuth2Token> secondFailure = mock(OAuth2TokenValidator.class);
+		OAuth2Error otherDetail = new OAuth2Error("another-error");
+		given(firstFailure.validate(any(OAuth2Token.class))).willReturn(OAuth2TokenValidatorResult.failure(DETAIL));
+		given(secondFailure.validate(any(OAuth2Token.class)))
+			.willReturn(OAuth2TokenValidatorResult.failure(otherDetail));
+		ReactiveDelegatingOAuth2TokenValidator<OAuth2Token> tokenValidator = new ReactiveDelegatingOAuth2TokenValidator<>(firstFailure,
+				secondFailure);
+		OAuth2Token token = mock(OAuth2Token.class);
+		OAuth2TokenValidatorResult result = tokenValidator.validate(token).block();
+		assertThat(result.hasErrors()).isTrue();
+		assertThat(result.getErrors()).containsExactly(DETAIL, otherDetail);
+	}
+
+	@Test
+	public void validateWhenAllValidatorsSucceedThenReturnsSuccessfulResult() {
+		OAuth2TokenValidator<OAuth2Token> firstSuccess = mock(OAuth2TokenValidator.class);
+		OAuth2TokenValidator<OAuth2Token> secondSuccess = mock(OAuth2TokenValidator.class);
+		given(firstSuccess.validate(any(OAuth2Token.class))).willReturn(OAuth2TokenValidatorResult.success());
+		given(secondSuccess.validate(any(OAuth2Token.class))).willReturn(OAuth2TokenValidatorResult.success());
+		ReactiveDelegatingOAuth2TokenValidator<OAuth2Token> tokenValidator =
+				new ReactiveDelegatingOAuth2TokenValidator<>(firstSuccess, secondSuccess);
+		OAuth2Token token = mock(OAuth2Token.class);
+		OAuth2TokenValidatorResult result = tokenValidator.validate(token).block();
+		assertThat(result.hasErrors()).isFalse();
+		assertThat(result.getErrors()).isEmpty();
+	}
+
+	@Test
+	public void constructorWhenInvokedWithNullValidatorListThenThrowsIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(
+				() -> new ReactiveDelegatingOAuth2TokenValidator<>((Collection<ReactiveOAuth2TokenValidator<OAuth2Token>>) null));
+	}
+
+	@Test
+	public void constructorsWhenInvokedWithSameInputsThenResultInSameOutputs() {
+		ReactiveOAuth2TokenValidator<OAuth2Token> firstSuccess = mock(ReactiveOAuth2TokenValidator.class);
+		ReactiveOAuth2TokenValidator<OAuth2Token> secondSuccess = mock(ReactiveOAuth2TokenValidator.class);
+		given(firstSuccess.validate(any(OAuth2Token.class))).willReturn(Mono.just(OAuth2TokenValidatorResult.success()));
+		given(secondSuccess.validate(any(OAuth2Token.class))).willReturn(Mono.just(OAuth2TokenValidatorResult.success()));
+		ReactiveDelegatingOAuth2TokenValidator<OAuth2Token> firstValidator =
+				new ReactiveDelegatingOAuth2TokenValidator<>(Arrays.asList(firstSuccess, secondSuccess));
+		ReactiveDelegatingOAuth2TokenValidator<OAuth2Token> secondValidator =
+				new ReactiveDelegatingOAuth2TokenValidator<>(firstSuccess, secondSuccess);
+		OAuth2Token token = mock(OAuth2Token.class);
+		firstValidator.validate(token).block();
+		secondValidator.validate(token).block();
+		verify(firstSuccess, times(2)).validate(token);
+		verify(secondSuccess, times(2)).validate(token);
+	}
+
+}

--- a/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/ReactiveWrappingOAuth2TokenValidatorTests.java
+++ b/oauth2/oauth2-core/src/test/java/org/springframework/security/oauth2/core/ReactiveWrappingOAuth2TokenValidatorTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for verifying {@link ReactiveWrappingOAuth2TokenValidatorTests}
+ *
+ * @author Iain Henderson
+ */
+public class ReactiveWrappingOAuth2TokenValidatorTests {
+
+	private static final OAuth2Error DETAIL = new OAuth2Error("error", "description", "uri");
+
+	@Test
+	public void validate() {
+		ReactiveWrappingOAuth2TokenValidator<OAuth2Token> tokenValidator =
+				new ReactiveWrappingOAuth2TokenValidator<>(token -> OAuth2TokenValidatorResult.success());
+		OAuth2Token token = mock(OAuth2Token.class);
+		assertThat(tokenValidator.validate(token).block().hasErrors()).isFalse();
+	}
+
+	@Test
+	public void validateFailure() {
+		ReactiveWrappingOAuth2TokenValidator<OAuth2Token> tokenValidator =
+				new ReactiveWrappingOAuth2TokenValidator<>(token -> OAuth2TokenValidatorResult.failure(DETAIL));
+		OAuth2Token token = mock(OAuth2Token.class);
+		OAuth2TokenValidatorResult result = tokenValidator.validate(token).block();
+		assertThat(result).isNotNull();
+		assertThat(result.hasErrors()).isTrue();
+		assertThat(result.getErrors()).containsExactly(DETAIL);
+	}
+
+	@Test
+	public void constructorWhenInvokedWithNullValidatorListThenThrowsIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> new ReactiveWrappingOAuth2TokenValidator<>(null));
+	}
+}

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtValidators.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtValidators.java
@@ -24,11 +24,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
-import org.springframework.security.oauth2.core.OAuth2Error;
-import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
-import org.springframework.security.oauth2.core.OAuth2TokenValidator;
-import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.core.*;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 
@@ -37,6 +33,7 @@ import org.springframework.util.CollectionUtils;
  *
  * @author Josh Cummings
  * @author Rob Winch
+ * @author Iain Henderson
  * @since 5.1
  */
 public final class JwtValidators {
@@ -71,13 +68,29 @@ public final class JwtValidators {
 	 * result of this method to {@code DelegatingOAuth2TokenValidator} along with the
 	 * additional validators.
 	 * </p>
-	 * @return - a delegating validator containing all standard validators as well as any
-	 * supplied
+	 * @return - a delegating validator containing all standard validators
 	 */
 	public static OAuth2TokenValidator<Jwt> createDefault() {
 		return new DelegatingOAuth2TokenValidator<>(Arrays.asList(JwtTypeValidator.jwt(), new JwtTimestampValidator(),
 				new X509CertificateThumbprintValidator(
 						X509CertificateThumbprintValidator.DEFAULT_X509_CERTIFICATE_SUPPLIER)));
+	}
+
+	/**
+	 * <p>
+	 * Create a reactive {@link Jwt} Validator that contains all standard validators.
+	 * </p>
+	 * <p>
+	 * User's wanting to leverage the defaults plus additional validation can add the
+	 * result of this method to {@code ReactiveDelegatingOAuth2TokenValidator} along with the
+	 * additional validators.
+	 * </p>
+	 * @return - a reactive delegating validator containing all standard validators
+	 */
+	public static ReactiveOAuth2TokenValidator<Jwt> createReactiveDefault() {
+		return new ReactiveDelegatingOAuth2TokenValidator<>(JwtTypeValidator.jwt(), new JwtTimestampValidator(),
+				new X509CertificateThumbprintValidator(
+						X509CertificateThumbprintValidator.DEFAULT_X509_CERTIFICATE_SUPPLIER));
 	}
 
 	/**

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoderTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoderTests.java
@@ -58,6 +58,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.ReactiveOAuth2TokenValidator;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -84,6 +85,7 @@ import static org.mockito.Mockito.verify;
 /**
  * @author Rob Winch
  * @author Joe Grandja
+ * @author Iain Henderson
  * @since 5.1
  */
 public class NimbusReactiveJwtDecoderTests {
@@ -293,7 +295,7 @@ public class NimbusReactiveJwtDecoderTests {
 	public void setJwtValidatorWhenGivenNullThrowsIllegalArgumentException() {
 		// @formatter:off
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> this.decoder.setJwtValidator(null));
+				.isThrownBy(() -> this.decoder.setJwtValidator((ReactiveOAuth2TokenValidator<Jwt>) null));
 		// @formatter:on
 	}
 
@@ -667,7 +669,7 @@ public class NimbusReactiveJwtDecoderTests {
 		NimbusReactiveJwtDecoder jwtDecoder = NimbusReactiveJwtDecoder.withPublicKey(TestKeys.DEFAULT_PUBLIC_KEY)
 			.validateType(false)
 			.build();
-		jwtDecoder.setJwtValidator((jwt) -> OAuth2TokenValidatorResult.success());
+		jwtDecoder.setJwtValidator((OAuth2TokenValidator<Jwt>) (jwt) -> OAuth2TokenValidatorResult.success());
 		RSAPrivateKey privateKey = TestKeys.DEFAULT_PRIVATE_KEY;
 		SignedJWT jwt = signedJwt(privateKey,
 				new JWSHeader.Builder(JWSAlgorithm.RS256).type(JOSEObjectType.JOSE).build(),
@@ -680,7 +682,7 @@ public class NimbusReactiveJwtDecoderTests {
 		NimbusReactiveJwtDecoder jwtDecoder = NimbusReactiveJwtDecoder.withSecretKey(TestKeys.DEFAULT_SECRET_KEY)
 			.validateType(false)
 			.build();
-		jwtDecoder.setJwtValidator((jwt) -> OAuth2TokenValidatorResult.success());
+		jwtDecoder.setJwtValidator((OAuth2TokenValidator<Jwt>) (jwt) -> OAuth2TokenValidatorResult.success());
 		SignedJWT jwt = signedJwt(TestKeys.DEFAULT_SECRET_KEY,
 				new JWSHeader.Builder(JWSAlgorithm.HS256).type(JOSEObjectType.JOSE).build(),
 				new JWTClaimsSet.Builder().subject("subject").build());
@@ -695,7 +697,7 @@ public class NimbusReactiveJwtDecoderTests {
 		NimbusReactiveJwtDecoder jwtDecoder = NimbusReactiveJwtDecoder.withJwkSource((jwt) -> Flux.just(jwk))
 			.validateType(false)
 			.build();
-		jwtDecoder.setJwtValidator((jwt) -> OAuth2TokenValidatorResult.success());
+		jwtDecoder.setJwtValidator((OAuth2TokenValidator<Jwt>) (jwt) -> OAuth2TokenValidatorResult.success());
 		SignedJWT jwt = signedJwt(TestKeys.DEFAULT_PRIVATE_KEY,
 				new JWSHeader.Builder(JWSAlgorithm.RS256).type(JOSEObjectType.JOSE).build(),
 				new JWTClaimsSet.Builder().subject("subject").build());


### PR DESCRIPTION
OAuth2TokenValidators are currently synchronous only. If a validator has an asynchronous dependency it cannot be used.

This PR updates NimbusReactiveJwtDecoder to utilize ReactiveOAuth2TokenValidator and adds a ReactiveWrappingOAuth2TokenValidator to facilitate using OAuth2TokenValidators in a reactive context.