### PR TITLE
Fix javadoc warnings for spring-security-oauth2-client

### DIFF
--- a/oauth2/oauth2-client/spring-security-oauth2-client.gradle
+++ b/oauth2/oauth2-client/spring-security-oauth2-client.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'javadoc-warnings-error'
+}
+
 apply plugin: 'io.spring.convention.spring-module'
 
 dependencies {

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistrations.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistrations.java
@@ -101,7 +101,7 @@ public final class ClientRegistrations {
 	 *     .clientSecret("client-secret")
 	 *     .build();
 	 * </pre>
-	 * @param the OpenID Provider configuration map
+	 * @param configuration the OpenID Provider configuration map
 	 * @return the {@link ClientRegistration} built from the configuration
 	 */
 	public static ClientRegistration.Builder fromOidcConfiguration(Map<String, Object> configuration) {


### PR DESCRIPTION
<img width="1306" height="120" alt="image" src="https://github.com/user-attachments/assets/10ae544f-3dba-488e-9f86-9f78ed848c3d" />

Fix one javadoc warning.

I took buildSrc/src/main/groovy/javadoc-warnings-error.gradle from PR #18473. It is identical.
Because it works well, so I decided to add.
Please ignore my javadoc-warnings-error.gradle when merging.


Closes gh-18460
