### PR TITLE
Add nullability contract to `PasswordEncoder#encode` implementations

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/AuthenticationConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/AuthenticationConfiguration.java
@@ -36,6 +36,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.core.log.LogMessage;
+import org.springframework.lang.Contract;
 import org.springframework.security.authentication.AuthenticationEventPublisher;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
@@ -302,6 +303,7 @@ public class AuthenticationConfiguration {
 		}
 
 		@Override
+		@Contract("!null -> !null; null -> null")
 		public String encode(CharSequence rawPassword) {
 			return getPasswordEncoder().encode(rawPassword);
 		}

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configuration/HttpSecurityConfiguration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configuration/HttpSecurityConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.io.support.SpringFactoriesLoader;
+import org.springframework.lang.Contract;
 import org.springframework.security.authentication.AuthenticationEventPublisher;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
@@ -293,6 +294,7 @@ class HttpSecurityConfiguration {
 		}
 
 		@Override
+		@Contract("!null -> !null; null -> null")
 		public String encode(CharSequence rawPassword) {
 			return getPasswordEncoder().encode(rawPassword);
 		}

--- a/crypto/src/main/java/org/springframework/security/crypto/password/AbstractValidatingPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password/AbstractValidatingPasswordEncoder.java
@@ -18,6 +18,7 @@ package org.springframework.security.crypto.password;
 
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.lang.Contract;
 import org.springframework.util.StringUtils;
 
 /**
@@ -33,6 +34,7 @@ import org.springframework.util.StringUtils;
 public abstract class AbstractValidatingPasswordEncoder implements PasswordEncoder {
 
 	@Override
+	@Contract("!null -> !null; null -> null")
 	public final @Nullable String encode(@Nullable CharSequence rawPassword) {
 		if (rawPassword == null) {
 			return null;

--- a/crypto/src/main/java/org/springframework/security/crypto/password/PasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password/PasswordEncoder.java
@@ -38,7 +38,7 @@ public interface PasswordEncoder {
 	 * @return A non-null encoded password, unless the rawPassword was null in which case
 	 * the result must be null.
 	 */
-	@Contract("null -> null; !null -> !null")
+	@Contract("!null -> !null; null -> null")
 	@Nullable String encode(@Nullable CharSequence rawPassword);
 
 	/**


### PR DESCRIPTION
This is a follow-up to https://github.com/spring-projects/spring-security/pull/18334#discussion_r2687263278.