### PR TITLE
Enable javadoc-warnings-error for oauth2-resource-server

### DIFF
--- a/oauth2/oauth2-resource-server/spring-security-oauth2-resource-server.gradle
+++ b/oauth2/oauth2-resource-server/spring-security-oauth2-resource-server.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'io.spring.convention.spring-module'
+apply plugin: 'javadoc-warnings-error'
 
 dependencies {
 	management platform(project(":spring-security-dependencies"))


### PR DESCRIPTION
This is my first contribution to Spring Security! 
and my first open source contribution, so there may be many shortcomings.

This PR enables the `javadoc-warnings-error` plugin for the  `spring-security-oauth2-resource-server` module as part of gh-18443

  ### Changes
  - Applied `javadoc-warnings-error` plugin to fail the build on Javadoc warnings

  ### Verification                                                                             
  - Verified that `./gradlew :spring-security-oauth2-resource-server:javadoc` passes without warnings                                                                                     

thanks!!!

Closes gh-18463   