### PR TITLE
Fix HttpSecurity javadoc formatting

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
@@ -1881,7 +1881,7 @@ public final class HttpSecurity extends AbstractConfiguredSecurityBuilder<Defaul
 	 *
 	 * <p>
 	 * Invoking {@link #securityMatchers(Customizer)} will not override previous
-	 * invocations of {@link #securityMatchers()}}, {@link #securityMatchers(Customizer)}
+	 * invocations of {@link #securityMatchers()}, {@link #securityMatchers(Customizer)}
 	 * {@link #securityMatcher(String...)} and {@link #securityMatcher(RequestMatcher)}
 	 * </p>
 	 *


### PR DESCRIPTION
* Fix extra brace in HttpSecurity#securityMatchers Javadoc