### PR TITLE
BearerTokenAuthenticationEntryPoint uses context path

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/BearerTokenAuthenticationEntryPoint.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/BearerTokenAuthenticationEntryPoint.java
@@ -98,9 +98,11 @@ public final class BearerTokenAuthenticationEntryPoint implements Authentication
 	}
 
 	private static String getResourceMetadataParameter(HttpServletRequest request) {
+		String path = request.getContextPath()
+				+ OAuth2ProtectedResourceMetadataFilter.DEFAULT_OAUTH2_PROTECTED_RESOURCE_METADATA_ENDPOINT_URI;
 		// @formatter:off
 		return UriComponentsBuilder.fromUriString(UrlUtils.buildFullRequestUrl(request))
-				.replacePath(OAuth2ProtectedResourceMetadataFilter.DEFAULT_OAUTH2_PROTECTED_RESOURCE_METADATA_ENDPOINT_URI)
+				.replacePath(path)
 				.replaceQuery(null)
 				.fragment(null)
 				.build()

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/BearerTokenAuthenticationEntryPointTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/BearerTokenAuthenticationEntryPointTests.java
@@ -66,6 +66,18 @@ public class BearerTokenAuthenticationEntryPointTests {
 	}
 
 	@Test
+	void commenceWhenNoBearerTokenErrorAndContextPathSetThenStatus401AndAuthHeaderWithContextPath() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setContextPath("/ctx");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		this.authenticationEntryPoint.commence(request, response, new BadCredentialsException("test"));
+		assertThat(response.getStatus()).isEqualTo(401);
+		assertThat(response.getHeader("WWW-Authenticate"))
+			.isEqualTo("Bearer resource_metadata=\"http://localhost/ctx/.well-known/oauth-protected-resource\"");
+
+	}
+
+	@Test
 	public void commenceWhenInvalidRequestErrorThenStatus400AndHeaderWithError() throws Exception {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		MockHttpServletResponse response = new MockHttpServletResponse();


### PR DESCRIPTION
Add context path to `BearerTokenAuthenticationEntryPoint`.