### PR TITLE
Fix javadoc warnings for spring-security-data

### DIFF
--- a/data/spring-security-data.gradle
+++ b/data/spring-security-data.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'security-nullability'
+	id 'javadoc-warnings-error'
 }
 
 apply plugin: 'io.spring.convention.spring-module'

--- a/data/src/main/java/org/springframework/security/data/repository/query/SecurityEvaluationContextExtension.java
+++ b/data/src/main/java/org/springframework/security/data/repository/query/SecurityEvaluationContextExtension.java
@@ -144,7 +144,8 @@ public class SecurityEvaluationContextExtension implements EvaluationContextExte
 	/**
 	 * Sets the {@link SecurityContextHolderStrategy} to use. The default action is to use
 	 * the {@link SecurityContextHolderStrategy} stored in {@link SecurityContextHolder}.
-	 *
+	 * @param securityContextHolderStrategy the {@link SecurityContextHolderStrategy} to
+	 * use. Cannot be null.
 	 * @since 5.8
 	 */
 	public void setSecurityContextHolderStrategy(SecurityContextHolderStrategy securityContextHolderStrategy) {


### PR DESCRIPTION
Following the initiative to address Javadoc warnings (https://github.com/spring-projects/spring-security/issues/18443), This PR removes javadoc warnings from the `spring-security-data` module.

## Changes

- Apply `javadoc-warnings-error` plugin to `spring-security-data.gradle` to enforce warning-free javadoc builds
- Add missing `@param` tag in `SecurityEvaluationContextExtension#setSecurityContextHolderStrategy` method

Closes gh-18451