### PR TITLE
Fix javadoc warnings for spring-security-kerberos-client

### DIFF
--- a/kerberos/kerberos-client/spring-security-kerberos-client.gradle
+++ b/kerberos/kerberos-client/spring-security-kerberos-client.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'io.spring.convention.spring-module'
+	id 'javadoc-warnings-error'
 }
 
 description = 'Spring Security Kerberos Client'

--- a/kerberos/kerberos-client/src/main/java/org/springframework/security/kerberos/client/KerberosRestTemplate.java
+++ b/kerberos/kerberos-client/src/main/java/org/springframework/security/kerberos/client/KerberosRestTemplate.java
@@ -182,7 +182,7 @@ public class KerberosRestTemplate extends RestTemplate {
 
 	/**
 	 * Builds the default instance of {@link HttpClient} having kerberos support.
-	 * @return the http client with spneno auth scheme
+	 * @return the http client with SPNEGO auth scheme
 	 */
 	private static HttpClient buildHttpClient() {
 		HttpClientBuilder builder = HttpClientBuilder.create();


### PR DESCRIPTION
There were no javadoc warnings and I fixed one typo.

## Changes

- Apply plugin 'javadoc-warnings-error'
- Fix typo `spneno` to `SPNEGO` in `KerberosRestTemplate.java`

Closes gh-18453