### PR TITLE
Fix javadoc warnings for spring-security-kerberos-core

### DIFF
--- a/kerberos/kerberos-core/spring-security-kerberos-core.gradle
+++ b/kerberos/kerberos-core/spring-security-kerberos-core.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'io.spring.convention.spring-module'
+	id 'javadoc-warnings-error'
 }
 
 description = 'Spring Security Kerberos Core'

--- a/kerberos/kerberos-core/src/main/java/org/springframework/security/kerberos/authentication/sun/SunJaasKerberosTicketValidator.java
+++ b/kerberos/kerberos-core/src/main/java/org/springframework/security/kerberos/authentication/sun/SunJaasKerberosTicketValidator.java
@@ -148,7 +148,7 @@ public class SunJaasKerberosTicketValidator implements KerberosTicketValidator, 
 
 	/**
 	 * <p>
-	 * The location of the keytab. You can use the normale Spring Resource prefixes like
+	 * The location of the keytab. You can use the normal Spring Resource prefixes like
 	 * <code>file:</code> or <code>classpath:</code>, but as the file is later on read by
 	 * JAAS, we cannot guarantee that <code>classpath</code> works in every environment,
 	 * esp. not in Java EE application servers. You should use <code>file:</code> there.


### PR DESCRIPTION
There were no javadoc warnings and I fixed one typo.

## Changes

- Apply plugin 'javadoc-warnings-error'
- Fix typo `normale` to `normal` in `SunJaasKerberosTicketValidator.java`

Closes gh-18454