### PR TITLE
Fix javadoc warning in spring-security-access

### DIFF
--- a/access/spring-security-access.gradle
+++ b/access/spring-security-access.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'javadoc-warnings-error'
+}
+
 apply plugin: 'io.spring.convention.spring-module'
 
 dependencies {

--- a/access/src/main/java/org/springframework/security/access/intercept/aopalliance/MethodSecurityMetadataSourceAdvisor.java
+++ b/access/src/main/java/org/springframework/security/access/intercept/aopalliance/MethodSecurityMetadataSourceAdvisor.java
@@ -53,7 +53,9 @@ import org.springframework.util.CollectionUtils;
  *
  * @author Ben Alex
  * @author Luke Taylor
- * @deprecated Use {@link EnableMethodSecurity} or publish interceptors directly
+ * @deprecated Use
+ * <code>org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity</code>
+ * or publish interceptors directly
  */
 @NullUnmarked
 @Deprecated


### PR DESCRIPTION
The spring-security-access module had the following (repeated) Javadoc warnings

<img width="1455" height="426" alt="spring-security-access-javadoc-warnings" src="https://github.com/user-attachments/assets/ee7fa558-f274-4d74-8f44-64c766fccdb2" />

This PR includes the following changes:

1. Update the Javadoc warning in the `MethodSecurityMetadataSourceAdvisor.java` with an incline `<code></code>` reference since the `EnableMethodSecurity` annotation from spring-security-config is not included in spring-security-access module's dependencies.
2. Apply the `javadoc-warnings-error` plugin

Closes https://github.com/spring-projects/spring-security/issues/18444