### PR TITLE
Introduce resource_metadata parameter resolver for BearerTokenAuthenticationEntryPoint

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/BearerTokenAuthenticationEntryPoint.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/BearerTokenAuthenticationEntryPoint.java
@@ -18,6 +18,7 @@ package org.springframework.security.oauth2.server.resource.web;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -51,6 +52,8 @@ public final class BearerTokenAuthenticationEntryPoint implements Authentication
 
 	private String realmName;
 
+	private Function<HttpServletRequest, String> resourceMetadataParameterResolver = BearerTokenAuthenticationEntryPoint::getResourceMetadataParameter;
+
 	/**
 	 * Collect error details from the provided parameters and format according to RFC
 	 * 6750, specifically {@code error}, {@code error_description}, {@code error_uri}, and
@@ -83,7 +86,7 @@ public final class BearerTokenAuthenticationEntryPoint implements Authentication
 				status = bearerTokenError.getHttpStatus();
 			}
 		}
-		parameters.put("resource_metadata", getResourceMetadataParameter(request));
+		parameters.put("resource_metadata", this.resourceMetadataParameterResolver.apply(request));
 		String wwwAuthenticate = computeWWWAuthenticateHeaderValue(parameters);
 		response.addHeader(HttpHeaders.WWW_AUTHENTICATE, wwwAuthenticate);
 		response.setStatus(status.value());
@@ -95,6 +98,16 @@ public final class BearerTokenAuthenticationEntryPoint implements Authentication
 	 */
 	public void setRealmName(String realmName) {
 		this.realmName = realmName;
+	}
+
+	/**
+	 * Set the resolver to compute the {@code resource_metadata} parameter from the
+	 * request.
+	 * @param resourceMetadataParameterResolver
+	 */
+	public void setResourceMetadataParameterResolver(
+			Function<HttpServletRequest, String> resourceMetadataParameterResolver) {
+		this.resourceMetadataParameterResolver = resourceMetadataParameterResolver;
 	}
 
 	private static String getResourceMetadataParameter(HttpServletRequest request) {

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/BearerTokenAuthenticationEntryPointTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/BearerTokenAuthenticationEntryPointTests.java
@@ -78,6 +78,19 @@ public class BearerTokenAuthenticationEntryPointTests {
 	}
 
 	@Test
+	public void commenceWhenNoBearerTokenErrorAndResourceMetadataResolverSetThenStatus401AndAuthHeaderWithResolvedResourceMetadata() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setAttribute("resource_id", "https://example.com/resource-from-request");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		this.authenticationEntryPoint
+			.setResourceMetadataParameterResolver((req) -> req.getAttribute("resource_id").toString());
+		this.authenticationEntryPoint.commence(request, response, new BadCredentialsException("test"));
+		assertThat(response.getStatus()).isEqualTo(401);
+		assertThat(response.getHeader("WWW-Authenticate"))
+			.isEqualTo("Bearer resource_metadata=\"https://example.com/resource-from-request\"");
+	}
+
+	@Test
 	public void commenceWhenInvalidRequestErrorThenStatus400AndHeaderWithError() throws Exception {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		MockHttpServletResponse response = new MockHttpServletResponse();


### PR DESCRIPTION
Dynamically the `resource_metadata` from the incoming HTTP request in `BearerTokenAuthenticationEntryPoint`. This is required when you want to, say, preserve the path parameter of the incoming request, or include a query string.

See [RFC 9728 >  3.1. Protected Resource Metadata Request](https://datatracker.ietf.org/doc/html/rfc9728#section-3.1

>  If the resource identifier value contains a path or query component, any terminating slash (/) following the host component MUST be removed before inserting /.well-known/ and the well-known URI path suffix between the host component and the path and/or query components. The consumer of the metadata would make the following request when the resource identifier is https://resource.example.com/resource1 and the well-known URI path suffix is oauth-protected-resource to obtain the metadata, since the resource identifier contains a path component:
>
>  GET /.well-known/oauth-protected-resource/resource1 HTTP/1.1
>  Host: resource.example.com
>
> Using path components enables supporting multiple resources per host. This is required in some multi-tenant hosting configurations.