### PR TITLE
Fix javadoc warnings for spring-security-config

### DIFF
--- a/config/spring-security-config.gradle
+++ b/config/spring-security-config.gradle
@@ -5,6 +5,7 @@ apply plugin: 'io.spring.convention.spring-module'
 apply plugin: 'trang'
 apply plugin: 'security-kotlin'
 apply plugin: 'test-compile-target-jdk25'
+apply plugin:  'javadoc-warnings-error'
 
 configurations {
 	opensaml5 {

--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
@@ -1881,7 +1881,7 @@ public final class HttpSecurity extends AbstractConfiguredSecurityBuilder<Defaul
 	 *
 	 * <p>
 	 * Invoking {@link #securityMatchers(Customizer)} will not override previous
-	 * invocations of {@link #securityMatchers()}, {@link #securityMatchers(Customizer)}
+	 * invocations of {@link #securityMatchers(Customizer)}
 	 * {@link #securityMatcher(String...)} and {@link #securityMatcher(RequestMatcher)}
 	 * </p>
 	 *
@@ -2004,8 +2004,7 @@ public final class HttpSecurity extends AbstractConfiguredSecurityBuilder<Defaul
 	 * <p>
 	 * Invoking {@link #securityMatcher(RequestMatcher)} will override previous
 	 * invocations of {@link #securityMatcher(RequestMatcher)},
-	 * {@link #securityMatcher(String...)}, {@link #securityMatchers(Customizer)} and
-	 * {@link #securityMatchers()}
+	 * {@link #securityMatcher(String...)} and {@link #securityMatchers(Customizer)}
 	 * </p>
 	 * @param requestMatcher the {@link RequestMatcher} to use, for example,
 	 * {@code PathPatternRequestMatcher.pathPattern(HttpMethod.GET, "/admin/**")}
@@ -2024,9 +2023,8 @@ public final class HttpSecurity extends AbstractConfiguredSecurityBuilder<Defaul
 	 *
 	 * <p>
 	 * Invoking {@link #securityMatcher(String...)} will override previous invocations of
-	 * {@link #securityMatcher(String...)} (String)}},
-	 * {@link #securityMatcher(RequestMatcher)} ()}, {@link #securityMatchers(Customizer)}
-	 * (String)} and {@link #securityMatchers()} (String)}.
+	 * {@link #securityMatcher(String...)}, {@link #securityMatcher(RequestMatcher)} and
+	 * {@link #securityMatchers(Customizer)}.
 	 * </p>
 	 * @param patterns the pattern to match on (i.e. "/admin/**")
 	 * @return the {@link HttpSecurity} for further customizations

--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/WebSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/WebSecurity.java
@@ -226,7 +226,7 @@ public final class WebSecurity extends AbstractConfiguredSecurityBuilder<Filter,
 	 *
 	 * <p>
 	 * Typically this method is invoked automatically within the framework from
-	 * {@link WebSecurityConfiguration#springSecurityFilterChain()}
+	 * {@link WebSecurityConfiguration#springSecurityFilterChain(ObjectProvider)}
 	 * </p>
 	 * @param securityFilterChainBuilder the builder to use to create the
 	 * {@link SecurityFilterChain} instances

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2ClientConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/client/OAuth2ClientConfigurer.java
@@ -47,8 +47,8 @@ import org.springframework.util.Assert;
  * The following configuration options are available:
  *
  * <ul>
- * <li>{@link #authorizationCodeGrant()} - support for the OAuth 2.0 Authorization Code
- * Grant</li>
+ * <li>{@link #authorizationCodeGrant(Customizer)} - support for the OAuth 2.0
+ * Authorization Code Grant</li>
  * </ul>
  *
  * <p>
@@ -59,7 +59,8 @@ import org.springframework.util.Assert;
  *
  * <h2>Security Filters</h2>
  *
- * The following {@code Filter}'s are populated for {@link #authorizationCodeGrant()}:
+ * The following {@code Filter}'s are populated for
+ * {@link #authorizationCodeGrant(Customizer)}:
  *
  * <ul>
  * <li>{@link OAuth2AuthorizationRequestRedirectFilter}</li>

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2MetadataConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2MetadataConfigurer.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 import org.opensaml.core.Version;
 
 import org.springframework.context.ApplicationContext;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.HttpSecurityBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -42,7 +43,8 @@ import org.springframework.util.Assert;
  *
  * <p>
  * Defaults are provided for all configuration options with the only required
- * configuration being a {@link Saml2LoginConfigurer#relyingPartyRegistrationRepository}.
+ * configuration being a
+ * {@link Saml2LoginConfigurer#relyingPartyRegistrationRepository(HttpSecurityBuilder)}.
  * Alternatively, a {@link RelyingPartyRegistrationRepository} {@code @Bean} may be
  * registered instead.
  *
@@ -67,7 +69,7 @@ import org.springframework.util.Assert;
  * </ul>
  *
  * @since 6.1
- * @see HttpSecurity#saml2Metadata()
+ * @see HttpSecurity#saml2Metadata(Customizer)
  * @see Saml2MetadataFilter
  * @see RelyingPartyRegistrationRepository
  */

--- a/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
@@ -2162,7 +2162,7 @@ public class ServerHttpSecurity {
 	 *
 	 * @author Evgeniy Cheban
 	 * @since 5.6
-	 * @see #passwordManagement()
+	 * @see #passwordManagement(Customizer)
 	 */
 	public final class PasswordManagementSpec {
 
@@ -2663,7 +2663,7 @@ public class ServerHttpSecurity {
 		/**
 		 * Configures cache control headers
 		 *
-		 * @see #cache()
+		 * @see HeaderSpec#cache(Customizer)
 		 */
 		public final class CacheSpec {
 
@@ -2684,7 +2684,7 @@ public class ServerHttpSecurity {
 		/**
 		 * The content type headers
 		 *
-		 * @see #contentTypeOptions()
+		 * @see HeaderSpec#contentTypeOptions(Customizer)
 		 */
 		public final class ContentTypeOptionsSpec {
 
@@ -2705,7 +2705,7 @@ public class ServerHttpSecurity {
 		/**
 		 * Configures frame options response header
 		 *
-		 * @see #frameOptions()
+		 * @see HeaderSpec#frameOptions(Customizer)
 		 */
 		public final class FrameOptionsSpec {
 
@@ -2737,7 +2737,7 @@ public class ServerHttpSecurity {
 		/**
 		 * Configures Strict Transport Security response header
 		 *
-		 * @see #hsts()
+		 * @see HeaderSpec#hsts(Customizer)
 		 */
 		public final class HstsSpec {
 
@@ -2796,7 +2796,7 @@ public class ServerHttpSecurity {
 		/**
 		 * Configures x-xss-protection response header
 		 *
-		 * @see #xssProtection()
+		 * @see HeaderSpec#xssProtection(Customizer)
 		 */
 		public final class XssProtectionSpec {
 
@@ -2830,7 +2830,7 @@ public class ServerHttpSecurity {
 		 * Configures {@code Content-Security-Policy} response header.
 		 *
 		 * @since 5.1
-		 * @see #contentSecurityPolicy(String)
+		 * @see HeaderSpec#contentSecurityPolicy(Customizer)
 		 */
 		public final class ContentSecurityPolicySpec {
 
@@ -2884,8 +2884,7 @@ public class ServerHttpSecurity {
 			 * Allows method chaining to continue configuring the
 			 * {@link ServerHttpSecurity}.
 			 * @return the {@link HeaderSpec} to continue configuring
-			 * @deprecated For removal in 7.0. Use {@link #featurePolicy(Customizer)}
-			 * instead
+			 * @deprecated For removal in 7.0. Use {@link #featurePolicy(String)} instead
 			 */
 			@Deprecated(since = "6.1", forRemoval = true)
 			public HeaderSpec and() {
@@ -2898,7 +2897,7 @@ public class ServerHttpSecurity {
 		 * Configures {@code Permissions-Policy} response header.
 		 *
 		 * @since 5.5
-		 * @see #permissionsPolicy()
+		 * @see HeaderSpec#permissionsPolicy(Customizer)
 		 */
 		public final class PermissionsPolicySpec {
 
@@ -2921,8 +2920,7 @@ public class ServerHttpSecurity {
 		 * Configures {@code Referrer-Policy} response header.
 		 *
 		 * @since 5.1
-		 * @see #referrerPolicy()
-		 * @see #referrerPolicy(ReferrerPolicy)
+		 * @see HeaderSpec#referrerPolicy(Customizer)
 		 */
 		public final class ReferrerPolicySpec {
 


### PR DESCRIPTION
Fixed javadoc warnings and added javadoc-warnings-error plugin

the #featurePolicy warning at the #and method in FeaturePolicySpec was fixed for now by referencing the #featurePolicy(String) method which is still there. This can be fixed when the actual featurePolicy(Customizer) method is implemented

closes gh-18448