### PR TITLE
Fail spring-security-messaging on javadoc warnings

### DIFF
--- a/messaging/spring-security-messaging.gradle
+++ b/messaging/spring-security-messaging.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'security-nullability'
+	id 'javadoc-warnings-error'
 }
 
 apply plugin: 'io.spring.convention.spring-module'


### PR DESCRIPTION
Found no javadoc warnings but added javadoc-warnings-error plugin

Closes to gh-18458
