### PR TITLE
Fail on compiler warnings for spring-security-access

### DIFF
--- a/access/spring-security-access.gradle
+++ b/access/spring-security-access.gradle
@@ -1,4 +1,5 @@
 plugins {
+	id 'compile-warnings-error'
 	id 'javadoc-warnings-error'
 }
 


### PR DESCRIPTION
There were no compiler warnings.

## Changes

- Apply plugin `compile-warnings-error`

Closes gh-18414
