### PR TITLE
Remove compiler warnings for spring-security-webauthn

### DIFF
--- a/webauthn/spring-security-webauthn.gradle
+++ b/webauthn/spring-security-webauthn.gradle
@@ -1,4 +1,5 @@
 plugins {
+	id 'compile-warnings-error'
 	id 'security-nullability'
 }
 

--- a/webauthn/src/test/java/org/springframework/security/web/webauthn/authentication/WebAuthnAuthenticationFilterTests.java
+++ b/webauthn/src/test/java/org/springframework/security/web/webauthn/authentication/WebAuthnAuthenticationFilterTests.java
@@ -101,6 +101,7 @@ class WebAuthnAuthenticationFilterTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void setConverterWhenNullThenIllegalArgumentException() {
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> this.filter.setConverter((GenericHttpMessageConverter<Object>) null));

--- a/webauthn/src/test/java/org/springframework/security/web/webauthn/jackson/CredProtectAuthenticationExtensionsClientInputJackson2Tests.java
+++ b/webauthn/src/test/java/org/springframework/security/web/webauthn/jackson/CredProtectAuthenticationExtensionsClientInputJackson2Tests.java
@@ -29,6 +29,7 @@ import org.springframework.security.web.webauthn.api.ImmutableAuthenticationExte
  *
  * @author Rob Winch
  */
+@SuppressWarnings("removal")
 class CredProtectAuthenticationExtensionsClientInputJackson2Tests {
 
 	private ObjectMapper mapper;

--- a/webauthn/src/test/java/org/springframework/security/web/webauthn/jackson/Jackson2Tests.java
+++ b/webauthn/src/test/java/org/springframework/security/web/webauthn/jackson/Jackson2Tests.java
@@ -44,6 +44,7 @@ import org.springframework.security.web.webauthn.api.UserVerificationRequirement
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("removal")
 class Jackson2Tests {
 
 	private ObjectMapper mapper;


### PR DESCRIPTION
## Changes

- Add `@SuppressWarnings("removal")` to `WebAuthnAuthenticationFilterTests.java` (tests null validation for deprecated `setConverter(GenericHttpMessageConverter)` method)                                                                                                        
- Add `@SuppressWarnings("removal")` to `Jackson2Tests.java` (tests deprecated `WebauthnJackson2Module` class)                                                 
- Add `@SuppressWarnings("removal")` to `CredProtectAuthenticationExtensionsClientInputJackson2Tests.java` (tests deprecated `WebauthnJackson2Module` class)  
- Apply plugin `compile-warnings-error`

Closes gh-18442