### PR TITLE
Fail on compiler warnings for spring-security-acl

### DIFF
--- a/acl/spring-security-acl.gradle
+++ b/acl/spring-security-acl.gradle
@@ -1,4 +1,5 @@
 plugins {
+	id 'compile-warnings-error'
 	id 'javadoc-warnings-error'
 }
 


### PR DESCRIPTION
There were no compiler warnings.

## Changes

- Apply plugin `compile-warnings-error`

Closes gh-18415