### PR TITLE
Add reactive handle method to ServerCsrfTokenRequestHandler

### DIFF
--- a/config/src/test/java/org/springframework/security/config/web/server/ServerHttpSecurityTests.java
+++ b/config/src/test/java/org/springframework/security/config/web/server/ServerHttpSecurityTests.java
@@ -552,6 +552,7 @@ public class ServerHttpSecurityTests {
 		given(this.csrfTokenRepository.loadToken(any(ServerWebExchange.class))).willReturn(Mono.just(csrfToken));
 		given(this.csrfTokenRepository.generateToken(any(ServerWebExchange.class))).willReturn(Mono.empty());
 		ServerCsrfTokenRequestHandler requestHandler = mock(ServerCsrfTokenRequestHandler.class);
+		given(requestHandler.handleAsync(any(ServerWebExchange.class), any())).willReturn(Mono.empty());
 		given(requestHandler.resolveCsrfTokenValue(any(ServerWebExchange.class), any(CsrfToken.class)))
 			.willReturn(Mono.just(csrfToken.getToken()));
 		// @formatter:off
@@ -564,7 +565,7 @@ public class ServerHttpSecurityTests {
 		client.post().uri("/").exchange().expectStatus().isOk();
 		verify(this.csrfTokenRepository, times(2)).loadToken(any(ServerWebExchange.class));
 		verify(this.csrfTokenRepository).generateToken(any(ServerWebExchange.class));
-		verify(requestHandler).handle(any(ServerWebExchange.class), any());
+		verify(requestHandler).handleAsync(any(ServerWebExchange.class), any());
 		verify(requestHandler).resolveCsrfTokenValue(any(ServerWebExchange.class), any());
 	}
 

--- a/web/src/main/java/org/springframework/security/web/server/csrf/CsrfWebFilter.java
+++ b/web/src/main/java/org/springframework/security/web/server/csrf/CsrfWebFilter.java
@@ -60,6 +60,7 @@ import org.springframework.web.server.WebFilterChain;
  * @author Rob Winch
  * @author Parikshit Dutta
  * @author Steve Riesenberg
+ * @author Andrey Litvitski
  * @since 5.0
  */
 public class CsrfWebFilter implements WebFilter {
@@ -147,8 +148,7 @@ public class CsrfWebFilter implements WebFilter {
 	private Mono<Void> continueFilterChain(ServerWebExchange exchange, WebFilterChain chain) {
 		return Mono.defer(() -> {
 			Mono<CsrfToken> csrfToken = csrfToken(exchange);
-			this.requestHandler.handle(exchange, csrfToken);
-			return chain.filter(exchange);
+			return this.requestHandler.handleAsync(exchange, csrfToken).then(chain.filter(exchange));
 		});
 	}
 

--- a/web/src/main/java/org/springframework/security/web/server/csrf/ServerCsrfTokenRequestHandler.java
+++ b/web/src/main/java/org/springframework/security/web/server/csrf/ServerCsrfTokenRequestHandler.java
@@ -29,6 +29,7 @@ import org.springframework.web.server.ServerWebExchange;
  * made available to the application through exchange attributes.
  *
  * @author Steve Riesenberg
+ * @author Andrey Litvitski
  * @since 5.8
  * @see ServerCsrfTokenRequestAttributeHandler
  */
@@ -40,8 +41,22 @@ public interface ServerCsrfTokenRequestHandler extends ServerCsrfTokenRequestRes
 	 * @param exchange the {@code ServerWebExchange} with the request being handled
 	 * @param csrfToken the {@code Mono<CsrfToken>} created by the
 	 * {@link ServerCsrfTokenRepository}
+	 * @deprecated since 7.0 in favor of {@link #handleAsync(ServerWebExchange, Mono)}
 	 */
+	@Deprecated(since = "7.0", forRemoval = true)
 	void handle(ServerWebExchange exchange, Mono<CsrfToken> csrfToken);
+
+	/**
+	 * Handles a request using a {@link CsrfToken}.
+	 * @param exchange the {@code ServerWebExchange} with the request being handled
+	 * @param csrfToken the {@code Mono<CsrfToken>} created by the
+	 * {@link ServerCsrfTokenRepository}
+	 * @return a {@code Mono} that completes when handling is finished
+	 */
+	default Mono<Void> handleAsync(ServerWebExchange exchange, Mono<CsrfToken> csrfToken) {
+		handle(exchange, csrfToken);
+		return Mono.empty();
+	}
 
 	@Override
 	default Mono<String> resolveCsrfTokenValue(ServerWebExchange exchange, CsrfToken csrfToken) {

--- a/web/src/test/java/org/springframework/security/web/server/csrf/CsrfWebFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/csrf/CsrfWebFilterTests.java
@@ -164,6 +164,7 @@ public class CsrfWebFilterTests {
 	@Test
 	public void filterWhenRequestHandlerSetThenUsed() {
 		ServerCsrfTokenRequestHandler requestHandler = mock(ServerCsrfTokenRequestHandler.class);
+		given(requestHandler.handleAsync(any(ServerWebExchange.class), any())).willReturn(Mono.empty());
 		given(requestHandler.resolveCsrfTokenValue(any(ServerWebExchange.class), any(CsrfToken.class)))
 			.willReturn(Mono.just(this.token.getToken()));
 		this.csrfFilter.setRequestHandler(requestHandler);
@@ -179,7 +180,7 @@ public class CsrfWebFilterTests {
 		StepVerifier.create(result).verifyComplete();
 		chainResult.assertWasSubscribed();
 
-		verify(requestHandler).handle(eq(this.post), any());
+		verify(requestHandler).handleAsync(eq(this.post), any());
 		verify(requestHandler).resolveCsrfTokenValue(this.post, this.token);
 	}
 


### PR DESCRIPTION
Returning Mono<Void> from `ServerCsrfTokenRequestHandler#handle` would allow non-blocking response writes.

Closes: gh-16869
