### PR TITLE
Construct SecureRandom in BCryptPasswordEncoder

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoder.java
@@ -17,6 +17,7 @@
 package org.springframework.security.crypto.bcrypt;
 
 import java.security.SecureRandom;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -44,7 +45,7 @@ public class BCryptPasswordEncoder extends AbstractValidatingPasswordEncoder {
 
 	private final BCryptVersion version;
 
-	private final SecureRandom random;
+	private final Supplier<SecureRandom> random;
 
 	public BCryptPasswordEncoder() {
 		this(-1);
@@ -99,7 +100,7 @@ public class BCryptPasswordEncoder extends AbstractValidatingPasswordEncoder {
 		}
 		this.version = version;
 		this.strength = (strength == -1) ? 10 : strength;
-		this.random = (random != null) ? random : SecureRandomHolder.INSTANCE;
+		this.random = (random != null) ? () -> random : SecureRandomHolder::getInstance;
 	}
 
 	@Override
@@ -109,7 +110,7 @@ public class BCryptPasswordEncoder extends AbstractValidatingPasswordEncoder {
 	}
 
 	private String getSalt() {
-		return BCrypt.gensalt(this.version.getVersion(), this.strength, this.random);
+		return BCrypt.gensalt(this.version.getVersion(), this.strength, this.random.get());
 	}
 
 	@Override
@@ -159,6 +160,10 @@ public class BCryptPasswordEncoder extends AbstractValidatingPasswordEncoder {
 	private static final class SecureRandomHolder {
 
 		private static final SecureRandom INSTANCE = new SecureRandom();
+
+		private static SecureRandom getInstance() {
+			return INSTANCE;
+		}
 
 	}
 


### PR DESCRIPTION
Deprecate `BCrypt.gensalt(String, int)` and modify `BCryptPasswordEncoder` constructors to create and reuse `SecureRandom` instances.

Closes gh-17824