### PR TITLE
Clarify need for method attribute in JSP authorize tag

### DIFF
--- a/docs/modules/ROOT/pages/servlet/integrations/jsp-taglibs.adoc
+++ b/docs/modules/ROOT/pages/servlet/integrations/jsp-taglibs.adoc
@@ -63,19 +63,9 @@ To use this tag, you must also have an instance of `WebInvocationPrivilegeEvalua
 If you are using the namespace, one is automatically registered.
 This is an instance of `DefaultWebInvocationPrivilegeEvaluator`, which creates a dummy web request for the supplied URL and invokes the security interceptor to see whether the request would succeed or fail.
 This lets you delegate to the access-control setup you defined by using `intercept-url` declarations within the `<http>` namespace configuration and saves having to duplicate the information (such as the required roles) within your JSPs.
-You can also combine this approach with a `method` attribute (supplying the HTTP method, such as `POST`) for a more specific match.
 
-[NOTE]
-====
-If the underlying authorization configuration uses a `RequestMatcher` that is constrained to an HTTP method
-(for example, an `AntPathRequestMatcher` or `MvcRequestMatcher` configured with a method),
-specify the same `method` on the `<sec:authorize>` tag so that it can be evaluated against the intended rule.
-
-When access rules are method-specific, omitting `method` may cause the tag to be evaluated without an HTTP method,
-which can lead to unexpected results.
-
-For example, if access is configured for `POST /admin`, then use `<sec:authorize url="/admin" method="POST">`.
-====
+If you have xref:servlet/authorization/authorize-http-requests.adoc#match-by-httpmethod[method-based authorization rules], you should combine this approach with the `method` attribute (supplying the HTTP method, such as `POST`) to activate the intended method-based rule.
+For example, if you have a rule `.requestMatchers(POST, "/admin").hasRole("ADMIN")`, then you should do `<sec:authorize method="POST" url="/admin">` to match.
 
 You can store the Boolean result of evaluating the tag (whether it grants or denies access) in a page context scope variable by setting the `var` attribute to the variable name, avoiding the need for duplicating and re-evaluating the condition at other points in the page.
 


### PR DESCRIPTION
Closes gh-16530

Adds a NOTE to the JSP taglibs documentation clarifying that when authorization is configured with a method-specific RequestMatcher, <sec:authorize> should specify the corresponding method so it is evaluated against the intended rule.

This follows the background discussion in gh-16529.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
