### PR TITLE
Remove compiler warnings for spring-security-rsocket

### DIFF
--- a/rsocket/spring-security-rsocket.gradle
+++ b/rsocket/spring-security-rsocket.gradle
@@ -1,4 +1,5 @@
 plugins {
+	id 'compile-warnings-error'
 	id 'security-nullability'
 }
 
@@ -8,6 +9,7 @@ dependencies {
 	management platform(project(":spring-security-dependencies"))
 	api project(':spring-security-core')
 	api 'io.rsocket:rsocket-core'
+	compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 	optional project(':spring-security-oauth2-resource-server')
 	optional 'org.springframework:spring-messaging'
 	testImplementation 'io.projectreactor:reactor-test'


### PR DESCRIPTION
Closes gh-18437

  ## Changes

  - Apply plugin `compile-warnings-error`
  - Add `jsr305` as compileOnly dependency to resolve `unknown enum constant When.MAYBE` warning caused by reactor-core/rsocket-core dependencies


  ### Before
<img width="1529" height="402" alt="스크린샷 2026-01-25 오후 6 31 26" src="https://github.com/user-attachments/assets/4e030a51-5a4c-46e2-891a-ee342e5b7c46" />

  ### After
<img width="1519" height="412" alt="스크린샷 2026-01-25 오후 6 45 47" src="https://github.com/user-attachments/assets/8733152f-b43d-4664-8422-e524407abb46" />

  ## Remaining Deprecation Note

  `AuthenticationPayloadInterceptor` uses deprecated `BasicAuthenticationPayloadExchangeConverter` as default value.

  Changing the default to `AuthenticationPayloadExchangeConverter` would resolve this warning, but it may introduce a **breaking change** since the two converters use different authentication protocols:
  - `BasicAuthenticationPayloadExchangeConverter`: `BASIC_AUTHENTICATION_MIME_TYPE`
  - `AuthenticationPayloadExchangeConverter`: RSocket Authentication Extension

  Please advise if this change should be included.


  ## Test plan

  - [x] `./gradlew --no-build-cache clean :spring-security-rsocket:check`
