### PR TITLE
 Fail on compiler warnings for spring-security-javascript

### DIFF
--- a/javascript/spring-security-javascript.gradle
+++ b/javascript/spring-security-javascript.gradle
@@ -18,6 +18,7 @@
 plugins {
     id 'base'
     id 'com.github.node-gradle.node' version '7.1.0'
+    id 'compile-warnings-error'
 }
 
 node {


### PR DESCRIPTION
Closes gh-18425

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
