### PR TITLE
Remove compiler warnings for spring-security-kerberos-core

### DIFF
--- a/kerberos/kerberos-core/spring-security-kerberos-core.gradle
+++ b/kerberos/kerberos-core/spring-security-kerberos-core.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'security-nullability'
 	id 'io.spring.convention.spring-module'
 	id 'javadoc-warnings-error'
+	id 'compile-warnings-error'
 }
 
 description = 'Spring Security Kerberos Core'


### PR DESCRIPTION
Closes gh-18427

No compiler warnings for `spring-security-kerberos-core` if `spring-security-core` has been resolved
<img width="1430" height="323" alt="image" src="https://github.com/user-attachments/assets/a9490d7d-908b-48d9-9250-a3234d950bea" />

