### PR TITLE
Remove compiler warnings for spring-security-kerberos-web

### DIFF
--- a/kerberos/kerberos-web/spring-security-kerberos-web.gradle
+++ b/kerberos/kerberos-web/spring-security-kerberos-web.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'security-nullability'
 	id 'io.spring.convention.spring-module'
 	id 'javadoc-warnings-error'
+	id 'compile-warnings-error'
 }
 
 description = 'Spring Security Kerberos Web'


### PR DESCRIPTION
Closes gh-18429

No compiler warnings for `spring-security-kerberos-web` if `spring-security-web` has been resolved
<img width="1380" height="545" alt="image" src="https://github.com/user-attachments/assets/a221947b-bd0e-4121-8fbd-447d0c28e78d" />
