### PR TITLE
Remove compiler warnings for spring-security-saml2-service-provider

### DIFF
--- a/saml2/saml2-service-provider/spring-security-saml2-service-provider.gradle
+++ b/saml2/saml2-service-provider/spring-security-saml2-service-provider.gradle
@@ -1,3 +1,7 @@
+plugins {
+	id 'compile-warnings-error'
+}
+
 apply plugin: 'io.spring.convention.spring-module'
 
 configurations {
@@ -109,6 +113,7 @@ dependencies {
 
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testRuntimeOnly 'org.hsqldb:hsqldb'
+	opensamlFiveMain "org.apiguardian:apiguardian-api:1.1.2"
 }
 
 jar {


### PR DESCRIPTION
Closes gh-18438

Add `opensamlFiveMain "org.apiguardian:apiguardian-api:1.1.2"` to prevent the warning `unknown enum constant Status.STABLE`
