### PR TITLE
Fail on compiler warnings for spring-security-taglibs

### DIFF
--- a/taglibs/spring-security-taglibs.gradle
+++ b/taglibs/spring-security-taglibs.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'security-nullability'
+	id 'compile-warnings-error'
 }
 
 apply plugin: 'io.spring.convention.spring-module'


### PR DESCRIPTION
Closes gh-18439

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
