### PR TITLE
Remove compiler warnings for spring-security-cas

### DIFF
--- a/cas/spring-security-cas.gradle
+++ b/cas/spring-security-cas.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id 'security-nullability'
 	id 'javadoc-warnings-error'
+	id 'compile-warnings-error'
 }
 
 apply plugin: 'io.spring.convention.spring-module'

--- a/cas/src/main/java/org/springframework/security/cas/web/CasAuthenticationEntryPoint.java
+++ b/cas/src/main/java/org/springframework/security/cas/web/CasAuthenticationEntryPoint.java
@@ -91,7 +91,8 @@ public class CasAuthenticationEntryPoint implements AuthenticationEntryPoint, In
 	 */
 	protected String createServiceUrl(HttpServletRequest request, HttpServletResponse response) {
 		return WebUtils.constructServiceUrl(null, response, this.serviceProperties.getService(), null,
-				this.serviceProperties.getArtifactParameter(), this.encodeServiceUrlWithSessionId);
+				this.serviceProperties.getServiceParameter(), this.serviceProperties.getArtifactParameter(),
+				this.encodeServiceUrlWithSessionId);
 	}
 
 	/**


### PR DESCRIPTION
Closes https://github.com/spring-projects/spring-security/issues/18418

### **Summary**

When running ./gradlew --no-build-cache clean :spring-security-cas:check, CasAuthenticationEntryPoint was using the deprecated WebUtils.constructServiceUrl overload (6 parameters).


### **Changes**
-Apply plugin compile-warnings-error
-Use the non-deprecated 7-parameter overload and passes serviceParameter from serviceProperties.
CasGatewayAuthenticationRedirectFilter already uses this API and retrieves serviceParameter from serviceProperties, so I followed the same approach for consistency.

### **Test**
 ./gradlew --no-build-cache clean :spring-security-cas:check