### PR TITLE
Clarify behavior when multiple CorsConfigurationSource beans are present

### DIFF
--- a/docs/modules/ROOT/pages/servlet/integrations/cors.adoc
+++ b/docs/modules/ROOT/pages/servlet/integrations/cors.adoc
@@ -42,6 +42,42 @@ fun corsConfigurationSource(): UrlBasedCorsConfigurationSource {
 ----
 ======
 
+[[cors-multiple-beans]]
+===== Multiple CorsConfigurationSource Beans
+
+When using Spring Boot 3 or Spring Framework 6, you may encounter an error like:
+
+----
+Parameter X of constructor ... required a single bean, but 2 were found:
+- corsConfigurationSource
+- ...
+----
+
+This happens when more than one `CorsConfigurationSource` bean is present in the application context.
+
+Spring Security does not automatically choose one when multiple candidates are available.
+
+To resolve this, explicitly specify which `CorsConfigurationSource` should be used in your security configuration.
+
+[source,java]
+----
+@Configuration
+public class SecurityConfig {
+
+  public SecurityConfig(
+      @Qualifier("corsConfigurationSource")
+      CorsConfigurationSource corsConfigurationSource) {
+    ...
+  }
+
+}
+----
+
+Alternatively, you can mark one of the beans as `@Primary` so that it becomes the default candidate.
+
+Explicit configuration is the recommended approach when using a custom CORS setup.
+
+
 The following listing does the same thing in XML:
 
 [source,xml]


### PR DESCRIPTION
## Motivation

When more than one `CorsConfigurationSource` bean is present in the application context,
Spring Security fails to start with an ambiguous bean definition error.

From a user’s perspective, this is confusing because a custom
`CorsConfigurationSource` bean may already be defined, yet Spring Security
does not indicate which one it expects to use.

The current CORS section of the reference documentation does not describe
what happens when multiple `CorsConfigurationSource` beans are present.

---

## Changes in this PR

This PR updates the CORS section of the Spring Security reference documentation to:

- Clarify that Spring Security does not automatically select one
  `CorsConfigurationSource` when multiple candidates are available.
- Explain that users must explicitly specify which bean should be used.
- Show common ways to do this using `@Qualifier`, `@Primary`, or the `.cors()` DSL.

---

## Related Issue

Fixes #18583
