### PR TITLE
Lazily instantiate default components in WebAuthnConfigurer

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/WebAuthnConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/WebAuthnConfigurer.java
@@ -169,9 +169,9 @@ public class WebAuthnConfigurer<H extends HttpSecurityBuilder<H>>
 			.orElseThrow(() -> new IllegalStateException("Missing UserDetailsService Bean"));
 		PublicKeyCredentialUserEntityRepository userEntities = getSharedOrBean(http,
 				PublicKeyCredentialUserEntityRepository.class)
-			.orElse(userEntityRepository());
+			.orElseGet(this::userEntityRepository);
 		UserCredentialRepository userCredentials = getSharedOrBean(http, UserCredentialRepository.class)
-			.orElse(userCredentialRepository());
+			.orElseGet(this::userCredentialRepository);
 		WebAuthnRelyingPartyOperations rpOperations = webAuthnRelyingPartyOperations(userEntities, userCredentials);
 		PublicKeyCredentialCreationOptionsRepository creationOptionsRepository = creationOptionsRepository();
 		WebAuthnAuthenticationFilter webAuthnAuthnFilter = new WebAuthnAuthenticationFilter();


### PR DESCRIPTION
Fixes #gh-18585

This PR replaces orElse with orElseGet in WebAuthnConfigurer
to ensure lazy instantiation of default repositories.

In the configure method of WebAuthnConfigurer, Optional.orElse() is currently
used to provide default implementations when specific Beans are not found
in the ApplicationContext.

<img width="831" height="209" alt="image" src="https://github.com/user-attachments/assets/11679edc-93ce-4ff6-b764-38b1d4e3f3c8" />

However, orElse() evaluates its argument eagerly. As a result,
userEntityRepository() and userCredentialRepository() are always invoked,
instantiating new repository objects even when a corresponding repository
Bean is already present in the ApplicationContext.

This leads to unnecessary object creation each time the configuration
is initialized.

I propose replacing orElse with orElseGet to ensure that the default
repositories are instantiated only when the Optional is empty.

<img width="838" height="205" alt="image" src="https://github.com/user-attachments/assets/d32eccf1-ca01-4c0b-955b-2d7de78fbcce" />


This change aligns with Java Optional best practices by avoiding unnecessary
object creation and ensuring that default components are initialized only
when they are actually needed.
