### PR TITLE
Fail spring-security-test on javadoc warnings

### DIFF
--- a/test/spring-security-test.gradle
+++ b/test/spring-security-test.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'security-nullability'
+	id 'javadoc-warnings-error'
 }
 
 apply plugin: 'io.spring.convention.spring-module'


### PR DESCRIPTION
Found no existing javadoc warnings by running ./gradlew --no-build-cache clean :spring-security-test:javadoc

Applied the javadoc-warnings-error plugin to ensure any future Javadoc warnings result in a build failure, as requested in gh-18443 and following the example in #18517.

Closes gh-18467