### PR TITLE
Fix compile warning in spring-security-test

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurationTests.java
@@ -222,7 +222,8 @@ public class WebSecurityConfigurationTests {
 	// SEC-2773
 	@Test
 	public void getMethodDelegatingApplicationListenerWhenWebSecurityConfigurationThenIsStatic() {
-		Method method = ClassUtils.getMethod(WebSecurityConfiguration.class, "delegatingApplicationListener", null);
+		Method method = ClassUtils.getMethod(WebSecurityConfiguration.class, "delegatingApplicationListener",
+				(Class<?>[]) null);
 		assertThat(Modifier.isStatic(method.getModifiers())).isTrue();
 	}
 

--- a/core/src/test/java/org/springframework/security/authentication/ott/OneTimeTokenAuthenticationTokenTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/ott/OneTimeTokenAuthenticationTokenTests.java
@@ -31,6 +31,7 @@ class OneTimeTokenAuthenticationTokenTests {
 
 	// gh-18095
 	@Test
+	@SuppressWarnings("removal")
 	void shouldBeAbleToDeserializeFromJsonWithDefaultTypingActivated() throws IOException {
 		ObjectMapper mapper = new ObjectMapper();
 		mapper.registerModules(SecurityJackson2Modules.getModules(getClass().getClassLoader()));

--- a/core/src/test/java/org/springframework/security/authentication/ott/reactive/OneTimeTokenReactiveAuthenticationManagerTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/ott/reactive/OneTimeTokenReactiveAuthenticationManagerTests.java
@@ -59,6 +59,7 @@ public class OneTimeTokenReactiveAuthenticationManagerTests {
 	private static final String TOKEN = "token";
 
 	@Test
+	@SuppressWarnings("removal")
 	public void constructorWhenOneTimeTokenServiceNullThenIllegalArgumentException() {
 		ReactiveUserDetailsService userDetailsService = mock(ReactiveUserDetailsService.class);
 		// @formatter:off
@@ -68,6 +69,7 @@ public class OneTimeTokenReactiveAuthenticationManagerTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	public void constructorWhenUserDetailsServiceNullThenIllegalArgumentException() {
 		ReactiveOneTimeTokenService oneTimeTokenService = mock(ReactiveOneTimeTokenService.class);
 		// @formatter:off
@@ -77,6 +79,7 @@ public class OneTimeTokenReactiveAuthenticationManagerTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void authenticateWhenOneTimeTokenAuthenticationTokenIsPresentThenSuccess() {
 		ReactiveOneTimeTokenService oneTimeTokenService = mock(ReactiveOneTimeTokenService.class);
 		given(oneTimeTokenService.consume(ArgumentMatchers.any(OneTimeTokenAuthenticationToken.class)))
@@ -103,6 +106,7 @@ public class OneTimeTokenReactiveAuthenticationManagerTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void authenticateWhenInvalidOneTimeTokenAuthenticationTokenIsPresentThenFail() {
 		ReactiveOneTimeTokenService oneTimeTokenService = mock(ReactiveOneTimeTokenService.class);
 		given(oneTimeTokenService.consume(ArgumentMatchers.any(OneTimeTokenAuthenticationToken.class)))
@@ -120,6 +124,7 @@ public class OneTimeTokenReactiveAuthenticationManagerTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void authenticateWhenIncorrectTypeOfAuthenticationIsPresentThenFail() {
 		ReactiveOneTimeTokenService oneTimeTokenService = mock(ReactiveOneTimeTokenService.class);
 		given(oneTimeTokenService.consume(ArgumentMatchers.any(OneTimeTokenAuthenticationToken.class)))

--- a/core/src/test/java/org/springframework/security/authorization/AuthorityAuthorizationManagerTests.java
+++ b/core/src/test/java/org/springframework/security/authorization/AuthorityAuthorizationManagerTests.java
@@ -61,7 +61,7 @@ public class AuthorityAuthorizationManagerTests {
 
 	@Test
 	public void hasAnyRoleWhenNullThenException() {
-		assertThatIllegalArgumentException().isThrownBy(() -> AuthorityAuthorizationManager.hasAnyRole(null))
+		assertThatIllegalArgumentException().isThrownBy(() -> AuthorityAuthorizationManager.hasAnyRole((String[]) null))
 			.withMessage("roles cannot be empty");
 	}
 
@@ -97,7 +97,8 @@ public class AuthorityAuthorizationManagerTests {
 
 	@Test
 	public void hasAnyAuthorityWhenNullThenException() {
-		assertThatIllegalArgumentException().isThrownBy(() -> AuthorityAuthorizationManager.hasAnyAuthority(null))
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> AuthorityAuthorizationManager.hasAnyAuthority((String[]) null))
 			.withMessage("authorities cannot be empty");
 	}
 

--- a/core/src/test/kotlin/org/springframework/security/access/expression/method/DefaultMethodSecurityExpressionHandlerKotlinTests.kt
+++ b/core/src/test/kotlin/org/springframework/security/access/expression/method/DefaultMethodSecurityExpressionHandlerKotlinTests.kt
@@ -73,7 +73,8 @@ class DefaultMethodSecurityExpressionHandlerKotlinTests {
         )
 
         assertThat(filtered).isInstanceOf(Map::class.java)
-        val result = (filtered as Map<String, String>)
+        @Suppress("UNCHECKED_CAST")
+        val result = filtered as Map<String, String>
         assertThat(result).hasSize(1)
         assertThat(result).containsKey("key2")
         assertThat(result).containsValue("value2")
@@ -95,7 +96,8 @@ class DefaultMethodSecurityExpressionHandlerKotlinTests {
         )
 
         assertThat(filtered).isInstanceOf(Map::class.java)
-        val result = (filtered as Map<String, String>)
+        @Suppress("UNCHECKED_CAST")
+        val result = filtered as Map<String, String>
         assertThat(result).hasSize(0)
     }
 
@@ -119,7 +121,8 @@ class DefaultMethodSecurityExpressionHandlerKotlinTests {
         )
 
         assertThat(filtered).isInstanceOf(Collection::class.java)
-        val result = (filtered as Collection<String>)
+        @Suppress("UNCHECKED_CAST")
+        val result = filtered as Collection<String>
         assertThat(result).hasSize(1)
         assertThat(result).contains("string2")
     }
@@ -140,7 +143,8 @@ class DefaultMethodSecurityExpressionHandlerKotlinTests {
         )
 
         assertThat(filtered).isInstanceOf(Collection::class.java)
-        val result = (filtered as Collection<String>)
+        @Suppress("UNCHECKED_CAST")
+        val result = filtered as Collection<String>
         assertThat(result).hasSize(0)
     }
 
@@ -164,7 +168,8 @@ class DefaultMethodSecurityExpressionHandlerKotlinTests {
         )
 
         assertThat(filtered).isInstanceOf(Array<String>::class.java)
-        val result = (filtered as Array<String>)
+        @Suppress("UNCHECKED_CAST")
+        val result = filtered as Array<String>
         assertThat(result).hasSize(1)
         assertThat(result).contains("string2")
     }
@@ -185,7 +190,8 @@ class DefaultMethodSecurityExpressionHandlerKotlinTests {
         )
 
         assertThat(filtered).isInstanceOf(Array<String>::class.java)
-        val result = (filtered as Array<String>)
+        @Suppress("UNCHECKED_CAST")
+        val result = filtered as Array<String>
         assertThat(result).hasSize(0)
     }
 
@@ -209,6 +215,7 @@ class DefaultMethodSecurityExpressionHandlerKotlinTests {
         )
 
         assertThat(filtered).isInstanceOf(Stream::class.java)
+        @Suppress("UNCHECKED_CAST")
         val result = (filtered as Stream<String>).toList()
         assertThat(result).hasSize(1)
         assertThat(result).contains("string2")
@@ -230,6 +237,7 @@ class DefaultMethodSecurityExpressionHandlerKotlinTests {
         )
 
         assertThat(filtered).isInstanceOf(Stream::class.java)
+        @Suppress("UNCHECKED_CAST")
         val result = (filtered as Stream<String>).toList()
         assertThat(result).hasSize(0)
     }

--- a/test/spring-security-test.gradle
+++ b/test/spring-security-test.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id 'security-nullability'
 	id 'javadoc-warnings-error'
+	id 'compile-warnings-error'
 }
 
 apply plugin: 'io.spring.convention.spring-module'

--- a/web/src/test/java/org/springframework/security/web/authentication/DelegatingAuthenticationEntryPointTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/DelegatingAuthenticationEntryPointTests.java
@@ -65,6 +65,7 @@ public class DelegatingAuthenticationEntryPointTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	public void testDefaultEntryPoint() throws Exception {
 		AuthenticationEntryPoint firstAEP = mock(AuthenticationEntryPoint.class);
 		RequestMatcher firstRM = mock(RequestMatcher.class);
@@ -78,6 +79,7 @@ public class DelegatingAuthenticationEntryPointTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	public void testFirstEntryPoint() throws Exception {
 		AuthenticationEntryPoint firstAEP = mock(AuthenticationEntryPoint.class);
 		RequestMatcher firstRM = mock(RequestMatcher.class);
@@ -96,6 +98,7 @@ public class DelegatingAuthenticationEntryPointTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	public void testSecondEntryPoint() throws Exception {
 		AuthenticationEntryPoint firstAEP = mock(AuthenticationEntryPoint.class);
 		RequestMatcher firstRM = mock(RequestMatcher.class);
@@ -114,6 +117,7 @@ public class DelegatingAuthenticationEntryPointTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	public void constructorAepListWhenNullEntryPoints() {
 		List<RequestMatcherEntry<AuthenticationEntryPoint>> entryPoints = null;
 		assertThatIllegalArgumentException().isThrownBy(
@@ -121,6 +125,7 @@ public class DelegatingAuthenticationEntryPointTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	public void constructorAepListWhenEmptyEntryPoints() {
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> new DelegatingAuthenticationEntryPoint(mock(AuthenticationEntryPoint.class),
@@ -128,6 +133,7 @@ public class DelegatingAuthenticationEntryPointTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	public void constructorAepListWhenNullDefaultEntryPoint() {
 		AuthenticationEntryPoint entryPoint = mock(AuthenticationEntryPoint.class);
 		RequestMatcher matcher = mock(RequestMatcher.class);
@@ -138,6 +144,7 @@ public class DelegatingAuthenticationEntryPointTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	public void constructorAepVargsWhenNullEntryPoints() {
 		RequestMatcherEntry<AuthenticationEntryPoint>[] entryPoints = null;
 		assertThatIllegalArgumentException().isThrownBy(
@@ -145,6 +152,7 @@ public class DelegatingAuthenticationEntryPointTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	public void constructorAepVargsWhenEmptyEntryPoints() {
 		RequestMatcherEntry<AuthenticationEntryPoint>[] entryPoints = new RequestMatcherEntry[0];
 		assertThatIllegalArgumentException().isThrownBy(
@@ -152,6 +160,7 @@ public class DelegatingAuthenticationEntryPointTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	public void constructorAepVargsWhenNullDefaultEntryPoint() {
 		AuthenticationEntryPoint entryPoint = mock(AuthenticationEntryPoint.class);
 		RequestMatcher matcher = mock(RequestMatcher.class);
@@ -162,6 +171,7 @@ public class DelegatingAuthenticationEntryPointTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	public void commenceWhenNoMatchThenDefaultEntryPoint() throws Exception {
 		AuthenticationEntryPoint firstAEP = mock(AuthenticationEntryPoint.class);
 		RequestMatcher firstRM = mock(RequestMatcher.class);
@@ -174,6 +184,7 @@ public class DelegatingAuthenticationEntryPointTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	public void commenceWhenMatchFirstEntryPointThenOthersNotInvoked() throws Exception {
 		AuthenticationEntryPoint firstAEP = mock(AuthenticationEntryPoint.class);
 		RequestMatcher firstRM = mock(RequestMatcher.class);
@@ -192,6 +203,7 @@ public class DelegatingAuthenticationEntryPointTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	public void commenceWhenSecondMatchesThenDefaultNotInvoked() throws Exception {
 		AuthenticationEntryPoint firstAEP = mock(AuthenticationEntryPoint.class);
 		RequestMatcher firstRM = mock(RequestMatcher.class);
@@ -220,6 +232,7 @@ public class DelegatingAuthenticationEntryPointTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void builderWhenDefaultNullThenFirstIsDefault() throws ServletException, IOException {
 		AuthenticationEntryPoint firstEntryPoint = mock(AuthenticationEntryPoint.class);
 		AuthenticationEntryPoint secondEntryPoint = mock(AuthenticationEntryPoint.class);
@@ -237,6 +250,7 @@ public class DelegatingAuthenticationEntryPointTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void builderWhenDefaultAndEmptyEntryPointsThenReturnsDefault() {
 		AuthenticationEntryPoint defaultEntryPoint = mock(AuthenticationEntryPoint.class);
 
@@ -248,6 +262,7 @@ public class DelegatingAuthenticationEntryPointTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void builderWhenNoEntryPointsThenIllegalStateException() {
 		DelegatingAuthenticationEntryPoint.Builder builder = DelegatingAuthenticationEntryPoint.builder();
 		assertThatIllegalStateException().isThrownBy(builder::build);

--- a/web/src/test/java/org/springframework/security/web/authentication/ott/OneTimeTokenAuthenticationFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/ott/OneTimeTokenAuthenticationFilterTests.java
@@ -70,11 +70,13 @@ class OneTimeTokenAuthenticationFilterTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void setAuthenticationConverterWhenNullThenIllegalArgumentException() {
 		assertThatIllegalArgumentException().isThrownBy(() -> this.filter.setAuthenticationConverter(null));
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void doFilterWhenUrlDoesNotMatchThenContinues() throws ServletException, IOException {
 		OneTimeTokenAuthenticationConverter converter = mock(OneTimeTokenAuthenticationConverter.class);
 		HttpServletResponse response = mock(HttpServletResponse.class);
@@ -85,6 +87,7 @@ class OneTimeTokenAuthenticationFilterTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void doFilterWhenMethodDoesNotMatchThenContinues() throws ServletException, IOException {
 		OneTimeTokenAuthenticationConverter converter = mock(OneTimeTokenAuthenticationConverter.class);
 		HttpServletResponse response = mock(HttpServletResponse.class);
@@ -95,6 +98,7 @@ class OneTimeTokenAuthenticationFilterTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void doFilterWhenMissingTokenThenPropagatesRequest() throws ServletException, IOException {
 		FilterChain chain = mock(FilterChain.class);
 		this.filter.doFilter(post("/login/ott").buildRequest(new MockServletContext()), this.response, chain);
@@ -102,6 +106,7 @@ class OneTimeTokenAuthenticationFilterTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void doFilterWhenInvalidTokenThenUnauthorized() throws ServletException, IOException {
 		given(this.authenticationManager.authenticate(any())).willThrow(new BadCredentialsException("invalid token"));
 		this.filter.doFilter(
@@ -112,6 +117,7 @@ class OneTimeTokenAuthenticationFilterTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void doFilterWhenValidThenRedirectsToSavedRequest() throws ServletException, IOException {
 		given(this.authenticationManager.authenticate(any()))
 			.willReturn(OneTimeTokenAuthenticationToken.authenticated("username", AuthorityUtils.NO_AUTHORITIES));


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->

#18440 

**Here's an explanation of the compiler warnings fixed in this PR:**

Fixed Warnings
**1. WebSecurityConfigurationTests.java** 
<img width="1375" height="95" alt="image" src="https://github.com/user-attachments/assets/461b05f2-be86-4d43-a37e-a25fe3ae9e16" />

Issue: Raw type warning due to missing generic type specification in ClassUtils.getMethod() call

Fix: Added (Class<?>[]) cast to ensure generic type safety

---
**2. OneTimeTokenAuthenticationTokenTests.java**
<img width="1375" height="162" alt="image" src="https://github.com/user-attachments/assets/0f47b47a-8265-409e-9300-c8ad6a8a1992" />

Issue: Warning from using deprecated functionality

Fix: Added @SuppressWarnings("removal") annotation to suppress the deprecation warning

---
**3. OneTimeTokenReactiveAuthenticationManagerTests.java**
<img width="1375" height="162" alt="image" src="https://github.com/user-attachments/assets/fb7feb92-f8a1-4381-8fbf-f7bf5465f8f2" />

Issue: Deprecation warnings from using deprecated OneTimeTokenAuthenticationToken or related deprecated APIs throughout the test methods

Fix: Added @SuppressWarnings("removal") annotation to each test method that uses the deprecated functionality

---
**4. AuthorityAuthorizationManagerTests.java**
<img width="1375" height="207" alt="image" src="https://github.com/user-attachments/assets/fbda9d4f-122c-4350-af30-027d2e6d331c" />

Issue: Ambiguous method call warnings. Passing null directly to varargs methods like hasAnyRole(String...) and hasAnyAuthority(String...) creates ambiguity - the compiler can't determine if null represents a null array or an array containing a single null element

Fix: Added explicit (String[]) cast to clarify that null represents a null array, not a single null element

---
**5. DefaultMethodSecurityExpressionHandlerKotlinTests.kt**
<img width="1375" height="207" alt="image" src="https://github.com/user-attachments/assets/14e12228-e6b1-45b6-9c31-71c494d55444" />

Issue: Kotlin's "unchecked cast" warnings when casting generic types. The compiler cannot verify at runtime that the cast to parameterized types like Map<String, String>, Collection<String>, Array<String>, or Stream<String> is type-safe, since generic type information is erased at runtime
Fix: Added @Suppress("UNCHECKED_CAST") annotation to explicitly acknowledge and suppress these unavoidable warnings

---
**6/ DelegatingAuthenticationEntryPointTests.java**
<img width="2714" height="398" alt="image" src="https://github.com/user-attachments/assets/26d78ebc-292b-4639-be66-d58f7d75b551" />

Issue: Deprecation warnings from using the deprecated DelegatingAuthenticationEntryPoint class or its constructors/methods

Fix: Added @SuppressWarnings("removal") annotation to each test method that uses the deprecated functionality

---
**7. OneTimeTokenAuthenticationFilterTests.java**
Issue: Deprecation warnings from using deprecated OneTimeTokenAuthenticationFilter or related one-time token authentication APIs
<img width="1357" height="112" alt="image" src="https://github.com/user-attachments/assets/9f161441-0d1a-40bd-bca5-e0b7022b20e7" />

Fix: Added @SuppressWarnings("removal") annotation to each test method that uses the deprecated functionality

