### PR TITLE
Fix compile warnings for spring-security-config

### DIFF
--- a/buildSrc/src/main/groovy/compile-warnings-error.gradle
+++ b/buildSrc/src/main/groovy/compile-warnings-error.gradle
@@ -8,3 +8,4 @@ tasks.withType(JavaCompile) {
 tasks.withType(KotlinCompile) {
     kotlinOptions.allWarningsAsErrors = true
 }
+

--- a/config/spring-security-config.gradle
+++ b/config/spring-security-config.gradle
@@ -5,6 +5,7 @@ apply plugin: 'io.spring.convention.spring-module'
 apply plugin: 'trang'
 apply plugin: 'security-kotlin'
 apply plugin: 'test-compile-target-jdk25'
+apply plugin: 'compile-warnings-error'
 apply plugin:  'javadoc-warnings-error'
 
 configurations {

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/resource/OAuth2ResourceServerConfigurer.java
@@ -521,8 +521,10 @@ public final class OAuth2ResourceServerConfigurer<H extends HttpSecurityBuilder<
 		public OpaqueTokenConfigurer introspectionUri(String introspectionUri) {
 			Assert.notNull(introspectionUri, "introspectionUri cannot be null");
 			this.introspectionUri = introspectionUri;
-			this.introspector = () -> new SpringOpaqueTokenIntrospector(this.introspectionUri, this.clientId,
-					this.clientSecret);
+			this.introspector = () -> SpringOpaqueTokenIntrospector.withIntrospectionUri(this.introspectionUri)
+				.clientId(this.clientId)
+				.clientSecret(this.clientSecret)
+				.build();
 			return this;
 		}
 
@@ -531,8 +533,10 @@ public final class OAuth2ResourceServerConfigurer<H extends HttpSecurityBuilder<
 			Assert.notNull(clientSecret, "clientSecret cannot be null");
 			this.clientId = clientId;
 			this.clientSecret = clientSecret;
-			this.introspector = () -> new SpringOpaqueTokenIntrospector(this.introspectionUri, this.clientId,
-					this.clientSecret);
+			this.introspector = () -> SpringOpaqueTokenIntrospector.withIntrospectionUri(this.introspectionUri)
+				.clientId(this.clientId)
+				.clientSecret(this.clientSecret)
+				.build();
 			return this;
 		}
 

--- a/config/src/main/kotlin/org/springframework/security/config/annotation/web/AuthorizeHttpRequestsDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/annotation/web/AuthorizeHttpRequestsDsl.kt
@@ -286,7 +286,7 @@ class AuthorizeHttpRequestsDsl : AbstractRequestMatcherDsl {
         if (factoryOfRequestAuthorizationContext != null) {
             return factoryOfRequestAuthorizationContext
         }
-        val factoryOfObjectType = ResolvableType.forClassWithGenerics(AuthorizationManagerFactory::class.java, Object::class.java)
+        val factoryOfObjectType = ResolvableType.forClassWithGenerics(AuthorizationManagerFactory::class.java, Any::class.java)
         val factoryOfAny = context.getBeanProvider<AuthorizationManagerFactory<Any>>(factoryOfObjectType).getIfUnique()
         if (factoryOfAny != null) {
             return factoryOfAny
@@ -303,20 +303,20 @@ class AuthorizeHttpRequestsDsl : AbstractRequestMatcherDsl {
         return defaultFactory
     }
 
-    private fun resolveRolePrefix(context: ApplicationContext): String {
+    private fun resolveRolePrefix(context: ApplicationContext): String? {
         val beanNames = context.getBeanNamesForType(GrantedAuthorityDefaults::class.java)
         if (beanNames.isNotEmpty()) {
             return context.getBean(GrantedAuthorityDefaults::class.java).rolePrefix
         }
-        return "ROLE_";
+        return null
     }
 
-    private fun resolveRoleHierarchy(context: ApplicationContext): RoleHierarchy {
+    private fun resolveRoleHierarchy(context: ApplicationContext): RoleHierarchy? {
         val beanNames = context.getBeanNamesForType(RoleHierarchy::class.java)
         if (beanNames.isNotEmpty()) {
             return context.getBean(RoleHierarchy::class.java)
         }
-        return NullRoleHierarchy()
+        return null
     }
 
 }

--- a/config/src/main/kotlin/org/springframework/security/config/annotation/web/HeadersDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/annotation/web/HeadersDsl.kt
@@ -37,9 +37,11 @@ class HeadersDsl {
     private var cacheControl: ((HeadersConfigurer<HttpSecurity>.CacheControlConfig) -> Unit)? = null
     private var hsts: ((HeadersConfigurer<HttpSecurity>.HstsConfig) -> Unit)? = null
     private var frameOptions: ((HeadersConfigurer<HttpSecurity>.FrameOptionsConfig) -> Unit)? = null
+    @Suppress("DEPRECATION")
     private var hpkp: ((HeadersConfigurer<HttpSecurity>.HpkpConfig) -> Unit)? = null
     private var contentSecurityPolicy: ((HeadersConfigurer<HttpSecurity>.ContentSecurityPolicyConfig) -> Unit)? = null
     private var referrerPolicy: ((HeadersConfigurer<HttpSecurity>.ReferrerPolicyConfig) -> Unit)? = null
+    @Suppress("DEPRECATION")
     private var featurePolicyDirectives: String? = null
     private var permissionsPolicy: ((HeadersConfigurer<HttpSecurity>.PermissionsPolicyConfig) -> Unit)? = null
     private var crossOriginOpenerPolicy: ((HeadersConfigurer<HttpSecurity>.CrossOriginOpenerPolicyConfig) -> Unit)? = null
@@ -120,6 +122,7 @@ class HeadersDsl {
      * @deprecated see <a href="https://owasp.org/www-community/controls/Certificate_and_Public_Key_Pinning">Certificate and Public Key Pinning</a> for more context
      */
     @Deprecated(message = "as of 5.8 with no replacement")
+    @Suppress("DEPRECATION")
     fun httpPublicKeyPinning(hpkpConfig: HttpPublicKeyPinningDsl.() -> Unit) {
         this.hpkp = HttpPublicKeyPinningDsl().apply(hpkpConfig).get()
     }
@@ -167,6 +170,7 @@ class HeadersDsl {
      * @param policyDirectives policyDirectives the security policy directive(s)
      */
     @Deprecated("Use 'permissionsPolicy { }' instead.")
+    @Suppress("DEPRECATION")
     fun featurePolicy(policyDirectives: String) {
         this.featurePolicyDirectives = policyDirectives
     }

--- a/config/src/main/kotlin/org/springframework/security/config/annotation/web/HttpSecurityDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/annotation/web/HttpSecurityDsl.kt
@@ -614,6 +614,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * @see [RequiresChannelDsl]
      * @deprecated please use [redirectToHttps] instead
      */
+    @Suppress("DEPRECATION")
     @Deprecated(message="since 6.5 use redirectToHttps instead")
     fun requiresChannel(requiresChannelConfiguration: RequiresChannelDsl.() -> Unit) {
         val requiresChannelCustomizer = RequiresChannelDsl().apply(requiresChannelConfiguration).get()

--- a/config/src/main/kotlin/org/springframework/security/config/annotation/web/RequiresChannelDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/annotation/web/RequiresChannelDsl.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package org.springframework.security.config.annotation.web
 
 import org.springframework.security.config.annotation.web.builders.HttpSecurity

--- a/config/src/main/kotlin/org/springframework/security/config/annotation/web/X509Dsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/annotation/web/X509Dsl.kt
@@ -62,6 +62,7 @@ class X509Dsl {
             authenticationDetailsSource?.also { x509.authenticationDetailsSource(authenticationDetailsSource) }
             userDetailsService?.also { x509.userDetailsService(userDetailsService) }
             authenticationUserDetailsService?.also { x509.authenticationUserDetailsService(authenticationUserDetailsService) }
+            @Suppress("DEPRECATION")
             subjectPrincipalRegex?.also { x509.subjectPrincipalRegex(subjectPrincipalRegex) }
         }
     }

--- a/config/src/main/kotlin/org/springframework/security/config/annotation/web/headers/HttpPublicKeyPinningDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/annotation/web/headers/HttpPublicKeyPinningDsl.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package org.springframework.security.config.annotation.web.headers
 
 import org.springframework.security.config.annotation.web.builders.HttpSecurity

--- a/config/src/main/kotlin/org/springframework/security/config/annotation/web/session/SessionFixationDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/annotation/web/session/SessionFixationDsl.kt
@@ -68,12 +68,11 @@ class SessionFixationDsl {
     internal fun get(): (SessionManagementConfigurer<HttpSecurity>.SessionFixationConfigurer) -> Unit {
         return { sessionFixation ->
             strategy?.also {
-                when (strategy) {
+                when (it) {
                     SessionFixationStrategy.NEW -> sessionFixation.newSession()
                     SessionFixationStrategy.MIGRATE -> sessionFixation.migrateSession()
                     SessionFixationStrategy.CHANGE_ID -> sessionFixation.changeSessionId()
                     SessionFixationStrategy.NONE -> sessionFixation.none()
-                    null -> null
                 }
             }
         }

--- a/config/src/test/java/org/springframework/security/SerializationSamples.java
+++ b/config/src/test/java/org/springframework/security/SerializationSamples.java
@@ -284,6 +284,14 @@ final class SerializationSamples {
 		Authentication authentication = TestAuthentication.authenticated(user);
 		SecurityContext securityContext = new SecurityContextImpl(authentication);
 
+		instancioByClassName.put(OneTimeTokenAuthenticationToken.class, () -> {
+			@SuppressWarnings("removal")
+			InstancioOfClassApi<?> instancio = Instancio.of(OneTimeTokenAuthenticationToken.class);
+			instancio.supply(Select.all(OneTimeTokenAuthenticationToken.class),
+					(r) -> applyDetails(new OneTimeTokenAuthenticationToken("token")));
+			return instancio;
+		});
+
 		// oauth2-core
 		generatorByClassName.put(DefaultOAuth2User.class, (r) -> TestOAuth2Users.create());
 		generatorByClassName.put(OAuth2AuthorizationRequest.class,
@@ -597,8 +605,7 @@ final class SerializationSamples {
 			token.setDetails(details);
 			return token;
 		});
-		generatorByClassName.put(OneTimeTokenAuthenticationToken.class,
-				(r) -> applyDetails(new OneTimeTokenAuthenticationToken("username", "token")));
+
 		generatorByClassName.put(OneTimeTokenAuthentication.class,
 				(r) -> applyDetails(new OneTimeTokenAuthentication("username", authentication.getAuthorities())));
 		generatorByClassName.put(AccessDeniedException.class,

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurationTests.java
@@ -222,7 +222,8 @@ public class WebSecurityConfigurationTests {
 	// SEC-2773
 	@Test
 	public void getMethodDelegatingApplicationListenerWhenWebSecurityConfigurationThenIsStatic() {
-		Method method = ClassUtils.getMethod(WebSecurityConfiguration.class, "delegatingApplicationListener", null);
+		Method method = ClassUtils.getMethod(WebSecurityConfiguration.class, "delegatingApplicationListener",
+				(Class<?>[]) null);
 		assertThat(Modifier.isStatic(method.getModifiers())).isTrue();
 	}
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/HeadersConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/HeadersConfigurerTests.java
@@ -1201,6 +1201,7 @@ public class HeadersConfigurerTests {
 
 	@Configuration
 	@EnableWebSecurity
+	@SuppressWarnings("removal")
 	static class PermissionsPolicyConfig {
 
 		@Bean
@@ -1221,6 +1222,7 @@ public class HeadersConfigurerTests {
 	static class PermissionsPolicyStringConfig {
 
 		@Bean
+		@SuppressWarnings("removal")
 		SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 			// @formatter:off
 			http
@@ -1235,6 +1237,7 @@ public class HeadersConfigurerTests {
 
 	@Configuration
 	@EnableWebSecurity
+	@SuppressWarnings("removal")
 	static class PermissionsPolicyInvalidConfig {
 
 		@Bean
@@ -1252,6 +1255,7 @@ public class HeadersConfigurerTests {
 
 	@Configuration
 	@EnableWebSecurity
+	@SuppressWarnings("removal")
 	static class PermissionsPolicyInvalidStringConfig {
 
 		@Bean

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OAuth2AuthorizationCodeGrantTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OAuth2AuthorizationCodeGrantTests.java
@@ -1257,6 +1257,7 @@ public class OAuth2AuthorizationCodeGrantTests {
 		}
 
 		@Bean
+		@SuppressWarnings("removal")
 		RegisteredClientRepository registeredClientRepository(JdbcOperations jdbcOperations) {
 			JdbcRegisteredClientRepository jdbcRegisteredClientRepository = new JdbcRegisteredClientRepository(
 					jdbcOperations);

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OAuth2ClientCredentialsGrantTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OAuth2ClientCredentialsGrantTests.java
@@ -535,6 +535,7 @@ public class OAuth2ClientCredentialsGrantTests {
 		}
 
 		@Bean
+		@SuppressWarnings("removal")
 		RegisteredClientRepository registeredClientRepository(JdbcOperations jdbcOperations) {
 			JdbcRegisteredClientRepository jdbcRegisteredClientRepository = new JdbcRegisteredClientRepository(
 					jdbcOperations);

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OAuth2ClientRegistrationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OAuth2ClientRegistrationTests.java
@@ -647,6 +647,7 @@ public class OAuth2ClientRegistrationTests {
 		// @formatter:on
 
 		@Bean
+		@SuppressWarnings("removal")
 		RegisteredClientRepository registeredClientRepository(JdbcOperations jdbcOperations) {
 			RegisteredClient registeredClient = TestRegisteredClients.registeredClient().build();
 			RegisteredClientParametersMapper registeredClientParametersMapper = new RegisteredClientParametersMapper();

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OAuth2RefreshTokenGrantTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OAuth2RefreshTokenGrantTests.java
@@ -469,6 +469,7 @@ public class OAuth2RefreshTokenGrantTests {
 		}
 
 		@Bean
+		@SuppressWarnings("removal")
 		RegisteredClientRepository registeredClientRepository(JdbcOperations jdbcOperations) {
 			JdbcRegisteredClientRepository jdbcRegisteredClientRepository = new JdbcRegisteredClientRepository(
 					jdbcOperations);

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OAuth2TokenIntrospectionTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OAuth2TokenIntrospectionTests.java
@@ -515,6 +515,7 @@ public class OAuth2TokenIntrospectionTests {
 		}
 
 		@Bean
+		@SuppressWarnings("removal")
 		RegisteredClientRepository registeredClientRepository(JdbcOperations jdbcOperations) {
 			JdbcRegisteredClientRepository jdbcRegisteredClientRepository = new JdbcRegisteredClientRepository(
 					jdbcOperations);

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OAuth2TokenRevocationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OAuth2TokenRevocationTests.java
@@ -318,6 +318,7 @@ public class OAuth2TokenRevocationTests {
 		}
 
 		@Bean
+		@SuppressWarnings("removal")
 		RegisteredClientRepository registeredClientRepository(JdbcOperations jdbcOperations) {
 			JdbcRegisteredClientRepository jdbcRegisteredClientRepository = new JdbcRegisteredClientRepository(
 					jdbcOperations);

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OidcClientRegistrationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OidcClientRegistrationTests.java
@@ -778,6 +778,7 @@ public class OidcClientRegistrationTests {
 		// @formatter:on
 
 		@Bean
+		@SuppressWarnings("removal")
 		RegisteredClientRepository registeredClientRepository(JdbcOperations jdbcOperations) {
 			RegisteredClient registeredClient = TestRegisteredClients.registeredClient().build();
 			RegisteredClientParametersMapper registeredClientParametersMapper = new RegisteredClientParametersMapper();

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OidcTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OidcTests.java
@@ -633,6 +633,7 @@ public class OidcTests {
 		}
 
 		@Bean
+		@SuppressWarnings("removal")
 		RegisteredClientRepository registeredClientRepository(JdbcOperations jdbcOperations) {
 			JdbcRegisteredClientRepository jdbcRegisteredClientRepository = new JdbcRegisteredClientRepository(
 					jdbcOperations);

--- a/config/src/test/java/org/springframework/security/config/web/server/OAuth2ResourceServerSpecTests.java
+++ b/config/src/test/java/org/springframework/security/config/web/server/OAuth2ResourceServerSpecTests.java
@@ -100,6 +100,7 @@ import static org.mockito.Mockito.verify;
  * {@link org.springframework.security.config.web.server.ServerHttpSecurity.OAuth2ResourceServerSpec}
  */
 @ExtendWith({ SpringTestContextExtension.class })
+@SuppressWarnings("removal")
 public class OAuth2ResourceServerSpecTests {
 
 	private String expired = "eyJhbGciOiJSUzI1NiJ9.eyJleHAiOjE1MzUwMzc4OTd9.jqZDDjfc2eysX44lHXEIr9XFd2S8vjIZHCccZU-dRWMRJNsQ1QN5VNnJGklqJBXJR4qgla6cmVqPOLkUHDb0sL0nxM5XuzQaG5ZzKP81RV88shFyAiT0fD-6nl1k-Fai-Fu-VkzSpNXgeONoTxDaYhdB-yxmgrgsApgmbOTE_9AcMk-FQDXQ-pL9kynccFGV0lZx4CA7cyknKN7KBxUilfIycvXODwgKCjj_1WddLTCNGYogJJSg__7NoxzqbyWd3udbHVjqYq7GsMMrGB4_2kBD4CkghOSNcRHbT_DIXowxfAVT7PAg7Q0E5ruZsr2zPZacEUDhJ6-wbvlA0FAOUg";

--- a/config/src/test/java/org/springframework/security/config/web/server/OidcLogoutSpecTests.java
+++ b/config/src/test/java/org/springframework/security/config/web/server/OidcLogoutSpecTests.java
@@ -167,6 +167,7 @@ public class OidcLogoutSpecTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void logoutWhenInvalidLogoutTokenThenBadRequest() {
 		this.spring.register(WebServerConfig.class, OidcProviderConfig.class, DefaultConfig.class).autowire();
 		this.test.get().uri("/token/logout").exchange().expectStatus().isUnauthorized();
@@ -209,6 +210,7 @@ public class OidcLogoutSpecTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void logoutWhenLogoutTokenSpecifiesOneSessionThenRemotelyInvalidatesOnlyThatSession() throws Exception {
 		this.spring.register(WebServerConfig.class, OidcProviderConfig.class, DefaultConfig.class).autowire();
 		String registrationId = this.clientRegistration.getRegistrationId();
@@ -252,6 +254,7 @@ public class OidcLogoutSpecTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void logoutWhenRemoteLogoutUriThenUses() {
 		this.spring.register(WebServerConfig.class, OidcProviderConfig.class, LogoutUriConfig.class).autowire();
 		String registrationId = this.clientRegistration.getRegistrationId();
@@ -302,6 +305,7 @@ public class OidcLogoutSpecTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void logoutWhenDifferentCookieNameThenUses() {
 		this.spring.register(OidcProviderConfig.class, CookieConfig.class).autowire();
 		String registrationId = this.clientRegistration.getRegistrationId();
@@ -325,6 +329,7 @@ public class OidcLogoutSpecTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void logoutWhenRemoteLogoutFailsThenReportsPartialLogout() {
 		this.spring.register(WebServerConfig.class, OidcProviderConfig.class, WithBrokenLogoutConfig.class).autowire();
 		ServerLogoutHandler logoutHandler = this.spring.getContext().getBean(ServerLogoutHandler.class);

--- a/config/src/test/java/org/springframework/security/config/web/server/ServerHttpSecurityTests.java
+++ b/config/src/test/java/org/springframework/security/config/web/server/ServerHttpSecurityTests.java
@@ -737,6 +737,7 @@ public class ServerHttpSecurityTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void resourcesWhenLoginPageConfiguredThenServesCss() {
 		this.http.formLogin(withDefaults());
 		this.http.authenticationManager(this.authenticationManager);

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/AuthorizeHttpRequestsDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/AuthorizeHttpRequestsDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/CsrfDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/CsrfDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/FormLoginDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/FormLoginDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/HttpBasicDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/HttpBasicDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/HttpSecurityDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/HttpSecurityDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/PortMapperDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/PortMapperDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/RequiresChannelDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/RequiresChannelDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/Saml2DslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/Saml2DslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/Saml2LogoutDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/Saml2LogoutDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/Saml2MetadataDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/Saml2MetadataDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/SecurityContextDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/SecurityContextDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/WebAuthnDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/WebAuthnDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
 
  * Copyright 2004-present the original author or authors.

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/X509DslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/X509DslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/headers/HttpPublicKeyPinningDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/headers/HttpPublicKeyPinningDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/resourceserver/OpaqueTokenDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/oauth2/resourceserver/OpaqueTokenDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/session/SessionConcurrencyDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/session/SessionConcurrencyDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/session/SessionFixationDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/session/SessionFixationDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/AuthorizeExchangeDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/AuthorizeExchangeDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerExceptionHandlingDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerExceptionHandlingDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerFormLoginDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerFormLoginDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerHttpBasicDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerHttpBasicDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerOpaqueTokenDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerOpaqueTokenDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerRequestCacheDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerRequestCacheDslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *

--- a/config/src/test/kotlin/org/springframework/security/config/web/server/ServerX509DslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/web/server/ServerX509DslTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "PLATFORM_CLASS_MAPPED_TO_KOTLIN", "UNCHECKED_CAST")
+
 /*
  * Copyright 2004-present the original author or authors.
  *


### PR DESCRIPTION
This PR removes all compiler warnings from the `spring-security-config` module and applies the `compile-warnings-error` plugin to prevent future warnings.

## Changes

### Java Changes
- **OAuth2ResourceServerConfigurer.java**: Replaced deprecated `SpringOpaqueTokenIntrospector` constructor with the new Builder pattern introduced in Spring Security 6.5
  - Changed from: `new SpringOpaqueTokenIntrospector(introspectionUri, clientId, clientSecret)`
  - Changed to: `SpringOpaqueTokenIntrospector.withIntrospectionUri(...).clientId(...).clientSecret(...).build()`

### Kotlin Changes
- **AuthorizeHttpRequestsDsl.kt**: 
  - Replaced `Object::class.java` with `Any::class.java` (Kotlin best practice)
  - Changed `resolveRolePrefix()` and `resolveRoleHierarchy()` return types to nullable to fix "condition always true" warnings
  
- **HeadersDsl.kt**: Added `@Suppress("DEPRECATION")` for deprecated `HpkpConfig` usage (class itself is deprecated)

- **HttpSecurityDsl.kt**: Added `@Suppress("DEPRECATION")` for deprecated `requiresChannel()` method

- **RequiresChannelDsl.kt**: Added `@file:Suppress("DEPRECATION")` for deprecated channel security classes

- **X509Dsl.kt**: Added `@Suppress("DEPRECATION")` for deprecated `subjectPrincipalRegex` property

- **HttpPublicKeyPinningDsl.kt**: Added `@file:Suppress("DEPRECATION")` for deprecated HPKP classes

- **SessionFixationDsl.kt**: Removed unnecessary null case in when expression

### Build Configuration
- **spring-security-config.gradle**: Applied `compile-warnings-error` plugin to fail build on warnings

## Testing
- All existing tests continue to pass
- The functionality remains unchanged; only deprecated API usage was updated
- Build now fails on new warnings, ensuring code quality

## Related Issues
Closes gh-18419
