### PR TITLE
Support single-line PEM encoded RSA keys in `RsaKeyConverters`

### DIFF
--- a/core/src/main/java/org/springframework/security/converter/RsaKeyConverters.java
+++ b/core/src/main/java/org/springframework/security/converter/RsaKeyConverters.java
@@ -87,9 +87,17 @@ public final class RsaKeyConverters {
 					"Key is not in PEM-encoded PKCS#8 format, please check that the header begins with "
 							+ PKCS8_PEM_HEADER);
 			StringBuilder base64Encoded = new StringBuilder();
-			for (String line : lines) {
-				if (RsaKeyConverters.isNotPkcs8Wrapper(line)) {
-					base64Encoded.append(line);
+			if (lines.size() == 1) {
+				base64Encoded.append(lines.get(0)
+					.replace(PKCS8_PEM_HEADER, "")
+					.replace(PKCS8_PEM_FOOTER, "")
+					.replaceAll("\\s+", ""));
+			}
+			else {
+				for (String line : lines) {
+					if (RsaKeyConverters.isNotPkcs8Wrapper(line)) {
+						base64Encoded.append(line);
+					}
 				}
 			}
 			byte[] pkcs8 = Base64.getDecoder().decode(base64Encoded.toString());
@@ -165,9 +173,15 @@ public final class RsaKeyConverters {
 		@Override
 		public @NonNull RSAPublicKey convert(List<String> lines) {
 			StringBuilder base64Encoded = new StringBuilder();
-			for (String line : lines) {
-				if (isNotX509PemWrapper(line)) {
-					base64Encoded.append(line);
+			if (lines.size() == 1) {
+				base64Encoded.append(
+						lines.get(0).replace(X509_PEM_HEADER, "").replace(X509_PEM_FOOTER, "").replaceAll("\\s+", ""));
+			}
+			else {
+				for (String line : lines) {
+					if (isNotX509PemWrapper(line)) {
+						base64Encoded.append(line);
+					}
 				}
 			}
 			byte[] x509 = Base64.getDecoder().decode(base64Encoded.toString());
@@ -196,9 +210,17 @@ public final class RsaKeyConverters {
 		@Override
 		public @NonNull RSAPublicKey convert(List<String> lines) {
 			StringBuilder base64Encoded = new StringBuilder();
-			for (String line : lines) {
-				if (isNotX509CertificateWrapper(line)) {
-					base64Encoded.append(line);
+			if (lines.size() == 1) {
+				base64Encoded.append(lines.get(0)
+					.replace(X509_CERT_HEADER, "")
+					.replace(X509_CERT_FOOTER, "")
+					.replaceAll("\\s+", ""));
+			}
+			else {
+				for (String line : lines) {
+					if (isNotX509CertificateWrapper(line)) {
+						base64Encoded.append(line);
+					}
 				}
 			}
 			byte[] x509 = Base64.getDecoder().decode(base64Encoded.toString());

--- a/core/src/test/java/org/springframework/security/converter/RsaKeyConvertersTests.java
+++ b/core/src/test/java/org/springframework/security/converter/RsaKeyConvertersTests.java
@@ -121,6 +121,13 @@ public class RsaKeyConvertersTests {
 	}
 
 	@Test
+	public void pkcs8WhenConvertingSingleLinePkcs8PrivateKeyThenOk() {
+		RSAPrivateKey key = this.pkcs8.convert(toInputStream(PKCS8_PRIVATE_KEY.replace("\n", "")));
+		Assertions.assertThat(key).isInstanceOf(RSAPrivateCrtKey.class);
+		Assertions.assertThat(key.getModulus().bitLength()).isEqualTo(2048);
+	}
+
+	@Test
 	public void pkcs8WhenConvertingPkcs1PrivateKeyThenIllegalArgumentException() {
 		assertThatIllegalArgumentException().isThrownBy(() -> this.pkcs8.convert(toInputStream(PKCS1_PRIVATE_KEY)));
 	}
@@ -132,8 +139,20 @@ public class RsaKeyConvertersTests {
 	}
 
 	@Test
+	public void x509WhenConvertingSingleLineX509PublicKeyThenOk() {
+		RSAPublicKey key = this.x509.convert(toInputStream(X509_PUBLIC_KEY.replace("\n", "")));
+		Assertions.assertThat(key.getModulus().bitLength()).isEqualTo(1024);
+	}
+
+	@Test
 	public void x509WhenConvertingX509CertificateThenOk() {
 		RSAPublicKey key = this.x509.convert(toInputStream(X509_CERTIFICATE));
+		Assertions.assertThat(key.getModulus().bitLength()).isEqualTo(1024);
+	}
+
+	@Test
+	public void x509WhenConvertingX509SingleLineCertificateThenOk() {
+		RSAPublicKey key = this.x509.convert(toInputStream(X509_CERTIFICATE.replace("\n", "")));
 		Assertions.assertThat(key.getModulus().bitLength()).isEqualTo(1024);
 	}
 


### PR DESCRIPTION
`RsaKeyConverters` currently assumes that PEM-encoded RSA keys are provided in a multi-line format, where the PEM header, footer, and Base64-encoded content are separated across multiple lines.
However, in environment variable–based configurations (ex. `.env` files), PEM keys are commonly stored as single-line strings, with newline characters removed or escaped.

Examples:

- `-----BEGIN PUBLIC KEY-----MIIBIjANBgkq...IDAQAB-----END PUBLIC KEY-----`
- `-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkq...IDAQAB\n-----END PUBLIC KEY-----`

While these representations are functionally equivalent to the traditional multi-line PEM format, they are currently not supported by `RsaKeyConverters` and result in conversion failures.
Therefore, this PR improves `RsaKeyConverters` to correctly handle single-line RSA keys while preserving the existing conversion structure.