### PR TITLE
Fix typo in authorize-http-requests.adoc

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authorization/authorize-http-requests.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/authorize-http-requests.adoc
@@ -192,7 +192,7 @@ public SecurityFilterChain web(HttpSecurity http) throws Exception {
         .authorizeHttpRequests((authorize) -> authorize
 	    .requestMatchers("/endpoint").hasAuthority("USER")
             .anyRequest().authenticated()
-        )
+        );
         // ...
 
     return http.build();


### PR DESCRIPTION
semicolon added for java configuration

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
