### PR TITLE
Fail spring-security-rsocket on javadoc warnings

### DIFF
--- a/rsocket/spring-security-rsocket.gradle
+++ b/rsocket/spring-security-rsocket.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id 'compile-warnings-error'
 	id 'security-nullability'
+	id 'javadoc-warnings-error'
 }
 
 apply plugin: 'io.spring.convention.spring-module'


### PR DESCRIPTION
no javadoc issues found but added javadoc-errors-warning plugin

Closes gh-18464
