### PR TITLE
Fail spring-security-saml2-service-provider on javadoc warnings

### DIFF
--- a/saml2/saml2-service-provider/spring-security-saml2-service-provider.gradle
+++ b/saml2/saml2-service-provider/spring-security-saml2-service-provider.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'compile-warnings-error'
+	id 'javadoc-warnings-error'
 }
 
 apply plugin: 'io.spring.convention.spring-module'


### PR DESCRIPTION
no javadoc issues found but added javadoc-errors-warning plugin

Closes gh-18465

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
