### PR TITLE
Fail spring-security-webauthn on javadoc warnings

### DIFF
--- a/webauthn/spring-security-webauthn.gradle
+++ b/webauthn/spring-security-webauthn.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id 'compile-warnings-error'
 	id 'security-nullability'
+	id 'javadoc-warnings-error'
 }
 
 apply plugin: 'io.spring.convention.spring-module'


### PR DESCRIPTION
no javadoc issues found but added javadoc-errors-warning plugin

Closes gh-18469

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
