### PR TITLE
Fail spring-security-docs on javadoc warnings

### DIFF
--- a/docs/spring-security-docs.gradle
+++ b/docs/spring-security-docs.gradle
@@ -6,6 +6,7 @@ plugins {
 	id 'java-toolchain'
 	id 'test-compile-target-jdk25'
 	id 'compile-warnings-error'
+	id 'javadoc-warnings-error'
 }
 
 apply plugin: 'io.spring.convention.docs'


### PR DESCRIPTION
no javadoc issues found but added javadoc-errors-warning plugin

Closes gh-18452

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
