### PR TITLE
Fix compiler warnings in spring-security-acl

### DIFF
--- a/acl/src/main/java/org/springframework/security/acls/jdbc/AclClassIdUtils.java
+++ b/acl/src/main/java/org/springframework/security/acls/jdbc/AclClassIdUtils.java
@@ -87,7 +87,7 @@ class AclClassIdUtils {
 		}
 	}
 
-	private <T extends Serializable> @Nullable Class<T> classIdTypeFrom(ResultSet resultSet) throws SQLException {
+	private @Nullable Class<? extends Serializable> classIdTypeFrom(ResultSet resultSet) throws SQLException {
 		try {
 			return classIdTypeFrom(resultSet.getString(DEFAULT_CLASS_ID_TYPE_COLUMN_NAME));
 		}
@@ -97,15 +97,19 @@ class AclClassIdUtils {
 		}
 	}
 
-	private <T extends Serializable> @Nullable Class<T> classIdTypeFrom(String className) {
+	private @Nullable Class<? extends Serializable> classIdTypeFrom(String className) {
 		if (className == null) {
 			return null;
 		}
 		try {
-			return (Class) Class.forName(className);
+			return Class.forName(className).asSubclass(Serializable.class);
 		}
 		catch (ClassNotFoundException ex) {
 			log.debug("Unable to find class id type on classpath", ex);
+			return null;
+		}
+		catch (ClassCastException ex) {
+			log.debug("Class id type is not a Serializable type", ex);
 			return null;
 		}
 	}

--- a/acl/src/test/java/org/springframework/security/acls/domain/AclImplTests.java
+++ b/acl/src/test/java/org/springframework/security/acls/domain/AclImplTests.java
@@ -478,6 +478,7 @@ public class AclImplTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void hashCodeWithoutStackOverFlow() throws Exception {
 		Sid sid = new PrincipalSid("pSid");
 		ObjectIdentity oid = new ObjectIdentityImpl("type", 1);

--- a/acl/src/test/java/org/springframework/security/acls/jdbc/JdbcAclServiceTests.java
+++ b/acl/src/test/java/org/springframework/security/acls/jdbc/JdbcAclServiceTests.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -46,7 +47,6 @@ import org.springframework.security.acls.model.Sid;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -109,7 +109,8 @@ public class JdbcAclServiceTests {
 		List<ObjectIdentity> result = new ArrayList<>();
 		result.add(new ObjectIdentityImpl(Object.class, "5577"));
 		Object[] args = { "1", "org.springframework.security.acls.jdbc.JdbcAclServiceTests$MockLongIdDomainObject" };
-		given(this.jdbcOperations.query(anyString(), any(RowMapper.class), eq(args))).willReturn(result);
+		given(this.jdbcOperations.query(anyString(), ArgumentMatchers.<RowMapper<ObjectIdentity>>any(), eq(args)))
+			.willReturn(result);
 		ObjectIdentity objectIdentity = new ObjectIdentityImpl(MockLongIdDomainObject.class, 1L);
 		List<ObjectIdentity> objectIdentities = this.aclService.findChildren(objectIdentity);
 		assertThat(objectIdentities).hasSize(1);

--- a/acl/src/test/java/org/springframework/security/acls/jdbc/SpringCacheBasedAclCacheTests.java
+++ b/acl/src/test/java/org/springframework/security/acls/jdbc/SpringCacheBasedAclCacheTests.java
@@ -80,11 +80,10 @@ public class SpringCacheBasedAclCacheTests {
 		assertThatIllegalArgumentException().isThrownBy(() -> new SpringCacheBasedAclCache(null, null, null));
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Test
 	public void cacheOperationsAclWithoutParent() {
 		Cache cache = getCache();
-		Map realCache = (Map) cache.getNativeCache();
+		Map<?, ?> realCache = (Map<?, ?>) cache.getNativeCache();
 		ObjectIdentity identity = new ObjectIdentityImpl(TARGET_CLASS, 100L);
 		AclAuthorizationStrategy aclAuthorizationStrategy = new AclAuthorizationStrategyImpl(
 				new SimpleGrantedAuthority("ROLE_OWNERSHIP"), new SimpleGrantedAuthority("ROLE_AUDITING"),
@@ -116,11 +115,10 @@ public class SpringCacheBasedAclCacheTests {
 		assertThat(realCache).isEmpty();
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Test
 	public void cacheOperationsAclWithParent() throws Exception {
 		Cache cache = getCache();
-		Map realCache = (Map) cache.getNativeCache();
+		Map<?, ?> realCache = (Map<?, ?>) cache.getNativeCache();
 		Authentication auth = new TestingAuthenticationToken("user", "password", "ROLE_GENERAL");
 		auth.setAuthenticated(true);
 		SecurityContextHolder.getContext().setAuthentication(auth);


### PR DESCRIPTION
- Use asSubclass() in AclClassIdUtils to avoid a unchecked cast warning
- Replace raw Map type with Map<?, ?> unbounded wildcard to avoid raw type warnings
- Use ArgumentMatchers to avoid a unchecked cast warning
- Suppress an unavoidable unchecked warning in reflection-based test code

Closes gh-18413

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
