### PR TITLE
fix(18718)-CsrfConfigurer.spa() overrides custom CsrfTokenRepository

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurer.java
@@ -232,7 +232,9 @@ public final class CsrfConfigurer<H extends HttpSecurityBuilder<H>>
 	 * @since 7.0
 	 */
 	public CsrfConfigurer<H> spa() {
-		this.csrfTokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
+		 if (this.csrfTokenRepository == null) {
+        	this.csrfTokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
+    	}
 		this.requestHandler = new SpaCsrfTokenRequestHandler();
 		return this;
 	}


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
