### PR TITLE
fix(18718): CsrfConfigurer.spa() overrides custom CsrfTokenRepository…

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/CsrfConfigurer.java
@@ -231,11 +231,13 @@ public final class CsrfConfigurer<H extends HttpSecurityBuilder<H>>
 	 * @return the {@link CsrfConfigurer} for further customizations
 	 * @since 7.0
 	 */
-	public CsrfConfigurer<H> spa() {
-		this.csrfTokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
-		this.requestHandler = new SpaCsrfTokenRequestHandler();
-		return this;
-	}
+    public CsrfConfigurer<H> spa() {
+        if(this.csrfTokenRepository == null) {
+            this.csrfTokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
+        }
+        this.requestHandler = new SpaCsrfTokenRequestHandler();
+        return this;
+    }
 
 	@SuppressWarnings("unchecked")
 	@Override


### PR DESCRIPTION
…  The .spa() convenience method was overwriting any custom CsrfTokenRepository  previously configured in the DSL chain. This change ensures that .spa()  respects custom repository settings (such as custom header or cookie names)  while still applying the necessary SpaCsrfTokenRequestHandler.  Closes spring-projects#18718  Signed-off-by: Lakshmaiah Tatikonda <tlaxman88@gmail.com>

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
