### PR TITLE
Add tests for PathPatternRequestMatcher request path caching

### DIFF
--- a/web/src/test/java/org/springframework/security/web/servlet/util/matcher/PathPatternRequestMatcherTests.java
+++ b/web/src/test/java/org/springframework/security/web/servlet/util/matcher/PathPatternRequestMatcherTests.java
@@ -154,6 +154,25 @@ public class PathPatternRequestMatcherTests {
 		assertThat(matcher.matches(mock)).isFalse();
 	}
 
+	@Test
+	void matcherWhenRequestPathNotParsedThenDoesNotLeaveParsedRequestPath() {
+		RequestMatcher matcher = pathPattern("/uri");
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/uri");
+		assertThat(ServletRequestPathUtils.hasParsedRequestPath(request)).isFalse();
+		assertThat(matcher.matches(request)).isTrue();
+		assertThat(ServletRequestPathUtils.hasParsedRequestPath(request)).isFalse();
+	}
+
+	@Test
+	void matcherWhenRequestPathAlreadyParsedThenLeavesParsedRequestPath() {
+		RequestMatcher matcher = pathPattern("/uri");
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/uri");
+		ServletRequestPathUtils.parseAndCache(request);
+		assertThat(ServletRequestPathUtils.hasParsedRequestPath(request)).isTrue();
+		assertThat(matcher.matches(request)).isTrue();
+		assertThat(ServletRequestPathUtils.hasParsedRequestPath(request)).isTrue();
+	}
+
 	MockHttpServletRequest request(String uri) {
 		MockHttpServletRequest request = new MockHttpServletRequest("GET", uri);
 		ServletRequestPathUtils.parseAndCache(request);


### PR DESCRIPTION
## What changed
- Add tests asserting PathPatternRequestMatcher does not leave a parsed request path behind when it parses one
- Add test asserting an already-parsed request path remains available after matching
- Tests cover both cases: request path not pre-parsed vs pre-parsed
## Why
PathPatternRequestMatcher parses and caches the request path when needed and should clear it afterwards to avoid
unexpected side effects on downstream components that rely on ServletRequestPathUtils caching.
## Verification
- ./gradlew :spring-security-web:check