### PR TITLE
Update request-matcher XML property to support PathPatternRequestMatcher

### DIFF
--- a/config/src/main/resources/org/springframework/security/config/spring-security-7.0.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-7.0.rnc
@@ -12,8 +12,8 @@ base64 =
 	## Whether a string should be base64 encoded
 	attribute base64 {xsd:boolean}
 request-matcher =
-	## Defines the strategy use for matching incoming requests. Currently the options are 'mvc' (for Spring MVC matcher), 'ant' (for ant path patterns), 'regex' for regular expressions and 'ciRegex' for case-insensitive regular expressions.
-	attribute request-matcher {"mvc" | "ant" | "regex" | "ciRegex"}
+	## Defines the strategy use for matching incoming requests. Currently the options are 'path' (for PathPatternRequestMatcher), 'regex' for regular expressions and 'ciRegex' for case-insensitive regular expressions.
+	attribute request-matcher {"path" | "regex" | "ciRegex"}
 port =
 	## Specifies an IP port number. Used to configure an embedded LDAP server, for example.
 	attribute port { xsd:nonNegativeInteger }

--- a/config/src/main/resources/org/springframework/security/config/spring-security-7.0.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-7.0.xsd
@@ -27,15 +27,14 @@
   <xs:attributeGroup name="request-matcher">
       <xs:attribute name="request-matcher" use="required">
          <xs:annotation>
-            <xs:documentation>Defines the strategy use for matching incoming requests. Currently the options are 'mvc'
-                (for Spring MVC matcher), 'ant' (for ant path patterns), 'regex' for regular expressions
-                and 'ciRegex' for case-insensitive regular expressions.
+            <xs:documentation>Defines the strategy use for matching incoming requests. Currently the options are 'path'
+                (for PathPatternRequestMatcher), 'regex' for regular expressions and 'ciRegex' for
+                case-insensitive regular expressions.
                 </xs:documentation>
          </xs:annotation>
          <xs:simpleType>
             <xs:restriction base="xs:token">
-               <xs:enumeration value="mvc"/>
-               <xs:enumeration value="ant"/>
+               <xs:enumeration value="path"/>
                <xs:enumeration value="regex"/>
                <xs:enumeration value="ciRegex"/>
             </xs:restriction>
@@ -1306,15 +1305,14 @@
       </xs:attribute>
       <xs:attribute name="request-matcher">
          <xs:annotation>
-            <xs:documentation>Defines the strategy use for matching incoming requests. Currently the options are 'mvc'
-                (for Spring MVC matcher), 'ant' (for ant path patterns), 'regex' for regular expressions
-                and 'ciRegex' for case-insensitive regular expressions.
+            <xs:documentation>Defines the strategy use for matching incoming requests. Currently the options are 'path'
+                (for PathPatternRequestMatcher), 'regex' for regular expressions and 'ciRegex' for
+                case-insensitive regular expressions.
                 </xs:documentation>
          </xs:annotation>
          <xs:simpleType>
             <xs:restriction base="xs:token">
-               <xs:enumeration value="mvc"/>
-               <xs:enumeration value="ant"/>
+               <xs:enumeration value="path"/>
                <xs:enumeration value="regex"/>
                <xs:enumeration value="ciRegex"/>
             </xs:restriction>
@@ -2474,15 +2472,14 @@
   <xs:attributeGroup name="filter-chain-map.attlist">
       <xs:attribute name="request-matcher">
          <xs:annotation>
-            <xs:documentation>Defines the strategy use for matching incoming requests. Currently the options are 'mvc'
-                (for Spring MVC matcher), 'ant' (for ant path patterns), 'regex' for regular expressions
-                and 'ciRegex' for case-insensitive regular expressions.
+            <xs:documentation>Defines the strategy use for matching incoming requests. Currently the options are 'path'
+                (for PathPatternRequestMatcher), 'regex' for regular expressions and 'ciRegex' for
+                case-insensitive regular expressions.
                 </xs:documentation>
          </xs:annotation>
          <xs:simpleType>
             <xs:restriction base="xs:token">
-               <xs:enumeration value="mvc"/>
-               <xs:enumeration value="ant"/>
+               <xs:enumeration value="path"/>
                <xs:enumeration value="regex"/>
                <xs:enumeration value="ciRegex"/>
             </xs:restriction>
@@ -2580,15 +2577,14 @@
       </xs:attribute>
       <xs:attribute name="request-matcher">
          <xs:annotation>
-            <xs:documentation>Defines the strategy use for matching incoming requests. Currently the options are 'mvc'
-                (for Spring MVC matcher), 'ant' (for ant path patterns), 'regex' for regular expressions
-                and 'ciRegex' for case-insensitive regular expressions.
+            <xs:documentation>Defines the strategy use for matching incoming requests. Currently the options are 'path'
+                (for PathPatternRequestMatcher), 'regex' for regular expressions and 'ciRegex' for
+                case-insensitive regular expressions.
                 </xs:documentation>
          </xs:annotation>
          <xs:simpleType>
             <xs:restriction base="xs:token">
-               <xs:enumeration value="mvc"/>
-               <xs:enumeration value="ant"/>
+               <xs:enumeration value="path"/>
                <xs:enumeration value="regex"/>
                <xs:enumeration value="ciRegex"/>
             </xs:restriction>

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-AntMatcherServletPath.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-AntMatcherServletPath.xml
@@ -24,7 +24,7 @@
 			http://www.springframework.org/schema/beans
 			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<http request-matcher="ant" use-authorization-manager="false">
+	<http request-matcher="path" use-authorization-manager="false">
 		<intercept-url pattern="/path" access="denyAll" servlet-path="/spring"/>
 		<http-basic/>
 	</http>

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-AntMatcherServletPathAuthorizationManager.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-AntMatcherServletPathAuthorizationManager.xml
@@ -24,7 +24,7 @@
 			http://www.springframework.org/schema/beans
 			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<http request-matcher="ant">
+	<http request-matcher="path">
 		<intercept-url pattern="/path" access="denyAll" servlet-path="/spring"/>
 		<http-basic/>
 	</http>

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-MvcMatchers.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-MvcMatchers.xml
@@ -27,7 +27,7 @@
 			http://www.springframework.org/schema/mvc
 			https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
-	<http auto-config="true" request-matcher="mvc" use-authorization-manager="false">
+	<http auto-config="true" request-matcher="path" use-authorization-manager="false">
 		<intercept-url pattern="/path" access="denyAll"/>
 		<http-basic/>
 	</http>

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-MvcMatchersAuthorizationManager.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-MvcMatchersAuthorizationManager.xml
@@ -27,7 +27,7 @@
 			http://www.springframework.org/schema/mvc
 			https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
-	<http auto-config="true" request-matcher="mvc">
+	<http auto-config="true" request-matcher="path">
 		<intercept-url pattern="/path" access="denyAll"/>
 		<http-basic/>
 	</http>

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-MvcMatchersServletPath.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-MvcMatchersServletPath.xml
@@ -27,7 +27,7 @@
 			http://www.springframework.org/schema/mvc
 			https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
-	<http auto-config="true" request-matcher="mvc" use-authorization-manager="false">
+	<http auto-config="true" request-matcher="path" use-authorization-manager="false">
 		<intercept-url pattern="/path" access="denyAll" servlet-path="/spring"/>
 		<http-basic/>
 	</http>

--- a/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-MvcMatchersServletPathAuthorizationManager.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/InterceptUrlConfigTests-MvcMatchersServletPathAuthorizationManager.xml
@@ -27,7 +27,7 @@
 			http://www.springframework.org/schema/mvc
 			https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
-	<http auto-config="true" request-matcher="mvc">
+	<http auto-config="true" request-matcher="path">
 		<intercept-url pattern="/path" access="denyAll" servlet-path="/spring"/>
 		<http-basic/>
 	</http>


### PR DESCRIPTION
This PR updates the request-matcher schema to reflect the current supported matcher values.

- Adds `path` and removes legacy `mvc`/`ant` from the schema
- Updates XML test resources that use `request-matcher="mvc"`/`"ant"` to use `path`

The `.xsd` file was generated from the updated `.rnc` using:
`./gradlew :spring-security-config:rncToXsd`

Fixes #18641.

Note: XML test resource filenames still reference `mvc`/`ant`. A follow-up cleanup issue #18736 has been opened to evaluate whether these resources and the related tests should be removed or updated, as this is outside the scope of this PR.


