### PR TITLE
Add XML support for UserDetailsPasswordService

### DIFF
--- a/config/src/main/java/org/springframework/security/config/Elements.java
+++ b/config/src/main/java/org/springframework/security/config/Elements.java
@@ -86,6 +86,8 @@ public abstract class Elements {
 
 	public static final String PASSWORD_ENCODER = "password-encoder";
 
+	public static final String USER_DETAILS_PASSWORD_SERVICE = "user-details-password-service";
+
 	public static final String PORT_MAPPINGS = "port-mappings";
 
 	public static final String PORT_MAPPING = "port-mapping";

--- a/config/src/main/java/org/springframework/security/config/authentication/AuthenticationProviderBeanDefinitionParser.java
+++ b/config/src/main/java/org/springframework/security/config/authentication/AuthenticationProviderBeanDefinitionParser.java
@@ -40,6 +40,8 @@ public class AuthenticationProviderBeanDefinitionParser implements BeanDefinitio
 
 	private static final String ATT_USER_DETAILS_REF = "user-service-ref";
 
+	private static final String ATT_REF = "ref";
+
 	@Override
 	public BeanDefinition parse(Element element, ParserContext pc) {
 		RootBeanDefinition authProvider = new RootBeanDefinition(DaoAuthenticationProvider.class);
@@ -49,6 +51,18 @@ public class AuthenticationProviderBeanDefinitionParser implements BeanDefinitio
 		BeanMetadataElement passwordEncoder = pep.getPasswordEncoder();
 		if (passwordEncoder != null) {
 			authProvider.getPropertyValues().addPropertyValue("passwordEncoder", passwordEncoder);
+		}
+		Element userDetailsPasswordServiceElt = DomUtils.getChildElementByTagName(element,
+				Elements.USER_DETAILS_PASSWORD_SERVICE);
+		if (userDetailsPasswordServiceElt != null) {
+			String userDetailsPasswordServiceRef = userDetailsPasswordServiceElt.getAttribute(ATT_REF);
+			if (!StringUtils.hasText(userDetailsPasswordServiceRef)) {
+				pc.getReaderContext().error(
+						"The '" + Elements.USER_DETAILS_PASSWORD_SERVICE + "' element requires a 'ref' attribute",
+						userDetailsPasswordServiceElt);
+			}
+			authProvider.getPropertyValues()
+				.addPropertyValue("userDetailsPasswordService", new RuntimeBeanReference(userDetailsPasswordServiceRef));
 		}
 		Element userServiceElt = DomUtils.getChildElementByTagName(element, Elements.USER_SERVICE);
 		if (userServiceElt == null) {

--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.8.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.8.rnc
@@ -66,6 +66,13 @@ use-expressions =
 	## Enables the use of expressions in the 'access' attributes in <intercept-url> elements rather than the traditional list of configuration attributes. Defaults to 'true'. If enabled, each attribute should contain a single boolean expression. If the expression evaluates to 'true', access will be granted.
 	attribute use-expressions {xsd:boolean}
 
+user-details-password-service =
+	## Defines a reference to a bean that implements UserDetailsPasswordService.
+	element user-details-password-service {user-details-password-service.attlist}
+user-details-password-service.attlist &=
+	## Defines a reference to a Spring bean that implements UserDetailsPasswordService.
+	ref
+
 ldap-server =
 	## Defines an LDAP server location or starts an embedded server. The url indicates the location of a remote server. If no url is given, an embedded server will be started, listening on the supplied port number. The port is optional and defaults to 33389. A Spring LDAP ContextSource bean will be registered for the server with the id supplied.
 	element ldap-server {ldap-server.attlist}
@@ -1088,7 +1095,7 @@ authman.attlist &=
 
 authentication-provider =
 	## Indicates that the contained user-service should be used as an authentication source.
-	element authentication-provider {ap.attlist & any-user-service & password-encoder?}
+	element authentication-provider {ap.attlist & any-user-service & password-encoder? & user-details-password-service?}
 ap.attlist &=
 	## Specifies a reference to a separately configured AuthenticationProvider instance which should be registered within the AuthenticationManager.
 	ref?

--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.8.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.8.xsd
@@ -3018,6 +3018,15 @@
                            <xs:attributeGroup ref="security:password-encoder.attlist"/>
                         </xs:complexType>
                      </xs:element>
+                     <xs:element name="user-details-password-service">
+                        <xs:annotation>
+                           <xs:documentation>Defines a reference to a bean that implements UserDetailsPasswordService.
+                </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                           <xs:attributeGroup ref="security:ref"/>
+                        </xs:complexType>
+                     </xs:element>
                   </xs:choice>
                   <xs:attributeGroup ref="security:ap.attlist"/>
                </xs:complexType>

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.0.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.0.rnc
@@ -66,6 +66,13 @@ use-expressions =
 	## Enables the use of expressions in the 'access' attributes in <intercept-url> elements rather than the traditional list of configuration attributes. Defaults to 'true'. If enabled, each attribute should contain a single boolean expression. If the expression evaluates to 'true', access will be granted.
 	attribute use-expressions {xsd:boolean}
 
+user-details-password-service =
+	## Defines a reference to a bean that implements UserDetailsPasswordService.
+	element user-details-password-service {user-details-password-service.attlist}
+user-details-password-service.attlist &=
+	## Defines a reference to a Spring bean that implements UserDetailsPasswordService.
+	ref
+
 ldap-server =
 	## Defines an LDAP server location or starts an embedded server. The url indicates the location of a remote server. If no url is given, an embedded server will be started, listening on the supplied port number. The port is optional and defaults to 33389. A Spring LDAP ContextSource bean will be registered for the server with the id supplied.
 	element ldap-server {ldap-server.attlist}
@@ -1069,7 +1076,7 @@ authman.attlist &=
 
 authentication-provider =
 	## Indicates that the contained user-service should be used as an authentication source.
-	element authentication-provider {ap.attlist & any-user-service & password-encoder?}
+	element authentication-provider {ap.attlist & any-user-service & password-encoder? & user-details-password-service?}
 ap.attlist &=
 	## Specifies a reference to a separately configured AuthenticationProvider instance which should be registered within the AuthenticationManager.
 	ref?

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.0.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.0.xsd
@@ -2940,6 +2940,15 @@
                            <xs:attributeGroup ref="security:password-encoder.attlist"/>
                         </xs:complexType>
                      </xs:element>
+                     <xs:element name="user-details-password-service">
+                        <xs:annotation>
+                           <xs:documentation>Defines a reference to a bean that implements UserDetailsPasswordService.
+                </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                           <xs:attributeGroup ref="security:ref"/>
+                        </xs:complexType>
+                     </xs:element>
                   </xs:choice>
                   <xs:attributeGroup ref="security:ap.attlist"/>
                </xs:complexType>

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.1.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.1.rnc
@@ -66,6 +66,13 @@ use-expressions =
 	## Enables the use of expressions in the 'access' attributes in <intercept-url> elements rather than the traditional list of configuration attributes. Defaults to 'true'. If enabled, each attribute should contain a single boolean expression. If the expression evaluates to 'true', access will be granted.
 	attribute use-expressions {xsd:boolean}
 
+user-details-password-service =
+	## Defines a reference to a bean that implements UserDetailsPasswordService.
+	element user-details-password-service {user-details-password-service.attlist}
+user-details-password-service.attlist &=
+	## Defines a reference to a Spring bean that implements UserDetailsPasswordService.
+	ref
+
 ldap-server =
 	## Defines an LDAP server location or starts an embedded server. The url indicates the location of a remote server. If no url is given, an embedded server will be started, listening on the supplied port number. The port is optional and defaults to 33389. A Spring LDAP ContextSource bean will be registered for the server with the id supplied.
 	element ldap-server {ldap-server.attlist}
@@ -1069,7 +1076,7 @@ authman.attlist &=
 
 authentication-provider =
 	## Indicates that the contained user-service should be used as an authentication source.
-	element authentication-provider {ap.attlist & any-user-service & password-encoder?}
+	element authentication-provider {ap.attlist & any-user-service & password-encoder? & user-details-password-service?}
 ap.attlist &=
 	## Specifies a reference to a separately configured AuthenticationProvider instance which should be registered within the AuthenticationManager.
 	ref?

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.1.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.1.xsd
@@ -2940,6 +2940,15 @@
                            <xs:attributeGroup ref="security:password-encoder.attlist"/>
                         </xs:complexType>
                      </xs:element>
+                     <xs:element name="user-details-password-service">
+                        <xs:annotation>
+                           <xs:documentation>Defines a reference to a bean that implements UserDetailsPasswordService.
+                </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                           <xs:attributeGroup ref="security:ref"/>
+                        </xs:complexType>
+                     </xs:element>
                   </xs:choice>
                   <xs:attributeGroup ref="security:ap.attlist"/>
                </xs:complexType>

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.2.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.2.rnc
@@ -66,6 +66,13 @@ use-expressions =
 	## Enables the use of expressions in the 'access' attributes in <intercept-url> elements rather than the traditional list of configuration attributes. Defaults to 'true'. If enabled, each attribute should contain a single boolean expression. If the expression evaluates to 'true', access will be granted.
 	attribute use-expressions {xsd:boolean}
 
+user-details-password-service =
+	## Defines a reference to a bean that implements UserDetailsPasswordService.
+	element user-details-password-service {user-details-password-service.attlist}
+user-details-password-service.attlist &=
+	## Defines a reference to a Spring bean that implements UserDetailsPasswordService.
+	ref
+
 ldap-server =
 	## Defines an LDAP server location or starts an embedded server. The url indicates the location of a remote server. If no url is given, an embedded server will be started, listening on the supplied port number. The port is optional and defaults to 33389. A Spring LDAP ContextSource bean will be registered for the server with the id supplied.
 	element ldap-server {ldap-server.attlist}
@@ -1069,7 +1076,7 @@ authman.attlist &=
 
 authentication-provider =
 	## Indicates that the contained user-service should be used as an authentication source.
-	element authentication-provider {ap.attlist & any-user-service & password-encoder?}
+	element authentication-provider {ap.attlist & any-user-service & password-encoder? & user-details-password-service?}
 ap.attlist &=
 	## Specifies a reference to a separately configured AuthenticationProvider instance which should be registered within the AuthenticationManager.
 	ref?

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.2.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.2.xsd
@@ -2940,6 +2940,15 @@
                            <xs:attributeGroup ref="security:password-encoder.attlist"/>
                         </xs:complexType>
                      </xs:element>
+                     <xs:element name="user-details-password-service">
+                        <xs:annotation>
+                           <xs:documentation>Defines a reference to a bean that implements UserDetailsPasswordService.
+                </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                           <xs:attributeGroup ref="security:ref"/>
+                        </xs:complexType>
+                     </xs:element>
                   </xs:choice>
                   <xs:attributeGroup ref="security:ap.attlist"/>
                </xs:complexType>

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.3.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.3.rnc
@@ -66,6 +66,13 @@ use-expressions =
 	## Enables the use of expressions in the 'access' attributes in <intercept-url> elements rather than the traditional list of configuration attributes. Defaults to 'true'. If enabled, each attribute should contain a single boolean expression. If the expression evaluates to 'true', access will be granted.
 	attribute use-expressions {xsd:boolean}
 
+user-details-password-service =
+	## Defines a reference to a bean that implements UserDetailsPasswordService.
+	element user-details-password-service {user-details-password-service.attlist}
+user-details-password-service.attlist &=
+	## Defines a reference to a Spring bean that implements UserDetailsPasswordService.
+	ref
+
 ldap-server =
 	## Defines an LDAP server location or starts an embedded server. The url indicates the location of a remote server. If no url is given, an embedded server will be started, listening on the supplied port number. The port is optional and defaults to 33389. A Spring LDAP ContextSource bean will be registered for the server with the id supplied.
 	element ldap-server {ldap-server.attlist}
@@ -1072,7 +1079,7 @@ authman.attlist &=
 
 authentication-provider =
 	## Indicates that the contained user-service should be used as an authentication source.
-	element authentication-provider {ap.attlist & any-user-service & password-encoder?}
+	element authentication-provider {ap.attlist & any-user-service & password-encoder? & user-details-password-service?}
 ap.attlist &=
 	## Specifies a reference to a separately configured AuthenticationProvider instance which should be registered within the AuthenticationManager.
 	ref?

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.3.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.3.xsd
@@ -2949,6 +2949,15 @@
                            <xs:attributeGroup ref="security:password-encoder.attlist"/>
                         </xs:complexType>
                      </xs:element>
+                     <xs:element name="user-details-password-service">
+                        <xs:annotation>
+                           <xs:documentation>Defines a reference to a bean that implements UserDetailsPasswordService.
+                </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                           <xs:attributeGroup ref="security:ref"/>
+                        </xs:complexType>
+                     </xs:element>
                   </xs:choice>
                   <xs:attributeGroup ref="security:ap.attlist"/>
                </xs:complexType>

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.4.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.4.rnc
@@ -66,6 +66,13 @@ use-expressions =
 	## Enables the use of expressions in the 'access' attributes in <intercept-url> elements rather than the traditional list of configuration attributes. Defaults to 'true'. If enabled, each attribute should contain a single boolean expression. If the expression evaluates to 'true', access will be granted.
 	attribute use-expressions {xsd:boolean}
 
+user-details-password-service =
+	## Defines a reference to a bean that implements UserDetailsPasswordService.
+	element user-details-password-service {user-details-password-service.attlist}
+user-details-password-service.attlist &=
+	## Defines a reference to a Spring bean that implements UserDetailsPasswordService.
+	ref
+
 ldap-server =
 	## Defines an LDAP server location or starts an embedded server. The url indicates the location of a remote server. If no url is given, an embedded server will be started, listening on the supplied port number. The port is optional and defaults to 33389. A Spring LDAP ContextSource bean will be registered for the server with the id supplied.
 	element ldap-server {ldap-server.attlist}
@@ -1072,7 +1079,7 @@ authman.attlist &=
 
 authentication-provider =
 	## Indicates that the contained user-service should be used as an authentication source.
-	element authentication-provider {ap.attlist & any-user-service & password-encoder?}
+	element authentication-provider {ap.attlist & any-user-service & password-encoder? & user-details-password-service?}
 ap.attlist &=
 	## Specifies a reference to a separately configured AuthenticationProvider instance which should be registered within the AuthenticationManager.
 	ref?

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.4.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.4.xsd
@@ -2949,6 +2949,15 @@
                            <xs:attributeGroup ref="security:password-encoder.attlist"/>
                         </xs:complexType>
                      </xs:element>
+                     <xs:element name="user-details-password-service">
+                        <xs:annotation>
+                           <xs:documentation>Defines a reference to a bean that implements UserDetailsPasswordService.
+                </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                           <xs:attributeGroup ref="security:ref"/>
+                        </xs:complexType>
+                     </xs:element>
                   </xs:choice>
                   <xs:attributeGroup ref="security:ap.attlist"/>
                </xs:complexType>

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.5.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.5.rnc
@@ -66,6 +66,13 @@ use-expressions =
 	## Enables the use of expressions in the 'access' attributes in <intercept-url> elements rather than the traditional list of configuration attributes. Defaults to 'true'. If enabled, each attribute should contain a single boolean expression. If the expression evaluates to 'true', access will be granted.
 	attribute use-expressions {xsd:boolean}
 
+user-details-password-service =
+	## Defines a reference to a bean that implements UserDetailsPasswordService.
+	element user-details-password-service {user-details-password-service.attlist}
+user-details-password-service.attlist &=
+	## Defines a reference to a Spring bean that implements UserDetailsPasswordService.
+	ref
+
 ldap-server =
 	## Defines an LDAP server location or starts an embedded server. The url indicates the location of a remote server. If no url is given, an embedded server will be started, listening on the supplied port number. The port is optional and defaults to 33389. A Spring LDAP ContextSource bean will be registered for the server with the id supplied.
 	element ldap-server {ldap-server.attlist}
@@ -1078,7 +1085,7 @@ authman.attlist &=
 
 authentication-provider =
 	## Indicates that the contained user-service should be used as an authentication source.
-	element authentication-provider {ap.attlist & any-user-service & password-encoder?}
+	element authentication-provider {ap.attlist & any-user-service & password-encoder? & user-details-password-service?}
 ap.attlist &=
 	## Specifies a reference to a separately configured AuthenticationProvider instance which should be registered within the AuthenticationManager.
 	ref?

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.5.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.5.xsd
@@ -2963,6 +2963,15 @@
                            <xs:attributeGroup ref="security:password-encoder.attlist"/>
                         </xs:complexType>
                      </xs:element>
+                     <xs:element name="user-details-password-service">
+                        <xs:annotation>
+                           <xs:documentation>Defines a reference to a bean that implements UserDetailsPasswordService.
+                </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                           <xs:attributeGroup ref="security:ref"/>
+                        </xs:complexType>
+                     </xs:element>
                   </xs:choice>
                   <xs:attributeGroup ref="security:ap.attlist"/>
                </xs:complexType>

--- a/config/src/main/resources/org/springframework/security/config/spring-security-7.0.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-7.0.rnc
@@ -66,6 +66,13 @@ use-expressions =
 	## Enables the use of expressions in the 'access' attributes in <intercept-url> elements rather than the traditional list of configuration attributes. Defaults to 'true'. If enabled, each attribute should contain a single boolean expression. If the expression evaluates to 'true', access will be granted.
 	attribute use-expressions {xsd:boolean}
 
+user-details-password-service =
+	## Defines a reference to a bean that implements UserDetailsPasswordService.
+	element user-details-password-service {user-details-password-service.attlist}
+user-details-password-service.attlist &=
+	## Defines a reference to a Spring bean that implements UserDetailsPasswordService.
+	ref
+
 ldap-server =
 	## Defines an LDAP server location or starts an embedded server. The url indicates the location of a remote server. If no url is given, an embedded server will be started, listening on the supplied port number. The port is optional and defaults to 33389. A Spring LDAP ContextSource bean will be registered for the server with the id supplied.
 	element ldap-server {ldap-server.attlist}
@@ -1084,7 +1091,7 @@ authman.attlist &=
 
 authentication-provider =
 	## Indicates that the contained user-service should be used as an authentication source.
-	element authentication-provider {ap.attlist & any-user-service & password-encoder?}
+	element authentication-provider {ap.attlist & any-user-service & password-encoder? & user-details-password-service?}
 ap.attlist &=
 	## Specifies a reference to a separately configured AuthenticationProvider instance which should be registered within the AuthenticationManager.
 	ref?

--- a/config/src/main/resources/org/springframework/security/config/spring-security-7.0.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-7.0.xsd
@@ -2974,6 +2974,15 @@
                            <xs:attributeGroup ref="security:password-encoder.attlist"/>
                         </xs:complexType>
                      </xs:element>
+                     <xs:element name="user-details-password-service">
+                        <xs:annotation>
+                           <xs:documentation>Defines a reference to a bean that implements UserDetailsPasswordService.
+                </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                           <xs:attributeGroup ref="security:ref"/>
+                        </xs:complexType>
+                     </xs:element>
                   </xs:choice>
                   <xs:attributeGroup ref="security:ap.attlist"/>
                </xs:complexType>

--- a/config/src/main/resources/org/springframework/security/config/spring-security-7.1.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-7.1.rnc
@@ -66,6 +66,13 @@ use-expressions =
 	## Enables the use of expressions in the 'access' attributes in <intercept-url> elements rather than the traditional list of configuration attributes. Defaults to 'true'. If enabled, each attribute should contain a single boolean expression. If the expression evaluates to 'true', access will be granted.
 	attribute use-expressions {xsd:boolean}
 
+user-details-password-service =
+	## Defines a reference to a bean that implements UserDetailsPasswordService.
+	element user-details-password-service {user-details-password-service.attlist}
+user-details-password-service.attlist &=
+	## Defines a reference to a Spring bean that implements UserDetailsPasswordService.
+	ref
+
 ldap-server =
 	## Defines an LDAP server location or starts an embedded server. The url indicates the location of a remote server. If no url is given, an embedded server will be started, listening on the supplied port number. The port is optional and defaults to 33389. A Spring LDAP ContextSource bean will be registered for the server with the id supplied.
 	element ldap-server {ldap-server.attlist}
@@ -1084,7 +1091,7 @@ authman.attlist &=
 
 authentication-provider =
 	## Indicates that the contained user-service should be used as an authentication source.
-	element authentication-provider {ap.attlist & any-user-service & password-encoder?}
+	element authentication-provider {ap.attlist & any-user-service & password-encoder? & user-details-password-service?}
 ap.attlist &=
 	## Specifies a reference to a separately configured AuthenticationProvider instance which should be registered within the AuthenticationManager.
 	ref?

--- a/config/src/main/resources/org/springframework/security/config/spring-security-7.1.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-7.1.xsd
@@ -2974,6 +2974,15 @@
                            <xs:attributeGroup ref="security:password-encoder.attlist"/>
                         </xs:complexType>
                      </xs:element>
+                     <xs:element name="user-details-password-service">
+                        <xs:annotation>
+                           <xs:documentation>Defines a reference to a bean that implements UserDetailsPasswordService.
+                </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                           <xs:attributeGroup ref="security:ref"/>
+                        </xs:complexType>
+                     </xs:element>
                   </xs:choice>
                   <xs:attributeGroup ref="security:ap.attlist"/>
                </xs:complexType>

--- a/docs/modules/ROOT/pages/servlet/appendix/namespace/authentication-manager.adoc
+++ b/docs/modules/ROOT/pages/servlet/appendix/namespace/authentication-manager.adoc
@@ -97,6 +97,7 @@ A reference to a bean that implements UserDetailsService that may be created usi
 * <<nsa-jdbc-user-service,jdbc-user-service>>
 * xref:servlet/appendix/namespace/ldap.adoc#nsa-ldap-user-service[ldap-user-service]
 * <<nsa-password-encoder,password-encoder>>
+* <<nsa-user-details-password-service,user-details-password-service>>
 * <<nsa-user-service,user-service>>
 
 
@@ -208,6 +209,28 @@ We recommend strongly against using MD4, as it is a very weak hashing algorithm.
 [[nsa-password-encoder-ref]]
 * **ref**
 Defines a reference to a Spring bean that implements `PasswordEncoder`.
+
+
+[[nsa-user-details-password-service]]
+== <user-details-password-service>
+Authentication providers can optionally be configured with a `UserDetailsPasswordService`.
+This allows `DaoAuthenticationProvider` to persist upgraded password hashes after successful authentication when password encoding should be updated.
+
+
+[[nsa-user-details-password-service-parents]]
+=== Parent Elements of <user-details-password-service>
+
+
+* <<nsa-authentication-provider,authentication-provider>>
+
+
+[[nsa-user-details-password-service-attributes]]
+=== <user-details-password-service> Attributes
+
+
+[[nsa-user-details-password-service-ref]]
+* **ref**
+Defines a reference to a Spring bean that implements `UserDetailsPasswordService`.
 
 
 [[nsa-user-service]]


### PR DESCRIPTION
Closes gh-7746

This PR adds XML namespace support for configuring UserDetailsPasswordService on <authentication-provider>.

It introduces support for:
```xml
<security:user-details-password-service ref="..."/>
```
Changes include:

- parsing and wiring userDetailsPasswordService in AuthenticationProviderBeanDefinitionParser
- schema updates in namespace RNC/XSD files (5.8 through 7.1)
- parser test coverage for the new element
- namespace appendix documentation update