### PR TITLE
Warn when securityMatcher misses oauth2Login URLs

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
@@ -177,6 +177,7 @@ public final class HttpSecurity extends AbstractConfiguredSecurityBuilder<Defaul
 		}
 		ApplicationContext context = (ApplicationContext) sharedObjects.get(ApplicationContext.class);
 		this.requestMatcherConfigurer = new RequestMatcherConfigurer(context);
+		setSharedObject(RequestMatcher.class, this.requestMatcher);
 	}
 
 	private ApplicationContext getContext() {
@@ -2013,6 +2014,7 @@ public final class HttpSecurity extends AbstractConfiguredSecurityBuilder<Defaul
 	 */
 	public HttpSecurity securityMatcher(RequestMatcher requestMatcher) {
 		this.requestMatcher = requestMatcher;
+		setSharedObject(RequestMatcher.class, this.requestMatcher);
 		return this;
 	}
 
@@ -2038,6 +2040,7 @@ public final class HttpSecurity extends AbstractConfiguredSecurityBuilder<Defaul
 			matchers.add(builder.matcher(pattern));
 		}
 		this.requestMatcher = new OrRequestMatcher(matchers);
+		setSharedObject(RequestMatcher.class, this.requestMatcher);
 		return this;
 	}
 


### PR DESCRIPTION
Closes gh-14096

When `oauth2Login()` is configured together with a restrictive `securityMatcher`, it is easy to accidentally exclude one of the OAuth2 login endpoints, which can lead to 404 responses.

This change adds a warning when the configured `securityMatcher` does not match OAuth2 login endpoints.

Changes include:

- expose the current `HttpSecurity` request matcher as a shared object
- in `OAuth2LoginConfigurer`, warn when `securityMatcher` does not match:
  - authorization request endpoint (`/oauth2/authorization/{registrationId}` by default)
  - authorization response endpoint (`/login/oauth2/code/*` by default, or a custom redirection endpoint base URI)
- add tests for warning and no-warning scenarios
