### PR TITLE
Add authentication-failure-handler-ref to <session-management>

### DIFF
--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.8.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.8.rnc
@@ -944,7 +944,9 @@ session-management.attlist &=
 session-management.attlist &=
 	## Defines the URL of the error page which should be shown when the SessionAuthenticationStrategy raises an exception. If not set, an unauthorized (401) error code will be returned to the client. Note that this attribute doesn't apply if the error occurs during a form-based login, where the URL for authentication failure will take precedence.
 	attribute session-authentication-error-url {xsd:token}?
-
+session-management.attlist &=
+	## Reference to an AuthenticationFailureHandler bean which should be used to handle a failed authentication request. Use either this or session-authentication-error-url but not both.
+	attribute authentication-failure-handler-ref {xsd:token}?
 
 concurrency-control =
 	## Enables concurrent session control, limiting the number of authenticated sessions a user may have at the same time.

--- a/config/src/main/resources/org/springframework/security/config/spring-security-5.8.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-5.8.xsd
@@ -2747,6 +2747,14 @@
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="authentication-failure-handler-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationFailureHandler bean which should be used to handle a failed
+                authentication request. Use either this or session-authentication-error-url but not
+                both.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
   </xs:attributeGroup>
   
   <xs:attributeGroup name="concurrency-control.attlist">

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.0.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.0.rnc
@@ -922,7 +922,9 @@ session-management.attlist &=
 session-management.attlist &=
 	## Defines the URL of the error page which should be shown when the SessionAuthenticationStrategy raises an exception. If not set, an unauthorized (401) error code will be returned to the client. Note that this attribute doesn't apply if the error occurs during a form-based login, where the URL for authentication failure will take precedence.
 	attribute session-authentication-error-url {xsd:token}?
-
+session-management.attlist &=
+	## Reference to an AuthenticationFailureHandler bean which should be used to handle a failed authentication request. Use either this or session-authentication-error-url but not both.
+	attribute authentication-failure-handler-ref {xsd:token}?
 
 concurrency-control =
 	## Enables concurrent session control, limiting the number of authenticated sessions a user may have at the same time.

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.0.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.0.xsd
@@ -2669,6 +2669,14 @@
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="authentication-failure-handler-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationFailureHandler bean which should be used to handle a failed
+                authentication request. Use either this or session-authentication-error-url but not
+                both.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
   </xs:attributeGroup>
   
   <xs:attributeGroup name="concurrency-control.attlist">

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.1.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.1.rnc
@@ -922,7 +922,9 @@ session-management.attlist &=
 session-management.attlist &=
 	## Defines the URL of the error page which should be shown when the SessionAuthenticationStrategy raises an exception. If not set, an unauthorized (401) error code will be returned to the client. Note that this attribute doesn't apply if the error occurs during a form-based login, where the URL for authentication failure will take precedence.
 	attribute session-authentication-error-url {xsd:token}?
-
+session-management.attlist &=
+	## Reference to an AuthenticationFailureHandler bean which should be used to handle a failed authentication request. Use either this or session-authentication-error-url but not both.
+	attribute authentication-failure-handler-ref {xsd:token}?
 
 concurrency-control =
 	## Enables concurrent session control, limiting the number of authenticated sessions a user may have at the same time.

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.1.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.1.xsd
@@ -2669,6 +2669,14 @@
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="authentication-failure-handler-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationFailureHandler bean which should be used to handle a failed
+                authentication request. Use either this or session-authentication-error-url but not
+                both.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
   </xs:attributeGroup>
   
   <xs:attributeGroup name="concurrency-control.attlist">

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.2.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.2.rnc
@@ -922,7 +922,9 @@ session-management.attlist &=
 session-management.attlist &=
 	## Defines the URL of the error page which should be shown when the SessionAuthenticationStrategy raises an exception. If not set, an unauthorized (401) error code will be returned to the client. Note that this attribute doesn't apply if the error occurs during a form-based login, where the URL for authentication failure will take precedence.
 	attribute session-authentication-error-url {xsd:token}?
-
+session-management.attlist &=
+	## Reference to an AuthenticationFailureHandler bean which should be used to handle a failed authentication request. Use either this or session-authentication-error-url but not both.
+	attribute authentication-failure-handler-ref {xsd:token}?
 
 concurrency-control =
 	## Enables concurrent session control, limiting the number of authenticated sessions a user may have at the same time.

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.2.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.2.xsd
@@ -2669,6 +2669,14 @@
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="authentication-failure-handler-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationFailureHandler bean which should be used to handle a failed
+                authentication request. Use either this or session-authentication-error-url but not
+                both.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
   </xs:attributeGroup>
   
   <xs:attributeGroup name="concurrency-control.attlist">

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.3.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.3.rnc
@@ -925,7 +925,9 @@ session-management.attlist &=
 session-management.attlist &=
 	## Defines the URL of the error page which should be shown when the SessionAuthenticationStrategy raises an exception. If not set, an unauthorized (401) error code will be returned to the client. Note that this attribute doesn't apply if the error occurs during a form-based login, where the URL for authentication failure will take precedence.
 	attribute session-authentication-error-url {xsd:token}?
-
+session-management.attlist &=
+	## Reference to an AuthenticationFailureHandler bean which should be used to handle a failed authentication request. Use either this or session-authentication-error-url but not both.
+	attribute authentication-failure-handler-ref {xsd:token}?
 
 concurrency-control =
 	## Enables concurrent session control, limiting the number of authenticated sessions a user may have at the same time.

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.3.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.3.xsd
@@ -2678,6 +2678,14 @@
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="authentication-failure-handler-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationFailureHandler bean which should be used to handle a failed
+                authentication request. Use either this or session-authentication-error-url but not
+                both.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
   </xs:attributeGroup>
   
   <xs:attributeGroup name="concurrency-control.attlist">

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.4.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.4.rnc
@@ -925,7 +925,9 @@ session-management.attlist &=
 session-management.attlist &=
 	## Defines the URL of the error page which should be shown when the SessionAuthenticationStrategy raises an exception. If not set, an unauthorized (401) error code will be returned to the client. Note that this attribute doesn't apply if the error occurs during a form-based login, where the URL for authentication failure will take precedence.
 	attribute session-authentication-error-url {xsd:token}?
-
+session-management.attlist &=
+	## Reference to an AuthenticationFailureHandler bean which should be used to handle a failed authentication request. Use either this or session-authentication-error-url but not both.
+	attribute authentication-failure-handler-ref {xsd:token}?
 
 concurrency-control =
 	## Enables concurrent session control, limiting the number of authenticated sessions a user may have at the same time.

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.4.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.4.xsd
@@ -2678,6 +2678,14 @@
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="authentication-failure-handler-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationFailureHandler bean which should be used to handle a failed
+                authentication request. Use either this or session-authentication-error-url but not
+                both.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
   </xs:attributeGroup>
   
   <xs:attributeGroup name="concurrency-control.attlist">

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.5.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.5.rnc
@@ -928,7 +928,9 @@ session-management.attlist &=
 session-management.attlist &=
 	## Defines the URL of the error page which should be shown when the SessionAuthenticationStrategy raises an exception. If not set, an unauthorized (401) error code will be returned to the client. Note that this attribute doesn't apply if the error occurs during a form-based login, where the URL for authentication failure will take precedence.
 	attribute session-authentication-error-url {xsd:token}?
-
+session-management.attlist &=
+	## Reference to an AuthenticationFailureHandler bean which should be used to handle a failed authentication request. Use either this or session-authentication-error-url but not both.
+	attribute authentication-failure-handler-ref {xsd:token}?
 
 concurrency-control =
 	## Enables concurrent session control, limiting the number of authenticated sessions a user may have at the same time.

--- a/config/src/main/resources/org/springframework/security/config/spring-security-6.5.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-6.5.xsd
@@ -2685,6 +2685,14 @@
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="authentication-failure-handler-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationFailureHandler bean which should be used to handle a failed
+                authentication request. Use either this or session-authentication-error-url but not
+                both.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
   </xs:attributeGroup>
   
   <xs:attributeGroup name="concurrency-control.attlist">

--- a/config/src/main/resources/org/springframework/security/config/spring-security-7.0.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-7.0.rnc
@@ -931,7 +931,9 @@ session-management.attlist &=
 session-management.attlist &=
 	## Defines the URL of the error page which should be shown when the SessionAuthenticationStrategy raises an exception. If not set, an unauthorized (401) error code will be returned to the client. Note that this attribute doesn't apply if the error occurs during a form-based login, where the URL for authentication failure will take precedence.
 	attribute session-authentication-error-url {xsd:token}?
-
+session-management.attlist &=
+	## Reference to an AuthenticationFailureHandler bean which should be used to handle a failed authentication request. Use either this or session-authentication-error-url but not both.
+	attribute authentication-failure-handler-ref {xsd:token}?
 
 concurrency-control =
 	## Enables concurrent session control, limiting the number of authenticated sessions a user may have at the same time.

--- a/config/src/main/resources/org/springframework/security/config/spring-security-7.0.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-7.0.xsd
@@ -2690,6 +2690,14 @@
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="authentication-failure-handler-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationFailureHandler bean which should be used to handle a failed
+                authentication request. Use either this or session-authentication-error-url but not
+                both.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
   </xs:attributeGroup>
   
   <xs:attributeGroup name="concurrency-control.attlist">

--- a/config/src/main/resources/org/springframework/security/config/spring-security-7.1.rnc
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-7.1.rnc
@@ -931,7 +931,9 @@ session-management.attlist &=
 session-management.attlist &=
 	## Defines the URL of the error page which should be shown when the SessionAuthenticationStrategy raises an exception. If not set, an unauthorized (401) error code will be returned to the client. Note that this attribute doesn't apply if the error occurs during a form-based login, where the URL for authentication failure will take precedence.
 	attribute session-authentication-error-url {xsd:token}?
-
+session-management.attlist &=
+	## Reference to an AuthenticationFailureHandler bean which should be used to handle a failed authentication request. Use either this or session-authentication-error-url but not both.
+	attribute authentication-failure-handler-ref {xsd:token}?
 
 concurrency-control =
 	## Enables concurrent session control, limiting the number of authenticated sessions a user may have at the same time.

--- a/config/src/main/resources/org/springframework/security/config/spring-security-7.1.xsd
+++ b/config/src/main/resources/org/springframework/security/config/spring-security-7.1.xsd
@@ -2690,6 +2690,14 @@
                 </xs:documentation>
          </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="authentication-failure-handler-ref" type="xs:token">
+         <xs:annotation>
+            <xs:documentation>Reference to an AuthenticationFailureHandler bean which should be used to handle a failed
+                authentication request. Use either this or session-authentication-error-url but not
+                both.
+                </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
   </xs:attributeGroup>
   
   <xs:attributeGroup name="concurrency-control.attlist">

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-SessionAuthenticationErrorUrlAndFailureHandlerRef.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-SessionAuthenticationErrorUrlAndFailureHandlerRef.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2004-present the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<b:beans xmlns:b="http://www.springframework.org/schema/beans"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xmlns="http://www.springframework.org/schema/security"
+		xsi:schemaLocation="
+			http://www.springframework.org/schema/security
+			https://www.springframework.org/schema/security/spring-security.xsd
+			http://www.springframework.org/schema/beans
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<http auto-config="true" use-expressions="true">
+		<intercept-url pattern="/auth/**" access="authenticated"/>
+		<session-management
+			authentication-strategy-explicit-invocation="false"
+			session-authentication-strategy-ref="teapotSessionAuthenticationStrategy"
+			session-authentication-error-url="/error"
+			authentication-failure-handler-ref="teapotAuthenticationFailureHandler"/>
+	</http>
+
+	<b:bean name="basicController"
+			class="org.springframework.security.config.http.SessionManagementConfigTests.BasicController"/>
+
+	<b:bean name="teapotSessionAuthenticationStrategy"
+			class="org.springframework.security.config.http.SessionManagementConfigTests.TeapotSessionAuthenticationStrategy"/>
+
+	<b:bean name="teapotAuthenticationFailureHandler"
+			class="org.springframework.security.config.http.SessionManagementConfigTests.TeapotAuthenticationFailureHandler"/>
+
+	<b:import resource="userservice.xml"/>
+</b:beans>

--- a/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-SessionAuthenticationFailureHandlerRef.xml
+++ b/config/src/test/resources/org/springframework/security/config/http/SessionManagementConfigTests-SessionAuthenticationFailureHandlerRef.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2004-present the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<b:beans xmlns:b="http://www.springframework.org/schema/beans"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xmlns="http://www.springframework.org/schema/security"
+		xsi:schemaLocation="
+			http://www.springframework.org/schema/security
+			https://www.springframework.org/schema/security/spring-security.xsd
+			http://www.springframework.org/schema/beans
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<http auto-config="true" use-expressions="true">
+		<intercept-url pattern="/auth/**" access="authenticated"/>
+		<session-management
+			authentication-strategy-explicit-invocation="false"
+			session-authentication-strategy-ref="throwingSessionAuthenticationStrategy"
+			authentication-failure-handler-ref="teapotAuthenticationFailureHandler"/>
+	</http>
+
+	<b:bean name="basicController"
+			class="org.springframework.security.config.http.SessionManagementConfigTests.BasicController"/>
+
+	<b:bean name="throwingSessionAuthenticationStrategy"
+			class="org.springframework.security.config.http.SessionManagementConfigTests.ThrowingSessionAuthenticationStrategy"/>
+
+	<b:bean name="teapotAuthenticationFailureHandler"
+			class="org.springframework.security.config.http.SessionManagementConfigTests.TeapotAuthenticationFailureHandler"/>
+
+	<b:import resource="userservice.xml"/>
+</b:beans>

--- a/docs/modules/ROOT/pages/servlet/appendix/namespace/http.adoc
+++ b/docs/modules/ROOT/pages/servlet/appendix/namespace/http.adoc
@@ -2108,6 +2108,11 @@ Defines the URL of the error page which should be shown when the SessionAuthenti
 If not set, an unauthorized (401) error code will be returned to the client.
 Note that this attribute doesn't apply if the error occurs during a form-based login, where the URL for authentication failure will take precedence.
 
+[[nsa-session-management-authentication-failure-handler-ref]]
+* **authentication-failure-handler-ref**
+Allows injection of the `AuthenticationFailureHandler` instance used by the `SessionManagementFilter`.
+Use either this or the `session-authentication-error-url` attribute but not both.
+
 
 [[nsa-session-management-session-authentication-strategy-ref]]
 * **session-authentication-strategy-ref**


### PR DESCRIPTION
Closes gh-2000

This PR adds XML namespace support for configuring a custom `AuthenticationFailureHandler` on `<session-management>`.

It introduces support for:

```xml
<session-management authentication-failure-handler-ref="..."/>
```

Changes include:
- parsing and wiring `authentication-failure-handler-ref` in `HttpConfigurationBuilder`
- validation to prevent using `authentication-failure-handler-ref` together with `session-authentication-error-url`
- schema updates in namespace RNC/XSD files (5.8 through 7.1)
- session-management namespace appendix documentation update
- integration tests for custom failure handler invocation
- integration tests for mutual-exclusion parsing error when both attributes are configured
