### PR TITLE
Ensure tests clear AuthorizationServerContextHolder

### DIFF
--- a/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/JwtClientAssertionAuthenticationProviderTests.java
+++ b/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/JwtClientAssertionAuthenticationProviderTests.java
@@ -30,6 +30,7 @@ import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.OctetSequenceKey;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -110,6 +111,11 @@ public class JwtClientAssertionAuthenticationProviderTests {
 			.build();
 		AuthorizationServerContextHolder
 			.setContext(new TestAuthorizationServerContext(this.authorizationServerSettings, null));
+	}
+
+	@AfterEach
+	public void tearDown() {
+		AuthorizationServerContextHolder.resetContext();
 	}
 
 	@Test

--- a/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeRequestAuthenticationProviderTests.java
+++ b/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeRequestAuthenticationProviderTests.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -109,6 +110,11 @@ public class OAuth2AuthorizationCodeRequestAuthenticationProviderTests {
 			.build();
 		AuthorizationServerContextHolder
 			.setContext(new TestAuthorizationServerContext(authorizationServerSettings, null));
+	}
+
+	@AfterEach
+	public void tearDown() {
+		AuthorizationServerContextHolder.resetContext();
 	}
 
 	@Test

--- a/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationConsentAuthenticationProviderTests.java
+++ b/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationConsentAuthenticationProviderTests.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -93,6 +94,11 @@ public class OAuth2AuthorizationConsentAuthenticationProviderTests {
 			.build();
 		AuthorizationServerContextHolder
 			.setContext(new TestAuthorizationServerContext(authorizationServerSettings, null));
+	}
+
+	@AfterEach
+	public void tearDown() {
+		AuthorizationServerContextHolder.resetContext();
 	}
 
 	@Test

--- a/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2DeviceVerificationAuthenticationProviderTests.java
+++ b/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2DeviceVerificationAuthenticationProviderTests.java
@@ -25,6 +25,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -94,6 +95,11 @@ public class OAuth2DeviceVerificationAuthenticationProviderTests {
 		this.authenticationProvider = new OAuth2DeviceVerificationAuthenticationProvider(
 				this.registeredClientRepository, this.authorizationService, this.authorizationConsentService);
 		mockAuthorizationServerContext();
+	}
+
+	@AfterEach
+	public void tearDown() {
+		AuthorizationServerContextHolder.resetContext();
 	}
 
 	@Test


### PR DESCRIPTION
There are tests that do not clear AuthorizationServerContextHolder which causes flakey tests to happen. For example, this test [occasionally](https://github.com/spring-projects/spring-security/actions/runs/22199265654/job/64207619518) fails:

```

OAuth2AuthorizationCodeRequestAuthenticationProviderTests > authenticateWhenAuthorizationCodeRequestWithRequestUriThenReturnAuthorizationCode() FAILED
    org.springframework.security.oauth2.server.authorization.authentication.OAuth2AuthorizationCodeRequestAuthenticationException at OAuth2AuthorizationCodeRequestAuthenticationProviderTests.java:629
```