### PR TITLE
Document the change in dependency coordinates with Spring Security 7

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/kerberos/introduction.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/kerberos/introduction.adoc
@@ -3,3 +3,38 @@
 
 Spring Security Kerberos {spring-security-version} is built and tested with JDK 17,
 Spring Security {spring-security-version} and Spring Framework {spring-core-version}.
+
+The dependency coordinates changed with Spring Security 7:
+
+[tabs]
+======
+Maven::
++
+.pom.xml
+[source,xml,subs="verbatim,attributes"]
+----
+<dependencies>
+	<!-- ... other dependency elements ... -->
+	<dependency>
+		<groupId>org.springframework.security</groupId>
+		<artifactId>spring-security-kerberos-core</artifactId>
+	</dependency>
+	<dependency>
+		<groupId>org.springframework.security</groupId>
+		<artifactId>spring-security-kerberos-web</artifactId>
+	</dependency>
+</dependencies>
+----
+
+Gradle::
++
+.build.gradle
+[source,groovy]
+[subs="verbatim,attributes"]
+----
+dependencies {
+	implementation "org.springframework.security:spring-security-kerberos-core"
+	implementation "org.springframework.security:spring-security-kerberos-web"
+}
+----
+======


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
Include the updated dependency coordinates for Spring Security Kerberos, so that people upgrading to Spring Security 7 realise that they still have to bring in extra dependencies, but with a different group ID.

Closes gh-18698