### PR TITLE
Add application-scoped access tokens for reactive OAuth2 client

### DIFF
--- a/docs/modules/ROOT/pages/reactive/oauth2/client/authorization-grants.adoc
+++ b/docs/modules/ROOT/pages/reactive/oauth2/client/authorization-grants.adoc
@@ -704,7 +704,7 @@ If not provided, it will be obtained from the https://projectreactor.io/docs/cor
 When making requests that are not associated with a specific user (e.g. background jobs, batch processes, or scheduled tasks), use `AuthorizedClientServiceReactiveOAuth2AuthorizedClientManager` instead of `DefaultReactiveOAuth2AuthorizedClientManager`.
 Unlike `DefaultReactiveOAuth2AuthorizedClientManager`, `AuthorizedClientServiceReactiveOAuth2AuthorizedClientManager` operates outside of a `ServerWebExchange` context, making it suitable for application-scoped access tokens.
 
-The following example shows how to configure a `WebClient` for application-scoped access tokens using the Client Credentials grant:
+The following example shows how to configure a `WebClient` with a custom `ExchangeFilterFunction` backed by `AuthorizedClientServiceReactiveOAuth2AuthorizedClientManager` for application-scoped access tokens:
 
 .WebClient with Application-Scoped Access Tokens
 [tabs]
@@ -721,6 +721,7 @@ include::{tests-dir}/reactive/oauth2/webclient/ApplicationScopedAccessTokenConfi
 ====
 `AuthorizedClientServiceReactiveOAuth2AuthorizedClientManager` uses a `ReactiveOAuth2AuthorizedClientService` to persist authorized clients, rather than a `ServerOAuth2AuthorizedClientRepository`.
 This makes it suitable for use cases where there is no active `ServerWebExchange`, such as background tasks or scheduled jobs.
+Unlike `ServerOAuth2AuthorizedClientExchangeFilterFunction`, a custom `ExchangeFilterFunction` avoids resolving the principal from a `ServerWebExchange`, ensuring it works correctly in application-scoped contexts.
 ====
 
 [[oauth2-client-jwt-bearer]]

--- a/docs/src/test/java/org/springframework/security/docs/reactive/oauth2/webclient/ApplicationScopedAccessTokenConfiguration.java
+++ b/docs/src/test/java/org/springframework/security/docs/reactive/oauth2/webclient/ApplicationScopedAccessTokenConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,13 @@ package org.springframework.security.docs.reactive.oauth2.webclient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.client.AuthorizedClientServiceReactiveOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientProviderBuilder;
 import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
-import org.springframework.security.oauth2.client.web.reactive.function.client.ServerOAuth2AuthorizedClientExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
@@ -48,11 +50,24 @@ public class ApplicationScopedAccessTokenConfiguration {
 
 	@Bean
 	WebClient webClient(ReactiveOAuth2AuthorizedClientManager authorizedClientManager) {
-		var oauth2Client = new ServerOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager);
-		oauth2Client.setDefaultClientRegistrationId("my-client");
+		ExchangeFilterFunction oauth2Filter = (request, next) -> {
+			OAuth2AuthorizeRequest authorizeRequest = OAuth2AuthorizeRequest
+					.withClientRegistrationId("my-client")
+					.principal("my-client")
+					.build();
+
+			return authorizedClientManager.authorize(authorizeRequest)
+					.map(authorizedClient -> authorizedClient.getAccessToken().getTokenValue())
+					.flatMap(token -> {
+						ClientRequest authorized = ClientRequest.from(request)
+								.headers(h -> h.setBearerAuth(token))
+								.build();
+						return next.exchange(authorized);
+					});
+		};
 
 		return WebClient.builder()
-				.filter(oauth2Client)
+				.filter(oauth2Filter)
 				.build();
 	}
 	// end::webclient-client-credentials[]

--- a/docs/src/test/java/org/springframework/security/docs/reactive/oauth2/webclient/ApplicationScopedAccessTokenTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/reactive/oauth2/webclient/ApplicationScopedAccessTokenTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-present the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Closes #17129

## Problem
The Spring Security documentation explains how to use application-scoped 
access tokens (Client Credentials grant) for servlet applications, but 
there was no equivalent documentation for reactive applications.

## Solution
Add a new section to the reactive OAuth2 client authorization-grants 
documentation that shows how to configure WebClient with 
AuthorizedClientServiceReactiveOAuth2AuthorizedClientManager for 
application-scoped (non-user-scoped) access tokens.

## Changes
- docs: Add new section "Use the Client Credentials Grant for 
  Application-Scoped Access Tokens" to authorization-grants.adoc
- test: Add ApplicationScopedAccessTokenConfiguration.java
- test: Add ApplicationScopedAccessTokenTests.java