### PR TITLE
Allow empty passwords in NoOpPasswordEncoder

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/password/AbstractValidatingPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password/AbstractValidatingPasswordEncoder.java
@@ -46,7 +46,7 @@ public abstract class AbstractValidatingPasswordEncoder implements PasswordEncod
 
 	@Override
 	public final boolean matches(@Nullable CharSequence rawPassword, @Nullable String encodedPassword) {
-		if (!StringUtils.hasLength(rawPassword) || !StringUtils.hasLength(encodedPassword)) {
+		if (rawPassword == null || encodedPassword == null) {
 			return false;
 		}
 		return matchesNonNull(rawPassword.toString(), encodedPassword);

--- a/crypto/src/test/java/org/springframework/security/crypto/password/AbstractPasswordEncoderValidationTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/password/AbstractPasswordEncoderValidationTests.java
@@ -53,18 +53,8 @@ public abstract class AbstractPasswordEncoderValidationTests {
 	}
 
 	@Test
-	void matchesWhenEncodedPasswordEmptyThenFalse() {
-		assertThat(this.encoder.matches("raw", "")).isFalse();
-	}
-
-	@Test
 	void matchesWhenRawPasswordNullThenFalse() {
 		assertThat(this.encoder.matches(null, this.encoder.encode("password"))).isFalse();
-	}
-
-	@Test
-	void matchesWhenRawPasswordEmptyThenFalse() {
-		assertThat(this.encoder.matches("", this.encoder.encode("password"))).isFalse();
 	}
 
 }

--- a/crypto/src/test/java/org/springframework/security/crypto/password/NoOpPasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/password/NoOpPasswordEncoderTests.java
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.security.crypto.password;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test {@link NoOpPasswordEncoder}.
@@ -28,6 +30,21 @@ class NoOpPasswordEncoderTests extends AbstractPasswordEncoderValidationTests {
 	@BeforeEach
 	void setup() {
 		setEncoder(NoOpPasswordEncoder.getInstance());
+	}
+
+	@Test
+	void matchesWhenBothPasswordsEmptyThenTrue() {
+		assertThat(NoOpPasswordEncoder.getInstance().matches("", "")).isTrue();
+	}
+
+	@Test
+	void matchesWhenRawPasswordEmptyAndEncodedPasswordNonEmptyThenFalse() {
+		assertThat(NoOpPasswordEncoder.getInstance().matches("", "password")).isFalse();
+	}
+
+	@Test
+	void matchesWhenRawPasswordNonEmptyAndEncodedPasswordEmptyThenFalse() {
+		assertThat(NoOpPasswordEncoder.getInstance().matches("password", "")).isFalse();
 	}
 
 }


### PR DESCRIPTION
Closes gh-18640

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
