### PR TITLE
Restore upgradeEncoding condition in DaoAuthenticationProvider

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/dao/DaoAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/dao/DaoAuthenticationProvider.java
@@ -16,6 +16,7 @@
 
 package org.springframework.security.authentication.dao;
 
+import java.util.Objects;
 import java.util.function.Supplier;
 
 import org.jspecify.annotations.Nullable;
@@ -43,6 +44,7 @@ import org.springframework.util.function.SingletonSupplier;
  *
  * @author Ben Alex
  * @author Rob Winch
+ * @author Andrey Litvitski
  */
 public class DaoAuthenticationProvider extends AbstractUserDetailsAuthenticationProvider {
 
@@ -131,7 +133,8 @@ public class DaoAuthenticationProvider extends AbstractUserDetailsAuthentication
 			throw new CompromisedPasswordException("The provided password is compromised, please change your password");
 		}
 		String existingEncodedPassword = user.getPassword();
-		boolean upgradeEncoding = existingEncodedPassword != null && this.userDetailsPasswordService != null
+		boolean upgradeEncoding = existingEncodedPassword != null
+				&& !Objects.equals(this.userDetailsPasswordService, UserDetailsPasswordService.NOOP)
 				&& this.passwordEncoder.get().upgradeEncoding(existingEncodedPassword);
 		if (upgradeEncoding) {
 			String newPassword = this.passwordEncoder.get().encode(presentedPassword);


### PR DESCRIPTION
After adding jspecify support in the module that contains the DaoAuthenticationProvider class, we actually changed the contract logic, which is a good thing, and this commit fixes it.

Closes: gh-18781

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
