### PR TITLE
Fix SecurityContextLogoutHandler.logout @param response Javadoc (cannot be null)

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/logout/SecurityContextLogoutHandler.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/logout/SecurityContextLogoutHandler.java
@@ -61,7 +61,7 @@ public class SecurityContextLogoutHandler implements LogoutHandler {
 	/**
 	 * Requires the request to be passed in.
 	 * @param request from which to obtain a HTTP session (cannot be null)
-	 * @param response not used (can be <code>null</code>)
+	 * @param response the response (cannot be null)
 	 * @param authentication not used (can be <code>null</code>)
 	 */
 	@Override


### PR DESCRIPTION
The Javadoc needs updating since the `LogoutHandler` interface contract requires @NonNull HttpServletResponse in order to support writing cookies to the response. Since the implementation delegates to an instance of `LogoutHandler` which requires a non-null response, the parameter passed in must also be non-null.

Closes gh-18357
