### PR TITLE
Add Missing OnCommitedResponseWrapper Header Overrides

### DIFF
--- a/web/src/main/java/org/springframework/security/web/util/OnCommittedResponseWrapper.java
+++ b/web/src/main/java/org/springframework/security/web/util/OnCommittedResponseWrapper.java
@@ -58,10 +58,38 @@ public abstract class OnCommittedResponseWrapper extends HttpServletResponseWrap
 
 	@Override
 	public void addHeader(String name, String value) {
+		checkContentLengthHeader(name, value);
+		super.addHeader(name, value);
+	}
+
+	@Override
+	public void addIntHeader(String name, int value) {
+		checkContentLengthHeader(name, value);
+		super.addIntHeader(name, value);
+	}
+
+	@Override
+	public void setHeader(String name, String value) {
+		checkContentLengthHeader(name, value);
+		super.setHeader(name, value);
+	}
+
+	@Override
+	public void setIntHeader(String name, int value) {
+		checkContentLengthHeader(name, value);
+		super.setIntHeader(name, value);
+	}
+
+	private void checkContentLengthHeader(String name, int value) {
+		if ("Content-Length".equalsIgnoreCase(name)) {
+			setContentLength(value);
+		}
+	}
+
+	private void checkContentLengthHeader(String name, String value) {
 		if ("Content-Length".equalsIgnoreCase(name)) {
 			setContentLength(Long.parseLong(value));
 		}
-		super.addHeader(name, value);
 	}
 
 	@Override

--- a/web/src/test/java/org/springframework/security/web/util/OnCommittedResponseWrapperTests.java
+++ b/web/src/test/java/org/springframework/security/web/util/OnCommittedResponseWrapperTests.java
@@ -1007,6 +1007,33 @@ public class OnCommittedResponseWrapperTests {
 	}
 
 	@Test
+	public void addIntHeaderContentLengthPrintWriterWriteStringCommits() throws Exception {
+		givenGetWriterThenReturn();
+		int expected = 1234;
+		this.response.addIntHeader("Content-Length", String.valueOf(expected).length());
+		this.response.getWriter().write(expected);
+		assertThat(this.committed).isTrue();
+	}
+
+	@Test
+	public void setHeaderContentLengthPrintWriterWriteStringCommits() throws Exception {
+		givenGetWriterThenReturn();
+		int expected = 1234;
+		this.response.setHeader("Content-Length", String.valueOf(String.valueOf(expected).length()));
+		this.response.getWriter().write(expected);
+		assertThat(this.committed).isTrue();
+	}
+
+	@Test
+	public void setIntHeaderContentLengthPrintWriterWriteStringCommits() throws Exception {
+		givenGetWriterThenReturn();
+		int expected = 1234;
+		this.response.setIntHeader("Content-Length", String.valueOf(expected).length());
+		this.response.getWriter().write(expected);
+		assertThat(this.committed).isTrue();
+	}
+
+	@Test
 	public void bufferSizePrintWriterWriteCommits() throws Exception {
 		givenGetWriterThenReturn();
 		String expected = "1234567890";


### PR DESCRIPTION
Spring Security's `OnCommitedResponseWrapper` does not override the `setHeader`, `setIntHeader`, `addIntHeader`
methods. This means that if the `Content-Length` response header is specified using any of those methods then
the response body length is not tracked and can be committed before the response headers are written.

Spring Security should override the missing methods and track `Content-Length` as is already done for `addHeader`.

This issue is the underlying problem for spring-projects/spring-framework#36381

Closes gh-18797
