### PR TITLE
Fix ClientAttributes Javadoc Typos

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/ClientAttributes.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/web/ClientAttributes.java
@@ -24,7 +24,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.util.Assert;
 
 /**
- * Used for accessing the attribute that stores the the
+ * Used for accessing the attribute that stores the
  * {@link ClientRegistration#getRegistrationId()}. This ensures that
  * {@link org.springframework.security.oauth2.client.web.client.ClientRegistrationIdProcessor}
  * aligns with all of ways of setting on both
@@ -44,7 +44,7 @@ public final class ClientAttributes {
 	/**
 	 * Resolves the {@link ClientRegistration#getRegistrationId() clientRegistrationId} to
 	 * be used to look up the {@link OAuth2AuthorizedClient}.
-	 * @param attributes the to search
+	 * @param attributes the attributes to search.
 	 * @return the registration id to use.
 	 */
 	public static String resolveClientRegistrationId(Map<String, Object> attributes) {


### PR DESCRIPTION
## Description
I found and fixed minor typos in the Javadoc for the `ClientAttributes` class.
1. Fixed a redundant 'the' (the the) in the class-level documentation.
2. Corrected a missing word in the `@param attributes` description for the `resolveClientRegistrationId` method.

## Motivation
These changes improve the clarity and professional quality of the documentation for developers using Spring Security's OAuth2 client features.

## Related Issues
No issue was created as these are straightforward typo and documentation fixes.
