### PR TITLE
Clarify @WithSecurityContext thread scope

### DIFF
--- a/docs/modules/ROOT/pages/servlet/test/method.adoc
+++ b/docs/modules/ROOT/pages/servlet/test/method.adoc
@@ -184,6 +184,13 @@ You can change this to happen during the `TestExecutionListener.beforeTestExecut
 @WithSecurityContext(setupBefore = TestExecutionEvent.TEST_EXECUTION)
 ----
 
+[NOTE]
+====
+`@WithMockUser`, `@WithUserDetails`, and `@WithSecurityContext` populate the xref:servlet/authentication/architecture.adoc#servlet-authentication-securitycontextholder[`SecurityContextHolder`] for the test thread.
+This works for method-security tests and for xref:servlet/test/mockmvc/index.adoc[`MockMvc`] (when using `testSecurityContext()`), but does not automatically apply to full HTTP requests made through external clients (for example, REST-assured against a running server), because those requests are handled on a different thread.
+For end-to-end HTTP tests, xref:servlet/authentication/index.adoc[authenticate] the request itself (for example, with HTTP Basic or a bearer token).
+====
+
 
 [[test-method-meta-annotations]]
 == Test Meta Annotations


### PR DESCRIPTION
Closes gh-3721

Clarify that `@WithMockUser`, `@WithUserDetails`, and `@WithSecurityContext`
populate `SecurityContextHolder` for the test thread.

Document that this works for method-security tests and for MockMvc when using
`testSecurityContext()`, but does not automatically apply to full HTTP client
tests against a running server because those requests execute on different threads.

Also add guidance to authenticate end-to-end HTTP requests directly
(for example, HTTP Basic or Bearer token).
