### PR TITLE
Ensure mockOAuth2Login works without springSecurity()

### DIFF
--- a/test/src/main/java/org/springframework/security/test/web/reactive/server/SecurityMockServerConfigurers.java
+++ b/test/src/main/java/org/springframework/security/test/web/reactive/server/SecurityMockServerConfigurers.java
@@ -410,7 +410,12 @@ public final class SecurityMockServerConfigurers {
 		}
 
 		private Consumer<List<WebFilter>> addSetupMutatorFilter() {
-			return (filters) -> filters.add(0, new SetupMutatorFilter(this.context));
+			return (filters) -> {
+				if (filters.stream().noneMatch(MutatorFilter.class::isInstance)) {
+					filters.add(0, new MutatorFilter());
+				}
+				filters.add(0, new SetupMutatorFilter(this.context));
+			};
 		}
 
 	}

--- a/test/src/test/java/org/springframework/security/test/web/reactive/server/SecurityMockServerConfigurersOAuth2LoginTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/reactive/server/SecurityMockServerConfigurersOAuth2LoginTests.java
@@ -88,6 +88,26 @@ public class SecurityMockServerConfigurersOAuth2LoginTests extends AbstractMockS
 	}
 
 	@Test
+	public void oauth2LoginWhenSpringSecurityConfigurerMissingThenStillProducesDefaultAuthentication() {
+		WebTestClient client = WebTestClient.bindToController(this.controller)
+			.argumentResolvers((c) -> c.addCustomResolver(new OAuth2AuthorizedClientArgumentResolver(
+					this.clientRegistrationRepository, this.authorizedClientRepository)))
+			.webFilter(new SecurityContextServerWebExchangeWebFilter())
+			.configureClient()
+			.defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+			.build();
+		client.mutateWith(SecurityMockServerConfigurers.mockOAuth2Login())
+			.get()
+			.uri("/token")
+			.exchange()
+			.expectStatus()
+			.isOk();
+		OAuth2AuthenticationToken token = this.controller.token;
+		assertThat(token).isNotNull();
+		assertThat(token.getAuthorizedClientRegistrationId()).isEqualTo("test");
+	}
+
+	@Test
 	public void oauth2LoginWhenUsingDefaultsThenProducesDefaultAuthorizedClient() {
 		this.client.mutateWith(SecurityMockServerConfigurers.mockOAuth2Login())
 			.get()


### PR DESCRIPTION
Closes gh-18782

Ensure `mockOAuth2Login()` works even when
`SecurityMockServerConfigurers.springSecurity()` has not been explicitly
applied to `WebTestClient`.

Previously, `mockOAuth2Login()` added `SetupMutatorFilter` but assumed
`MutatorFilter` already existed. In setups like `@SpringBootTest` +
`@AutoConfigureWebTestClient`, that assumption can be false, resulting in
a missing reactive `SecurityContext` and a 401 response.

Changes include:

- ensure `MutatorFilter` is present in `MutatorWebTestClientConfigurer`
  before adding `SetupMutatorFilter`
- add regression coverage for `mockOAuth2Login()` when `springSecurity()`
  is not explicitly applied
