### PR TITLE
Remove compiler warnings in spring-security-web

### DIFF
--- a/web/spring-security-web.gradle
+++ b/web/spring-security-web.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id 'io.spring.convention.spring-module'
 	id 'security-nullability'
+	id 'compile-warnings-error'
 	id 'javadoc-warnings-error'
 	id 'test-compile-target-jdk25'
 }

--- a/web/src/main/java/org/springframework/security/web/authentication/ott/OneTimeTokenAuthenticationConverter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/ott/OneTimeTokenAuthenticationConverter.java
@@ -46,7 +46,7 @@ public class OneTimeTokenAuthenticationConverter implements AuthenticationConver
 			this.logger.debug("No token found in request");
 			return null;
 		}
-		return OneTimeTokenAuthenticationToken.unauthenticated(token);
+		return new OneTimeTokenAuthenticationToken(token);
 	}
 
 }

--- a/web/src/main/java/org/springframework/security/web/authentication/rememberme/JdbcTokenRepositoryImpl.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/rememberme/JdbcTokenRepositoryImpl.java
@@ -35,6 +35,7 @@ import org.springframework.jdbc.core.support.JdbcDaoSupport;
  * @author Luke Taylor
  * @since 2.0
  */
+@SuppressWarnings("removal")
 public class JdbcTokenRepositoryImpl extends JdbcDaoSupport implements PersistentTokenRepository {
 
 	/** Default SQL for creating the database table to store the tokens */

--- a/web/src/main/java/org/springframework/security/web/server/authentication/ott/ServerOneTimeTokenAuthenticationConverter.java
+++ b/web/src/main/java/org/springframework/security/web/server/authentication/ott/ServerOneTimeTokenAuthenticationConverter.java
@@ -51,13 +51,13 @@ public final class ServerOneTimeTokenAuthenticationConverter implements ServerAu
 		if (isFormEncodedRequest(exchange.getRequest())) {
 			return exchange.getFormData()
 				.flatMap((data) -> Mono.justOrEmpty(data.getFirst(TOKEN)))
-				.map((data) -> OneTimeTokenAuthenticationToken.unauthenticated(data));
+				.map(OneTimeTokenAuthenticationToken::new);
 		}
 		String token = resolveTokenFromRequest(exchange.getRequest());
 		if (!StringUtils.hasText(token)) {
 			return Mono.empty();
 		}
-		return Mono.just(OneTimeTokenAuthenticationToken.unauthenticated(token));
+		return Mono.just(new OneTimeTokenAuthenticationToken(token));
 	}
 
 	private @Nullable String resolveTokenFromRequest(ServerHttpRequest request) {

--- a/web/src/test/java/org/springframework/security/web/authentication/DelegatingAuthenticationEntryPointTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/DelegatingAuthenticationEntryPointTests.java
@@ -18,7 +18,6 @@ package org.springframework.security.web.authentication;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 
 import jakarta.servlet.ServletException;
@@ -52,8 +51,6 @@ public class DelegatingAuthenticationEntryPointTests {
 
 	private DelegatingAuthenticationEntryPoint daep;
 
-	private LinkedHashMap<RequestMatcher, AuthenticationEntryPoint> entryPoints;
-
 	private AuthenticationEntryPoint defaultEntryPoint;
 
 	private HttpServletRequest request = new MockHttpServletRequest();
@@ -61,7 +58,6 @@ public class DelegatingAuthenticationEntryPointTests {
 	@BeforeEach
 	public void before() {
 		this.defaultEntryPoint = mock(AuthenticationEntryPoint.class);
-		this.entryPoints = new LinkedHashMap<>();
 	}
 
 	@Test
@@ -70,9 +66,8 @@ public class DelegatingAuthenticationEntryPointTests {
 		AuthenticationEntryPoint firstAEP = mock(AuthenticationEntryPoint.class);
 		RequestMatcher firstRM = mock(RequestMatcher.class);
 		given(firstRM.matches(this.request)).willReturn(false);
-		this.entryPoints.put(firstRM, firstAEP);
-		this.daep = new DelegatingAuthenticationEntryPoint(this.entryPoints);
-		this.daep.setDefaultEntryPoint(this.defaultEntryPoint);
+		this.daep = new DelegatingAuthenticationEntryPoint(this.defaultEntryPoint,
+				new RequestMatcherEntry<>(firstRM, firstAEP));
 		this.daep.commence(this.request, null, null);
 		verify(this.defaultEntryPoint).commence(this.request, null, null);
 		verify(firstAEP, never()).commence(this.request, null, null);
@@ -86,10 +81,8 @@ public class DelegatingAuthenticationEntryPointTests {
 		AuthenticationEntryPoint secondAEP = mock(AuthenticationEntryPoint.class);
 		RequestMatcher secondRM = mock(RequestMatcher.class);
 		given(firstRM.matches(this.request)).willReturn(true);
-		this.entryPoints.put(firstRM, firstAEP);
-		this.entryPoints.put(secondRM, secondAEP);
-		this.daep = new DelegatingAuthenticationEntryPoint(this.entryPoints);
-		this.daep.setDefaultEntryPoint(this.defaultEntryPoint);
+		this.daep = new DelegatingAuthenticationEntryPoint(this.defaultEntryPoint,
+				new RequestMatcherEntry<>(firstRM, firstAEP), new RequestMatcherEntry<>(secondRM, secondAEP));
 		this.daep.commence(this.request, null, null);
 		verify(firstAEP).commence(this.request, null, null);
 		verify(secondAEP, never()).commence(this.request, null, null);
@@ -106,10 +99,8 @@ public class DelegatingAuthenticationEntryPointTests {
 		RequestMatcher secondRM = mock(RequestMatcher.class);
 		given(firstRM.matches(this.request)).willReturn(false);
 		given(secondRM.matches(this.request)).willReturn(true);
-		this.entryPoints.put(firstRM, firstAEP);
-		this.entryPoints.put(secondRM, secondAEP);
-		this.daep = new DelegatingAuthenticationEntryPoint(this.entryPoints);
-		this.daep.setDefaultEntryPoint(this.defaultEntryPoint);
+		this.daep = new DelegatingAuthenticationEntryPoint(this.defaultEntryPoint,
+				new RequestMatcherEntry<>(firstRM, firstAEP), new RequestMatcherEntry<>(secondRM, secondAEP));
 		this.daep.commence(this.request, null, null);
 		verify(secondAEP).commence(this.request, null, null);
 		verify(firstAEP, never()).commence(this.request, null, null);

--- a/web/src/test/java/org/springframework/security/web/authentication/ott/OneTimeTokenAuthenticationFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/ott/OneTimeTokenAuthenticationFilterTests.java
@@ -31,7 +31,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.authentication.ott.OneTimeTokenAuthenticationToken;
+import org.springframework.security.authentication.ott.OneTimeTokenAuthentication;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.web.servlet.MockServletContext;
 
@@ -120,7 +120,7 @@ class OneTimeTokenAuthenticationFilterTests {
 	@SuppressWarnings("removal")
 	void doFilterWhenValidThenRedirectsToSavedRequest() throws ServletException, IOException {
 		given(this.authenticationManager.authenticate(any()))
-			.willReturn(OneTimeTokenAuthenticationToken.authenticated("username", AuthorityUtils.NO_AUTHORITIES));
+			.willReturn(new OneTimeTokenAuthentication("username", AuthorityUtils.NO_AUTHORITIES));
 		this.filter.doFilter(
 				post("/login/ott").param("token", "some-token-value").buildRequest(new MockServletContext()),
 				this.response, this.chain);


### PR DESCRIPTION
This PR resolves the compiler warnings in the `spring-security-web` module.

Some of these warnings were straight forward changes:
- `ServerOneTimeTokenAuthenticationConverter`:  Replace deprecated call `OneTimeTokenAuthenticationToken.unauthenticated` with `OneTimeTokenAuthenticationToken(String token)` 
- Update `HttpMessageConverterAuthenticationSuccessHandler` to replace deprecated `MappingJackson2HttpMessageConverter` with `JacksonJsonHttpMessageConverter`
- Replace updated `OneTimeTokenAuthenticationConverter` to use non-deprecated `OneTimeTokenAuthenticationToken` constructor
- update tests classes `DelegatingAuthenticationEntryPointTests` / `OneTimeTokenAuthenticationFilterTests` to remove use of deprecated methods
- Enabled `compile-warnings-error` for `spring-security-web`

### `JdbcTokenRepositoryImpl` changes

@rwinch The more involved change was in `JdbcTokenRepositoryImpl` with the extension of deprecated `JdbcDaoSupport`. What would be the best way to handle this?

To start off for now, I opted to try an implementation that removes `extends JdbcDaoSupport`. However, this _could_ be a breaking change for anyone that has extended `JdbcTokenRepositoryImpl` directly via the no-arg constructor with `setDataSource()` pattern. 

If it would be best to not introduce this change or take a different approach, let me know.

Here is a summary of changes I made:
- Added a `DataSource` constructor parameter (replaces inherited `setDataSource()`) and used to create `JdbcTemplate` in the class
- Added own `logger` field (previously inherited from `JdbcDaoSupport`)
- preserved the `setCreateTableOnStartup(true)` by implementing `InitializingBean` to preserve the `afterPropertiesSet()` call to `initDao()` lifecycle
- Updated `RememberMeBeanDefinitionParser` to accommodate changes from property injection to constructor injection of the `DataSource`
- Updated `JdbcTokenRepositoryImplTests` accordingly

Closes #18441 
