### PR TITLE
Prefer dispatcher context for authorize tag beans

### DIFF
--- a/taglibs/src/main/java/org/springframework/security/taglibs/authz/AbstractAuthorizeTag.java
+++ b/taglibs/src/main/java/org/springframework/security/taglibs/authz/AbstractAuthorizeTag.java
@@ -62,8 +62,6 @@ import org.springframework.util.StringUtils;
  */
 public abstract class AbstractAuthorizeTag {
 
-	private static final String DISPATCHER_SERVLET_CONTEXT_ATTRIBUTE = "org.springframework.web.servlet.DispatcherServlet.CONTEXT";
-
 	@SuppressWarnings("NullAway.Init")
 	private @Nullable String access;
 
@@ -226,11 +224,15 @@ public abstract class AbstractAuthorizeTag {
 	}
 
 	private ApplicationContext getApplicationContext() {
-		Object dispatcherContext = getRequest().getAttribute(DISPATCHER_SERVLET_CONTEXT_ATTRIBUTE);
-		if (dispatcherContext instanceof ApplicationContext applicationContext) {
-			return applicationContext;
+		Object value = getRequest().getAttribute(WebAttributes.APPLICATION_CONTEXT_ATTRIBUTE);
+		if (value == null) {
+			return SecurityWebApplicationContextUtils.findRequiredWebApplicationContext(getServletContext());
 		}
-		return SecurityWebApplicationContextUtils.findRequiredWebApplicationContext(getServletContext());
+		if (value instanceof ApplicationContext context) {
+			return context;
+		}
+		throw new IllegalArgumentException("WebAttributes.APPLICATION_CONTEXT_ATTRIBUTE value must be of type "
+				+ "ApplicationContext, found type " + value.getClass());
 	}
 
 }

--- a/taglibs/src/test/java/org/springframework/security/taglibs/authz/AbstractAuthorizeTagTests.java
+++ b/taglibs/src/test/java/org/springframework/security/taglibs/authz/AbstractAuthorizeTagTests.java
@@ -42,6 +42,7 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.GenericWebApplicationContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -136,20 +137,24 @@ public class AbstractAuthorizeTagTests {
 
 	@Test
 	@SuppressWarnings("rawtypes")
-	public void expressionFromDispatcherContextWhenRootContextPresent() throws IOException {
+	public void expressionWhenApplicationContextAttributeIsSetThenUsed() throws IOException {
 		SecurityContextHolder.getContext().setAuthentication(new TestingAuthenticationToken("user", "pass", "USER"));
-		WebApplicationContext root = mock(WebApplicationContext.class);
-		given(root.getBeansOfType(SecurityExpressionHandler.class)).willReturn(Collections.emptyMap());
-		given(root.getBeanNamesForType(SecurityContextHolderStrategy.class)).willReturn(new String[0]);
-		this.servletContext.setAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, root);
 		DefaultWebSecurityExpressionHandler expected = new DefaultWebSecurityExpressionHandler();
-		WebApplicationContext dispatcher = mock(WebApplicationContext.class);
-		given(dispatcher.getBeansOfType(SecurityExpressionHandler.class))
+		WebApplicationContext context = mock(WebApplicationContext.class);
+		given(context.getBeansOfType(SecurityExpressionHandler.class))
 			.willReturn(Collections.<String, SecurityExpressionHandler>singletonMap("wipe", expected));
-		given(dispatcher.getBeanNamesForType(SecurityContextHolderStrategy.class)).willReturn(new String[0]);
-		this.request.setAttribute("org.springframework.web.servlet.DispatcherServlet.CONTEXT", dispatcher);
+		given(context.getBeanNamesForType(SecurityContextHolderStrategy.class)).willReturn(new String[0]);
+		this.request.setAttribute(WebAttributes.APPLICATION_CONTEXT_ATTRIBUTE, context);
 		this.tag.setAccess("permitAll");
 		assertThat(this.tag.authorize()).isTrue();
+		verify(context).getBeansOfType(SecurityExpressionHandler.class);
+	}
+
+	@Test
+	public void expressionWhenApplicationContextAttributeIsWrongTypeThenIllegalArgumentException() {
+		this.request.setAttribute(WebAttributes.APPLICATION_CONTEXT_ATTRIBUTE, "notAnApplicationContext");
+		this.tag.setAccess("permitAll");
+		assertThatIllegalArgumentException().isThrownBy(() -> this.tag.authorize());
 	}
 
 	private class AuthzTag extends AbstractAuthorizeTag {

--- a/web/src/main/java/org/springframework/security/web/WebAttributes.java
+++ b/web/src/main/java/org/springframework/security/web/WebAttributes.java
@@ -38,6 +38,22 @@ public final class WebAttributes {
 	public static final String ACCESS_DENIED_403 = "SPRING_SECURITY_403_EXCEPTION";
 
 	/**
+	 * Set as a request attribute to provide an
+	 * {@link org.springframework.context.ApplicationContext} for use by JSP authorize
+	 * tags when resolving security beans.
+	 * <p>
+	 * When set, this attribute is preferred over the root web application context. The
+	 * value must be of type {@link org.springframework.context.ApplicationContext}.
+	 *
+	 * <p>
+	 * Used in {@code org.springframework.security.taglibs.authz.AbstractAuthorizeTag}.
+	 *
+	 * @since 7.1
+	 */
+	public static final String APPLICATION_CONTEXT_ATTRIBUTE = WebAttributes.class.getName()
+			+ ".APPLICATION_CONTEXT_ATTRIBUTE";
+
+	/**
 	 * Used to cache an authentication-failure exception in the session.
 	 *
 	 * @see org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler


### PR DESCRIPTION
Closes gh-8843

When both root and child web application contexts are present, JSP authorize
tags should resolve security beans from the DispatcherServlet context used for
the current request.

Previously, `AbstractAuthorizeTag` always resolved beans from
`findRequiredWebApplicationContext(servletContext)`, which prefers the root
context. If security beans were defined only in the child context, this could
cause failures like missing `WebSecurityExpressionHandler`.

Changes include:

- resolve application context from the current request's DispatcherServlet
  context attribute when available
- fall back to `SecurityWebApplicationContextUtils.findRequiredWebApplicationContext`
  when no dispatcher context is present
- add regression coverage for root+child context setup to ensure
  `<sec:authorize>` expression evaluation succeeds
