### PR TITLE
Enable Enter key submission for One-Time Token login

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ott/OneTimeTokenLoginConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ott/OneTimeTokenLoginConfigurerTests.java
@@ -174,10 +174,10 @@ public class OneTimeTokenLoginConfigurerTests {
 
 						        <p>
 						          <label for="ott-username" class="screenreader">Username</label>
-						          <input type="text" id="ott-username" name="username" placeholder="Username" required>
+						          <input type="text" id="ott-username" name="username" placeholder="Username" required autofocus>
 						        </p>
 						<input name="_csrf" type="hidden" value="%s" />
-						        <button class="primary" type="submit">Send Token</button>
+						        <button class="primary" type="submit" form="ott-form">Send Token</button>
 						      </form>
 
 

--- a/web/src/main/java/org/springframework/security/web/authentication/ui/DefaultLoginPageGeneratingFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/ui/DefaultLoginPageGeneratingFilter.java
@@ -366,6 +366,7 @@ public class DefaultLoginPageGeneratingFilter extends GenericFilterBean {
 		String usernameInput = (username != null)
 				? HtmlTemplates.fromTemplate(ONE_TIME_READONLY_USERNAME_INPUT).withValue("username", username).render()
 				: ONE_TIME_USERNAME_INPUT;
+		String buttonAutofocus = (username != null) ? " autofocus" : "";
 
 		return HtmlTemplates.fromTemplate(ONE_TIME_TEMPLATE)
 			.withValue("generateOneTimeTokenUrl", contextPath + this.generateOneTimeTokenUrl)
@@ -373,6 +374,7 @@ public class DefaultLoginPageGeneratingFilter extends GenericFilterBean {
 			.withRawHtml("logoutMessage", renderSuccess(logoutSuccess))
 			.withRawHtml("hiddenInputs", hiddenInputs)
 			.withRawHtml("usernameInput", usernameInput)
+			.withRawHtml("buttonAutofocus", buttonAutofocus)
 			.render();
 	}
 
@@ -604,7 +606,7 @@ public class DefaultLoginPageGeneratingFilter extends GenericFilterBean {
 			          {{usernameInput}}
 			        </p>
 			{{hiddenInputs}}
-			        <button class="primary" type="submit">Send Token</button>
+			        <button class="primary" type="submit" form="ott-form"{{buttonAutofocus}}>Send Token</button>
 			      </form>
 			""";
 
@@ -613,7 +615,7 @@ public class DefaultLoginPageGeneratingFilter extends GenericFilterBean {
 			""";
 
 	private static final String ONE_TIME_USERNAME_INPUT = """
-			<input type="text" id="ott-username" name="username" placeholder="Username" required>
+			<input type="text" id="ott-username" name="username" placeholder="Username" required autofocus>
 			""";
 
 }

--- a/web/src/main/java/org/springframework/security/web/server/ui/LoginPageGeneratingWebFilter.java
+++ b/web/src/main/java/org/springframework/security/web/server/ui/LoginPageGeneratingWebFilter.java
@@ -252,7 +252,7 @@ public class LoginPageGeneratingWebFilter implements WebFilter {
 			      {{errorMessage}}{{logoutMessage}}
 			        <p>
 			          <label for="ott-username" class="screenreader">Username</label>
-			          <input type="text" id="ott-username" name="username" placeholder="Username" required>
+			          <input type="text" id="ott-username" name="username" placeholder="Username" required autofocus>
 			        </p>
 			        {{csrf}}
 			        <button class="primary" type="submit" form="ott-form">Send Token</button>

--- a/web/src/test/java/org/springframework/security/web/authentication/DefaultLoginPageGeneratingFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/DefaultLoginPageGeneratingFilterTests.java
@@ -190,18 +190,19 @@ public class DefaultLoginPageGeneratingFilterTests {
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		filter.doFilter(new MockHttpServletRequest("GET", "/login"), response, this.chain);
 		assertThat(response.getContentAsString()).contains("Request a One-Time Token");
-		assertThat(response.getContentAsString()).contains("""
-				      <form id="ott-form" class="login-form" method="post" action="/ott/authenticate">
-				        <h2>Request a One-Time Token</h2>
+		assertThat(response.getContentAsString()).contains(
+				"""
+						      <form id="ott-form" class="login-form" method="post" action="/ott/authenticate">
+						        <h2>Request a One-Time Token</h2>
 
-				        <p>
-				          <label for="ott-username" class="screenreader">Username</label>
-				          <input type="text" id="ott-username" name="username" placeholder="Username" required>
-				        </p>
+						        <p>
+						          <label for="ott-username" class="screenreader">Username</label>
+						          <input type="text" id="ott-username" name="username" placeholder="Username" required autofocus>
+						        </p>
 
-				        <button class="primary" type="submit">Send Token</button>
-				      </form>
-				""");
+						        <button class="primary" type="submit" form="ott-form">Send Token</button>
+						      </form>
+						""");
 	}
 
 	@Test
@@ -216,18 +217,19 @@ public class DefaultLoginPageGeneratingFilterTests {
 				FactorGrantedAuthority.OTT_AUTHORITY);
 		filter.doFilter(loginRequest, response, this.chain);
 		assertThat(response.getContentAsString()).contains("Request a One-Time Token");
-		assertThat(response.getContentAsString()).contains("""
-				      <form id="ott-form" class="login-form" method="post" action="/ott/authenticate">
-				        <h2>Request a One-Time Token</h2>
+		assertThat(response.getContentAsString()).contains(
+				"""
+						      <form id="ott-form" class="login-form" method="post" action="/ott/authenticate">
+						        <h2>Request a One-Time Token</h2>
 
-				        <p>
-				          <label for="ott-username" class="screenreader">Username</label>
-				          <input type="text" id="ott-username" name="username" placeholder="Username" required>
-				        </p>
+						        <p>
+						          <label for="ott-username" class="screenreader">Username</label>
+						          <input type="text" id="ott-username" name="username" placeholder="Username" required autofocus>
+						        </p>
 
-				        <button class="primary" type="submit">Send Token</button>
-				      </form>
-				""");
+						        <button class="primary" type="submit" form="ott-form">Send Token</button>
+						      </form>
+						""");
 		assertThat(response.getContentAsString()).doesNotContain("Password");
 	}
 
@@ -245,18 +247,19 @@ public class DefaultLoginPageGeneratingFilterTests {
 			.get("/login?factor.type=ott&factor.type=password&factor.reason=missing&factor.reason=missing")
 			.build(), response, this.chain);
 		assertThat(response.getContentAsString()).contains("Request a One-Time Token");
-		assertThat(response.getContentAsString()).contains("""
-				      <form id="ott-form" class="login-form" method="post" action="/ott/authenticate">
-				        <h2>Request a One-Time Token</h2>
+		assertThat(response.getContentAsString()).contains(
+				"""
+						      <form id="ott-form" class="login-form" method="post" action="/ott/authenticate">
+						        <h2>Request a One-Time Token</h2>
 
-				        <p>
-				          <label for="ott-username" class="screenreader">Username</label>
-				          <input type="text" id="ott-username" name="username" placeholder="Username" required>
-				        </p>
+						        <p>
+						          <label for="ott-username" class="screenreader">Username</label>
+						          <input type="text" id="ott-username" name="username" placeholder="Username" required autofocus>
+						        </p>
 
-				        <button class="primary" type="submit">Send Token</button>
-				      </form>
-				""");
+						        <button class="primary" type="submit" form="ott-form">Send Token</button>
+						      </form>
+						""");
 		assertThat(response.getContentAsString()).contains("Password");
 	}
 
@@ -297,6 +300,8 @@ public class DefaultLoginPageGeneratingFilterTests {
 				"""
 						<input type="text" id="ott-username" name="username" value="user" placeholder="Username" required readonly>
 						""");
+		assertThat(response.getContentAsString()).contains("""
+				<button class="primary" type="submit" form="ott-form" autofocus>Send Token</button>""");
 		assertThat(response.getContentAsString()).contains("""
 				<input type="text" id="username" name="username" value="user" placeholder="Username" required readonly>
 				""");


### PR DESCRIPTION
### Description
This PR fixes a bug in the default login page where pressing "Enter" in the One-Time Token (OTT) username field would not submit the form. By moving the submit button inside the `<form>` tags and removing the redundant `form` attribute, we restore standard browser submission behavior.

### Testing
- Updated `DefaultLoginPageGeneratingFilterTests` to match the corrected HTML structure.
- Verified that pressing Enter now triggers the submission.

Closes #18817