### PR TITLE
Add `Reporting-Endpoints` header support to `ContentSecurityPolicyConfig`

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HeadersConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/HeadersConfigurer.java
@@ -75,6 +75,7 @@ import org.springframework.util.Assert;
  * @author Vedran Pavic
  * @author Ankur Pathak
  * @author Daniel Garnier-Moiroux
+ * @author Andrey Litvitski
  * @since 3.2
  */
 public class HeadersConfigurer<H extends HttpSecurityBuilder<H>>
@@ -948,6 +949,17 @@ public class HeadersConfigurer<H extends HttpSecurityBuilder<H>>
 		 */
 		public ContentSecurityPolicyConfig policyDirectives(String policyDirectives) {
 			this.writer.setPolicyDirectives(policyDirectives);
+			return this;
+		}
+
+		/**
+		 * Sets the reporting endpoints to be used in the response header.
+		 * @param reportingEndpoints the reporting endpoints
+		 * @return the {@link ContentSecurityPolicyConfig} for additional configuration
+		 * @throws IllegalArgumentException if reportingEndpoints is null or empty
+		 */
+		public ContentSecurityPolicyConfig reportingEndpoints(String reportingEndpoints) {
+			this.writer.setReportingEndpoints(reportingEndpoints);
 			return this;
 		}
 

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/HeadersConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/HeadersConfigurerTests.java
@@ -61,6 +61,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Eleftheria Stein
  * @author Marcus Da Coregio
  * @author Daniel Garnier-Moiroux
+ * @author Andrey Litvitski
  */
 @ExtendWith(SpringTestContextExtension.class)
 public class HeadersConfigurerTests {
@@ -573,6 +574,105 @@ public class HeadersConfigurerTests {
 			.andReturn();
 		assertThat(mvcResult.getResponse().getHeaderNames()).containsExactly(HttpHeaders.CROSS_ORIGIN_OPENER_POLICY,
 				HttpHeaders.CROSS_ORIGIN_EMBEDDER_POLICY, HttpHeaders.CROSS_ORIGIN_RESOURCE_POLICY);
+	}
+
+	@Test
+	public void getWhenContentSecurityPolicyWithReportingEndpointsThenBothHeadersInResponse() throws Exception {
+		this.spring.register(ContentSecurityPolicyWithReportingEndpointsConfig.class).autowire();
+		ResultMatcher csp = header().string(HttpHeaders.CONTENT_SECURITY_POLICY,
+				"default-src 'self'; report-to csp-endpoint");
+		ResultMatcher reportingEndpoints = header().string("Reporting-Endpoints",
+				"csp-endpoint=\"https://example.com/csp-reports\"");
+		// @formatter:off
+		MvcResult mvcResult = this.mvc.perform(get("/").secure(true))
+				.andExpect(csp)
+				.andExpect(reportingEndpoints)
+				.andReturn();
+		// @formatter:on
+		assertThat(mvcResult.getResponse().getHeaderNames())
+			.containsExactlyInAnyOrder(HttpHeaders.CONTENT_SECURITY_POLICY, "Reporting-Endpoints");
+	}
+
+	@Test
+	public void getWhenContentSecurityPolicyReportOnlyWithReportingEndpointsThenBothHeadersInResponse()
+			throws Exception {
+		this.spring.register(ContentSecurityPolicyReportOnlyWithReportingEndpointsConfig.class).autowire();
+		ResultMatcher csp = header().string(HttpHeaders.CONTENT_SECURITY_POLICY_REPORT_ONLY,
+				"default-src 'self'; report-to csp-endpoint");
+		ResultMatcher reportingEndpoints = header().string("Reporting-Endpoints",
+				"csp-endpoint=\"https://example.com/csp-reports\"");
+		// @formatter:off
+		MvcResult mvcResult = this.mvc.perform(get("/").secure(true))
+				.andExpect(csp)
+				.andExpect(reportingEndpoints)
+				.andReturn();
+		// @formatter:on
+		assertThat(mvcResult.getResponse().getHeaderNames())
+			.containsExactlyInAnyOrder(HttpHeaders.CONTENT_SECURITY_POLICY_REPORT_ONLY, "Reporting-Endpoints");
+	}
+
+	@Test
+	public void getWhenContentSecurityPolicyWithInvalidReportingEndpointsThenBeanCreationException() {
+		assertThatExceptionOfType(BeanCreationException.class).isThrownBy(
+				() -> this.spring.register(ContentSecurityPolicyWithInvalidReportingEndpointsConfig.class).autowire());
+	}
+
+	@Configuration
+	@EnableWebSecurity
+	static class ContentSecurityPolicyWithReportingEndpointsConfig {
+
+		@Bean
+		SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+			// @formatter:off
+			http
+					.headers((headers) -> headers
+							.defaultsDisabled()
+							.contentSecurityPolicy((csp) -> csp
+									.policyDirectives("default-src 'self'; report-to csp-endpoint")
+									.reportingEndpoints("csp-endpoint=\"https://example.com/csp-reports\"")));
+			return http.build();
+			// @formatter:on
+		}
+
+	}
+
+	@Configuration
+	@EnableWebSecurity
+	static class ContentSecurityPolicyReportOnlyWithReportingEndpointsConfig {
+
+		@Bean
+		SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+			// @formatter:off
+			http
+					.headers((headers) -> headers
+							.defaultsDisabled()
+							.contentSecurityPolicy((csp) -> csp
+									.policyDirectives("default-src 'self'; report-to csp-endpoint")
+									.reportOnly()
+									.reportingEndpoints("csp-endpoint=\"https://example.com/csp-reports\"")));
+			return http.build();
+			// @formatter:on
+		}
+
+	}
+
+	@Configuration
+	@EnableWebSecurity
+	static class ContentSecurityPolicyWithInvalidReportingEndpointsConfig {
+
+		@Bean
+		SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+			// @formatter:off
+			http
+					.headers((headers) -> headers
+							.defaultsDisabled()
+							.contentSecurityPolicy((csp) -> csp
+									.policyDirectives("default-src 'self'")
+									.reportingEndpoints("")));
+			return http.build();
+			// @formatter:on
+		}
+
 	}
 
 	@Configuration

--- a/web/src/main/java/org/springframework/security/web/header/writers/ContentSecurityPolicyHeaderWriter.java
+++ b/web/src/main/java/org/springframework/security/web/header/writers/ContentSecurityPolicyHeaderWriter.java
@@ -18,6 +18,7 @@ package org.springframework.security.web.header.writers;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.security.web.header.HeaderWriter;
 import org.springframework.util.Assert;
@@ -60,6 +61,7 @@ import org.springframework.util.Assert;
  * <ul>
  * <li>Content-Security-Policy</li>
  * <li>Content-Security-Policy-Report-Only</li>
+ * <li>Reporting-Endpoints (optional)</li>
  * </ul>
  *
  * <p>
@@ -71,6 +73,12 @@ import org.springframework.util.Assert;
  * </p>
  *
  * <p>
+ * To enable violation reporting, use {@link #setReportingEndpoints(String)} to declare
+ * one or more reporting endpoints, and include the {@code report-to} directive in the
+ * policy.
+ * </p>
+ *
+ * <p>
  * <strong> CSP is not intended as a first line of defense against content injection
  * vulnerabilities. Instead, CSP is used to reduce the harm caused by content injection
  * attacks. As a first line of defense against content injection, web application authors
@@ -79,6 +87,7 @@ import org.springframework.util.Assert;
  *
  * @author Joe Grandja
  * @author Ankur Pathak
+ * @author Andrey Litvitski
  * @since 4.1
  */
 public final class ContentSecurityPolicyHeaderWriter implements HeaderWriter {
@@ -87,11 +96,15 @@ public final class ContentSecurityPolicyHeaderWriter implements HeaderWriter {
 
 	private static final String CONTENT_SECURITY_POLICY_REPORT_ONLY_HEADER = "Content-Security-Policy-Report-Only";
 
+	private static final String REPORTING_ENDPOINTS_HEADER = "Reporting-Endpoints";
+
 	private static final String DEFAULT_SRC_SELF_POLICY = "default-src 'self'";
 
 	private String policyDirectives;
 
 	private boolean reportOnly;
+
+	@Nullable private String reportingEndpoints;
 
 	/**
 	 * Creates a new instance. Default value: default-src 'self'
@@ -117,10 +130,13 @@ public final class ContentSecurityPolicyHeaderWriter implements HeaderWriter {
 	 */
 	@Override
 	public void writeHeaders(HttpServletRequest request, HttpServletResponse response) {
-		String headerName = (!this.reportOnly) ? CONTENT_SECURITY_POLICY_HEADER
+		String policyHeader = (!this.reportOnly) ? CONTENT_SECURITY_POLICY_HEADER
 				: CONTENT_SECURITY_POLICY_REPORT_ONLY_HEADER;
-		if (!response.containsHeader(headerName)) {
-			response.setHeader(headerName, this.policyDirectives);
+		if (!response.containsHeader(policyHeader)) {
+			response.setHeader(policyHeader, this.policyDirectives);
+		}
+		if (this.reportingEndpoints != null && !response.containsHeader(REPORTING_ENDPOINTS_HEADER)) {
+			response.setHeader(REPORTING_ENDPOINTS_HEADER, this.reportingEndpoints);
 		}
 	}
 
@@ -135,6 +151,16 @@ public final class ContentSecurityPolicyHeaderWriter implements HeaderWriter {
 	}
 
 	/**
+	 * Sets the reporting endpoints to be used in the response header.
+	 * @param reportingEndpoints the reporting endpoints
+	 * @throws IllegalArgumentException if reportingEndpoints is null or empty
+	 */
+	public void setReportingEndpoints(String reportingEndpoints) {
+		Assert.hasLength(reportingEndpoints, "reportingEndpoints cannot be null or empty");
+		this.reportingEndpoints = reportingEndpoints;
+	}
+
+	/**
 	 * If true, includes the Content-Security-Policy-Report-Only header in the response,
 	 * otherwise, defaults to the Content-Security-Policy header.
 	 * @param reportOnly set to true for reporting policy violations only
@@ -146,7 +172,7 @@ public final class ContentSecurityPolicyHeaderWriter implements HeaderWriter {
 	@Override
 	public String toString() {
 		return getClass().getName() + " [policyDirectives=" + this.policyDirectives + "; reportOnly=" + this.reportOnly
-				+ "]";
+				+ "; reportingEndpoints= " + this.reportingEndpoints + "]";
 	}
 
 }


### PR DESCRIPTION
`Reporting-Endpoints` is a full member of CSP (Content Security Policy), and if we ignore deprecations, it's the third member. The others have already been added and implemented in `ContentSecurityPolicyConfig` and `ContentSecurityPolicyHeaderWriter`. The goal of this commit is to provide a simpler API for interacting with and installing `Reporting-Endpoints`.

Closes: gh-18783
