### PR TITLE
Relax auth_time validation on ID token refresh

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/RefreshOidcUserReactiveOAuth2AuthorizationSuccessHandler.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/RefreshOidcUserReactiveOAuth2AuthorizationSuccessHandler.java
@@ -273,7 +273,7 @@ public final class RefreshOidcUserReactiveOAuth2AuthorizationSuccessHandler
 		if (idToken.getAuthenticatedAt() == null) {
 			return;
 		}
-		if (!idToken.getAuthenticatedAt().equals(existingOidcUser.getIdToken().getAuthenticatedAt())) {
+		if (idToken.getAuthenticatedAt().isAfter(idToken.getIssuedAt().plus(this.clockSkew))) {
 			OAuth2Error oauth2Error = new OAuth2Error(INVALID_ID_TOKEN_ERROR_CODE, "Invalid authenticated at time",
 					REFRESH_TOKEN_RESPONSE_ERROR_URI);
 			throw new OAuth2AuthenticationException(oauth2Error, oauth2Error.toString());

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/authentication/OidcAuthorizedClientRefreshedEventListener.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/authentication/OidcAuthorizedClientRefreshedEventListener.java
@@ -300,7 +300,7 @@ public final class OidcAuthorizedClientRefreshedEventListener
 			return;
 		}
 
-		if (!idToken.getAuthenticatedAt().equals(existingOidcUser.getIdToken().getAuthenticatedAt())) {
+		if (idToken.getAuthenticatedAt().isAfter(idToken.getIssuedAt().plus(this.clockSkew))) {
 			OAuth2Error oauth2Error = new OAuth2Error(INVALID_ID_TOKEN_ERROR_CODE, "Invalid authenticated at time",
 					REFRESH_TOKEN_RESPONSE_ERROR_URI);
 			throw new OAuth2AuthenticationException(oauth2Error, oauth2Error.toString());

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/RefreshOidcUserReactiveOAuth2AuthorizationSuccessHandlerTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/RefreshOidcUserReactiveOAuth2AuthorizationSuccessHandlerTests.java
@@ -316,7 +316,7 @@ class RefreshOidcUserReactiveOAuth2AuthorizationSuccessHandlerTests {
 	}
 
 	@Test
-	void onAuthorizationSuccessWhenIdTokenAuthTimeNotSameThenException() {
+	void onAuthorizationSuccessWhenIdTokenAuthTimeAfterIssuedAtThenException() {
 		ClientRegistration clientRegistration = TestClientRegistrations.clientRegistration().build();
 		DefaultOidcUser principal = TestOidcUsers.create();
 		OAuth2AuthenticationToken authenticationToken = new OAuth2AuthenticationToken(principal,
@@ -331,7 +331,7 @@ class RefreshOidcUserReactiveOAuth2AuthorizationSuccessHandlerTests {
 		claims.put("iss", principal.getIssuer());
 		claims.put("sub", principal.getSubject());
 		claims.put("aud", principal.getAudience());
-		claims.put("auth_time", principal.getIssuedAt());
+		claims.put("auth_time", principal.getIssuedAt().plus(Duration.ofMinutes(2)));
 		claims.put("nonce", principal.getNonce());
 		Jwt jwt = mock(Jwt.class);
 		given(jwt.getTokenValue()).willReturn("id-token-1234");
@@ -350,6 +350,46 @@ class RefreshOidcUserReactiveOAuth2AuthorizationSuccessHandlerTests {
 		handler.setServerSecurityContextRepository(serverSecurityContextRepository);
 		StepVerifier.create(handler.onAuthorizationSuccess(authorizedClient, authenticationToken, attributes))
 			.verifyErrorMessage("[invalid_id_token] Invalid authenticated at time");
+	}
+
+	@Test
+	void onAuthorizationSuccessWhenIdTokenAuthTimeBeforeIssuedAtThenSecurityContextRefreshed() {
+		ClientRegistration clientRegistration = TestClientRegistrations.clientRegistration().build();
+		DefaultOidcUser principal = TestOidcUsers.create();
+		OAuth2AuthenticationToken authenticationToken = new OAuth2AuthenticationToken(principal,
+				principal.getAuthorities(), clientRegistration.getRegistrationId());
+		OAuth2AccessToken accessToken = createAccessToken();
+		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(clientRegistration, principal.getName(),
+				accessToken, null);
+		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
+		Map<String, Object> attributes = Map.of(ServerWebExchange.class.getName(), exchange,
+				OidcParameterNames.ID_TOKEN, "id-token-1234");
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("iss", principal.getIssuer());
+		claims.put("sub", principal.getSubject());
+		claims.put("aud", principal.getAudience());
+		claims.put("auth_time", principal.getIssuedAt());
+		claims.put("nonce", principal.getNonce());
+		Jwt jwt = mock(Jwt.class);
+		given(jwt.getTokenValue()).willReturn("id-token-1234");
+		given(jwt.getIssuedAt()).willReturn(principal.getIssuedAt().plus(Duration.ofMinutes(1)));
+		given(jwt.getClaims()).willReturn(claims);
+		ReactiveJwtDecoder jwtDecoder = mock(ReactiveJwtDecoder.class);
+		given(jwtDecoder.decode(any())).willReturn(Mono.just(jwt));
+		ReactiveJwtDecoderFactory<ClientRegistration> reactiveJwtDecoderFactory = mock(ReactiveJwtDecoderFactory.class);
+		given(reactiveJwtDecoderFactory.createDecoder(any())).willReturn(jwtDecoder);
+		ReactiveOAuth2UserService<OidcUserRequest, OidcUser> userService = mock(ReactiveOAuth2UserService.class);
+		given(userService.loadUser(any())).willReturn(Mono.just(principal));
+		WebSessionServerSecurityContextRepository serverSecurityContextRepository = new WebSessionServerSecurityContextRepository();
+		RefreshOidcUserReactiveOAuth2AuthorizationSuccessHandler handler = new RefreshOidcUserReactiveOAuth2AuthorizationSuccessHandler();
+		handler.setJwtDecoderFactory(reactiveJwtDecoderFactory);
+		handler.setUserService(userService);
+		handler.setServerSecurityContextRepository(serverSecurityContextRepository);
+		StepVerifier.create(handler.onAuthorizationSuccess(authorizedClient, authenticationToken, attributes))
+			.verifyComplete();
+		StepVerifier.create(serverSecurityContextRepository.load(exchange).map(SecurityContext::getAuthentication))
+			.expectNext(authenticationToken)
+			.verifyComplete();
 	}
 
 	@Test

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/authentication/OidcAuthorizedClientRefreshedEventListenerTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/oidc/authentication/OidcAuthorizedClientRefreshedEventListenerTests.java
@@ -419,9 +419,10 @@ public class OidcAuthorizedClientRefreshedEventListenerTests {
 	}
 
 	@Test
-	public void onApplicationEventWhenIdTokenAuthenticatedAtDoesNotMatchThenThrowsOAuth2AuthenticationException() {
-		Instant authTime = this.oidcUser.getAuthenticatedAt().plus(5, ChronoUnit.SECONDS);
-		Jwt jwt = createJwt().claim(IdTokenClaimNames.AUTH_TIME, authTime).build();
+	public void onApplicationEventWhenIdTokenAuthenticatedAtAfterIssuedAtThenThrowsOAuth2AuthenticationException() {
+		Instant issuedAt = Instant.now();
+		Instant authTime = issuedAt.plus(2, ChronoUnit.MINUTES);
+		Jwt jwt = createJwt().issuedAt(issuedAt).claim(IdTokenClaimNames.AUTH_TIME, authTime).build();
 		SecurityContextImpl securityContext = new SecurityContextImpl(this.authentication);
 		given(this.securityContextHolderStrategy.getContext()).willReturn(securityContext);
 		given(this.jwtDecoder.decode(anyString())).willReturn(jwt);
@@ -438,6 +439,23 @@ public class OidcAuthorizedClientRefreshedEventListenerTests {
 		verify(this.jwtDecoder).decode(this.jwt.getTokenValue());
 		verifyNoMoreInteractions(this.securityContextHolderStrategy, this.jwtDecoder);
 		verifyNoInteractions(this.userService, this.applicationEventPublisher);
+	}
+
+	@Test
+	public void onApplicationEventWhenIdTokenAuthenticatedAtBeforeIssuedAtThenOidcUserRefreshedEventPublished() {
+		Instant authTime = this.oidcUser.getAuthenticatedAt().plus(5, ChronoUnit.SECONDS);
+		Jwt jwt = createJwt().claim(IdTokenClaimNames.AUTH_TIME, authTime).build();
+		SecurityContextImpl securityContext = new SecurityContextImpl(this.authentication);
+		given(this.securityContextHolderStrategy.getContext()).willReturn(securityContext);
+		given(this.jwtDecoder.decode(anyString())).willReturn(jwt);
+		given(this.userService.loadUser(any(OidcUserRequest.class))).willReturn(this.oidcUser);
+
+		OAuth2AuthorizedClientRefreshedEvent authorizedClientRefreshedEvent = new OAuth2AuthorizedClientRefreshedEvent(
+				this.accessTokenResponse, this.authorizedClient);
+		this.eventListener.onApplicationEvent(authorizedClientRefreshedEvent);
+
+		verify(this.applicationEventPublisher).publishEvent(any(OidcUserRefreshedEvent.class));
+		verifyNoMoreInteractions(this.applicationEventPublisher);
 	}
 
 	@Test


### PR DESCRIPTION
When an OP refreshes an ID token and updates auth_time (for example after SSO session renewal), strict equality with the previous ID token can reject an otherwise valid refreshed token.

This change relaxes that check in both servlet and reactive paths:
- keep issuer/sub/aud/nonce checks as-is
- validate auth_time is not after refreshed token iat (with configured clock skew)

Updated tests:
- OidcAuthorizedClientRefreshedEventListenerTests
- RefreshOidcUserReactiveOAuth2AuthorizationSuccessHandlerTests

Verification:
- ./gradlew -PtestToolchain=21 -PtestCompileTargetVersion=21 :spring-security-oauth2-client:test --tests "org.springframework.security.oauth2.client.oidc.authentication.OidcAuthorizedClientRefreshedEventListenerTests" --tests "org.springframework.security.oauth2.client.RefreshOidcUserReactiveOAuth2AuthorizationSuccessHandlerTests" -x :spring-security-javascript:nodeSetup -x :spring-security-javascript:npmInstall -x :spring-security-javascript:npm_run_assemble -x :spring-security-javascript:assemble

Fixes #18839
