### PR TITLE
Fail on javadoc warnings for spring-security-aspects

### DIFF
--- a/aspects/spring-security-aspects.gradle
+++ b/aspects/spring-security-aspects.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'io.spring.convention.spring-module'
 apply plugin: 'io.freefair.aspectj'
+apply plugin: 'javadoc-warnings-error'
 apply plugin: 'compile-warnings-error'
 
 compileAspectj {


### PR DESCRIPTION
This PR addresses gh-18446.

Summary:
- apply javadoc-warnings-error to spring-security-aspects

Context:
- :spring-security-aspects:javadoc currently reports NO-SOURCE because this module contains AspectJ (.aj) sources and no Java sources for the javadoc task.
- This change keeps behavior unchanged today and aligns the module with the javadoc warnings policy used by other modules.

Verification:
- JAVA_HOME=<jdk17> ./gradlew --no-build-cache clean :spring-security-aspects:javadoc :spring-security-aspects:check
- Result: BUILD SUCCESSFUL, and :spring-security-aspects:javadoc remains NO-SOURCE

Closes gh-18446