### PR TITLE
`saveAuthenticationRequest` should read `relayState` from `authenticationRequest`

### DIFF
--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/CacheSaml2AuthenticationRequestRepository.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/CacheSaml2AuthenticationRequestRepository.java
@@ -35,6 +35,7 @@ import org.springframework.util.Assert;
  * that it was for the user trying to log in. Please see the reference for details.
  *
  * @author Josh Cummings
+ * @author Andrey Litvitski
  * @since 6.5
  */
 public final class CacheSaml2AuthenticationRequestRepository
@@ -53,7 +54,7 @@ public final class CacheSaml2AuthenticationRequestRepository
 	public void saveAuthenticationRequest(AbstractSaml2AuthenticationRequest authenticationRequest,
 			HttpServletRequest request, HttpServletResponse response) {
 		Assert.notNull(authenticationRequest, "authenticationRequest must not be null");
-		String relayState = request.getParameter(Saml2ParameterNames.RELAY_STATE);
+		String relayState = authenticationRequest.getRelayState();
 		Assert.notNull(relayState, "relayState must not be null");
 		this.cache.put(relayState, authenticationRequest);
 	}

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/web/CacheSaml2AuthenticationRequestRepositoryTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/web/CacheSaml2AuthenticationRequestRepositoryTests.java
@@ -42,9 +42,10 @@ class CacheSaml2AuthenticationRequestRepositoryTests {
 
 	@Test
 	void loadAuthenticationRequestWhenCachedThenReturns() {
-		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.setParameter(Saml2ParameterNames.RELAY_STATE, "test");
 		Saml2PostAuthenticationRequest authenticationRequest = TestSaml2PostAuthenticationRequests.create();
+		String relayState = authenticationRequest.getRelayState();
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setParameter(Saml2ParameterNames.RELAY_STATE, relayState);
 		this.repository.saveAuthenticationRequest(authenticationRequest, request, null);
 		assertThat(this.repository.loadAuthenticationRequest(request)).isEqualTo(authenticationRequest);
 		this.repository.removeAuthenticationRequest(request, null);
@@ -77,15 +78,16 @@ class CacheSaml2AuthenticationRequestRepositoryTests {
 		CacheSaml2AuthenticationRequestRepository repository = new CacheSaml2AuthenticationRequestRepository();
 		Cache cache = spy(new ConcurrentMapCache("requests"));
 		repository.setCache(cache);
-		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.setParameter(Saml2ParameterNames.RELAY_STATE, "test");
 		Saml2PostAuthenticationRequest authenticationRequest = TestSaml2PostAuthenticationRequests.create();
+		String relayState = authenticationRequest.getRelayState();
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setParameter(Saml2ParameterNames.RELAY_STATE, relayState);
 		repository.saveAuthenticationRequest(authenticationRequest, request, null);
-		verify(cache).put(eq("test"), any());
+		verify(cache).put(eq(relayState), any());
 		repository.loadAuthenticationRequest(request);
-		verify(cache).get("test", AbstractSaml2AuthenticationRequest.class);
+		verify(cache).get(relayState, AbstractSaml2AuthenticationRequest.class);
 		repository.removeAuthenticationRequest(request, null);
-		verify(cache).evict("test");
+		verify(cache).evict(relayState);
 	}
 
 }


### PR DESCRIPTION
I believe there are a number of design implementation mistakes in `CacheSaml2AuthenticationRequestRepository`.

One of them is that in `CacheSaml2AuthenticationRequest#saveAuthenticationRequest`, if `authenticationRequest == null`, we cache the cache itself with a null value, whereas we should be removing it.

Furthermore, I believe we should take the relay state directly from `authenticationRequest` and not from request, since our `Saml2AuthenticationRequestResolver` should resolve and return an object that should be passed to our method.

Closes: gh-18243

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
