### PR TITLE
Add Jackson Mixin for WebAuthnAuthentication

### DIFF
--- a/webauthn/src/main/java/org/springframework/security/web/webauthn/jackson/ImmutablePublicKeyCredentialUserEntityMixin.java
+++ b/webauthn/src/main/java/org/springframework/security/web/webauthn/jackson/ImmutablePublicKeyCredentialUserEntityMixin.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.webauthn.jackson;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.springframework.security.web.webauthn.api.Bytes;
+import org.springframework.security.web.webauthn.api.ImmutablePublicKeyCredentialUserEntity;
+
+/**
+ * Jackson mixin for {@link ImmutablePublicKeyCredentialUserEntity}
+ *
+ * @author Toshiaki Maki
+ * @since 7.0.4
+ */
+abstract class ImmutablePublicKeyCredentialUserEntityMixin {
+
+	ImmutablePublicKeyCredentialUserEntityMixin(@JsonProperty("name") String name, @JsonProperty("id") Bytes id,
+			@JsonProperty("displayName") String displayName) {
+	}
+
+}

--- a/webauthn/src/main/java/org/springframework/security/web/webauthn/jackson/WebAuthnAuthenticationMixin.java
+++ b/webauthn/src/main/java/org/springframework/security/web/webauthn/jackson/WebAuthnAuthenticationMixin.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.webauthn.jackson;
+
+import java.util.Collection;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.webauthn.api.PublicKeyCredentialUserEntity;
+import org.springframework.security.web.webauthn.authentication.WebAuthnAuthentication;
+
+/**
+ * Jackson mixin for {@link WebAuthnAuthentication}
+ *
+ * @author Toshiaki Maki
+ * @since 7.0.4
+ */
+@JsonIgnoreProperties({ "authenticated" })
+abstract class WebAuthnAuthenticationMixin {
+
+	WebAuthnAuthenticationMixin(@JsonProperty("principal") PublicKeyCredentialUserEntity principal,
+			@JsonProperty("authorities") Collection<? extends GrantedAuthority> authorities) {
+	}
+
+}

--- a/webauthn/src/main/java/org/springframework/security/web/webauthn/jackson/WebauthnJacksonModule.java
+++ b/webauthn/src/main/java/org/springframework/security/web/webauthn/jackson/WebauthnJacksonModule.java
@@ -33,12 +33,14 @@ import org.springframework.security.web.webauthn.api.Bytes;
 import org.springframework.security.web.webauthn.api.COSEAlgorithmIdentifier;
 import org.springframework.security.web.webauthn.api.CredProtectAuthenticationExtensionsClientInput;
 import org.springframework.security.web.webauthn.api.CredentialPropertiesOutput;
+import org.springframework.security.web.webauthn.api.ImmutablePublicKeyCredentialUserEntity;
 import org.springframework.security.web.webauthn.api.PublicKeyCredential;
 import org.springframework.security.web.webauthn.api.PublicKeyCredentialCreationOptions;
 import org.springframework.security.web.webauthn.api.PublicKeyCredentialRequestOptions;
 import org.springframework.security.web.webauthn.api.PublicKeyCredentialType;
 import org.springframework.security.web.webauthn.api.ResidentKeyRequirement;
 import org.springframework.security.web.webauthn.api.UserVerificationRequirement;
+import org.springframework.security.web.webauthn.authentication.WebAuthnAuthentication;
 import org.springframework.security.web.webauthn.management.RelyingPartyPublicKey;
 
 /**
@@ -47,6 +49,7 @@ import org.springframework.security.web.webauthn.management.RelyingPartyPublicKe
  *
  * @author Sebastien Deleuze
  * @author Rob Winch
+ * @author Toshiaki Maki
  * @since 7.0
  */
 @SuppressWarnings("serial")
@@ -61,6 +64,8 @@ public class WebauthnJacksonModule extends SecurityJacksonModule {
 
 	@Override
 	public void configurePolymorphicTypeValidator(BasicPolymorphicTypeValidator.Builder builder) {
+		builder.allowIfSubType(WebAuthnAuthentication.class)
+			.allowIfSubType(ImmutablePublicKeyCredentialUserEntity.class);
 	}
 
 	@Override
@@ -92,6 +97,9 @@ public class WebauthnJacksonModule extends SecurityJacksonModule {
 		context.setMixIn(RelyingPartyPublicKey.class, RelyingPartyPublicKeyMixin.class);
 		context.setMixIn(ResidentKeyRequirement.class, ResidentKeyRequirementMixin.class);
 		context.setMixIn(UserVerificationRequirement.class, UserVerificationRequirementMixin.class);
+		context.setMixIn(WebAuthnAuthentication.class, WebAuthnAuthenticationMixin.class);
+		context.setMixIn(ImmutablePublicKeyCredentialUserEntity.class,
+				ImmutablePublicKeyCredentialUserEntityMixin.class);
 	}
 
 }

--- a/webauthn/src/test/java/org/springframework/security/web/webauthn/jackson/WebAuthnAuthenticationMixinTests.java
+++ b/webauthn/src/test/java/org/springframework/security/web/webauthn/jackson/WebAuthnAuthenticationMixinTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.webauthn.jackson;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.jackson.SecurityJacksonModules;
+import org.springframework.security.web.webauthn.api.Bytes;
+import org.springframework.security.web.webauthn.api.ImmutablePublicKeyCredentialUserEntity;
+import org.springframework.security.web.webauthn.authentication.WebAuthnAuthentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link WebAuthnAuthenticationMixin} and
+ * {@link ImmutablePublicKeyCredentialUserEntityMixin} with polymorphic type handling.
+ *
+ * <p>
+ * This test class is separate from {@link JacksonTests} because it requires a
+ * {@link JsonMapper} configured with {@link SecurityJacksonModules} to enable polymorphic
+ * type information ({@code @class}). {@link JacksonTests} uses a {@link JsonMapper}
+ * configured only with {@link WebauthnJacksonModule}, and its existing custom serializers
+ * are not compatible with the automatic inclusion of type information enabled by
+ * {@link SecurityJacksonModules}.
+ *
+ * @author Toshiaki Maki
+ * @since 7.1
+ */
+class WebAuthnAuthenticationMixinTests {
+
+	private JsonMapper mapper;
+
+	@BeforeEach
+	void setup() {
+		ClassLoader classLoader = getClass().getClassLoader();
+		WebauthnJacksonModule webauthnJacksonModule = new WebauthnJacksonModule();
+		BasicPolymorphicTypeValidator.Builder typeValidatorBuilder = BasicPolymorphicTypeValidator.builder();
+		webauthnJacksonModule.configurePolymorphicTypeValidator(typeValidatorBuilder);
+		List<JacksonModule> modules = SecurityJacksonModules.getModules(classLoader, typeValidatorBuilder);
+		modules.add(webauthnJacksonModule);
+		this.mapper = JsonMapper.builder().addModules(modules).build();
+	}
+
+	@Test
+	void writeWebAuthnAuthentication() throws Exception {
+		ImmutablePublicKeyCredentialUserEntity principal = (ImmutablePublicKeyCredentialUserEntity) ImmutablePublicKeyCredentialUserEntity
+			.builder()
+			.name("user@example.localhost")
+			.id(Bytes.fromBase64("oWJtkJ6vJ_m5b84LB4_K7QKTCTEwLIjCh4tFMCGHO4w"))
+			.displayName("User")
+			.build();
+		WebAuthnAuthentication authentication = new WebAuthnAuthentication(principal,
+				List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+		String json = this.mapper.writeValueAsString(authentication);
+
+		String expected = """
+				{
+					"@class": "org.springframework.security.web.webauthn.authentication.WebAuthnAuthentication",
+					"principal": {
+						"@class": "org.springframework.security.web.webauthn.api.ImmutablePublicKeyCredentialUserEntity",
+						"name": "user@example.localhost",
+						"id": "oWJtkJ6vJ_m5b84LB4_K7QKTCTEwLIjCh4tFMCGHO4w",
+						"displayName": "User"
+					},
+					"authorities": ["java.util.Collections$UnmodifiableRandomAccessList", [
+						{
+							"@class": "org.springframework.security.core.authority.SimpleGrantedAuthority",
+							"authority": "ROLE_USER"
+						}
+					]]
+				}
+				""";
+		JSONAssert.assertEquals(expected, json, false);
+		assertThat(json).doesNotContain("\"authenticated\"");
+	}
+
+	@Test
+	void readWebAuthnAuthentication() throws Exception {
+		String json = """
+				{
+					"@class": "org.springframework.security.web.webauthn.authentication.WebAuthnAuthentication",
+					"principal": {
+						"@class": "org.springframework.security.web.webauthn.api.ImmutablePublicKeyCredentialUserEntity",
+						"name": "user@example.localhost",
+						"id": "oWJtkJ6vJ_m5b84LB4_K7QKTCTEwLIjCh4tFMCGHO4w",
+						"displayName": "User"
+					},
+					"authorities": ["java.util.Collections$UnmodifiableRandomAccessList", [
+						{
+							"@class": "org.springframework.security.core.authority.SimpleGrantedAuthority",
+							"authority": "ROLE_USER"
+						}
+					]]
+				}
+				""";
+		ImmutablePublicKeyCredentialUserEntity expectedPrincipal = (ImmutablePublicKeyCredentialUserEntity) ImmutablePublicKeyCredentialUserEntity
+			.builder()
+			.name("user@example.localhost")
+			.id(Bytes.fromBase64("oWJtkJ6vJ_m5b84LB4_K7QKTCTEwLIjCh4tFMCGHO4w"))
+			.displayName("User")
+			.build();
+		WebAuthnAuthentication expected = new WebAuthnAuthentication(expectedPrincipal,
+				List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+		WebAuthnAuthentication authentication = this.mapper.readValue(json, WebAuthnAuthentication.class);
+
+		assertThat(authentication).usingRecursiveComparison().isEqualTo(expected);
+	}
+
+}


### PR DESCRIPTION
This PR adds Jackson Mixin for WebAuthnAuthentication.
Without this change, Passkeys support with Authorization Server + `JdbcOAuth2AuthorizationService` won't work.

Closes gh-18034

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
