### PR TITLE
Always fallback to AccessDeniedHandlerImpl for unmatched requests

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ExceptionHandlingConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ExceptionHandlingConfigurer.java
@@ -285,9 +285,6 @@ public final class ExceptionHandlingConfigurer<H extends HttpSecurityBuilder<H>>
 		if (this.defaultDeniedHandlerMappings.isEmpty()) {
 			return new AccessDeniedHandlerImpl();
 		}
-		if (this.defaultDeniedHandlerMappings.size() == 1) {
-			return this.defaultDeniedHandlerMappings.values().iterator().next();
-		}
 		return new RequestMatcherDelegatingAccessDeniedHandler(this.defaultDeniedHandlerMappings,
 				new AccessDeniedHandlerImpl());
 	}

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ExceptionHandlingConfigurerAccessDeniedHandlerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/ExceptionHandlingConfigurerAccessDeniedHandlerTests.java
@@ -70,10 +70,11 @@ public class ExceptionHandlingConfigurerAccessDeniedHandlerTests {
 
 	@Test
 	@WithMockUser(roles = "ANYTHING")
-	public void getWhenAccessDeniedOverriddenByOnlyOneHandlerThenAllRequestsUseThatHandler() throws Exception {
+	public void getWhenAccessDeniedOverriddenByOnlyOneHandlerThenFallbackHandlerHandlesNonMatchingRequests()
+			throws Exception {
 		this.spring.register(SingleRequestMatcherAccessDeniedHandlerConfig.class).autowire();
 		this.mvc.perform(get("/hello")).andExpect(status().isIAmATeapot());
-		this.mvc.perform(get("/goodbye")).andExpect(status().isIAmATeapot());
+		this.mvc.perform(get("/goodbye")).andExpect(status().isForbidden());
 	}
 
 	@Configuration


### PR DESCRIPTION
Fixes gh-18871

`ExceptionHandlingConfigurer#createDefaultAccessDeniedHandler` currently returns the configured handler directly when only one `defaultAccessDeniedHandlerFor` mapping is registered. In that case, unmatched requests do not fall back to `AccessDeniedHandlerImpl`.

This change always uses `RequestMatcherDelegatingAccessDeniedHandler` when default denied handler mappings are present so that unmatched requests consistently fall back to `AccessDeniedHandlerImpl`.

It also updates the regression test for the single-matcher case to verify that only matching requests use the custom handler and non-matching requests return `403 Forbidden`.

Testing:
- `export JAVA_HOME=/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home; export PATH="$JAVA_HOME/bin:$PATH"; export NPM_CONFIG_WORKSPACES=false; ./gradlew :spring-security-config:test --tests org.springframework.security.config.annotation.web.configurers.ExceptionHandlingConfigurerAccessDeniedHandlerTests`
