### PR TITLE
Add equals and hashcode to `HttpMethodRequestMatcher`

### DIFF
--- a/web/src/main/java/org/springframework/security/web/servlet/util/matcher/PathPatternRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/servlet/util/matcher/PathPatternRequestMatcher.java
@@ -306,6 +306,19 @@ public final class PathPatternRequestMatcher implements RequestMatcher {
 		}
 
 		@Override
+		public boolean equals(Object o) {
+			if (!(o instanceof HttpMethodRequestMatcher that)) {
+				return false;
+			}
+			return Objects.equals(this.method, that.method);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(this.method);
+		}
+
+		@Override
 		public String toString() {
 			return "HttpMethod [" + this.method + "]";
 		}

--- a/web/src/test/java/org/springframework/security/web/servlet/util/matcher/PathPatternRequestMatcherTests.java
+++ b/web/src/test/java/org/springframework/security/web/servlet/util/matcher/PathPatternRequestMatcherTests.java
@@ -145,6 +145,17 @@ public class PathPatternRequestMatcherTests {
 		assertThat(matcher.matches(mock)).isTrue();
 	}
 
+	// gh-18911
+	@Test
+	void testEqualsWithSameAndDifferentHttpMethod() {
+		PathPatternRequestMatcher.Builder builder = PathPatternRequestMatcher.withDefaults();
+		PathPatternRequestMatcher matcher1 = builder.matcher(HttpMethod.GET, "/foo");
+		PathPatternRequestMatcher matcher2 = builder.matcher(HttpMethod.GET, "/foo");
+		PathPatternRequestMatcher matcher3 = builder.matcher(HttpMethod.POST, "/foo");
+		assertThat(matcher1).isEqualTo(matcher2);
+		assertThat(matcher1).isNotEqualTo(matcher3);
+	}
+
 	MockHttpServletRequest request(String uri) {
 		MockHttpServletRequest request = new MockHttpServletRequest("GET", uri);
 		ServletRequestPathUtils.parseAndCache(request);


### PR DESCRIPTION
Closes gh-18911

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
