### PR TITLE
Document risks of retaining credentials

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/builders/AuthenticationManagerBuilder.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/builders/AuthenticationManagerBuilder.java
@@ -104,7 +104,9 @@ public class AuthenticationManagerBuilder
 
 	/**
 	 * @param eraseCredentials true if {@link AuthenticationManager} should clear the
-	 * credentials from the {@link Authentication} object after authenticating
+	 * credentials from the {@link Authentication} object after authenticating. Setting
+	 * this to {@code false} is generally discouraged because it retains credentials in
+	 * memory for longer than necessary.
 	 * @return the {@link AuthenticationManagerBuilder} for further customizations
 	 */
 	public AuthenticationManagerBuilder eraseCredentials(boolean eraseCredentials) {

--- a/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
@@ -63,7 +63,9 @@ import org.springframework.util.CollectionUtils;
  * {@code Authentication} object, if it implements the {@link CredentialsContainer}
  * interface. This behaviour can be controlled by modifying the
  * {@link #setEraseCredentialsAfterAuthentication(boolean)
- * eraseCredentialsAfterAuthentication} property.
+ * eraseCredentialsAfterAuthentication} property. Disabling credential erasure is
+ * generally discouraged, since retaining credentials increases the likelihood of exposing
+ * sensitive data in memory or in serialized {@code Authentication} instances.
  *
  * <h2>Event Publishing</h2>
  * <p>
@@ -302,6 +304,10 @@ public class ProviderManager implements AuthenticationManager, MessageSourceAwar
 	 * {@code CredentialsContainer} interface will have its
 	 * {@link CredentialsContainer#eraseCredentials() eraseCredentials} method called
 	 * before it is returned from the {@code authenticate()} method.
+	 * <p>
+	 * Setting this property to {@literal false} is generally discouraged, since retaining
+	 * the credentials increases the likelihood of exposing sensitive data in memory or in
+	 * serialized {@code Authentication} instances.
 	 * @param eraseSecretData set to {@literal false} to retain the credentials data in
 	 * memory. Defaults to {@literal true}.
 	 */


### PR DESCRIPTION
Closes #12631

This documents the risks of disabling credential erasure in `ProviderManager` and surfaces the same warning on `AuthenticationManagerBuilder#eraseCredentials`.

Verification:
- `./gradlew format`
- `./gradlew :spring-security-core:compileJava :spring-security-config:compileJava`

Note:
- `./gradlew check` currently fails locally in three existing `spring-security-config:test` cases unrelated to this Javadoc-only change.