### PR TITLE
Add unless support to AdditionalRequiredFactorsBuilder

### DIFF
--- a/core/src/main/java/org/springframework/security/authorization/AuthorizationManagerFactories.java
+++ b/core/src/main/java/org/springframework/security/authorization/AuthorizationManagerFactories.java
@@ -29,6 +29,7 @@ import org.springframework.util.Assert;
  * Creates common {@link AuthorizationManagerFactory} instances.
  *
  * @author Rob Winch
+ * @author Andrey Litvitski
  * @since 7.0
  * @see DefaultAuthorizationManagerFactory
  */
@@ -57,6 +58,7 @@ public final class AuthorizationManagerFactories {
 	 *
 	 * @param <T> the type for the {@link DefaultAuthorizationManagerFactory}
 	 * @author Rob Winch
+	 * @author Andrey Litvitski
 	 */
 	public static final class AdditionalRequiredFactorsBuilder<T> {
 
@@ -64,6 +66,8 @@ public final class AuthorizationManagerFactories {
 			.builder();
 
 		private @Nullable Predicate<Authentication> whenCondition;
+
+		private @Nullable Predicate<Authentication> unlessCondition;
 
 		/**
 		 * Apply the required factors only when the given condition is true for the
@@ -82,6 +86,21 @@ public final class AuthorizationManagerFactories {
 		}
 
 		/**
+		 * Skip the required factors when the given condition is true for the current
+		 * {@link Authentication}. When the condition is true, no additional factors are
+		 * required. Implemented using
+		 * {@link ConditionalAuthorizationManager#when(java.util.function.Predicate)}.
+		 * @param condition the condition to evaluate (must not be null)
+		 * @return the {@link AdditionalRequiredFactorsBuilder} to further customize
+		 * @since 7.1
+		 */
+		public AdditionalRequiredFactorsBuilder<T> unless(Predicate<Authentication> condition) {
+			Assert.notNull(condition, "condition cannot be null");
+			this.unlessCondition = condition;
+			return this;
+		}
+
+		/**
 		 * Customize the condition that determines if the required factors are evaluated.
 		 * @param condition a function that takes the current condition and returns the
 		 * new condition
@@ -92,6 +111,20 @@ public final class AuthorizationManagerFactories {
 				Function<@Nullable Predicate<Authentication>, @Nullable Predicate<Authentication>> condition) {
 			Assert.notNull(condition, "condition cannot be null");
 			this.whenCondition = condition.apply(this.whenCondition);
+			return this;
+		}
+
+		/**
+		 * Customize the condition that determines if the required factors are skipped.
+		 * @param condition a function that takes the current condition and returns the
+		 * new condition
+		 * @return the {@link AdditionalRequiredFactorsBuilder} to further customize
+		 * @since 7.1
+		 */
+		public AdditionalRequiredFactorsBuilder<T> withUnless(
+				Function<@Nullable Predicate<Authentication>, @Nullable Predicate<Authentication>> condition) {
+			Assert.notNull(condition, "condition cannot be null");
+			this.unlessCondition = condition.apply(this.unlessCondition);
 			return this;
 		}
 
@@ -132,6 +165,12 @@ public final class AuthorizationManagerFactories {
 			if (this.whenCondition != null) {
 				additionalChecks = ConditionalAuthorizationManager.<T>when(this.whenCondition)
 					.whenTrue(additionalChecks)
+					.build();
+			}
+			if (this.unlessCondition != null) {
+				additionalChecks = ConditionalAuthorizationManager.<T>when(this.unlessCondition)
+					.whenTrue(SingleResultAuthorizationManager.permitAll())
+					.whenFalse(additionalChecks)
 					.build();
 			}
 			result.setAdditionalAuthorization(additionalChecks);

--- a/core/src/test/java/org/springframework/security/authorization/AuthorizationManagerFactoryTests.java
+++ b/core/src/test/java/org/springframework/security/authorization/AuthorizationManagerFactoryTests.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
  * Tests for {@link AuthorizationManagerFactory}.
  *
  * @author Steve Riesenberg
+ * @author Andrey Litvitski
  */
 public class AuthorizationManagerFactoryTests {
 
@@ -364,6 +365,42 @@ public class AuthorizationManagerFactoryTests {
 			.multiFactor();
 		assertThatIllegalArgumentException().isThrownBy(() -> builder.withWhen(null))
 			.withMessage("condition cannot be null");
+	}
+
+	@Test
+	public void builderWhenUnlessConditionFalseThenRequiredFactorsEnforced() {
+		AuthorizationManagerFactory<String> factory = AuthorizationManagerFactories.<String>multiFactor()
+			.requireFactors("ROLE_ADMIN")
+			.unless((auth) -> "bearer".equals(auth.getName()))
+			.build();
+		assertUserDenied(factory.hasRole("USER"));
+	}
+
+	@Test
+	public void builderWhenUnlessConditionTrueThenMfaSkipped() {
+		AuthorizationManagerFactory<String> factory = AuthorizationManagerFactories.<String>multiFactor()
+			.requireFactors("ROLE_ADMIN")
+			.unless((auth) -> "bearer".equals(auth.getName()))
+			.build();
+		assertThat(factory.hasRole("USER")
+			.authorize(() -> new TestingAuthenticationToken("bearer", "password", "ROLE_USER"), "")
+			.isGranted()).isTrue();
+	}
+
+	@Test
+	public void builderWhenWithUnlessConditionThenConditionIsCustomized() {
+		AuthorizationManagerFactory<String> factory = AuthorizationManagerFactories.<String>multiFactor()
+			.requireFactors("ROLE_ADMIN")
+			.unless((auth) -> "bearer".equals(auth.getName()))
+			.withUnless((current) -> (auth) -> current != null && current.test(auth) && auth.isAuthenticated())
+			.build();
+		assertThat(factory.hasRole("USER")
+			.authorize(() -> new TestingAuthenticationToken("bearer", "password", "ROLE_USER"), "")
+			.isGranted()).isTrue();
+		TestingAuthenticationToken unauthenticatedBearer = new TestingAuthenticationToken("bearer", "password",
+				"ROLE_USER");
+		unauthenticatedBearer.setAuthenticated(false);
+		assertThat(factory.hasRole("USER").authorize(() -> unauthenticatedBearer, "").isGranted()).isFalse();
 	}
 
 	private void assertUserGranted(AuthorizationManager<String> manager) {


### PR DESCRIPTION
In this commit, we are adding support for 'unless' to 'AdditionalRequiredFactorsBuilder'. This is useful if we want a specific user type or factor to disable MFA.

Closes: gh-18925

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
