### PR TITLE
Fix handling of missing access token during refresh token invalidation

### DIFF
--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/OAuth2Authorization.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/OAuth2Authorization.java
@@ -503,8 +503,10 @@ public class OAuth2Authorization implements Serializable {
 			token(token, (metadata) -> metadata.put(OAuth2Authorization.Token.INVALIDATED_METADATA_NAME, true));
 			if (OAuth2RefreshToken.class.isAssignableFrom(token.getClass())) {
 				Token<?> accessToken = this.tokens.get(OAuth2AccessToken.class);
-				token(accessToken.getToken(),
-						(metadata) -> metadata.put(OAuth2Authorization.Token.INVALIDATED_METADATA_NAME, true));
+				if (accessToken != null && !accessToken.isInvalidated()) {
+					token(accessToken.getToken(),
+							(metadata) -> metadata.put(OAuth2Authorization.Token.INVALIDATED_METADATA_NAME, true));
+				}
 
 				Token<?> authorizationCode = this.tokens.get(OAuth2AuthorizationCode.class);
 				if (authorizationCode != null && !authorizationCode.isInvalidated()) {

--- a/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/OAuth2AuthorizationTests.java
+++ b/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/OAuth2AuthorizationTests.java
@@ -138,4 +138,17 @@ public class OAuth2AuthorizationTests {
 		assertThat(authorization.getRefreshToken().getToken()).isEqualTo(REFRESH_TOKEN);
 	}
 
+	@Test
+	public void invalidateRefreshTokenWhenNoAccessTokenThenDoesNotThrow() {
+		OAuth2Authorization authorization = OAuth2Authorization.withRegisteredClient(REGISTERED_CLIENT)
+			.principalName(PRINCIPAL_NAME)
+			.authorizationGrantType(AUTHORIZATION_GRANT_TYPE)
+			.refreshToken(REFRESH_TOKEN)
+			.build();
+
+		OAuth2Authorization invalidated = OAuth2Authorization.from(authorization).invalidate(REFRESH_TOKEN).build();
+
+		assertThat(invalidated.getRefreshToken().isInvalidated()).isTrue();
+	}
+
 }


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-security/issues/18935

This change adds a null check when invalidating the access token in `OAuth2Authorization.Builder.invalidate()`.

This is necessary because the builder allows independent configuration of tokens, making it valid to construct an OAuth2Authorization where the access token is absent. The current implementation assumes its presence and can throw a NullPointerException during refresh token revocation.