### PR TITLE
Gracefully handle detached HEAD in branch version check

### DIFF
--- a/buildSrc/src/main/java/org/springframework/security/CheckExpectedBranchVersionPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/security/CheckExpectedBranchVersionPlugin.java
@@ -21,8 +21,12 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
@@ -30,6 +34,7 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.TaskExecutionException;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.VerificationException;
+import org.gradle.process.ExecOutput;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -44,21 +49,53 @@ public class CheckExpectedBranchVersionPlugin implements Plugin<Project> {
 		TaskProvider<CheckExpectedBranchVersionTask> checkExpectedBranchVersionTask = project.getTasks().register("checkExpectedBranchVersion", CheckExpectedBranchVersionTask.class, (task) -> {
 			task.setGroup("Build");
 			task.setDescription("Check if the project version matches the branch version");
-			task.onlyIf("skipCheckExpectedBranchVersion property is false or not present", CheckExpectedBranchVersionPlugin::skipPropertyFalseOrNotPresent);
+			task.onlyIf("Property 'skipCheckExpectedBranchVersion' is false or not present", skipPropertyFalseOrNotPresent(project.getProviders()));
+			task.onlyIf("Branch name matches expected version pattern *.x", CheckExpectedBranchVersionPlugin::isVersionBranch);
 			task.getVersion().convention(project.provider(() -> project.getVersion().toString()));
-			task.getBranchName().convention(project.getProviders().exec((execSpec) -> execSpec.setCommandLine("git", "symbolic-ref", "--short", "HEAD")).getStandardOutput().getAsText());
+			task.getBranchName().convention(getBranchName(project.getProviders(), project.getLogger()));
 			task.getOutputFile().convention(project.getLayout().getBuildDirectory().file("check-expected-branch-version"));
 		});
 		project.getTasks().named(JavaBasePlugin.CHECK_TASK_NAME, checkTask -> checkTask.dependsOn(checkExpectedBranchVersionTask));
 	}
 
-	private static boolean skipPropertyFalseOrNotPresent(Task task) {
-		return task.getProject()
-				.getProviders()
+	private static Spec<Task> skipPropertyFalseOrNotPresent(ProviderFactory providers) {
+		Provider<Boolean> skipPropertyFalseOrNotPresent = providers
 				.gradleProperty("skipCheckExpectedBranchVersion")
 				.orElse("false")
-				.map("false"::equalsIgnoreCase)
-				.get();
+				.map("false"::equalsIgnoreCase);
+		return (task) -> skipPropertyFalseOrNotPresent.get();
+	}
+
+	private static boolean isVersionBranch(Task task) {
+		return isVersionBranch((CheckExpectedBranchVersionTask) task);
+	}
+
+	private static boolean isVersionBranch(CheckExpectedBranchVersionTask task) {
+		String branchName = task.getBranchName().getOrNull();
+		if (branchName == null) {
+			return false;
+		}
+		return branchName.matches("^[0-9]+\\.[0-9]+\\.x$");
+	}
+
+	private static Provider<String> getBranchName(ProviderFactory providers, Logger logger) {
+		ExecOutput execOutput = providers.exec((execSpec) -> {
+			execSpec.setCommandLine("git", "symbolic-ref", "--short", "HEAD");
+			execSpec.setIgnoreExitValue(true);
+		});
+
+		return providers.provider(() -> {
+			int exitValue = execOutput.getResult().get().getExitValue();
+			if (exitValue != 0) {
+				logger.warn("Unable to determine branch name. Received exit code '{}' from `git`.", exitValue);
+				logger.warn(execOutput.getStandardError().getAsText().getOrNull());
+				return null;
+			}
+
+			String branchName = execOutput.getStandardOutput().getAsText().get().trim();
+			logger.info("Git branch name is '{}'.", branchName);
+			return branchName;
+		});
 	}
 
 	@CacheableTask
@@ -77,15 +114,10 @@ public class CheckExpectedBranchVersionPlugin implements Plugin<Project> {
 		public void run() {
 			String version = getVersion().get();
 			String branchVersion = getBranchName().map(String::trim).get();
-			if (!branchVersion.matches("^[0-9]+\\.[0-9]+\\.x$")) {
-				String msg = String.format("Branch version [%s] does not match *.x, ignoring", branchVersion);
-				getLogger().warn(msg);
-				writeExpectedVersionOutput(msg);
-				return;
-			}
 			if (!versionsMatch(version, branchVersion)) {
 				String msg = String.format("Project version [%s] does not match branch version [%s]. " +
-						"Please verify that the branch contains the right version.", version, branchVersion);
+						"Please verify that the branch contains the right version. " +
+						"To bypass this check, run the build with -PskipCheckExpectedBranchVersion.", version, branchVersion);
 				writeExpectedVersionOutput(msg);
 				throw new VerificationException(msg);
 			}


### PR DESCRIPTION
Previously, the `CheckExpectedBranchVersionPlugin` would crash the Gradle configuration phase if the project was in a detached HEAD state or not in a Git repository, e.g., downloaded as a ZIP.

This commit refactors the plugin to be lazy and adopts several Gradle best practices:

- Prevents build crashes on Git failures by gracefully catching non-zero exit codes, e.g., when checked out in a detached HEAD state. For example:
  - **Before:** https://ge.solutions-team.gradle.com/s/ypkq46kbitvsi/failures#1
  - **After:** https://ge.solutions-team.gradle.com/s/wn2zyjwwuqxcs/console-log/task/:checkExpectedBranchVersion?anchor=3&page=1
- Moves the branch validation out of the task's main execution action and into an `onlyIf` predicate, allowing Gradle to skip the task entirely instead of executing an early return. This makes the skip outcome and reason visible in a Build Scan, rather than making it appear as if it executed. For example:
  - **Before:** https://ge.solutions-team.gradle.com/s/cfspokcokomes/timeline?details=syfcidn3kytxg
    - You _could_ see [the console logs](https://ge.solutions-team.gradle.com/s/cfspokcokomes/console-log/task/:checkExpectedBranchVersion?anchor=1&page=1) before.
  - **After:** https://ge.solutions-team.gradle.com/s/geowrnjfb3xiy/timeline?details=syfcidn3kytxg
- Defers the Git `exec` call to the execution phase using a lazy provider.
- Makes the task configuration cache compatible by avoiding illegal `Project` access inside the execution-time `onlyIf` closure. For example:
  - **Before:** https://ge.solutions-team.gradle.com/s/eccu2mvc7knhg/failures#1
  - **After:** https://ge.solutions-team.gradle.com/s/auvsdrvnkcx2u/performance/configuration#summary-configuration-caching-total
- Improves user-facing logs and adds actionable bypass instructions when the project version doesn't match the branch version.
  - **Example:** https://ge.solutions-team.gradle.com/s/eqwxias5o743m/failures#1

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
