### PR TITLE
Handle setHeader null values in response wrappers

### DIFF
--- a/web/src/main/java/org/springframework/security/web/firewall/FirewalledResponse.java
+++ b/web/src/main/java/org/springframework/security/web/firewall/FirewalledResponse.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletResponseWrapper;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.util.Assert;
 
@@ -29,6 +30,7 @@ import org.springframework.util.Assert;
  * @author Eddú Meléndez
  * @author Gabriel Lavoie
  * @author Luke Butters
+ * @author Andrey Litvitski
  */
 class FirewalledResponse extends HttpServletResponseWrapper {
 
@@ -49,7 +51,7 @@ class FirewalledResponse extends HttpServletResponseWrapper {
 	}
 
 	@Override
-	public void setHeader(String name, String value) {
+	public void setHeader(String name, @Nullable String value) {
 		validateCrlf(name, value);
 		super.setHeader(name, value);
 	}
@@ -71,11 +73,11 @@ class FirewalledResponse extends HttpServletResponseWrapper {
 		super.addCookie(cookie);
 	}
 
-	void validateCrlf(String name, String value) {
+	void validateCrlf(String name, @Nullable String value) {
 		Assert.isTrue(!hasCrlf(name) && !hasCrlf(value), () -> "Invalid characters (CR/LF) in header " + name);
 	}
 
-	private boolean hasCrlf(String value) {
+	private boolean hasCrlf(@Nullable String value) {
 		return value != null && (value.indexOf('\n') != -1 || value.indexOf('\r') != -1);
 	}
 

--- a/web/src/main/java/org/springframework/security/web/util/OnCommittedResponseWrapper.java
+++ b/web/src/main/java/org/springframework/security/web/util/OnCommittedResponseWrapper.java
@@ -31,6 +31,7 @@ import org.jspecify.annotations.Nullable;
  * the {@link jakarta.servlet.http.HttpServletResponse} is committed.
  *
  * @author Rob Winch
+ * @author Andrey Litvitski
  * @since 4.0.2
  */
 public abstract class OnCommittedResponseWrapper extends HttpServletResponseWrapper {
@@ -70,8 +71,10 @@ public abstract class OnCommittedResponseWrapper extends HttpServletResponseWrap
 	}
 
 	@Override
-	public void setHeader(String name, String value) {
-		checkContentLengthHeader(name, value);
+	public void setHeader(String name, @Nullable String value) {
+		if (value != null) {
+			checkContentLengthHeader(name, value);
+		}
 		super.setHeader(name, value);
 	}
 

--- a/web/src/test/java/org/springframework/security/web/util/OnCommittedResponseWrapperTests.java
+++ b/web/src/test/java/org/springframework/security/web/util/OnCommittedResponseWrapperTests.java
@@ -1054,4 +1054,11 @@ public class OnCommittedResponseWrapperTests {
 		assertThat(this.committed).isFalse();
 	}
 
+	// gh-18970
+	@Test
+	public void setHeaderContentLengthNull() {
+		this.response.setHeader("Content-Length", null);
+		assertThat(this.delegate.getHeader("Content-Length")).isNull();
+	}
+
 }


### PR DESCRIPTION
The main problem is that `HttpServletResponse`, according to its contract, accepts null values in `setHeader`. When an argument is null, we must remove the header. So, the main idea is to make these arguments `@Nullable` in our implementations and handle cases where they are null as described in the contract.

By the way, some methods, such as `addHeader` in the same interface, can also accept null by contract, but in that case, we don't have to do anything. I think we're handling this correctly now, and we can afford to make their arguments nonnullable, as is now.

https://github.com/jakartaee/servlet/blob/main/api/src/main/java/jakarta/servlet/http/HttpServletResponse.java#L306

Closes: gh-18970

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
