### PR TITLE
Use existing token repository if present

### DIFF
--- a/test/src/main/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessors.java
+++ b/test/src/main/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessors.java
@@ -520,7 +520,7 @@ public final class SecurityMockMvcRequestPostProcessors {
 			CsrfTokenRequestHandler handler = WebTestUtils.getCsrfTokenRequestHandler(request);
 			Assert.isTrue(handler != null, "No CsrfTokenRequestHandler found");
 			if (!(repository instanceof TestCsrfTokenRepository)) {
-				repository = new TestCsrfTokenRepository(new HttpSessionCsrfTokenRepository());
+				repository = new TestCsrfTokenRepository(repository == null ? new HttpSessionCsrfTokenRepository(): repository);
 				WebTestUtils.setCsrfTokenRepository(request, repository);
 			}
 			TestCsrfTokenRepository.enable(request);

--- a/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsCsrfForCookieCsrfTokenRepositoryTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/servlet/request/SecurityMockMvcRequestPostProcessorsCsrfForCookieCsrfTokenRepositoryTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.test.web.servlet.request;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+@WebAppConfiguration
+public class SecurityMockMvcRequestPostProcessorsCsrfForCookieCsrfTokenRepositoryTests {
+
+	@Autowired
+	WebApplicationContext wac;
+
+	@Test
+	void withCsrfDoesNotResetTokenRepositorySetInProductionCode_shouldReturnCsrfCookie() throws Exception {
+		MockMvc mockMvc = MockMvcBuilders
+				.webAppContextSetup(wac)
+				.apply(springSecurity())
+				.build();
+		mockMvc.perform(post("/").with(csrf()))
+				.andExpect(status().isOk());
+
+		mockMvc.perform(get("/"))
+				.andExpect(status().isOk())
+				.andExpect(cookie().httpOnly("XSRF-TOKEN", false));
+	}
+
+	@Configuration
+	@EnableWebSecurity
+	public static class SpaConfig {
+
+		@Bean
+		public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+			http.csrf(CsrfConfigurer::spa);
+			return http.build();
+		}
+
+		@RestController
+		static class TheController {
+
+			@RequestMapping("/")
+			String index() {
+				return "Hi";
+			}
+
+		}
+	}
+}


### PR DESCRIPTION
Hi, this PR prevents overwriting the repository set in production code. Instead it only wrap existing repository.

In this way, we avoid communicating tests; otherwise the csrf cookie is not returned in the GET request, once a test has run before that had a call to `with(csrf())` to mock the CSRF token. 

I know that the tests are far from optimal with using a separate test class.
If there's a better way to make the test setup, please let me know

Closes #17082

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
