### PR TITLE
Add RestTemplate overloads to ClientRegistrations methods

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistrations.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/registration/ClientRegistrations.java
@@ -146,9 +146,14 @@ public final class ClientRegistrations {
 	 * @return a {@link ClientRegistration.Builder} that was initialized by the OpenID
 	 * Provider Configuration.
 	 */
-	public static ClientRegistration.Builder fromOidcIssuerLocation(String issuer) {
+	public static ClientRegistration.Builder fromOidcIssuerLocation(RestTemplate restTemplate, String issuer) {
+		Assert.notNull(restTemplate, "restTemplate cannot be null");
 		Assert.hasText(issuer, "issuer cannot be empty");
-		return getBuilder(issuer, oidc(issuer));
+		return getBuilder(issuer, oidc(restTemplate, issuer));
+	}
+
+	public static ClientRegistration.Builder fromOidcIssuerLocation(String issuer) {
+		return fromOidcIssuerLocation(rest, issuer);
 	}
 
 	/**
@@ -174,7 +179,7 @@ public final class ClientRegistrations {
 	 * </ol>
 	 *
 	 * Note that the second endpoint is the equivalent of calling
-	 * {@link ClientRegistrations#fromOidcIssuerLocation(String)}.
+	 * {@link ClientRegistrations#fromOidcIssuerLocation(RestTemplate, String)}.
 	 *
 	 * <p>
 	 * Example usage:
@@ -185,21 +190,28 @@ public final class ClientRegistrations {
 	 *     .clientSecret("client-secret")
 	 *     .build();
 	 * </pre>
+	 * @param restTemplate
 	 * @param issuer
 	 * @return a {@link ClientRegistration.Builder} that was initialized by one of the
 	 * described endpoints
 	 */
-	public static ClientRegistration.Builder fromIssuerLocation(String issuer) {
+	public static ClientRegistration.Builder fromIssuerLocation(RestTemplate restTemplate, String issuer) {
+		Assert.notNull(restTemplate, "restTemplate cannot be null");
 		Assert.hasText(issuer, "issuer cannot be empty");
-		return getBuilder(issuer, oidc(issuer), oidcRfc8414(issuer), oauth(issuer));
+		return getBuilder(issuer, oidc(restTemplate, issuer), oidcRfc8414(restTemplate, issuer),
+				oauth(restTemplate, issuer));
 	}
 
-	static Supplier<ClientRegistration.Builder> oidc(String issuer) {
+	public static ClientRegistration.Builder fromIssuerLocation(String issuer) {
+		return fromIssuerLocation(rest, issuer);
+	}
+
+	static Supplier<ClientRegistration.Builder> oidc(RestTemplate restTemplate, String issuer) {
 		UriComponents uri = oidcUri(issuer);
 		// @formatter:on
 		return () -> {
 			RequestEntity<Void> request = RequestEntity.get(uri.toUriString()).build();
-			Map<String, Object> configuration = rest.exchange(request, typeReference).getBody();
+			Map<String, Object> configuration = restTemplate.exchange(request, typeReference).getBody();
 			Assert.notNull(configuration, "OIDC provider configuration cannot be null");
 			OIDCProviderMetadata metadata = parse(configuration, OIDCProviderMetadata::parse);
 			ClientRegistration.Builder builder = withProviderConfiguration(metadata, issuer)
@@ -219,10 +231,10 @@ public final class ClientRegistrations {
 				.build();
 	}
 
-	static Supplier<ClientRegistration.Builder> oidcRfc8414(String issuer) {
+	static Supplier<ClientRegistration.Builder> oidcRfc8414(RestTemplate restTemplate, String issuer) {
 		UriComponents uri = oidcRfc8414Uri(issuer);
 		// @formatter:on
-		return getRfc8414Builder(issuer, uri);
+		return getRfc8414Builder(restTemplate, issuer, uri);
 	}
 
 	static UriComponents oidcRfc8414Uri(String issuer) {
@@ -233,9 +245,9 @@ public final class ClientRegistrations {
 				.build();
 	}
 
-	static Supplier<ClientRegistration.Builder> oauth(String issuer) {
+	static Supplier<ClientRegistration.Builder> oauth(RestTemplate restTemplate, String issuer) {
 		UriComponents uri = oauthUri(issuer);
-		return getRfc8414Builder(issuer, uri);
+		return getRfc8414Builder(restTemplate, issuer, uri);
 	}
 
 	static UriComponents oauthUri(String issuer) {
@@ -247,10 +259,11 @@ public final class ClientRegistrations {
 		// @formatter:on
 	}
 
-	private static Supplier<ClientRegistration.Builder> getRfc8414Builder(String issuer, UriComponents uri) {
+	private static Supplier<ClientRegistration.Builder> getRfc8414Builder(RestTemplate restTemplate, String issuer,
+			UriComponents uri) {
 		return () -> {
 			RequestEntity<Void> request = RequestEntity.get(uri.toUriString()).build();
-			Map<String, Object> configuration = rest.exchange(request, typeReference).getBody();
+			Map<String, Object> configuration = restTemplate.exchange(request, typeReference).getBody();
 			Assert.notNull(configuration, "Authorization server configuration cannot be null");
 			AuthorizationServerMetadata metadata = parse(configuration, AuthorizationServerMetadata::parse);
 			ClientRegistration.Builder builder = withProviderConfiguration(metadata, issuer);

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/ClientRegistrationsTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/registration/ClientRegistrationsTests.java
@@ -32,8 +32,10 @@ import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -116,12 +118,20 @@ public class ClientRegistrationsTests {
 
 	private String issuer;
 
+	private RestTemplate restTemplate;
+
 	@BeforeEach
 	public void setup() throws Exception {
 		this.server = new MockWebServer();
 		this.server.start();
 		this.response = this.mapper.readValue(DEFAULT_RESPONSE, new TypeReference<Map<String, Object>>() {
 		});
+
+		this.restTemplate = new RestTemplate();
+		SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+		requestFactory.setConnectTimeout(30_000);
+		requestFactory.setReadTimeout(30_000);
+		this.restTemplate.setRequestFactory(requestFactory);
 	}
 
 	@AfterEach
@@ -678,6 +688,132 @@ public class ClientRegistrationsTests {
 				.setBody(body)
 				.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
 		// @formatter:on
+	}
+
+	@Test
+	public void oidcIssuerLocationWithRestTemplateWhenSuccess() throws Exception {
+		ClientRegistration registration = registrationWithRestTemplate("").build();
+		ClientRegistration.ProviderDetails provider = registration.getProviderDetails();
+		assertIssuerMetadata(registration, provider);
+		assertThat(provider.getUserInfoEndpoint().getUri()).isEqualTo("https://example.com/oauth2/v3/userinfo");
+	}
+
+	@Test
+	public void oidcIssuerLocationWithRestTemplateWhenNullRestTemplateThrowsException() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> ClientRegistrations.fromOidcIssuerLocation(null, "https://example.com"))
+			.withMessageContaining("restTemplate cannot be null");
+	}
+
+	@Test
+	public void oidcIssuerLocationWithRestTemplateWhenEmptyIssuerThrowsException() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> ClientRegistrations.fromOidcIssuerLocation(this.restTemplate, ""))
+			.withMessageContaining("issuer cannot be empty");
+	}
+
+	@Test
+	public void issuerLocationWithRestTemplateWhenNullRestTemplateThrowsException() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> ClientRegistrations.fromIssuerLocation(null, "https://example.com"))
+			.withMessageContaining("restTemplate cannot be null");
+	}
+
+	@Test
+	public void issuerLocationWithRestTemplateWhenEmptyIssuerThrowsException() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> ClientRegistrations.fromIssuerLocation(this.restTemplate, ""))
+			.withMessageContaining("issuer cannot be empty");
+	}
+
+	@Test
+	public void issuerLocationWithRestTemplateWhenOidcFallbackSuccess() throws Exception {
+		ClientRegistration registration = registrationOidcFallbackWithRestTemplate("issuer1", null).build();
+		ClientRegistration.ProviderDetails provider = registration.getProviderDetails();
+		assertIssuerMetadata(registration, provider);
+		assertThat(provider.getUserInfoEndpoint().getUri()).isEqualTo("https://example.com/oauth2/v3/userinfo");
+	}
+
+	@Test
+	public void issuerLocationWithRestTemplateWhenOAuth2Success() throws Exception {
+		ClientRegistration registration = registrationOAuth2WithRestTemplate("issuer1", null).build();
+		ClientRegistration.ProviderDetails provider = registration.getProviderDetails();
+		assertIssuerMetadata(registration, provider);
+	}
+
+	@Test
+	public void issuerLocationWithRestTemplateWhenAllEndpointsFailedThenExceptionIncludesFailureInformation() {
+		this.issuer = createIssuerFromServer("issuer1");
+		this.server.setDispatcher(new Dispatcher() {
+			@Override
+			public MockResponse dispatch(RecordedRequest request) {
+				int responseCode = switch (request.getPath()) {
+					case "/issuer1/.well-known/openid-configuration" -> 405;
+					case "/.well-known/openid-configuration/issuer1" -> 400;
+					default -> 404;
+				};
+				return new MockResponse().setResponseCode(responseCode);
+			}
+		});
+		assertThatExceptionOfType(IllegalArgumentException.class)
+			.isThrownBy(() -> ClientRegistrations.fromIssuerLocation(this.restTemplate, this.issuer).build())
+			.withMessageContaining("405")
+			.withMessageContaining("400")
+			.withMessageContaining("404");
+	}
+
+	private ClientRegistration.Builder registrationWithRestTemplate(String path) throws Exception {
+		this.issuer = createIssuerFromServer(path);
+		this.response.put("issuer", this.issuer);
+		String body = this.mapper.writeValueAsString(this.response);
+		MockResponse mockResponse = new MockResponse().setBody(body)
+			.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+		this.server.enqueue(mockResponse);
+		return ClientRegistrations.fromOidcIssuerLocation(this.restTemplate, this.issuer)
+			.clientId("client-id")
+			.clientSecret("client-secret");
+	}
+
+	private ClientRegistration.Builder registrationOidcFallbackWithRestTemplate(String path, String body)
+			throws Exception {
+		this.issuer = createIssuerFromServer(path);
+		this.response.put("issuer", this.issuer);
+		String responseBody = (body != null) ? body : this.mapper.writeValueAsString(this.response);
+		final Dispatcher dispatcher = new Dispatcher() {
+			@Override
+			public MockResponse dispatch(RecordedRequest request) {
+				return switch (request.getPath()) {
+					case "/issuer1/.well-known/openid-configuration", "/.well-known/openid-configuration/" ->
+						buildSuccessMockResponse(responseBody);
+					default -> new MockResponse().setResponseCode(404);
+				};
+			}
+		};
+		this.server.setDispatcher(dispatcher);
+		return ClientRegistrations.fromIssuerLocation(this.restTemplate, this.issuer)
+			.clientId("client-id")
+			.clientSecret("client-secret");
+	}
+
+	private ClientRegistration.Builder registrationOAuth2WithRestTemplate(String path, String body) throws Exception {
+		this.issuer = createIssuerFromServer(path);
+		this.response.put("issuer", this.issuer);
+		final String responseBody = (body != null) ? body : this.mapper.writeValueAsString(this.response);
+		final Dispatcher dispatcher = new Dispatcher() {
+			@Override
+			public MockResponse dispatch(RecordedRequest request) {
+				return switch (request.getPath()) {
+					case "/.well-known/oauth-authorization-server/issuer1",
+							"/.well-known/oauth-authorization-server/" ->
+						buildSuccessMockResponse(responseBody);
+					default -> new MockResponse().setResponseCode(404);
+				};
+			}
+		};
+		this.server.setDispatcher(dispatcher);
+		return ClientRegistrations.fromIssuerLocation(this.restTemplate, this.issuer)
+			.clientId("client-id")
+			.clientSecret("client-secret");
 	}
 
 }


### PR DESCRIPTION
This PR introduces overloaded methods in `ClientRegistrations` that accept a custom `RestTemplate`:

- `fromOidcIssuerLocation(RestTemplate restTemplate, String issuer)`
- `fromIssuerLocation(RestTemplate restTemplate, String issuer)`

Fixes #16833 #16920

### Motivation
Currently, the discovery endpoints (OIDC and OAuth2) are called using a static `RestTemplate` with fixed connection/read timeouts. This limits customization for users who need to:

- Configure a proxy
- Set custom timeouts
- Add interceptors (e.g., for logging or authentication)
- Use a different HTTP client (e.g., with mutual TLS)

By providing overloads that accept a `RestTemplate`, users can now inject their own configured instance while reusing the existing discovery logic.

### Changes
- Added two new public static methods as described above.
- The existing methods (`fromOidcIssuerLocation(String)` and `fromIssuerLocation(String)`) delegate to the new overloads using the default static `RestTemplate`.
- Internal `oidc(...)`, `oidcRfc8414(...)`, `oauth(...)` and `getRfc8414Builder(...)` methods were updated to accept a `RestTemplate` parameter; the existing static supplier-based approach remains unchanged.
- Added comprehensive tests for the new overloads, verifying:
  - Success scenarios (OIDC, OAuth2, and fallback flows)
  - Null `RestTemplate` or empty issuer handling
  - Error cases with proper exception propagation

### Impact
- Backward compatible: existing callers are unaffected.
- Users can now leverage their own `RestTemplate` for discovery requests.

### Testing
- All existing tests pass.
- New tests cover the added methods, using `MockWebServer` to simulate various discovery endpoints and responses.

Please review and let me know if any additional changes are needed.