### PR TITLE
Deprecate Hex in favor of `java.util.HexFormat`

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/codec/Hex.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/codec/Hex.java
@@ -24,7 +24,9 @@ package org.springframework.security.crypto.codec;
  *
  * @author Luke Taylor
  * @since 3.0
+ * @deprecated Use java.util.HexFormat
  */
+@Deprecated
 public final class Hex {
 
 	private static final char[] HEX = "0123456789abcdef".toCharArray();


### PR DESCRIPTION
The main point is that java.util.HexFormat essentially does the same thing as our Hex. We had a similar candidate with Base and deprecated it in favor of java.util.Base64. Moreover, we've already removed it: https://github.com/therepanic/spring-security/commit/2f53a2edb34b690ba2f533732d62f7a58a55d577.

Closes: gh-16867

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
