### PR TITLE
Add XML guidance to authorizeRequests deprecation warning

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/WebSecurityFilterChainValidator.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/WebSecurityFilterChainValidator.java
@@ -103,11 +103,15 @@ final class WebSecurityFilterChainValidator implements FilterChainProxy.FilterCh
 			}
 			if (authorizationFilter != null && filterSecurityInterceptor != null) {
 				this.logger.warn(
-						"It is not recommended to use authorizeRequests or FilterSecurityInterceptor in the configuration. Please only use authorizeHttpRequests");
+						"It is not recommended to use authorizeRequests or FilterSecurityInterceptor in the configuration. "
+								+ "Please only use authorizeHttpRequests. "
+								+ "For XML configuration, please add use-authorization-manager=\"true\" to your <http> element.");
 			}
 			if (filterSecurityInterceptor != null) {
 				this.logger.warn(
-						"Usage of authorizeRequests and FilterSecurityInterceptor are deprecated. Please use authorizeHttpRequests in the configuration");
+						"Usage of authorizeRequests and FilterSecurityInterceptor are deprecated. "
+								+ "Please use authorizeHttpRequests in the configuration. "
+								+ "For XML configuration, please add use-authorization-manager=\"true\" to your <http> element.");
 			}
 			authorizationFilter = null;
 			filterSecurityInterceptor = null;

--- a/config/src/main/java/org/springframework/security/config/http/DefaultFilterChainValidator.java
+++ b/config/src/main/java/org/springframework/security/config/http/DefaultFilterChainValidator.java
@@ -130,11 +130,15 @@ public class DefaultFilterChainValidator implements FilterChainProxy.FilterChain
 			}
 			if (authorizationFilter != null && filterSecurityInterceptor != null) {
 				this.logger.warn(
-						"It is not recommended to use authorizeRequests or FilterSecurityInterceptor in the configuration. Please only use authorizeHttpRequests");
+						"It is not recommended to use authorizeRequests or FilterSecurityInterceptor in the configuration. "
+								+ "Please only use authorizeHttpRequests. "
+								+ "For XML configuration, please add use-authorization-manager=\"true\" to your <http> element.");
 			}
 			if (filterSecurityInterceptor != null) {
 				this.logger.warn(
-						"Usage of authorizeRequests and FilterSecurityInterceptor are deprecated. Please use authorizeHttpRequests in the configuration");
+						"Usage of authorizeRequests and FilterSecurityInterceptor are deprecated. "
+								+ "Please use authorizeHttpRequests in the configuration. "
+								+ "For XML configuration, please add use-authorization-manager=\"true\" to your <http> element.");
 			}
 			authorizationFilter = null;
 			filterSecurityInterceptor = null;


### PR DESCRIPTION
The deprecation warning for `authorizeRequests` and `FilterSecurityInterceptor` now also includes guidance for XML-based configuration, advising users to add `use-authorization-manager="true"` to their `<http>` element.

This addresses the feedback in gh-17259 where XML-based configuration users were seeing deprecation warnings with no clear guidance on how to resolve them in XML.

Changes:
- Updated warning messages in `DefaultFilterChainValidator` and `WebSecurityFilterChainValidator` to include XML-specific guidance

Closes gh-17259
