### PR TITLE
Remove javadoc warnings for spring-security-ldap

### DIFF
--- a/ldap/src/main/java/org/springframework/security/ldap/DefaultLdapUsernameToDnMapper.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/DefaultLdapUsernameToDnMapper.java
@@ -21,10 +21,10 @@ import javax.naming.ldap.LdapName;
 import org.springframework.ldap.support.LdapNameBuilder;
 
 /**
- * This implementation appends a name component to the <tt>userDnBase</tt> context using
- * the <tt>usernameAttributeName</tt> property. So if the <tt>uid</tt> attribute is used
- * to store the username, and the base DN is <tt>cn=users</tt> and we are creating a new
- * user called "sam", then the DN will be <tt>uid=sam,cn=users</tt>.
+ * This implementation appends a name component to the {@code userDnBase} context using
+ * the {@code usernameAttributeName} property. So if the {@code uid} attribute is used
+ * to store the username, and the base DN is {@code cn=users} and we are creating a new
+ * user called "sam", then the DN will be {@code uid=sam,cn=users}.
  *
  * @author Luke Taylor
  */

--- a/ldap/src/main/java/org/springframework/security/ldap/DefaultSpringSecurityContextSource.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/DefaultSpringSecurityContextSource.java
@@ -34,18 +34,18 @@ import org.springframework.ldap.core.support.SimpleDirContextAuthenticationStrat
 import org.springframework.util.Assert;
 
 /**
- * ContextSource implementation which uses Spring LDAP's <tt>LdapContextSource</tt> as a
+ * ContextSource implementation which uses Spring LDAP's {@code LdapContextSource} as a
  * base class. Used internally by the Spring Security LDAP namespace configuration.
  * <p>
- * From Spring Security 3.0, Spring LDAP 1.3 is used and the <tt>ContextSource</tt>
+ * From Spring Security 3.0, Spring LDAP 1.3 is used and the {@code ContextSource}
  * interface provides support for binding with a username and password. As a result,
- * Spring LDAP <tt>ContextSource</tt> implementations such as <tt>LdapContextSource</tt>
+ * Spring LDAP {@code ContextSource} implementations such as {@code LdapContextSource}
  * may be used directly with Spring Security.
  * <p>
  * Spring LDAP 1.3 doesn't have JVM-level LDAP connection pooling enabled by default. This
- * class sets the <tt>pooled</tt> property to true, but customizes the
- * {@link DirContextAuthenticationStrategy} used to disable pooling when the <tt>DN</tt>
- * doesn't match the <tt>userDn</tt> property. This prevents pooling for calls to
+ * class sets the {@code pooled} property to true, but customizes the
+ * {@link DirContextAuthenticationStrategy} used to disable pooling when the {@code DN}
+ * doesn't match the {@code userDn} property. This prevents pooling for calls to
  * {@link #getContext(String, String)} to authenticate as specific users.
  *
  * @author Luke Taylor

--- a/ldap/src/main/java/org/springframework/security/ldap/LdapUtils.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/LdapUtils.java
@@ -125,7 +125,7 @@ public final class LdapUtils {
 	/**
 	 * Works out the root DN for an LDAP URL.
 	 * <p>
-	 * For example, the URL <tt>ldap://monkeymachine:11389/dc=springframework,dc=org</tt>
+	 * For example, the URL {@code ldap://monkeymachine:11389/dc=springframework,dc=org}
 	 * has the root DN "dc=springframework,dc=org".
 	 * </p>
 	 * @param url the LDAP URL
@@ -151,7 +151,7 @@ public final class LdapUtils {
 	/**
 	 * Parses the supplied LDAP URL.
 	 * @param url the URL (e.g.
-	 * <tt>ldap://monkeymachine:11389/dc=springframework,dc=org</tt>).
+	 * {@code ldap://monkeymachine:11389/dc=springframework,dc=org}).
 	 * @return the URI object created from the URL
 	 * @throws IllegalArgumentException if the URL is null, empty or the URI syntax is
 	 * invalid.

--- a/ldap/src/main/java/org/springframework/security/ldap/SpringSecurityLdapTemplate.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/SpringSecurityLdapTemplate.java
@@ -203,7 +203,7 @@ public class SpringSecurityLdapTemplate extends LdapTemplate {
 
 	/**
 	 * Returns the DN for the context representing this LDAP record. By default this is
-	 * using {@link javax.naming.Context#getNameInNamespace()} instead of
+	 * using {@code Context#getNameInNamespace()} instead of
 	 * {@link org.springframework.ldap.core.DirContextAdapter#getDn()} since the latter
 	 * returns a partial DN if a base has been specified.
 	 * @param adapter - the Context to extract the DN from
@@ -249,7 +249,7 @@ public class SpringSecurityLdapTemplate extends LdapTemplate {
 	 * Performs a search, with the requirement that the search shall return a single
 	 * directory entry, and uses the supplied mapper to create the object from that entry.
 	 * <p>
-	 * Ignores <tt>PartialResultException</tt> if thrown, for compatibility with Active
+	 * Ignores {@code PartialResultException} if thrown, for compatibility with Active
 	 * Directory (see {@link LdapTemplate#setIgnorePartialResultException(boolean)}).
 	 * @param base the search base, relative to the base context supplied by the context
 	 * source.

--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/AbstractLdapAuthenticationProvider.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/AbstractLdapAuthenticationProvider.java
@@ -95,8 +95,8 @@ public abstract class AbstractLdapAuthenticationProvider implements Authenticati
 	 * Creates the final {@code Authentication} object which will be returned from the
 	 * {@code authenticate} method.
 	 * @param authentication the original authentication request token
-	 * @param user the <tt>UserDetails</tt> instance returned by the configured
-	 * <tt>UserDetailsContextMapper</tt>.
+	 * @param user the {@code UserDetails} instance returned by the configured
+	 * {@code UserDetailsContextMapper}.
 	 * @return the Authentication object for the fully authenticated user.
 	 */
 	protected Authentication createSuccessfulAuthentication(UsernamePasswordAuthenticationToken authentication,
@@ -149,12 +149,12 @@ public abstract class AbstractLdapAuthenticationProvider implements Authenticati
 	}
 
 	/**
-	 * Allows a custom strategy to be used for creating the <tt>UserDetails</tt> which
-	 * will be stored as the principal in the <tt>Authentication</tt> returned by the
+	 * Allows a custom strategy to be used for creating the {@code UserDetails} which
+	 * will be stored as the principal in the {@code Authentication} returned by the
 	 * {@link #createSuccessfulAuthentication(org.springframework.security.authentication.UsernamePasswordAuthenticationToken, org.springframework.security.core.userdetails.UserDetails)}
 	 * method.
 	 * @param userDetailsContextMapper the strategy instance. If not set, defaults to a
-	 * simple <tt>LdapUserDetailsMapper</tt>.
+	 * simple {@code LdapUserDetailsMapper}.
 	 */
 	public void setUserDetailsContextMapper(UserDetailsContextMapper userDetailsContextMapper) {
 		Assert.notNull(userDetailsContextMapper, "UserDetailsContextMapper must not be null");

--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/AbstractLdapAuthenticator.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/AbstractLdapAuthenticator.java
@@ -86,9 +86,9 @@ public abstract class AbstractLdapAuthenticator implements LdapAuthenticator, In
 
 	/**
 	 * Builds list of possible DNs for the user, worked out from the
-	 * <tt>userDnPatterns</tt> property.
+	 * {@code userDnPatterns} property.
 	 * @param username the user's login name
-	 * @return the list of possible DN matches, empty if <tt>userDnPatterns</tt> wasn't
+	 * @return the list of possible DN matches, empty if {@code userDnPatterns} wasn't
 	 * set.
 	 */
 	protected List<String> getUserDns(String username) {

--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/LdapAuthenticationProvider.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/LdapAuthenticationProvider.java
@@ -95,12 +95,12 @@ import org.springframework.util.Assert;
  *
  * <p>
  * This would set up the provider to access an LDAP server with URL
- * <tt>ldap://monkeymachine:389/dc=springframework,dc=org</tt>. Authentication will be
+ * {@code ldap://monkeymachine:389/dc=springframework,dc=org}. Authentication will be
  * performed by attempting to bind with the DN
- * <tt>uid=&lt;user-login-name&gt;,ou=people,dc=springframework,dc=org</tt>. After
+ * {@code uid=&lt;user-login-name&gt;,ou=people,dc=springframework,dc=org}. After
  * successful authentication, roles will be assigned to the user by searching under the DN
- * <tt>ou=groups,dc=springframework,dc=org</tt> with the default filter
- * <tt>(member=&lt;user's-DN&gt;)</tt>. The role name will be taken from the "ou"
+ * {@code ou=groups,dc=springframework,dc=org} with the default filter
+ * {@code (member=&lt;user's-DN&gt;)}. The role name will be taken from the "ou"
  * attribute of each match.
  * <p>
  * The authenticate method will reject empty passwords outright. LDAP servers may allow an

--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/ad/ActiveDirectoryAuthenticationException.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/ad/ActiveDirectoryAuthenticationException.java
@@ -22,7 +22,7 @@ import org.springframework.security.core.AuthenticationException;
 
 /**
  * <p>
- * Thrown as a translation of an {@link javax.naming.AuthenticationException} when
+ * Thrown as a translation of a {@code javax.naming.AuthenticationException} when
  * attempting to authenticate against Active Directory using
  * {@link ActiveDirectoryLdapAuthenticationProvider}. Typically this error is wrapped by
  * an {@link AuthenticationException} since it does not provide a user friendly message.

--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/package-info.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/package-info.java
@@ -18,8 +18,8 @@
  * The LDAP authentication provider package. Interfaces are provided for both
  * authentication and retrieval of user roles from an LDAP server.
  * <p>
- * The main provider class is <tt>LdapAuthenticationProvider</tt>. This is configured with
- * an <tt>LdapAuthenticator</tt> instance and an <tt>LdapAuthoritiesPopulator</tt>. The
+ * The main provider class is {@code LdapAuthenticationProvider}. This is configured with
+ * an {@code LdapAuthenticator} instance and an {@code LdapAuthoritiesPopulator}. The
  * latter is used to obtain the list of roles for the user.
  */
 @NullMarked

--- a/ldap/src/main/java/org/springframework/security/ldap/ppolicy/PasswordPolicyAwareContextSource.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/ppolicy/PasswordPolicyAwareContextSource.java
@@ -28,11 +28,11 @@ import org.springframework.ldap.support.LdapUtils;
 import org.springframework.security.ldap.DefaultSpringSecurityContextSource;
 
 /**
- * Extended version of the <tt>DefaultSpringSecurityContextSource</tt> which adds support
+ * Extended version of the {@code DefaultSpringSecurityContextSource} which adds support
  * for the use of {@link PasswordPolicyControl} to make use of user account data stored in
  * the directory.
  * <p>
- * When binding with specific username (not the <tt>userDn</tt>) property it will connect
+ * When binding with specific username (not the {@code userDn}) property it will connect
  * first as the userDn, then reconnect as the user in order to retrieve any
  * password-policy control sent with the response, even if an exception occurs.
  *

--- a/ldap/src/main/java/org/springframework/security/ldap/ppolicy/PasswordPolicyControlExtractor.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/ppolicy/PasswordPolicyControlExtractor.java
@@ -25,7 +25,7 @@ import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Obtains the <tt>PasswordPolicyControl</tt> from a context for use by other classes.
+ * Obtains the {@code PasswordPolicyControl} from a context for use by other classes.
  *
  * @author Luke Taylor
  * @since 3.0

--- a/ldap/src/main/java/org/springframework/security/ldap/ppolicy/PasswordPolicyErrorStatus.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/ppolicy/PasswordPolicyErrorStatus.java
@@ -17,7 +17,7 @@
 package org.springframework.security.ldap.ppolicy;
 
 /**
- * Defines status codes for use with <tt>PasswordPolicyException</tt>, with error codes
+ * Defines status codes for use with {@code PasswordPolicyException}, with error codes
  * (for message source lookup) and default messages.
  *
  * <pre>

--- a/ldap/src/main/java/org/springframework/security/ldap/ppolicy/PasswordPolicyException.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/ppolicy/PasswordPolicyException.java
@@ -21,7 +21,7 @@ import java.io.Serial;
 /**
  * Generic exception raised by the ppolicy package.
  * <p>
- * The <tt>status</tt> property should be checked for more detail on the cause of the
+ * The {@code status} property should be checked for more detail on the cause of the
  * exception.
  *
  * @author Luke Taylor

--- a/ldap/src/main/java/org/springframework/security/ldap/ppolicy/PasswordPolicyResponseControl.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/ppolicy/PasswordPolicyResponseControl.java
@@ -37,11 +37,11 @@ import org.springframework.core.log.LogMessage;
 import org.springframework.dao.DataRetrievalFailureException;
 
 /**
- * Represents the response control received when a <tt>PasswordPolicyControl</tt> is used
+ * Represents the response control received when a {@code PasswordPolicyControl} is used
  * when binding to a directory. Currently tested with the OpenLDAP 2.3.19 implementation
  * of the LDAP Password Policy Draft. It extends the request control with the control
- * specific data. This is accomplished by the properties <tt>timeBeforeExpiration</tt>,
- * <tt>graceLoginsRemaining</tt>.
+ * specific data. This is accomplished by the properties {@code timeBeforeExpiration},
+ * {@code graceLoginsRemaining}.
  * <p>
  *
  * @author Stefan Zoerner

--- a/ldap/src/main/java/org/springframework/security/ldap/search/FilterBasedLdapUserSearch.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/search/FilterBasedLdapUserSearch.java
@@ -57,7 +57,7 @@ public class FilterBasedLdapUserSearch implements LdapUserSearch {
 	/**
 	 * The filter expression used in the user search. This is an LDAP search filter (as
 	 * defined in 'RFC 2254') with optional arguments. See the documentation for the
-	 * <tt>search</tt> methods in {@link javax.naming.directory.DirContext DirContext} for
+	 * {@code search} methods in {@code DirContext} for
 	 * more information.
 	 *
 	 * <p>

--- a/ldap/src/main/java/org/springframework/security/ldap/userdetails/DefaultLdapAuthoritiesPopulator.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/userdetails/DefaultLdapAuthoritiesPopulator.java
@@ -48,10 +48,10 @@ import org.springframework.util.CollectionUtils;
  * It obtains roles by performing a search for "groups" the user is a member of.
  * <p>
  * A typical group search scenario would be where each group/role is specified using the
- * <tt>groupOfNames</tt> (or <tt>groupOfUniqueNames</tt>) LDAP objectClass and the user's
- * DN is listed in the <tt>member</tt> (or <tt>uniqueMember</tt>) attribute to indicate
+ * {@code groupOfNames} (or {@code groupOfUniqueNames}) LDAP objectClass and the user's
+ * DN is listed in the {@code member} (or {@code uniqueMember}) attribute to indicate
  * that they should be assigned that role. The following LDIF sample has the groups stored
- * under the DN <tt>ou=groups,dc=springframework,dc=org</tt> and a group called
+ * under the DN {@code ou=groups,dc=springframework,dc=org} and a group called
  * "developers" with "ben" and "luke" as members:
  *
  * <pre>
@@ -70,13 +70,13 @@ import org.springframework.util.CollectionUtils;
  * ou: developer
  * </pre>
  * <p>
- * The group search is performed within a DN specified by the <tt>groupSearchBase</tt>
- * property, which should be relative to the root DN of its <tt>ContextSource</tt>. If the
+ * The group search is performed within a DN specified by the {@code groupSearchBase}
+ * property, which should be relative to the root DN of its {@code ContextSource}. If the
  * search base is null, group searching is disabled. The filter used in the search is
- * defined by the <tt>groupSearchFilter</tt> property, with the filter argument {0} being
+ * defined by the {@code groupSearchFilter} property, with the filter argument {0} being
  * the full DN of the user. You can also optionally use the parameter {1}, which will be
  * substituted with the username. You can also specify which attribute defines the role
- * name by setting the <tt>groupRoleAttribute</tt> property (the default is "cn").
+ * name by setting the {@code groupRoleAttribute} property (the default is "cn").
  * <p>
  * The configuration below shows how the group search might be performed with the above
  * schema.
@@ -97,9 +97,9 @@ import org.springframework.util.CollectionUtils;
  * A search for roles for user "uid=ben,ou=people,dc=springframework,dc=org" would return
  * the single granted authority "ROLE_DEVELOPER".
  * <p>
- * The single-level search is performed by default. Setting the <tt>searchSubTree</tt>
+ * The single-level search is performed by default. Setting the {@code searchSubTree}
  * property to true will enable a search of the entire subtree under
- * <tt>groupSearchBase</tt>.
+ * {@code groupSearchBase}.
  *
  * @author Luke Taylor
  * @author Filip Hanik
@@ -155,7 +155,7 @@ public class DefaultLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
 	private Function<Map<String, List<String>>, @Nullable GrantedAuthority> authorityMapper;
 
 	/**
-	 * Constructor for group search scenarios. <tt>userRoleAttributes</tt> may still be
+	 * Constructor for group search scenarios. {@code userRoleAttributes} may still be
 	 * set as a property.
 	 * @param contextSource supplies the contexts used to search for user roles.
 	 * @param groupSearchBase if this is an empty string the search will be performed from
@@ -277,7 +277,7 @@ public class DefaultLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
 
 	/**
 	 * Sets the prefix which will be prepended to the values loaded from the directory.
-	 * Defaults to "ROLE_" for compatibility with <tt>RoleVoter</tt>.
+	 * Defaults to "ROLE_" for compatibility with {@code RoleVoter}.
 	 */
 	public void setRolePrefix(String rolePrefix) {
 		Assert.notNull(rolePrefix, "rolePrefix must not be null");
@@ -288,7 +288,7 @@ public class DefaultLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
 	 * If set to true, a subtree scope search will be performed. If false a single-level
 	 * search is used.
 	 * @param searchSubtree set to true to enable searching of the entire tree below the
-	 * <tt>groupSearchBase</tt>.
+	 * {@code groupSearchBase}.
 	 */
 	public void setSearchSubtree(boolean searchSubtree) {
 		int searchScope = searchSubtree ? SearchControls.SUBTREE_SCOPE : SearchControls.ONELEVEL_SCOPE;

--- a/ldap/src/main/java/org/springframework/security/ldap/userdetails/InetOrgPerson.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/userdetails/InetOrgPerson.java
@@ -26,10 +26,10 @@ import org.springframework.util.Assert;
 
 /**
  * UserDetails implementation whose properties are based on a subset of the LDAP schema
- * for <tt>inetOrgPerson</tt>.
+ * for {@code inetOrgPerson}.
  *
  * <p>
- * The username will be mapped from the <tt>uid</tt> attribute by default.
+ * The username will be mapped from the {@code uid} attribute by default.
  *
  * @author Luke Taylor
  */

--- a/ldap/src/main/java/org/springframework/security/ldap/userdetails/LdapAuthoritiesPopulator.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/userdetails/LdapAuthoritiesPopulator.java
@@ -24,7 +24,7 @@ import org.springframework.security.core.GrantedAuthority;
 /**
  * Obtains a list of granted authorities for an Ldap user.
  * <p>
- * Used by the <tt>LdapAuthenticationProvider</tt> once a user has been authenticated to
+ * Used by the {@code LdapAuthenticationProvider} once a user has been authenticated to
  * create the final user details object.
  * </p>
  *

--- a/ldap/src/main/java/org/springframework/security/ldap/userdetails/LdapUserDetailsImpl.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/userdetails/LdapUserDetailsImpl.java
@@ -40,7 +40,7 @@ import org.springframework.util.Assert;
  * An instance may be created as the result of a search, or when user information is
  * retrieved during authentication.
  * <p>
- * An instance of this class will be used by the <tt>LdapAuthenticationProvider</tt> to
+ * An instance of this class will be used by the {@code LdapAuthenticationProvider} to
  * construct the final user details object that it returns.
  * <p>
  * The {@code equals} and {@code hashcode} methods are implemented using the {@code Dn}

--- a/ldap/src/main/java/org/springframework/security/ldap/userdetails/LdapUserDetailsManager.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/userdetails/LdapUserDetailsManager.java
@@ -365,7 +365,7 @@ public class LdapUserDetailsManager implements UserDetailsManager {
 	 * Sets the name of the multi-valued attribute which holds the DNs of users who are
 	 * members of a group.
 	 * <p>
-	 * Usually this will be <tt>uniquemember</tt> (the default value) or <tt>member</tt>.
+	 * Usually this will be {@code uniquemember} (the default value) or {@code member}.
 	 * </p>
 	 * @param groupMemberAttributeName the name of the attribute used to store group
 	 * members.

--- a/ldap/src/main/java/org/springframework/security/ldap/userdetails/LdapUserDetailsMapper.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/userdetails/LdapUserDetailsMapper.java
@@ -119,7 +119,7 @@ public class LdapUserDetailsMapper implements UserDetailsContextMapper {
 	 * object creation.
 	 * <p>
 	 * The default implementation converts string attributes to roles, making use of the
-	 * <tt>rolePrefix</tt> and <tt>convertToUpperCase</tt> properties. Non-String
+	 * {@code rolePrefix} and {@code convertToUpperCase} properties. Non-String
 	 * attributes are ignored.
 	 * </p>
 	 * @param role the attribute returned from
@@ -156,7 +156,7 @@ public class LdapUserDetailsMapper implements UserDetailsContextMapper {
 
 	/**
 	 * The names of any attributes in the user's entry which represent application roles.
-	 * These will be converted to <tt>GrantedAuthority</tt>s and added to the list in the
+	 * These will be converted to {@code GrantedAuthority}s and added to the list in the
 	 * returned LdapUserDetails object. The attribute values must be Strings by default.
 	 * @param roleAttributes the names of the role attributes.
 	 */

--- a/ldap/src/main/java/org/springframework/security/ldap/userdetails/LdapUserDetailsService.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/userdetails/LdapUserDetailsService.java
@@ -29,9 +29,9 @@ import org.springframework.util.Assert;
 
 /**
  * LDAP implementation of UserDetailsService based around an {@link LdapUserSearch} and an
- * {@link LdapAuthoritiesPopulator}. The final <tt>UserDetails</tt> object returned from
- * <tt>loadUserByUsername</tt> is created by the configured
- * <tt>UserDetailsContextMapper</tt>.
+ * {@link LdapAuthoritiesPopulator}. The final {@code UserDetails} object returned from
+ * {@code loadUserByUsername} is created by the configured
+ * {@code UserDetailsContextMapper}.
  *
  * @author Luke Taylor
  */

--- a/ldap/src/main/java/org/springframework/security/ldap/userdetails/NestedLdapAuthoritiesPopulator.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/userdetails/NestedLdapAuthoritiesPopulator.java
@@ -137,7 +137,7 @@ public class NestedLdapAuthoritiesPopulator extends DefaultLdapAuthoritiesPopula
 	private int maxSearchDepth = 10;
 
 	/**
-	 * Constructor for group search scenarios. <tt>userRoleAttributes</tt> may still be
+	 * Constructor for group search scenarios. {@code userRoleAttributes} may still be
 	 * set as a property.
 	 * @param contextSource supplies the contexts used to search for user roles.
 	 * @param groupSearchBase if this is an empty string the search will be performed from

--- a/ldap/src/main/java/org/springframework/security/ldap/userdetails/Person.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/userdetails/Person.java
@@ -29,7 +29,7 @@ import org.springframework.util.Assert;
 
 /**
  * UserDetails implementation whose properties are based on the LDAP schema for
- * <tt>Person</tt>.
+ * {@code Person}.
  *
  * @author Luke
  * @since 2.0


### PR DESCRIPTION
## Summary

Remove javadoc warnings for `spring-security-ldap` module.

- Replace all deprecated `<tt>` HTML tags with `{@code}` (22 files)
- Fix unresolvable `{@link javax.naming.*}` references by replacing with `{@code}` (3 files)

The `javadoc-warnings-error` plugin is already applied to this module.

Closes gh-18457
