### PR TITLE
Make FactorGrantedAuthority Builder constructor public

### DIFF
--- a/core/src/main/java/org/springframework/security/core/authority/FactorGrantedAuthority.java
+++ b/core/src/main/java/org/springframework/security/core/authority/FactorGrantedAuthority.java
@@ -184,7 +184,7 @@ public final class FactorGrantedAuthority implements GrantedAuthority {
 
 		private @Nullable Instant issuedAt;
 
-		private Builder(String authority) {
+		public Builder(String authority) {
 			Assert.hasText(authority, "A granted authority textual representation is required");
 			this.authority = authority;
 		}

--- a/core/src/test/java/org/springframework/security/core/authority/FactorGrantedAuthorityTests.java
+++ b/core/src/test/java/org/springframework/security/core/authority/FactorGrantedAuthorityTests.java
@@ -67,4 +67,16 @@ public class FactorGrantedAuthorityTests {
 			.withMessage("A granted authority textual representation is required");
 	}
 
+	@Test
+	public void builderConstructorWhenPublicThenCreatesCorrectly() {
+		Instant issuedAt = Instant.now();
+
+		FactorGrantedAuthority authority = new FactorGrantedAuthority.Builder("FACTOR_CUSTOM")
+			.issuedAt(issuedAt)
+			.build();
+
+		assertThat(authority.getAuthority()).isEqualTo("FACTOR_CUSTOM");
+		assertThat(authority.getIssuedAt()).isEqualTo(issuedAt);
+	}
+
 }


### PR DESCRIPTION
## Summary

Make the `FactorGrantedAuthority.Builder` constructor public so that external code can create a `Builder` directly and set a custom `issuedAt` value.

This enables scenarios like persisting MFA factor timestamps (along with user agent and IP address) so the user is not prompted for a configurable period when next logging in.

- Changed `Builder(String authority)` from `private` to `public`
- Added test to verify direct `Builder` construction

Closes gh-18975
