### PR TITLE
Document behavior when multiple CorsConfigurationSource beans are present

### DIFF
--- a/docs/modules/ROOT/pages/reactive/integrations/cors.adoc
+++ b/docs/modules/ROOT/pages/reactive/integrations/cors.adoc
@@ -7,6 +7,10 @@ If the request does not contain any cookies and Spring Security is first, the re
 
 The easiest way to ensure that CORS is handled first is to use the `CorsWebFilter`.
 Users can integrate the `CorsWebFilter` with Spring Security by providing a `CorsConfigurationSource`.
+
+NOTE: If multiple `CorsConfigurationSource` beans are defined in the application context, Spring Security will not automatically select one and will fail with an ambiguous bean definition error.
+In that case, you should specify which `CorsConfigurationSource` to use for each security filter chain by passing it directly to the `.cors()` DSL.
+
 For example, the following will integrate CORS support within Spring Security:
 
 [tabs]

--- a/docs/modules/ROOT/pages/servlet/integrations/cors.adoc
+++ b/docs/modules/ROOT/pages/servlet/integrations/cors.adoc
@@ -10,7 +10,10 @@ If the request does not contain any cookies and Spring Security is first, the re
 
 The easiest way to ensure that CORS is handled first is to use the `CorsFilter`.
 Users can integrate the `CorsFilter` with Spring Security by providing a `CorsConfigurationSource`.
-Note that Spring Security will automatically configure CORS only if a `UrlBasedCorsConfigurationSource` instance is present.
+Note that Spring Security will automatically configure CORS only if a single `UrlBasedCorsConfigurationSource` instance is present.
+If multiple `CorsConfigurationSource` beans are defined in the application context, Spring Security will not automatically select one and will fail with an ambiguous bean definition error.
+In that case, you should specify which `CorsConfigurationSource` to use for each `SecurityFilterChain` by passing it directly to the `.cors()` DSL as shown in the <<cors-per-chain-configuration>> section.
+
 For example, the following will integrate CORS support within Spring Security:
 
 [tabs]


### PR DESCRIPTION
## Summary

Clarify in both servlet and reactive CORS documentation that Spring Security fails with an ambiguous bean definition error when multiple CorsConfigurationSource beans are defined, and direct users to use the per-chain .cors() DSL to specify which source to use.

Closes gh-18583
