### PR TITLE
Add link to beginner-friendly code example for storing authentication manually

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/passwords/index.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/passwords/index.adoc
@@ -318,6 +318,7 @@ class LoginController(val authenticationManager: AuthenticationManager) {
 ====
 In this example, it is your responsibility to save the authenticated user in the `SecurityContextRepository` if needed.
 For example, if using the `HttpSession` to persist the `SecurityContext` between requests, you can use xref:servlet/authentication/persistence.adoc#httpsecuritycontextrepository[`HttpSessionSecurityContextRepository`].
+For a complete code example, see xref:servlet/authentication/session-management.adoc#store-authentication-manually[Store Authentication Manually].
 ====
 
 [[customize-global-authentication-manager]]


### PR DESCRIPTION
## Summary

Add a cross-reference link from the NOTE in the 'Publish an AuthenticationManager bean' section to the 'Store Authentication Manually' section, making it easier for beginners to find the complete code example.

Closes gh-18899