### PR TITLE
Lazily instantiate default components in WebAuthnConfigurer

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/WebAuthnConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/WebAuthnConfigurer.java
@@ -170,9 +170,9 @@ public class WebAuthnConfigurer<H extends HttpSecurityBuilder<H>>
 			.orElseThrow(() -> new IllegalStateException("Missing UserDetailsService Bean"));
 		PublicKeyCredentialUserEntityRepository userEntities = getSharedOrBean(http,
 				PublicKeyCredentialUserEntityRepository.class)
-			.orElse(userEntityRepository());
+			.orElseGet(this::userEntityRepository);
 		UserCredentialRepository userCredentials = getSharedOrBean(http, UserCredentialRepository.class)
-			.orElse(userCredentialRepository());
+			.orElseGet(this::userCredentialRepository);
 		WebAuthnRelyingPartyOperations rpOperations = webAuthnRelyingPartyOperations(userEntities, userCredentials);
 		PublicKeyCredentialCreationOptionsRepository creationOptionsRepository = creationOptionsRepository();
 		WebAuthnAuthenticationFilter webAuthnAuthnFilter = new WebAuthnAuthenticationFilter();


### PR DESCRIPTION
## Summary

Avoid unnecessary instantiation of `MapPublicKeyCredentialUserEntityRepository` and `MapUserCredentialRepository` in `WebAuthnConfigurer`.

- Changed `Optional.orElse()` to `Optional.orElseGet()` with method references
- Default Map-based implementations are now only created when no bean is found in the application context
- No behavioral change; existing tests continue to pass

Closes gh-18585
