### PR TITLE
Apply SessionAuthenticationStrategy to WebAuthnAuthenticationFilter

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/WebAuthnConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/WebAuthnConfigurer.java
@@ -171,9 +171,9 @@ public class WebAuthnConfigurer<H extends HttpSecurityBuilder<H>>
 			.orElseThrow(() -> new IllegalStateException("Missing UserDetailsService Bean"));
 		PublicKeyCredentialUserEntityRepository userEntities = getSharedOrBean(http,
 				PublicKeyCredentialUserEntityRepository.class)
-			.orElseGet(this::userEntityRepository);
+			.orElse(userEntityRepository());
 		UserCredentialRepository userCredentials = getSharedOrBean(http, UserCredentialRepository.class)
-			.orElseGet(this::userCredentialRepository);
+			.orElse(userCredentialRepository());
 		WebAuthnRelyingPartyOperations rpOperations = webAuthnRelyingPartyOperations(userEntities, userCredentials);
 		PublicKeyCredentialCreationOptionsRepository creationOptionsRepository = creationOptionsRepository();
 		WebAuthnAuthenticationFilter webAuthnAuthnFilter = new WebAuthnAuthenticationFilter();

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/WebAuthnConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/WebAuthnConfigurer.java
@@ -31,6 +31,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 import org.springframework.security.web.authentication.ui.DefaultLoginPageGeneratingFilter;
 import org.springframework.security.web.authentication.ui.DefaultResourcesFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
@@ -170,14 +171,19 @@ public class WebAuthnConfigurer<H extends HttpSecurityBuilder<H>>
 			.orElseThrow(() -> new IllegalStateException("Missing UserDetailsService Bean"));
 		PublicKeyCredentialUserEntityRepository userEntities = getSharedOrBean(http,
 				PublicKeyCredentialUserEntityRepository.class)
-			.orElse(userEntityRepository());
+			.orElseGet(this::userEntityRepository);
 		UserCredentialRepository userCredentials = getSharedOrBean(http, UserCredentialRepository.class)
-			.orElse(userCredentialRepository());
+			.orElseGet(this::userCredentialRepository);
 		WebAuthnRelyingPartyOperations rpOperations = webAuthnRelyingPartyOperations(userEntities, userCredentials);
 		PublicKeyCredentialCreationOptionsRepository creationOptionsRepository = creationOptionsRepository();
 		WebAuthnAuthenticationFilter webAuthnAuthnFilter = new WebAuthnAuthenticationFilter();
 		webAuthnAuthnFilter.setAuthenticationManager(
 				new ProviderManager(new WebAuthnAuthenticationProvider(rpOperations, userDetailsService)));
+		SessionAuthenticationStrategy sessionAuthenticationStrategy = http
+			.getSharedObject(SessionAuthenticationStrategy.class);
+		if (sessionAuthenticationStrategy != null) {
+			webAuthnAuthnFilter.setSessionAuthenticationStrategy(sessionAuthenticationStrategy);
+		}
 		webAuthnAuthnFilter = postProcess(webAuthnAuthnFilter);
 		WebAuthnRegistrationFilter webAuthnRegistrationFilter = new WebAuthnRegistrationFilter(userCredentials,
 				rpOperations);

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/WebAuthnConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/WebAuthnConfigurerTests.java
@@ -42,6 +42,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.session.CompositeSessionAuthenticationStrategy;
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 import org.springframework.security.web.authentication.ui.DefaultResourcesFilter;
 import org.springframework.security.web.webauthn.api.Bytes;
@@ -56,6 +57,7 @@ import org.springframework.security.web.webauthn.management.PublicKeyCredentialU
 import org.springframework.security.web.webauthn.management.UserCredentialRepository;
 import org.springframework.security.web.webauthn.management.WebAuthnRelyingPartyOperations;
 import org.springframework.security.web.webauthn.registration.HttpSessionPublicKeyCredentialCreationOptionsRepository;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -420,11 +422,10 @@ public class WebAuthnConfigurerTests {
 			.map(WebAuthnAuthenticationFilter.class::cast)
 			.findFirst()
 			.orElseThrow(() -> new AssertionError("WebAuthnAuthenticationFilter not found"));
-		SessionAuthenticationStrategy strategy = (SessionAuthenticationStrategy) org.springframework.test.util.ReflectionTestUtils
+		SessionAuthenticationStrategy strategy = (SessionAuthenticationStrategy) ReflectionTestUtils
 			.getField(webAuthnFilter, "sessionStrategy");
 		assertThat(strategy).isNotNull();
-		assertThat(strategy).isInstanceOf(
-				org.springframework.security.web.authentication.session.CompositeSessionAuthenticationStrategy.class);
+		assertThat(strategy).isInstanceOf(CompositeSessionAuthenticationStrategy.class);
 	}
 
 	@Configuration

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/WebAuthnConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/WebAuthnConfigurerTests.java
@@ -42,6 +42,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 import org.springframework.security.web.authentication.ui.DefaultResourcesFilter;
 import org.springframework.security.web.webauthn.api.Bytes;
 import org.springframework.security.web.webauthn.api.ImmutablePublicKeyCredentialUserEntity;
@@ -399,6 +400,50 @@ public class WebAuthnConfigurerTests {
 			// @formatter:off
 			http
 				.formLogin(Customizer.withDefaults())
+				.webAuthn((authn) -> authn
+					.rpId("example.com")
+				);
+			// @formatter:on
+			return http.build();
+		}
+
+	}
+
+	// gh-16685
+	@Test
+	public void webAuthnWhenSessionManagementConfiguredThenSessionAuthenticationStrategyApplied() {
+		this.spring.register(SessionManagementWebauthnConfiguration.class).autowire();
+		FilterChainProxy filterChain = this.spring.getContext().getBean(FilterChainProxy.class);
+		List<jakarta.servlet.Filter> filters = filterChain.getFilterChains().get(0).getFilters();
+		WebAuthnAuthenticationFilter webAuthnFilter = filters.stream()
+			.filter(WebAuthnAuthenticationFilter.class::isInstance)
+			.map(WebAuthnAuthenticationFilter.class::cast)
+			.findFirst()
+			.orElseThrow(() -> new AssertionError("WebAuthnAuthenticationFilter not found"));
+		SessionAuthenticationStrategy strategy = (SessionAuthenticationStrategy) org.springframework.test.util.ReflectionTestUtils
+			.getField(webAuthnFilter, "sessionStrategy");
+		assertThat(strategy).isNotNull();
+		assertThat(strategy).isInstanceOf(
+				org.springframework.security.web.authentication.session.CompositeSessionAuthenticationStrategy.class);
+	}
+
+	@Configuration
+	@EnableWebSecurity
+	static class SessionManagementWebauthnConfiguration {
+
+		@Bean
+		UserDetailsService userDetailsService() {
+			return new InMemoryUserDetailsManager();
+		}
+
+		@Bean
+		SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+			// @formatter:off
+			http
+				.formLogin(Customizer.withDefaults())
+				.sessionManagement((session) -> session
+					.maximumSessions(1)
+				)
 				.webAuthn((authn) -> authn
 					.rpId("example.com")
 				);


### PR DESCRIPTION
## Summary

Fix session concurrency control being bypassed during passkey (WebAuthn) authentication.

**Root Cause:** `WebAuthnConfigurer` did not apply the `SessionAuthenticationStrategy` to `WebAuthnAuthenticationFilter`. When `maximumSessions(1)` was configured, the constraint was enforced for form-based login but not for passkey login.

**Fix:** Retrieve the shared `SessionAuthenticationStrategy` and set it on `WebAuthnAuthenticationFilter`, following the same pattern used by `AbstractAuthenticationFilterConfigurer` and `RememberMeConfigurer`.

- Added `SessionAuthenticationStrategy` wiring in `WebAuthnConfigurer.configure()`
- Added test verifying the filter is properly configured when session management is enabled

Closes gh-16685
