### PR TITLE
Add allowed scopes validation for DCR endpoints

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OAuth2ClientRegistrationEndpointConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OAuth2ClientRegistrationEndpointConfigurer.java
@@ -17,7 +17,10 @@
 package org.springframework.security.config.annotation.web.configurers.oauth2.server.authorization;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -73,6 +76,8 @@ public final class OAuth2ClientRegistrationEndpointConfigurer extends AbstractOA
 	private AuthenticationFailureHandler errorResponseHandler;
 
 	private boolean openRegistrationAllowed;
+
+	private Set<String> allowedScopes;
 
 	/**
 	 * Restrict for internal use only.
@@ -195,6 +200,21 @@ public final class OAuth2ClientRegistrationEndpointConfigurer extends AbstractOA
 		return this;
 	}
 
+	/**
+	 * Sets the allowed scopes for client registration. When set, only the specified
+	 * scopes will be accepted during Dynamic Client Registration. If not set, any scope
+	 * value will be accepted.
+	 * @param allowedScopes the allowed scopes
+	 * @return the {@link OAuth2ClientRegistrationEndpointConfigurer} for further
+	 * configuration
+	 * @since 7.1
+	 */
+	public OAuth2ClientRegistrationEndpointConfigurer allowedScopes(String... allowedScopes) {
+		Assert.notEmpty(allowedScopes, "allowedScopes cannot be empty");
+		this.allowedScopes = new HashSet<>(Arrays.asList(allowedScopes));
+		return this;
+	}
+
 	@Override
 	void init(HttpSecurity httpSecurity) {
 		AuthorizationServerSettings authorizationServerSettings = OAuth2ConfigurerUtils
@@ -207,7 +227,7 @@ public final class OAuth2ClientRegistrationEndpointConfigurer extends AbstractOA
 			.matcher(HttpMethod.POST, clientRegistrationEndpointUri);
 
 		List<AuthenticationProvider> authenticationProviders = createDefaultAuthenticationProviders(httpSecurity,
-				this.openRegistrationAllowed);
+				this.openRegistrationAllowed, this.allowedScopes);
 		if (!this.authenticationProviders.isEmpty()) {
 			authenticationProviders.addAll(0, this.authenticationProviders);
 		}
@@ -258,7 +278,7 @@ public final class OAuth2ClientRegistrationEndpointConfigurer extends AbstractOA
 	}
 
 	private static List<AuthenticationProvider> createDefaultAuthenticationProviders(HttpSecurity httpSecurity,
-			boolean openRegistrationAllowed) {
+			boolean openRegistrationAllowed, Set<String> allowedScopes) {
 		List<AuthenticationProvider> authenticationProviders = new ArrayList<>();
 
 		OAuth2ClientRegistrationAuthenticationProvider clientRegistrationAuthenticationProvider = new OAuth2ClientRegistrationAuthenticationProvider(
@@ -269,6 +289,9 @@ public final class OAuth2ClientRegistrationEndpointConfigurer extends AbstractOA
 			clientRegistrationAuthenticationProvider.setPasswordEncoder(passwordEncoder);
 		}
 		clientRegistrationAuthenticationProvider.setOpenRegistrationAllowed(openRegistrationAllowed);
+		if (allowedScopes != null) {
+			clientRegistrationAuthenticationProvider.setAllowedScopes(allowedScopes);
+		}
 		authenticationProviders.add(clientRegistrationAuthenticationProvider);
 
 		return authenticationProviders;

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OidcClientRegistrationEndpointConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OidcClientRegistrationEndpointConfigurer.java
@@ -17,7 +17,10 @@
 package org.springframework.security.config.annotation.web.configurers.oauth2.server.authorization;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -74,6 +77,8 @@ public final class OidcClientRegistrationEndpointConfigurer extends AbstractOAut
 	private AuthenticationSuccessHandler clientRegistrationResponseHandler;
 
 	private AuthenticationFailureHandler errorResponseHandler;
+
+	private Set<String> allowedScopes;
 
 	/**
 	 * Restrict for internal use only.
@@ -182,6 +187,21 @@ public final class OidcClientRegistrationEndpointConfigurer extends AbstractOAut
 		return this;
 	}
 
+	/**
+	 * Sets the allowed scopes for client registration. When set, only the specified
+	 * scopes will be accepted during Dynamic Client Registration. If not set, any scope
+	 * value will be accepted.
+	 * @param allowedScopes the allowed scopes
+	 * @return the {@link OidcClientRegistrationEndpointConfigurer} for further
+	 * configuration
+	 * @since 7.1
+	 */
+	public OidcClientRegistrationEndpointConfigurer allowedScopes(String... allowedScopes) {
+		Assert.notEmpty(allowedScopes, "allowedScopes cannot be empty");
+		this.allowedScopes = new HashSet<>(Arrays.asList(allowedScopes));
+		return this;
+	}
+
 	@Override
 	void init(HttpSecurity httpSecurity) {
 		AuthorizationServerSettings authorizationServerSettings = OAuth2ConfigurerUtils
@@ -194,7 +214,8 @@ public final class OidcClientRegistrationEndpointConfigurer extends AbstractOAut
 				PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, clientRegistrationEndpointUri),
 				PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.GET, clientRegistrationEndpointUri));
 
-		List<AuthenticationProvider> authenticationProviders = createDefaultAuthenticationProviders(httpSecurity);
+		List<AuthenticationProvider> authenticationProviders = createDefaultAuthenticationProviders(httpSecurity,
+				this.allowedScopes);
 		if (!this.authenticationProviders.isEmpty()) {
 			authenticationProviders.addAll(0, this.authenticationProviders);
 		}
@@ -245,7 +266,8 @@ public final class OidcClientRegistrationEndpointConfigurer extends AbstractOAut
 		return authenticationConverters;
 	}
 
-	private static List<AuthenticationProvider> createDefaultAuthenticationProviders(HttpSecurity httpSecurity) {
+	private static List<AuthenticationProvider> createDefaultAuthenticationProviders(HttpSecurity httpSecurity,
+			Set<String> allowedScopes) {
 		List<AuthenticationProvider> authenticationProviders = new ArrayList<>();
 
 		OidcClientRegistrationAuthenticationProvider oidcClientRegistrationAuthenticationProvider = new OidcClientRegistrationAuthenticationProvider(
@@ -255,6 +277,9 @@ public final class OidcClientRegistrationEndpointConfigurer extends AbstractOAut
 		PasswordEncoder passwordEncoder = OAuth2ConfigurerUtils.getOptionalBean(httpSecurity, PasswordEncoder.class);
 		if (passwordEncoder != null) {
 			oidcClientRegistrationAuthenticationProvider.setPasswordEncoder(passwordEncoder);
+		}
+		if (allowedScopes != null) {
+			oidcClientRegistrationAuthenticationProvider.setAllowedScopes(allowedScopes);
 		}
 		authenticationProviders.add(oidcClientRegistrationAuthenticationProvider);
 

--- a/docs/modules/ROOT/pages/servlet/oauth2/authorization-server/protocol-endpoints.adoc
+++ b/docs/modules/ROOT/pages/servlet/oauth2/authorization-server/protocol-endpoints.adoc
@@ -730,6 +730,35 @@ The access token in a Client Registration request *REQUIRES* the OAuth2 scope `c
 [TIP]
 To allow open client registration (no access token in request), configure `OAuth2ClientRegistrationAuthenticationProvider.setOpenRegistrationAllowed(true)`.
 
+[[oauth2AuthorizationServer-oauth2-client-registration-endpoint-scope-validation]]
+=== Customizing Scope Validation
+
+By default, the OAuth2 Client Registration endpoint accepts any scope values in the registration request.
+It is recommended to configure the allowed scopes to restrict which scopes can be assigned to dynamically registered clients.
+
+[source,java]
+----
+@Bean
+public SecurityFilterChain authorizationServerSecurityFilterChain(HttpSecurity http) throws Exception {
+	http
+		.oauth2AuthorizationServer((authorizationServer) ->
+			authorizationServer
+				.clientRegistrationEndpoint(clientRegistrationEndpoint ->
+                    clientRegistrationEndpoint
+                        .allowedScopes("openid", "profile", "email") // <1>
+				)
+		);
+
+	return http.build();
+}
+----
+<1> `allowedScopes()`: Restricts which scope values are accepted during client registration. Registration requests containing scopes not in this set will be rejected with an `invalid_scope` error.
+
+[IMPORTANT]
+When enabling Dynamic Client Registration, it is recommended to always configure `allowedScopes()` to prevent dynamically registered clients from requesting arbitrary scope values.
+
+For advanced scope validation logic, use `setRegisteredClientConverter()` to provide a custom `Converter<OAuth2ClientRegistration, RegisteredClient>` that performs the required validation.
+
 [[oauth2AuthorizationServer-oauth2-authorization-server-metadata-endpoint]]
 == OAuth2 Authorization Server Metadata Endpoint
 
@@ -1041,3 +1070,35 @@ The access token in a Client Registration request *REQUIRES* the OAuth2 scope `c
 
 [IMPORTANT]
 The access token in a Client Read request *REQUIRES* the OAuth2 scope `client.read`.
+
+[[oauth2AuthorizationServer-oidc-client-registration-endpoint-scope-validation]]
+=== Customizing Scope Validation
+
+By default, the OIDC Client Registration endpoint accepts any scope values in the registration request.
+It is recommended to configure the allowed scopes to restrict which scopes can be assigned to dynamically registered clients.
+
+[source,java]
+----
+@Bean
+public SecurityFilterChain authorizationServerSecurityFilterChain(HttpSecurity http) throws Exception {
+	http
+		.oauth2AuthorizationServer((authorizationServer) ->
+			authorizationServer
+                .oidc(oidc ->
+                    oidc
+                        .clientRegistrationEndpoint(clientRegistrationEndpoint ->
+                            clientRegistrationEndpoint
+                                .allowedScopes("openid", "profile", "email") // <1>
+                        )
+                )
+		);
+
+	return http.build();
+}
+----
+<1> `allowedScopes()`: Restricts which scope values are accepted during client registration. Registration requests containing scopes not in this set will be rejected with an `invalid_scope` error.
+
+[IMPORTANT]
+When enabling Dynamic Client Registration, it is recommended to always configure `allowedScopes()` to prevent dynamically registered clients from requesting arbitrary scope values.
+
+For advanced scope validation logic, use `setRegisteredClientConverter()` to provide a custom `Converter<OidcClientRegistration, RegisteredClient>` that performs the required validation.

--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientRegistrationAuthenticationProvider.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientRegistrationAuthenticationProvider.java
@@ -87,6 +87,8 @@ public final class OAuth2ClientRegistrationAuthenticationProvider implements Aut
 
 	private boolean openRegistrationAllowed;
 
+	private Set<String> allowedScopes;
+
 	/**
 	 * Constructs an {@code OAuth2ClientRegistrationAuthenticationProvider} using the
 	 * provided parameters.
@@ -200,6 +202,18 @@ public final class OAuth2ClientRegistrationAuthenticationProvider implements Aut
 		this.openRegistrationAllowed = openRegistrationAllowed;
 	}
 
+	/**
+	 * Sets the allowed scopes for client registration. When set, only the specified
+	 * scopes will be accepted during Dynamic Client Registration. If not set, any scope
+	 * value will be accepted.
+	 * @param allowedScopes the {@code Set} of allowed scopes
+	 * @since 7.1
+	 */
+	public void setAllowedScopes(Set<String> allowedScopes) {
+		Assert.notNull(allowedScopes, "allowedScopes cannot be null");
+		this.allowedScopes = allowedScopes;
+	}
+
 	private OAuth2ClientRegistrationAuthenticationToken registerClient(
 			OAuth2ClientRegistrationAuthenticationToken clientRegistrationAuthentication,
 			@Nullable OAuth2Authorization authorization) {
@@ -208,6 +222,14 @@ public final class OAuth2ClientRegistrationAuthenticationProvider implements Aut
 		if (!isValidRedirectUris((redirectUris != null) ? redirectUris : Collections.emptyList())) {
 			throwInvalidClientRegistration(OAuth2ErrorCodes.INVALID_REDIRECT_URI,
 					OAuth2ClientMetadataClaimNames.REDIRECT_URIS);
+		}
+
+		if (this.allowedScopes != null) {
+			Set<String> requestedScopes = clientRegistrationAuthentication.getClientRegistration().getScopes();
+			if (!CollectionUtils.isEmpty(requestedScopes) && !this.allowedScopes.containsAll(requestedScopes)) {
+				throwInvalidClientRegistration(OAuth2ErrorCodes.INVALID_SCOPE,
+						OAuth2ClientMetadataClaimNames.SCOPE);
+			}
 		}
 
 		if (this.logger.isTraceEnabled()) {

--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/oidc/authentication/OidcClientRegistrationAuthenticationProvider.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/oidc/authentication/OidcClientRegistrationAuthenticationProvider.java
@@ -103,6 +103,8 @@ public final class OidcClientRegistrationAuthenticationProvider implements Authe
 
 	private PasswordEncoder passwordEncoder;
 
+	private Set<String> allowedScopes;
+
 	/**
 	 * Constructs an {@code OidcClientRegistrationAuthenticationProvider} using the
 	 * provided parameters.
@@ -208,6 +210,18 @@ public final class OidcClientRegistrationAuthenticationProvider implements Authe
 		this.passwordEncoder = passwordEncoder;
 	}
 
+	/**
+	 * Sets the allowed scopes for client registration. When set, only the specified
+	 * scopes will be accepted during Dynamic Client Registration. If not set, any scope
+	 * value will be accepted.
+	 * @param allowedScopes the {@code Set} of allowed scopes
+	 * @since 7.1
+	 */
+	public void setAllowedScopes(Set<String> allowedScopes) {
+		Assert.notNull(allowedScopes, "allowedScopes cannot be null");
+		this.allowedScopes = allowedScopes;
+	}
+
 	private OidcClientRegistrationAuthenticationToken registerClient(
 			OidcClientRegistrationAuthenticationToken clientRegistrationAuthentication,
 			OAuth2Authorization authorization) {
@@ -232,6 +246,14 @@ public final class OidcClientRegistrationAuthenticationProvider implements Authe
 		if (!isValidTokenEndpointAuthenticationMethod(clientRegistrationRequest)) {
 			throwInvalidClientRegistration("invalid_client_metadata",
 					OidcClientMetadataClaimNames.TOKEN_ENDPOINT_AUTH_METHOD);
+		}
+
+		if (this.allowedScopes != null) {
+			Set<String> requestedScopes = clientRegistrationRequest.getScopes();
+			if (!CollectionUtils.isEmpty(requestedScopes) && !this.allowedScopes.containsAll(requestedScopes)) {
+				throwInvalidClientRegistration(OAuth2ErrorCodes.INVALID_SCOPE,
+						OidcClientMetadataClaimNames.SCOPE);
+			}
 		}
 
 		if (this.logger.isTraceEnabled()) {

--- a/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientRegistrationAuthenticationProviderTests.java
+++ b/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientRegistrationAuthenticationProviderTests.java
@@ -478,6 +478,122 @@ public class OAuth2ClientRegistrationAuthenticationProviderTests {
 			.isEqualTo(registeredClient.getClientAuthenticationMethods().iterator().next().getValue());
 	}
 
+	@Test
+	public void setAllowedScopesWhenNullThenThrowIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.authenticationProvider.setAllowedScopes(null))
+			.withMessage("allowedScopes cannot be null");
+	}
+
+	@Test
+	public void authenticateWhenAllowedScopesSetAndRequestedScopesAllowedThenSuccess() {
+		Jwt jwt = createJwtClientRegistration();
+		OAuth2AccessToken jwtAccessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
+				jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaim(OAuth2ParameterNames.SCOPE));
+		RegisteredClient registeredClient = TestRegisteredClients.registeredClient().build();
+		OAuth2Authorization authorization = TestOAuth2Authorizations
+			.authorization(registeredClient, jwtAccessToken, jwt.getClaims())
+			.build();
+		given(this.authorizationService.findByToken(eq(jwtAccessToken.getTokenValue()),
+				eq(OAuth2TokenType.ACCESS_TOKEN)))
+			.willReturn(authorization);
+
+		this.authenticationProvider.setAllowedScopes(new HashSet<>(Arrays.asList("openid", "profile", "email")));
+
+		JwtAuthenticationToken principal = new JwtAuthenticationToken(jwt,
+				AuthorityUtils.createAuthorityList("SCOPE_client.create"));
+		// @formatter:off
+		OAuth2ClientRegistration clientRegistration = OAuth2ClientRegistration.builder()
+				.clientName("client-name")
+				.redirectUri("https://client.example.com")
+				.grantType(AuthorizationGrantType.AUTHORIZATION_CODE.getValue())
+				.scope("openid")
+				.scope("profile")
+				.build();
+		// @formatter:on
+
+		OAuth2ClientRegistrationAuthenticationToken authentication = new OAuth2ClientRegistrationAuthenticationToken(
+				principal, clientRegistration);
+		OAuth2ClientRegistrationAuthenticationToken authenticationResult = (OAuth2ClientRegistrationAuthenticationToken) this.authenticationProvider
+			.authenticate(authentication);
+
+		assertThat(authenticationResult.getClientRegistration()).isNotNull();
+	}
+
+	@Test
+	public void authenticateWhenAllowedScopesSetAndRequestedScopesNotAllowedThenThrowOAuth2AuthenticationException() {
+		Jwt jwt = createJwtClientRegistration();
+		OAuth2AccessToken jwtAccessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
+				jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaim(OAuth2ParameterNames.SCOPE));
+		RegisteredClient registeredClient = TestRegisteredClients.registeredClient().build();
+		OAuth2Authorization authorization = TestOAuth2Authorizations
+			.authorization(registeredClient, jwtAccessToken, jwt.getClaims())
+			.build();
+		given(this.authorizationService.findByToken(eq(jwtAccessToken.getTokenValue()),
+				eq(OAuth2TokenType.ACCESS_TOKEN)))
+			.willReturn(authorization);
+
+		this.authenticationProvider.setAllowedScopes(new HashSet<>(Arrays.asList("openid", "profile")));
+
+		JwtAuthenticationToken principal = new JwtAuthenticationToken(jwt,
+				AuthorityUtils.createAuthorityList("SCOPE_client.create"));
+		// @formatter:off
+		OAuth2ClientRegistration clientRegistration = OAuth2ClientRegistration.builder()
+				.clientName("client-name")
+				.redirectUri("https://client.example.com")
+				.grantType(AuthorizationGrantType.AUTHORIZATION_CODE.getValue())
+				.scope("admin")
+				.scope("ROLE_ADMIN")
+				.build();
+		// @formatter:on
+
+		OAuth2ClientRegistrationAuthenticationToken authentication = new OAuth2ClientRegistrationAuthenticationToken(
+				principal, clientRegistration);
+
+		assertThatExceptionOfType(OAuth2AuthenticationException.class)
+			.isThrownBy(() -> this.authenticationProvider.authenticate(authentication))
+			.extracting(OAuth2AuthenticationException::getError)
+			.satisfies((error) -> {
+				assertThat(error.getErrorCode()).isEqualTo(OAuth2ErrorCodes.INVALID_SCOPE);
+				assertThat(error.getDescription()).contains(OAuth2ClientMetadataClaimNames.SCOPE);
+			});
+	}
+
+	@Test
+	public void authenticateWhenAllowedScopesNotSetThenAnyScopeAllowed() {
+		Jwt jwt = createJwtClientRegistration();
+		OAuth2AccessToken jwtAccessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
+				jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaim(OAuth2ParameterNames.SCOPE));
+		RegisteredClient registeredClient = TestRegisteredClients.registeredClient().build();
+		OAuth2Authorization authorization = TestOAuth2Authorizations
+			.authorization(registeredClient, jwtAccessToken, jwt.getClaims())
+			.build();
+		given(this.authorizationService.findByToken(eq(jwtAccessToken.getTokenValue()),
+				eq(OAuth2TokenType.ACCESS_TOKEN)))
+			.willReturn(authorization);
+
+		JwtAuthenticationToken principal = new JwtAuthenticationToken(jwt,
+				AuthorityUtils.createAuthorityList("SCOPE_client.create"));
+		// @formatter:off
+		OAuth2ClientRegistration clientRegistration = OAuth2ClientRegistration.builder()
+				.clientName("client-name")
+				.redirectUri("https://client.example.com")
+				.grantType(AuthorizationGrantType.AUTHORIZATION_CODE.getValue())
+				.scope("admin")
+				.scope("ROLE_ADMIN")
+				.scope("superuser")
+				.build();
+		// @formatter:on
+
+		OAuth2ClientRegistrationAuthenticationToken authentication = new OAuth2ClientRegistrationAuthenticationToken(
+				principal, clientRegistration);
+		OAuth2ClientRegistrationAuthenticationToken authenticationResult = (OAuth2ClientRegistrationAuthenticationToken) this.authenticationProvider
+			.authenticate(authentication);
+
+		assertThat(authenticationResult.getClientRegistration()).isNotNull();
+		assertThat(authenticationResult.getClientRegistration().getScopes()).containsExactlyInAnyOrder("admin",
+				"ROLE_ADMIN", "superuser");
+	}
+
 	private static Jwt createJwtClientRegistration() {
 		return createJwt(Collections.singleton("client.create"));
 	}

--- a/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/oidc/authentication/OidcClientRegistrationAuthenticationProviderTests.java
+++ b/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/oidc/authentication/OidcClientRegistrationAuthenticationProviderTests.java
@@ -766,6 +766,124 @@ public class OidcClientRegistrationAuthenticationProviderTests {
 		assertThat(clientRegistrationResult.getRegistrationAccessToken()).isEqualTo(jwt.getTokenValue());
 	}
 
+	@Test
+	public void setAllowedScopesWhenNullThenThrowIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.authenticationProvider.setAllowedScopes(null))
+			.withMessage("allowedScopes cannot be null");
+	}
+
+	@Test
+	public void authenticateWhenAllowedScopesSetAndRequestedScopesAllowedThenSuccess() {
+		Jwt jwt = createJwtClientRegistration();
+		OAuth2AccessToken jwtAccessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
+				jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaim(OAuth2ParameterNames.SCOPE));
+		RegisteredClient registeredClient = TestRegisteredClients.registeredClient().build();
+		OAuth2Authorization authorization = TestOAuth2Authorizations
+			.authorization(registeredClient, jwtAccessToken, jwt.getClaims())
+			.build();
+		given(this.authorizationService.findByToken(eq(jwtAccessToken.getTokenValue()),
+				eq(OAuth2TokenType.ACCESS_TOKEN)))
+			.willReturn(authorization);
+		given(this.jwtEncoder.encode(any())).willReturn(createJwtClientConfiguration());
+
+		this.authenticationProvider.setAllowedScopes(new HashSet<>(Arrays.asList("openid", "profile", "email")));
+
+		JwtAuthenticationToken principal = new JwtAuthenticationToken(jwt,
+				AuthorityUtils.createAuthorityList("SCOPE_client.create"));
+		// @formatter:off
+		OidcClientRegistration clientRegistration = OidcClientRegistration.builder()
+				.clientName("client-name")
+				.redirectUri("https://client.example.com")
+				.grantType(AuthorizationGrantType.AUTHORIZATION_CODE.getValue())
+				.scope("openid")
+				.scope("profile")
+				.build();
+		// @formatter:on
+
+		OidcClientRegistrationAuthenticationToken authentication = new OidcClientRegistrationAuthenticationToken(
+				principal, clientRegistration);
+		OidcClientRegistrationAuthenticationToken authenticationResult = (OidcClientRegistrationAuthenticationToken) this.authenticationProvider
+			.authenticate(authentication);
+
+		assertThat(authenticationResult.getClientRegistration()).isNotNull();
+	}
+
+	@Test
+	public void authenticateWhenAllowedScopesSetAndRequestedScopesNotAllowedThenThrowOAuth2AuthenticationException() {
+		Jwt jwt = createJwtClientRegistration();
+		OAuth2AccessToken jwtAccessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
+				jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaim(OAuth2ParameterNames.SCOPE));
+		RegisteredClient registeredClient = TestRegisteredClients.registeredClient().build();
+		OAuth2Authorization authorization = TestOAuth2Authorizations
+			.authorization(registeredClient, jwtAccessToken, jwt.getClaims())
+			.build();
+		given(this.authorizationService.findByToken(eq(jwtAccessToken.getTokenValue()),
+				eq(OAuth2TokenType.ACCESS_TOKEN)))
+			.willReturn(authorization);
+
+		this.authenticationProvider.setAllowedScopes(new HashSet<>(Arrays.asList("openid", "profile")));
+
+		JwtAuthenticationToken principal = new JwtAuthenticationToken(jwt,
+				AuthorityUtils.createAuthorityList("SCOPE_client.create"));
+		// @formatter:off
+		OidcClientRegistration clientRegistration = OidcClientRegistration.builder()
+				.clientName("client-name")
+				.redirectUri("https://client.example.com")
+				.grantType(AuthorizationGrantType.AUTHORIZATION_CODE.getValue())
+				.scope("admin")
+				.scope("ROLE_ADMIN")
+				.build();
+		// @formatter:on
+
+		OidcClientRegistrationAuthenticationToken authentication = new OidcClientRegistrationAuthenticationToken(
+				principal, clientRegistration);
+
+		assertThatExceptionOfType(OAuth2AuthenticationException.class)
+			.isThrownBy(() -> this.authenticationProvider.authenticate(authentication))
+			.extracting(OAuth2AuthenticationException::getError)
+			.satisfies((error) -> {
+				assertThat(error.getErrorCode()).isEqualTo(OAuth2ErrorCodes.INVALID_SCOPE);
+				assertThat(error.getDescription()).contains(OidcClientMetadataClaimNames.SCOPE);
+			});
+	}
+
+	@Test
+	public void authenticateWhenAllowedScopesNotSetThenAnyScopeAllowed() {
+		Jwt jwt = createJwtClientRegistration();
+		OAuth2AccessToken jwtAccessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
+				jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaim(OAuth2ParameterNames.SCOPE));
+		RegisteredClient registeredClient = TestRegisteredClients.registeredClient().build();
+		OAuth2Authorization authorization = TestOAuth2Authorizations
+			.authorization(registeredClient, jwtAccessToken, jwt.getClaims())
+			.build();
+		given(this.authorizationService.findByToken(eq(jwtAccessToken.getTokenValue()),
+				eq(OAuth2TokenType.ACCESS_TOKEN)))
+			.willReturn(authorization);
+		given(this.jwtEncoder.encode(any())).willReturn(createJwtClientConfiguration());
+
+		JwtAuthenticationToken principal = new JwtAuthenticationToken(jwt,
+				AuthorityUtils.createAuthorityList("SCOPE_client.create"));
+		// @formatter:off
+		OidcClientRegistration clientRegistration = OidcClientRegistration.builder()
+				.clientName("client-name")
+				.redirectUri("https://client.example.com")
+				.grantType(AuthorizationGrantType.AUTHORIZATION_CODE.getValue())
+				.scope("admin")
+				.scope("ROLE_ADMIN")
+				.scope("superuser")
+				.build();
+		// @formatter:on
+
+		OidcClientRegistrationAuthenticationToken authentication = new OidcClientRegistrationAuthenticationToken(
+				principal, clientRegistration);
+		OidcClientRegistrationAuthenticationToken authenticationResult = (OidcClientRegistrationAuthenticationToken) this.authenticationProvider
+			.authenticate(authentication);
+
+		assertThat(authenticationResult.getClientRegistration()).isNotNull();
+		assertThat(authenticationResult.getClientRegistration().getScopes()).containsExactlyInAnyOrder("admin",
+				"ROLE_ADMIN", "superuser");
+	}
+
 	private static Jwt createJwtClientRegistration() {
 		return createJwt(Collections.singleton("client.create"));
 	}


### PR DESCRIPTION
## Summary

Add `allowedScopes` configuration to both OAuth2 and OIDC Dynamic Client Registration endpoints, along with documentation recommending its use.

Currently, DCR accepts any scope string verbatim during client registration. This PR adds a built-in mechanism to restrict which scopes are permitted, complementing the existing `setRegisteredClientConverter()` extension point with a simpler configuration option.

This was discussed in GHSA-wrvg-67fj-c87r, where @jgrandja agreed on adding documentation and considering a security enhancement.

## Changes

- Add `setAllowedScopes(Set<String>)` to `OidcClientRegistrationAuthenticationProvider` and `OAuth2ClientRegistrationAuthenticationProvider`
- Add `allowedScopes(String...)` fluent API to both endpoint configurers
- Add "Customizing Scope Validation" documentation section to both DCR endpoint pages in `protocol-endpoints.adoc`
- Add tests for scope validation, backward compatibility, and null safety

## Behavior

- When `allowedScopes` is configured, registration requests with scopes outside the set are rejected with `invalid_scope`
- When not configured (default), any scope is accepted — existing behavior is unchanged
- Follows the same configurer-to-provider wiring pattern as `openRegistrationAllowed`

Signed-off-by: addcontent <addcontent08@gmail.com>