### PR TITLE
Fix typo in OAuth2 migration guide code example

### DIFF
--- a/docs/modules/ROOT/pages/migration/servlet/oauth2.adoc
+++ b/docs/modules/ROOT/pages/migration/servlet/oauth2.adoc
@@ -120,7 +120,7 @@ BearerTokenAuthenticationConverter authenticationConverter =
     new BearerTokenAuthenticationConverter();
 authenticationConverter.setBearerTokenResolver(myBearerTokenResolver);
 authenticationConverter.setAuthenticationDetailsSource(myAuthenticationDetailsSource);
-BearerTokenAuthenticationFilter filter = new BearerTokenAuthenticationFilter(authenticationManager, authenicationConverter);
+BearerTokenAuthenticationFilter filter = new BearerTokenAuthenticationFilter(authenticationManager, authenticationConverter);
 ----
 
 Kotlin::


### PR DESCRIPTION
Fix misspelled variable name `authenicationConverter` to `authenticationConverter` in Java code example.