### PR TITLE
Stop CoreJacksonModule from overriding user DateTimeFeature configuration

### DIFF
--- a/core/src/main/java/org/springframework/security/jackson/CoreJacksonModule.java
+++ b/core/src/main/java/org/springframework/security/jackson/CoreJacksonModule.java
@@ -20,8 +20,6 @@ import java.time.Duration;
 import java.time.Instant;
 
 import tools.jackson.core.Version;
-import tools.jackson.databind.cfg.DateTimeFeature;
-import tools.jackson.databind.cfg.MapperBuilder;
 import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
@@ -101,7 +99,6 @@ public class CoreJacksonModule extends SecurityJacksonModule {
 
 	@Override
 	public void setupModule(SetupContext context) {
-		((MapperBuilder<?, ?>) context.getOwner()).enable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS);
 		context.setMixIn(AnonymousAuthenticationToken.class, AnonymousAuthenticationTokenMixin.class);
 		context.setMixIn(RememberMeAuthenticationToken.class, RememberMeAuthenticationTokenMixin.class);
 		context.setMixIn(SimpleGrantedAuthority.class, SimpleGrantedAuthorityMixin.class);

--- a/core/src/main/java/org/springframework/security/jackson/FactorGrantedAuthorityMixin.java
+++ b/core/src/main/java/org/springframework/security/jackson/FactorGrantedAuthorityMixin.java
@@ -20,6 +20,7 @@ import java.time.Instant;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
@@ -44,7 +45,10 @@ abstract class FactorGrantedAuthorityMixin {
 	 */
 	@JsonCreator
 	FactorGrantedAuthorityMixin(@JsonProperty("authority") String authority,
-			@JsonProperty("issuedAt") Instant issuedAt) {
+			@JsonProperty("issuedAt") @JsonFormat(shape = JsonFormat.Shape.NUMBER) Instant issuedAt) {
 	}
+
+	@JsonFormat(shape = JsonFormat.Shape.NUMBER)
+	abstract Instant getIssuedAt();
 
 }

--- a/core/src/test/java/org/springframework/security/jackson/FactorGrantedAuthorityMixinTests.java
+++ b/core/src/test/java/org/springframework/security/jackson/FactorGrantedAuthorityMixinTests.java
@@ -21,6 +21,9 @@ import java.time.Instant;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.FactorGrantedAuthority;
@@ -55,6 +58,43 @@ class FactorGrantedAuthorityMixinTests extends AbstractMixinTests {
 		assertThat(authority).isNotNull();
 		assertThat(authority.getAuthority()).isEqualTo("FACTOR_PASSWORD");
 		assertThat(authority.getIssuedAt()).isEqualTo(this.issuedAt);
+	}
+
+	@Test
+	void serializeWhenWriteDatesAsTimestampsDisabledThenStillUsesTimestamps() throws JSONException {
+		ClassLoader loader = getClass().getClassLoader();
+		JsonMapper customMapper = JsonMapper.builder()
+			.disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+			.addModules(SecurityJacksonModules.getModules(loader, BasicPolymorphicTypeValidator.builder()))
+			.build();
+		GrantedAuthority authority = FactorGrantedAuthority.withAuthority("FACTOR_PASSWORD")
+			.issuedAt(this.issuedAt)
+			.build();
+		String json = customMapper.writeValueAsString(authority);
+		JSONAssert.assertEquals(AUTHORITY_JSON, json, true);
+	}
+
+	@Test
+	void deserializeWhenWriteDatesAsTimestampsDisabledThenStillDeserializesTimestamps() {
+		ClassLoader loader = getClass().getClassLoader();
+		JsonMapper customMapper = JsonMapper.builder()
+			.disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+			.addModules(SecurityJacksonModules.getModules(loader, BasicPolymorphicTypeValidator.builder()))
+			.build();
+		FactorGrantedAuthority authority = (FactorGrantedAuthority) customMapper.readValue(AUTHORITY_JSON, Object.class);
+		assertThat(authority).isNotNull();
+		assertThat(authority.getAuthority()).isEqualTo("FACTOR_PASSWORD");
+		assertThat(authority.getIssuedAt()).isEqualTo(this.issuedAt);
+	}
+
+	@Test
+	void serializeDoesNotOverrideGlobalDateTimeFeature() {
+		ClassLoader loader = getClass().getClassLoader();
+		JsonMapper customMapper = JsonMapper.builder()
+			.disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+			.addModules(SecurityJacksonModules.getModules(loader, BasicPolymorphicTypeValidator.builder()))
+			.build();
+		assertThat(customMapper.isEnabled(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)).isFalse();
 	}
 
 }

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2AccessTokenMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2AccessTokenMixin.java
@@ -21,6 +21,7 @@ import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import tools.jackson.databind.annotation.JsonDeserialize;
@@ -45,8 +46,10 @@ abstract class OAuth2AccessTokenMixin {
 	OAuth2AccessTokenMixin(
 			@JsonProperty("tokenType") @JsonDeserialize(
 					converter = StdConverters.AccessTokenTypeConverter.class) OAuth2AccessToken.TokenType tokenType,
-			@JsonProperty("tokenValue") String tokenValue, @JsonProperty("issuedAt") Instant issuedAt,
-			@JsonProperty("expiresAt") Instant expiresAt, @JsonProperty("scopes") Set<String> scopes) {
+			@JsonProperty("tokenValue") String tokenValue,
+			@JsonProperty("issuedAt") @JsonFormat(shape = JsonFormat.Shape.NUMBER) Instant issuedAt,
+			@JsonProperty("expiresAt") @JsonFormat(shape = JsonFormat.Shape.NUMBER) Instant expiresAt,
+			@JsonProperty("scopes") Set<String> scopes) {
 	}
 
 }

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2RefreshTokenMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OAuth2RefreshTokenMixin.java
@@ -20,6 +20,7 @@ import java.time.Instant;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
@@ -40,7 +41,8 @@ import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 abstract class OAuth2RefreshTokenMixin {
 
 	@JsonCreator
-	OAuth2RefreshTokenMixin(@JsonProperty("tokenValue") String tokenValue, @JsonProperty("issuedAt") Instant issuedAt) {
+	OAuth2RefreshTokenMixin(@JsonProperty("tokenValue") String tokenValue,
+			@JsonProperty("issuedAt") @JsonFormat(shape = JsonFormat.Shape.NUMBER) Instant issuedAt) {
 	}
 
 }

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OidcIdTokenMixin.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/jackson/OidcIdTokenMixin.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
@@ -41,8 +42,10 @@ import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 abstract class OidcIdTokenMixin {
 
 	@JsonCreator
-	OidcIdTokenMixin(@JsonProperty("tokenValue") String tokenValue, @JsonProperty("issuedAt") Instant issuedAt,
-			@JsonProperty("expiresAt") Instant expiresAt, @JsonProperty("claims") Map<String, Object> claims) {
+	OidcIdTokenMixin(@JsonProperty("tokenValue") String tokenValue,
+			@JsonProperty("issuedAt") @JsonFormat(shape = JsonFormat.Shape.NUMBER) Instant issuedAt,
+			@JsonProperty("expiresAt") @JsonFormat(shape = JsonFormat.Shape.NUMBER) Instant expiresAt,
+			@JsonProperty("claims") Map<String, Object> claims) {
 	}
 
 }

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthorizedClientMixinTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthorizedClientMixinTests.java
@@ -26,7 +26,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import tools.jackson.core.JacksonException;
+import tools.jackson.databind.cfg.DateTimeFeature;
 import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 
 import org.springframework.security.jackson.SecurityJacksonModules;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
@@ -105,6 +107,47 @@ public class OAuth2AuthorizedClientMixinTests {
 		String expectedJson = asJson(authorizedClient);
 		String json = this.mapper.writeValueAsString(authorizedClient);
 		JSONAssert.assertEquals(expectedJson, json, true);
+	}
+
+	@Test
+	public void serializeWhenWriteDatesAsTimestampsDisabledThenTokenDatesStillUseTimestamps() throws Exception {
+		ClassLoader loader = getClass().getClassLoader();
+		JsonMapper customMapper = JsonMapper.builder()
+			.disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+			.addModules(SecurityJacksonModules.getModules(loader, BasicPolymorphicTypeValidator.builder()))
+			.build();
+		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.clientRegistrationBuilder.build(),
+				this.principalName, this.accessToken, this.refreshToken);
+		String expectedJson = asJson(authorizedClient);
+		String json = customMapper.writeValueAsString(authorizedClient);
+		JSONAssert.assertEquals(expectedJson, json, true);
+	}
+
+	@Test
+	public void deserializeWhenWriteDatesAsTimestampsDisabledThenTokenDatesStillDeserialize() throws Exception {
+		ClassLoader loader = getClass().getClassLoader();
+		JsonMapper customMapper = JsonMapper.builder()
+			.disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+			.addModules(SecurityJacksonModules.getModules(loader, BasicPolymorphicTypeValidator.builder()))
+			.build();
+		OAuth2AuthorizedClient expectedAuthorizedClient = new OAuth2AuthorizedClient(this.clientRegistrationBuilder.build(),
+				this.principalName, this.accessToken, this.refreshToken);
+		String json = asJson(expectedAuthorizedClient);
+		OAuth2AuthorizedClient authorizedClient = customMapper.readValue(json, OAuth2AuthorizedClient.class);
+		assertThat(authorizedClient.getAccessToken().getIssuedAt()).isEqualTo(this.accessToken.getIssuedAt());
+		assertThat(authorizedClient.getAccessToken().getExpiresAt()).isEqualTo(this.accessToken.getExpiresAt());
+		assertThat(authorizedClient.getRefreshToken()).isNotNull();
+		assertThat(authorizedClient.getRefreshToken().getIssuedAt()).isEqualTo(this.refreshToken.getIssuedAt());
+	}
+
+	@Test
+	public void setupWhenWriteDatesAsTimestampsDisabledThenSettingIsNotOverridden() {
+		ClassLoader loader = getClass().getClassLoader();
+		JsonMapper customMapper = JsonMapper.builder()
+			.disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+			.addModules(SecurityJacksonModules.getModules(loader, BasicPolymorphicTypeValidator.builder()))
+			.build();
+		assertThat(customMapper.isEnabled(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)).isFalse();
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Fixes #18561

CoreJacksonModule.setupModule() unconditionally called enable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS) on the MapperBuilder, which overrode any user configuration and forced all java.time types (e.g. LocalDateTime, Instant) to be serialized as timestamps/arrays instead of ISO-8601 strings.

## Changes

- **Removed** the global enable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS) call from CoreJacksonModule.setupModule()
- **Added** @JsonFormat(shape = JsonFormat.Shape.NUMBER) annotations on individual Mixin constructor parameters and getters that require timestamp serialization for backward compatibility:
  - FactorGrantedAuthorityMixin.issuedAt (constructor param + getter)
  - OAuth2AccessTokenMixin.issuedAt and expiresAt
  - OAuth2RefreshTokenMixin.issuedAt
  - OidcIdTokenMixin.issuedAt and expiresAt
- **Added 3 new tests** in FactorGrantedAuthorityMixinTests:
  - Verifies serialization still produces timestamps even when WRITE_DATES_AS_TIMESTAMPS is globally disabled
  - Verifies deserialization from timestamp format works with the feature disabled
  - Verifies the global DateTimeFeature setting is not overridden by Security modules
