### PR TITLE
fix: Add issuer URI to GitHub OAuth provider for RFC 9207 compliance

### DIFF
--- a/config/src/main/java/org/springframework/security/config/oauth2/client/CommonOAuth2Provider.java
+++ b/config/src/main/java/org/springframework/security/config/oauth2/client/CommonOAuth2Provider.java
@@ -66,6 +66,7 @@ public enum CommonOAuth2Provider {
 			builder.userInfoUri("https://api.github.com/user");
 			builder.userNameAttributeName("id");
 			builder.clientName("GitHub");
+			builder.issuerUri("https://github.com/login/oauth");
 			return builder;
 		}
 

--- a/config/src/test/java/org/springframework/security/config/oauth2/client/CommonOAuth2ProviderTests.java
+++ b/config/src/test/java/org/springframework/security/config/oauth2/client/CommonOAuth2ProviderTests.java
@@ -64,6 +64,8 @@ public class CommonOAuth2ProviderTests {
 		assertThat(providerDetails.getUserInfoEndpoint().getUri()).isEqualTo("https://api.github.com/user");
 		assertThat(providerDetails.getUserInfoEndpoint().getUserNameAttributeName()).isEqualTo("id");
 		assertThat(providerDetails.getJwkSetUri()).isNull();
+		// gh-19058: issuerUri must be set for RFC 9207 iss parameter validation
+		assertThat(providerDetails.getIssuerUri()).isEqualTo("https://github.com/login/oauth");
 		assertThat(registration.getClientAuthenticationMethod())
 			.isEqualTo(ClientAuthenticationMethod.CLIENT_SECRET_BASIC);
 		assertThat(registration.getAuthorizationGrantType()).isEqualTo(AuthorizationGrantType.AUTHORIZATION_CODE);
@@ -71,6 +73,18 @@ public class CommonOAuth2ProviderTests {
 		assertThat(registration.getScopes()).containsOnly("read:user");
 		assertThat(registration.getClientName()).isEqualTo("GitHub");
 		assertThat(registration.getRegistrationId()).isEqualTo("123");
+	}
+
+	@Test
+	public void getBuilderWhenGitHubShouldHaveIssuerUriForRfc9207Compliance() {
+		// gh-19058: GitHub enabled RFC 9207 issuer identification; the provider must
+		// declare an issuerUri so that the iss parameter returned in authorization
+		// responses can be validated against a known value.
+		ClientRegistration registration = build(CommonOAuth2Provider.GITHUB);
+		ProviderDetails providerDetails = registration.getProviderDetails();
+		assertThat(providerDetails.getIssuerUri())
+			.as("GitHub provider must have issuerUri set for RFC 9207 iss validation")
+			.isEqualTo("https://github.com/login/oauth");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
GitHub silently enabled RFC 9207 (OAuth 2.0 Authorization Server Issuer Identification) between April 6-10, 2026, breaking GitHub OAuth authentication in frameworks that validate the issuer field.

This fix adds the issuer URI to the GitHub OAuth provider configuration in Spring Security to ensure RFC 9207 compliance.

## Changes
- Added issuer URI configuration to GitHub OAuth provider in CommonOAuth2Provider.java

## References
- Langfuse Issue: https://github.com/langfuse/langfuse/issues/13091
- RFC 9207 Specification: https://datatracker.ietf.org/doc/html/rfc9207
