### PR TITLE
Feature: Improve AbstractAuthenticationFilterConfigurer by only using one instance of  successHandler

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/AbstractAuthenticationFilterConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/AbstractAuthenticationFilterConfigurer.java
@@ -32,6 +32,7 @@ import org.springframework.security.web.PortMapper;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.HasRequestCacheSetter;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.authentication.RememberMeServices;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
@@ -66,9 +67,9 @@ public abstract class AbstractAuthenticationFilterConfigurer<B extends HttpSecur
 
 	private AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource;
 
-	private SavedRequestAwareAuthenticationSuccessHandler defaultSuccessHandler = new SavedRequestAwareAuthenticationSuccessHandler();
+	private AuthenticationSuccessHandler successHandler = new SavedRequestAwareAuthenticationSuccessHandler();
 
-	private AuthenticationSuccessHandler successHandler = this.defaultSuccessHandler;
+	private boolean trySetRequestCacheIntoSuccessHandler = true;
 
 	private LoginUrlAuthenticationEntryPoint authenticationEntryPoint;
 
@@ -131,7 +132,7 @@ public abstract class AbstractAuthenticationFilterConfigurer<B extends HttpSecur
 		SavedRequestAwareAuthenticationSuccessHandler handler = new SavedRequestAwareAuthenticationSuccessHandler();
 		handler.setDefaultTargetUrl(defaultSuccessUrl);
 		handler.setAlwaysUseDefaultTargetUrl(alwaysUse);
-		this.defaultSuccessHandler = handler;
+		this.successHandler = handler;
 		return successHandler(handler);
 	}
 
@@ -180,6 +181,19 @@ public abstract class AbstractAuthenticationFilterConfigurer<B extends HttpSecur
 	 */
 	public final T successHandler(AuthenticationSuccessHandler successHandler) {
 		this.successHandler = successHandler;
+		return getSelf();
+	}
+
+	/**
+	 * Determines if {@link RequestCache} should be set into the
+	 * {@link AuthenticationSuccessHandler} when possible.
+	 * @param trySetRequestCacheIntoSuccessHandler true if it should be tried to set the
+	 * {@code RequestCache}
+	 * @return the {@link AbstractAuthenticationFilterConfigurer} for additional
+	 * customization
+	 */
+	public final T trySetRequestCacheIntoSuccessHandler(boolean trySetRequestCacheIntoSuccessHandler) {
+		this.trySetRequestCacheIntoSuccessHandler = trySetRequestCacheIntoSuccessHandler;
 		return getSelf();
 	}
 
@@ -273,9 +287,12 @@ public abstract class AbstractAuthenticationFilterConfigurer<B extends HttpSecur
 		if (portMapper != null) {
 			this.authenticationEntryPoint.setPortMapper(portMapper);
 		}
-		RequestCache requestCache = http.getSharedObject(RequestCache.class);
-		if (requestCache != null) {
-			this.defaultSuccessHandler.setRequestCache(requestCache);
+		if (this.trySetRequestCacheIntoSuccessHandler
+				&& this.successHandler instanceof HasRequestCacheSetter hasRequestCacheSetter) {
+			RequestCache requestCache = http.getSharedObject(RequestCache.class);
+			if (requestCache != null) {
+				hasRequestCacheSetter.setRequestCache(requestCache);
+			}
 		}
 		this.authFilter.setAuthenticationManager(http.getSharedObject(AuthenticationManager.class));
 		this.authFilter.setAuthenticationSuccessHandler(this.successHandler);

--- a/web/src/main/java/org/springframework/security/web/authentication/HasRequestCacheSetter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/HasRequestCacheSetter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.authentication;
+
+import org.springframework.security.web.savedrequest.RequestCache;
+
+/**
+ * Used to set a {@link RequestCache}, e.g. into a supporting
+ * {@link AuthenticationSuccessHandler}.
+ */
+public interface HasRequestCacheSetter {
+
+	void setRequestCache(RequestCache requestCache);
+
+}

--- a/web/src/main/java/org/springframework/security/web/authentication/SavedRequestAwareAuthenticationSuccessHandler.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/SavedRequestAwareAuthenticationSuccessHandler.java
@@ -63,7 +63,8 @@ import org.springframework.util.StringUtils;
  * @author Luke Taylor
  * @since 3.0
  */
-public class SavedRequestAwareAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+public class SavedRequestAwareAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler
+		implements HasRequestCacheSetter {
 
 	protected final Log logger = LogFactory.getLog(this.getClass());
 
@@ -90,6 +91,7 @@ public class SavedRequestAwareAuthenticationSuccessHandler extends SimpleUrlAuth
 		getRedirectStrategy().sendRedirect(request, response, targetUrl);
 	}
 
+	@Override
 	public void setRequestCache(RequestCache requestCache) {
 		this.requestCache = requestCache;
 	}


### PR DESCRIPTION
Fixes #19123

Instead of keeping 2 instances of successHandler (defaultSuccessHandler) only one is kept and the request cache is only set if the instance implements `HasRequestCacheSetter` and the `trySetRequestCacheIntoSuccessHandler` flag is set to true (default).

This way it's also easier for devs to customize the corresponding code as RequestCache must no longer be set manually when supplying a custom SuccessHandler.
