### PR TITLE
Fix `InetAddressMatchers#matchExternal` to exclude null and any local addresses

### DIFF
--- a/core/src/main/java/org/springframework/security/util/matcher/InetAddressMatchers.java
+++ b/core/src/main/java/org/springframework/security/util/matcher/InetAddressMatchers.java
@@ -31,6 +31,7 @@ import org.springframework.util.Assert;
  * strategies for IP addresses.
  *
  * @author Rob Winch
+ * @author Andrey Litvitski
  * @since 7.1
  */
 public final class InetAddressMatchers {
@@ -256,6 +257,9 @@ public final class InetAddressMatchers {
 			if (address == null) {
 				return false;
 			}
+			if (address.isAnyLocalAddress()) {
+				return true;
+			}
 			if (address.isLoopbackAddress() || address.isLinkLocalAddress() || address.isSiteLocalAddress()) {
 				return true;
 			}
@@ -335,6 +339,9 @@ public final class InetAddressMatchers {
 
 		@Override
 		public boolean matches(@Nullable InetAddress address) {
+			if (address == null) {
+				return false;
+			}
 			return !this.internalMatcher.matches(address);
 		}
 

--- a/core/src/test/java/org/springframework/security/util/matcher/InetAddressMatchersTests.java
+++ b/core/src/test/java/org/springframework/security/util/matcher/InetAddressMatchersTests.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  * Tests for {@link InetAddressMatchers}.
  *
  * @author Rob Winch
+ * @author Andrey Litvitski
  */
 class InetAddressMatchersTests {
 
@@ -49,6 +50,12 @@ class InetAddressMatchersTests {
 	void matchInternalWhenInvokedThenReturnsBuilder() {
 		InetAddressMatchers.Builder builder = InetAddressMatchers.matchInternal();
 		assertThat(builder).isNotNull();
+	}
+
+	@Test
+	void matchesWhenInetAddressNullThenReturnsFalse() {
+		InetAddressMatcher matcher = InetAddressMatchers.matchExternal().build();
+		assertThat(matcher.matches((InetAddress) null)).isFalse();
 	}
 
 	@Nested
@@ -408,6 +415,13 @@ class InetAddressMatchersTests {
 		void matchesWhenIpv6PublicThenReturnsFalse() throws Exception {
 			InetAddressMatcher matcher = InetAddressMatchers.matchInternal().build();
 			assertThat(matcher.matches(InetAddress.getByName("2001:4860:4860::8888"))).isFalse();
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = { "0.0.0.0", "::" })
+		void matchesWhenWildcardAddressThenReturnsFalse(String address) throws Exception {
+			InetAddressMatcher matcher = InetAddressMatchers.matchExternal().build();
+			assertThat(matcher.matches(InetAddress.getByName(address))).isFalse();
 		}
 
 	}


### PR DESCRIPTION
This commit fixes the incorrect behavior of
`InetAddressMatchers#matchExternal`, where `matchExternal` returns an incorrect answer when passing a null / local address argument, which is not reliable.

Closes: gh-19072
