### PR TITLE
Allow fluent use of `InetAddressMatchers#builder`

### DIFF
--- a/core/src/main/java/org/springframework/security/util/matcher/InetAddressMatchers.java
+++ b/core/src/main/java/org/springframework/security/util/matcher/InetAddressMatchers.java
@@ -18,7 +18,11 @@ package org.springframework.security.util.matcher;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -31,6 +35,7 @@ import org.springframework.util.Assert;
  * strategies for IP addresses.
  *
  * @author Rob Winch
+ * @author Andrey Litvitski
  * @since 7.1
  */
 public final class InetAddressMatchers {
@@ -86,15 +91,22 @@ public final class InetAddressMatchers {
 	 * @author Gábor Vaspöri
 	 * @author Rossen Stoyanchev
 	 * @author Rob Winch
+	 * @author Andrey Litvitski
 	 */
 	public static final class Builder {
 
-		private final List<InetAddressMatcher> matchers = new ArrayList<>();
+		private final Set<String> includeAddresses = new LinkedHashSet<>();
+
+		private final Set<String> excludeAddresses = new LinkedHashSet<>();
+
+		private final List<InetAddressMatcher> customMatchers = new ArrayList<>();
 
 		private boolean reportOnly;
 
 		/**
-		 * Adds an include list matcher that permits only the specified addresses.
+		 * Adds IP address patterns to the include list that permits only the specified
+		 * addresses. If called multiple times, the addresses are combined into a single
+		 * include rule.
 		 * @param addresses the list of IP address patterns to include (cannot be null or
 		 * empty)
 		 * @return this builder for method chaining
@@ -102,15 +114,13 @@ public final class InetAddressMatchers {
 		 */
 		public Builder includeAddresses(List<String> addresses) {
 			Assert.notEmpty(addresses, "addresses cannot be empty");
-			List<InetAddressMatcher> matchers = addresses.stream()
-				.<InetAddressMatcher>map(IpInetAddressMatcher::new)
-				.toList();
-			this.matchers.add(new IncludeListInetAddressMatcher(matchers));
+			this.includeAddresses.addAll(addresses);
 			return this;
 		}
 
 		/**
-		 * Adds an exclude list matcher that blocks the specified addresses.
+		 * Adds IP address patterns to the exclude list that blocks the specified
+		 * addresses.
 		 * @param addresses the list of IP address patterns to exclude (cannot be null or
 		 * empty)
 		 * @return this builder for method chaining
@@ -118,10 +128,7 @@ public final class InetAddressMatchers {
 		 */
 		public Builder excludeAddresses(List<String> addresses) {
 			Assert.notEmpty(addresses, "addresses cannot be empty");
-			List<InetAddressMatcher> matchers = addresses.stream()
-				.<InetAddressMatcher>map(IpInetAddressMatcher::new)
-				.toList();
-			this.matchers.add(new ExcludeListInetAddressMatcher(matchers));
+			this.excludeAddresses.addAll(addresses);
 			return this;
 		}
 
@@ -135,9 +142,7 @@ public final class InetAddressMatchers {
 		 */
 		public Builder matchAll(InetAddressMatcher... matchers) {
 			Assert.notEmpty(matchers, "matchers cannot be empty");
-			for (InetAddressMatcher matcher : matchers) {
-				this.matchers.add(matcher);
-			}
+			Collections.addAll(this.customMatchers, matchers);
 			return this;
 		}
 
@@ -157,7 +162,23 @@ public final class InetAddressMatchers {
 		 * @return the constructed {@link InetAddressMatcher}
 		 */
 		public InetAddressMatcher build() {
-			return new CompositeInetAddressMatcher(this.matchers, this.reportOnly);
+			List<InetAddressMatcher> result = new ArrayList<>();
+			if (!this.includeAddresses.isEmpty()) {
+				result.add(createListMatcher(this.includeAddresses, IncludeListInetAddressMatcher::new));
+			}
+			if (!this.excludeAddresses.isEmpty()) {
+				result.add(createListMatcher(this.excludeAddresses, ExcludeListInetAddressMatcher::new));
+			}
+			result.addAll(this.customMatchers);
+			return new CompositeInetAddressMatcher(result, this.reportOnly);
+		}
+
+		private InetAddressMatcher createListMatcher(Set<String> addresses,
+				Function<List<InetAddressMatcher>, InetAddressMatcher> constructor) {
+			List<InetAddressMatcher> matchers = addresses.stream()
+				.<InetAddressMatcher>map(IpInetAddressMatcher::new)
+				.toList();
+			return constructor.apply(matchers);
 		}
 
 	}

--- a/core/src/test/java/org/springframework/security/util/matcher/InetAddressMatchersTests.java
+++ b/core/src/test/java/org/springframework/security/util/matcher/InetAddressMatchersTests.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  * Tests for {@link InetAddressMatchers}.
  *
  * @author Rob Winch
+ * @author Andrey Litvitski
  */
 class InetAddressMatchersTests {
 
@@ -198,6 +199,17 @@ class InetAddressMatchersTests {
 			InetAddress address = InetAddress.getByName(testAddress);
 			boolean expected = testAddress.startsWith("192.168.1.") && !testAddress.equals("192.168.1.100");
 			assertThat(matcher.matches(address)).isEqualTo(expected);
+		}
+
+		@Test
+		void includeAddressesWhenCalledMultipleTimesThenMatchesAllAddresses() throws Exception {
+			InetAddressMatcher matcher = InetAddressMatchers.builder()
+				.includeAddresses(List.of("192.168.1.1"))
+				.includeAddresses(List.of("10.0.0.1"))
+				.build();
+			assertThat(matcher.matches(InetAddress.getByName("192.168.1.1"))).isTrue();
+			assertThat(matcher.matches(InetAddress.getByName("10.0.0.1"))).isTrue();
+			assertThat(matcher.matches(InetAddress.getByName("8.8.8.8"))).isFalse();
 		}
 
 	}


### PR DESCRIPTION
The main goal of this commit is to allow fluent use of `InetAddress Matchers#builder` to be called in a fluent manner.

Previously, calling `includeAddresses` twice would cause the logic to stop working, since our IP address can't be equal to two addresses in the list at the same time.

I think the current behavior is rather non-obvious, and we should definitely implement this change.

Closes: gh-19071

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
