### PR TITLE
Add AuthenticationValidator pattern for Dynamic Client Registration

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OAuth2ClientRegistrationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OAuth2ClientRegistrationTests.java
@@ -79,6 +79,7 @@ import org.springframework.security.oauth2.server.authorization.OAuth2Authorizat
 import org.springframework.security.oauth2.server.authorization.OAuth2ClientRegistration;
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientRegistrationAuthenticationProvider;
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientRegistrationAuthenticationToken;
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientRegistrationAuthenticationValidator;
 import org.springframework.security.oauth2.server.authorization.client.JdbcRegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.client.JdbcRegisteredClientRepository.RegisteredClientParametersMapper;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
@@ -411,6 +412,138 @@ public class OAuth2ClientRegistrationTests {
 			.isCloseTo(expectedSecretExpiryDate, allowedDelta);
 	}
 
+	// ----- CVE attack-replay tests (GHSA-qmmm-qvv5-j353) -----
+	// These tests use the default (strict) authentication validator — not the
+	// scope-permissive one the happy-path tests install — so the full filter chain,
+	// JSON converter, provider, and validator are exercised against the exact
+	// payloads from the disclosure. Each attack is expected to produce HTTP 400.
+
+	@Test
+	public void attackReplayWhenProtocolRelativeRedirectUriThenBadRequest() throws Exception {
+		this.spring.register(AttackReplayConfiguration.class).autowire();
+		assertThat(replayAttackJson("""
+				{
+				  "client_name": "attacker-client",
+				  "redirect_uris": ["//evil-attacker.example.com/steal"],
+				  "grant_types": ["authorization_code"]
+				}
+				""")).isEqualTo(HttpStatus.BAD_REQUEST.value());
+	}
+
+	@Test
+	public void attackReplayWhenJavascriptSchemeRedirectUriThenBadRequest() throws Exception {
+		this.spring.register(AttackReplayConfiguration.class).autowire();
+		assertThat(replayAttackJson("""
+				{
+				  "client_name": "attacker-client",
+				  "redirect_uris": ["javascript:alert(document.cookie)"],
+				  "grant_types": ["authorization_code"]
+				}
+				""")).isEqualTo(HttpStatus.BAD_REQUEST.value());
+	}
+
+	@Test
+	public void attackReplayWhenDataSchemeRedirectUriThenBadRequest() throws Exception {
+		this.spring.register(AttackReplayConfiguration.class).autowire();
+		assertThat(replayAttackJson("""
+				{
+				  "client_name": "attacker-client",
+				  "redirect_uris": ["data:text/html,<h1>xss</h1>"],
+				  "grant_types": ["authorization_code"]
+				}
+				""")).isEqualTo(HttpStatus.BAD_REQUEST.value());
+	}
+
+	@Test
+	public void attackReplayWhenHttpJwkSetUriToImdsThenBadRequest() throws Exception {
+		this.spring.register(AttackReplayConfiguration.class).autowire();
+		assertThat(replayAttackJson("""
+				{
+				  "client_name": "ssrf-client",
+				  "redirect_uris": ["https://example.com/callback"],
+				  "grant_types": ["authorization_code"],
+				  "jwks_uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials/app-role",
+				  "token_endpoint_auth_method": "private_key_jwt"
+				}
+				""")).isEqualTo(HttpStatus.BAD_REQUEST.value());
+	}
+
+	@Test
+	public void attackReplayWhenArbitraryScopeThenBadRequest() throws Exception {
+		this.spring.register(AttackReplayConfiguration.class).autowire();
+		assertThat(replayAttackJson("""
+				{
+				  "client_name": "scope-injection-client",
+				  "redirect_uris": ["https://example.com/callback"],
+				  "grant_types": ["client_credentials"],
+				  "scope": "admin ROLE_ADMIN superuser"
+				}
+				""")).isEqualTo(HttpStatus.BAD_REQUEST.value());
+	}
+
+	/**
+	 * Obtains a {@code client.create} bearer token and then POSTs the given raw JSON
+	 * (which may intentionally contain malformed or malicious values) to the DCR
+	 * endpoint, returning the HTTP status.
+	 */
+	private int replayAttackJson(String json) throws Exception {
+		String clientRegistrationScope = "client.create";
+		// @formatter:off
+		RegisteredClient clientRegistrar = RegisteredClient.withId("client-registrar-" + System.nanoTime())
+				.clientId("client-registrar-" + System.nanoTime())
+				.clientSecret("{noop}secret")
+				.clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+				.authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+				.scope(clientRegistrationScope)
+				.build();
+		// @formatter:on
+		this.registeredClientRepository.save(clientRegistrar);
+
+		MvcResult tokenResult = this.mvc
+			.perform(post(ISSUER.concat(DEFAULT_TOKEN_ENDPOINT_URI))
+				.param(OAuth2ParameterNames.GRANT_TYPE, AuthorizationGrantType.CLIENT_CREDENTIALS.getValue())
+				.param(OAuth2ParameterNames.SCOPE, clientRegistrationScope)
+				.with(httpBasic(clientRegistrar.getClientId(), "secret")))
+			.andExpect(status().isOk())
+			.andReturn();
+		OAuth2AccessToken accessToken = readAccessTokenResponse(tokenResult.getResponse()).getAccessToken();
+
+		HttpHeaders httpHeaders = new HttpHeaders();
+		httpHeaders.setBearerAuth(accessToken.getTokenValue());
+
+		MvcResult registerResult = this.mvc
+			.perform(post(ISSUER.concat(DEFAULT_OAUTH2_CLIENT_REGISTRATION_ENDPOINT_URI)).headers(httpHeaders)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(json))
+			.andReturn();
+		return registerResult.getResponse().getStatus();
+	}
+
+	@EnableWebSecurity
+	@Configuration(proxyBeanMethods = false)
+	static class AttackReplayConfiguration extends AuthorizationServerConfiguration {
+
+		// Override with Customizer.withDefaults() so the default (strict)
+		// OAuth2ClientRegistrationAuthenticationValidator is in effect — no
+		// scope-permissive override. This is what a fresh deployment gets.
+		// @formatter:off
+		@Bean
+		@Override
+		public SecurityFilterChain authorizationServerSecurityFilterChain(HttpSecurity http) throws Exception {
+			http
+					.oauth2AuthorizationServer((authorizationServer) ->
+							authorizationServer
+									.clientRegistrationEndpoint(Customizer.withDefaults())
+					)
+					.authorizeHttpRequests((authorize) ->
+							authorize.anyRequest().authenticated()
+					);
+			return http.build();
+		}
+		// @formatter:on
+
+	}
+
 	private OAuth2ClientRegistration registerClient(OAuth2ClientRegistration clientRegistration) throws Exception {
 		// ***** (1) Obtain the "initial" access token used for registering the client
 
@@ -512,7 +645,7 @@ public class OAuth2ClientRegistrationTests {
 													.clientRegistrationRequestConverter(authenticationConverter)
 													.clientRegistrationRequestConverters(authenticationConvertersConsumer)
 													.authenticationProvider(authenticationProvider)
-													.authenticationProviders(authenticationProvidersConsumer)
+													.authenticationProviders(scopePermissiveValidatorCustomizer().andThen(authenticationProvidersConsumer))
 													.clientRegistrationResponseHandler(authenticationSuccessHandler)
 													.errorResponseHandler(authenticationFailureHandler)
 									)
@@ -539,7 +672,7 @@ public class OAuth2ClientRegistrationTests {
 							authorizationServer
 									.clientRegistrationEndpoint((clientRegistration) ->
 											clientRegistration
-													.authenticationProviders(configureClientRegistrationConverters())
+													.authenticationProviders(scopePermissiveValidatorCustomizer().andThen(configureClientRegistrationConverters()))
 									)
 					)
 					.authorizeHttpRequests((authorize) ->
@@ -577,7 +710,7 @@ public class OAuth2ClientRegistrationTests {
 							authorizationServer
 									.clientRegistrationEndpoint((clientRegistration) ->
 											clientRegistration
-													.authenticationProviders(configureClientRegistrationConverters())
+													.authenticationProviders(scopePermissiveValidatorCustomizer().andThen(configureClientRegistrationConverters()))
 									)
 					)
 					.authorizeHttpRequests((authorize) ->
@@ -614,6 +747,7 @@ public class OAuth2ClientRegistrationTests {
 									.clientRegistrationEndpoint((clientRegistration) ->
 											clientRegistration
 													.openRegistrationAllowed(true)
+													.authenticationProviders(scopePermissiveValidatorCustomizer())
 									)
 					)
 					.authorizeHttpRequests((authorize) ->
@@ -627,6 +761,23 @@ public class OAuth2ClientRegistrationTests {
 
 	}
 
+	/**
+	 * Installs a scope-permissive composed validator on the DCR provider so happy-path
+	 * integration tests that send {@code scope} values continue to succeed after the
+	 * CVE fix. Deployers that legitimately need scopes in DCR will use this exact
+	 * pattern.
+	 */
+	static Consumer<List<AuthenticationProvider>> scopePermissiveValidatorCustomizer() {
+		return (authenticationProviders) -> authenticationProviders.forEach((authenticationProvider) -> {
+			if (authenticationProvider instanceof OAuth2ClientRegistrationAuthenticationProvider provider) {
+				provider.setAuthenticationValidator(
+						OAuth2ClientRegistrationAuthenticationValidator.DEFAULT_REDIRECT_URI_VALIDATOR
+							.andThen(OAuth2ClientRegistrationAuthenticationValidator.DEFAULT_JWK_SET_URI_VALIDATOR)
+							.andThen(OAuth2ClientRegistrationAuthenticationValidator.SIMPLE_SCOPE_VALIDATOR));
+			}
+		});
+	}
+
 	@EnableWebSecurity
 	@Configuration(proxyBeanMethods = false)
 	static class AuthorizationServerConfiguration {
@@ -637,7 +788,10 @@ public class OAuth2ClientRegistrationTests {
 			http
 					.oauth2AuthorizationServer((authorizationServer) ->
 							authorizationServer
-									.clientRegistrationEndpoint(Customizer.withDefaults())
+									.clientRegistrationEndpoint((clientRegistration) ->
+											clientRegistration
+													.authenticationProviders(scopePermissiveValidatorCustomizer())
+									)
 					)
 					.authorizeHttpRequests((authorize) ->
 							authorize.anyRequest().authenticated()

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OidcClientRegistrationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OidcClientRegistrationTests.java
@@ -96,6 +96,7 @@ import org.springframework.security.oauth2.server.authorization.client.TestRegis
 import org.springframework.security.oauth2.server.authorization.oidc.OidcClientRegistration;
 import org.springframework.security.oauth2.server.authorization.oidc.authentication.OidcClientConfigurationAuthenticationProvider;
 import org.springframework.security.oauth2.server.authorization.oidc.authentication.OidcClientRegistrationAuthenticationProvider;
+import org.springframework.security.oauth2.server.authorization.oidc.authentication.OidcClientRegistrationAuthenticationValidator;
 import org.springframework.security.oauth2.server.authorization.oidc.authentication.OidcClientRegistrationAuthenticationToken;
 import org.springframework.security.oauth2.server.authorization.oidc.converter.OidcClientRegistrationRegisteredClientConverter;
 import org.springframework.security.oauth2.server.authorization.oidc.converter.RegisteredClientOidcClientRegistrationConverter;
@@ -545,6 +546,133 @@ public class OidcClientRegistrationTests {
 			.isCloseTo(expectedSecretExpiryDate, allowedDelta);
 	}
 
+	// ----- CVE attack-replay tests (GHSA-qmmm-qvv5-j353) -----
+
+	@Test
+	public void attackReplayWhenProtocolRelativeRedirectUriThenBadRequest() throws Exception {
+		this.spring.register(AttackReplayConfiguration.class).autowire();
+		assertThat(replayAttackJson("""
+				{
+				  "client_name": "attacker-client",
+				  "redirect_uris": ["//evil-attacker.example.com/steal"],
+				  "grant_types": ["authorization_code"]
+				}
+				""")).isEqualTo(HttpStatus.BAD_REQUEST.value());
+	}
+
+	@Test
+	public void attackReplayWhenJavascriptSchemeRedirectUriThenBadRequest() throws Exception {
+		this.spring.register(AttackReplayConfiguration.class).autowire();
+		assertThat(replayAttackJson("""
+				{
+				  "client_name": "attacker-client",
+				  "redirect_uris": ["javascript:alert(document.cookie)"],
+				  "grant_types": ["authorization_code"]
+				}
+				""")).isEqualTo(HttpStatus.BAD_REQUEST.value());
+	}
+
+	@Test
+	public void attackReplayWhenJavascriptPostLogoutRedirectUriThenBadRequest() throws Exception {
+		this.spring.register(AttackReplayConfiguration.class).autowire();
+		assertThat(replayAttackJson("""
+				{
+				  "client_name": "xss-client",
+				  "redirect_uris": ["https://example.com/callback"],
+				  "post_logout_redirect_uris": ["javascript:alert(document.cookie)"],
+				  "grant_types": ["authorization_code"]
+				}
+				""")).isEqualTo(HttpStatus.BAD_REQUEST.value());
+	}
+
+	@Test
+	public void attackReplayWhenHttpJwkSetUriToImdsThenBadRequest() throws Exception {
+		this.spring.register(AttackReplayConfiguration.class).autowire();
+		assertThat(replayAttackJson("""
+				{
+				  "client_name": "ssrf-client",
+				  "redirect_uris": ["https://example.com/callback"],
+				  "grant_types": ["authorization_code"],
+				  "jwks_uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials/app-role",
+				  "token_endpoint_auth_method": "private_key_jwt"
+				}
+				""")).isEqualTo(HttpStatus.BAD_REQUEST.value());
+	}
+
+	@Test
+	public void attackReplayWhenArbitraryScopeThenBadRequest() throws Exception {
+		this.spring.register(AttackReplayConfiguration.class).autowire();
+		assertThat(replayAttackJson("""
+				{
+				  "client_name": "scope-injection-client",
+				  "redirect_uris": ["https://example.com/callback"],
+				  "grant_types": ["authorization_code"],
+				  "scope": "admin ROLE_ADMIN superuser"
+				}
+				""")).isEqualTo(HttpStatus.BAD_REQUEST.value());
+	}
+
+	private int replayAttackJson(String json) throws Exception {
+		String clientRegistrationScope = "client.create";
+		String clientId = "client-registrar-" + System.nanoTime();
+		// @formatter:off
+		RegisteredClient clientRegistrar = RegisteredClient.withId(clientId)
+				.clientId(clientId)
+				.clientSecret("{noop}secret")
+				.clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+				.authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+				.scope(clientRegistrationScope)
+				.build();
+		// @formatter:on
+		this.registeredClientRepository.save(clientRegistrar);
+
+		MvcResult tokenResult = this.mvc
+			.perform(post(ISSUER.concat(DEFAULT_TOKEN_ENDPOINT_URI))
+				.param(OAuth2ParameterNames.GRANT_TYPE, AuthorizationGrantType.CLIENT_CREDENTIALS.getValue())
+				.param(OAuth2ParameterNames.SCOPE, clientRegistrationScope)
+				.with(httpBasic(clientId, "secret")))
+			.andExpect(status().isOk())
+			.andReturn();
+		OAuth2AccessToken accessToken = readAccessTokenResponse(tokenResult.getResponse()).getAccessToken();
+
+		HttpHeaders httpHeaders = new HttpHeaders();
+		httpHeaders.setBearerAuth(accessToken.getTokenValue());
+
+		MvcResult registerResult = this.mvc
+			.perform(post(ISSUER.concat(DEFAULT_OIDC_CLIENT_REGISTRATION_ENDPOINT_URI)).headers(httpHeaders)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(json))
+			.andReturn();
+		return registerResult.getResponse().getStatus();
+	}
+
+	@EnableWebSecurity
+	@Configuration(proxyBeanMethods = false)
+	static class AttackReplayConfiguration extends AuthorizationServerConfiguration {
+
+		// Override with Customizer.withDefaults() so the default (strict)
+		// OidcClientRegistrationAuthenticationValidator is in effect.
+		// @formatter:off
+		@Bean
+		@Override
+		public SecurityFilterChain authorizationServerSecurityFilterChain(HttpSecurity http) throws Exception {
+			http
+					.oauth2AuthorizationServer((authorizationServer) ->
+							authorizationServer
+									.oidc((oidc) ->
+											oidc
+													.clientRegistrationEndpoint(Customizer.withDefaults())
+									)
+					)
+					.authorizeHttpRequests((authorize) ->
+							authorize.anyRequest().authenticated()
+					);
+			return http.build();
+		}
+		// @formatter:on
+
+	}
+
 	private OidcClientRegistration registerClient(OidcClientRegistration clientRegistration) throws Exception {
 		// ***** (1) Obtain the "initial" access token used for registering the client
 
@@ -660,7 +788,7 @@ public class OidcClientRegistrationTests {
 																	.clientRegistrationRequestConverter(authenticationConverter)
 																	.clientRegistrationRequestConverters(authenticationConvertersConsumer)
 																	.authenticationProvider(authenticationProvider)
-																	.authenticationProviders(authenticationProvidersConsumer)
+																	.authenticationProviders(scopePermissiveValidatorCustomizer().andThen(authenticationProvidersConsumer))
 																	.clientRegistrationResponseHandler(authenticationSuccessHandler)
 																	.errorResponseHandler(authenticationFailureHandler)
 													)
@@ -690,7 +818,7 @@ public class OidcClientRegistrationTests {
 											oidc
 													.clientRegistrationEndpoint((clientRegistration) ->
 															clientRegistration
-																	.authenticationProviders(configureClientRegistrationConverters())
+																	.authenticationProviders(scopePermissiveValidatorCustomizer().andThen(configureClientRegistrationConverters()))
 													)
 									)
 					)
@@ -731,7 +859,7 @@ public class OidcClientRegistrationTests {
 											oidc
 													.clientRegistrationEndpoint((clientRegistration) ->
 															clientRegistration
-																	.authenticationProviders(configureClientRegistrationConverters())
+																	.authenticationProviders(scopePermissiveValidatorCustomizer().andThen(configureClientRegistrationConverters()))
 													)
 									)
 					)
@@ -755,6 +883,23 @@ public class OidcClientRegistrationTests {
 
 	}
 
+	/**
+	 * Installs a scope-permissive composed validator on the OIDC DCR provider so
+	 * happy-path integration tests that send {@code scope} values continue to succeed
+	 * after the CVE fix.
+	 */
+	static Consumer<List<AuthenticationProvider>> scopePermissiveValidatorCustomizer() {
+		return (authenticationProviders) -> authenticationProviders.forEach((authenticationProvider) -> {
+			if (authenticationProvider instanceof OidcClientRegistrationAuthenticationProvider provider) {
+				provider.setAuthenticationValidator(
+						OidcClientRegistrationAuthenticationValidator.DEFAULT_REDIRECT_URI_VALIDATOR
+							.andThen(OidcClientRegistrationAuthenticationValidator.DEFAULT_POST_LOGOUT_REDIRECT_URI_VALIDATOR)
+							.andThen(OidcClientRegistrationAuthenticationValidator.DEFAULT_JWK_SET_URI_VALIDATOR)
+							.andThen(OidcClientRegistrationAuthenticationValidator.SIMPLE_SCOPE_VALIDATOR));
+			}
+		});
+	}
+
 	@EnableWebSecurity
 	@Configuration(proxyBeanMethods = false)
 	static class AuthorizationServerConfiguration {
@@ -767,7 +912,10 @@ public class OidcClientRegistrationTests {
 							authorizationServer
 									.oidc((oidc) ->
 											oidc
-													.clientRegistrationEndpoint(Customizer.withDefaults())
+													.clientRegistrationEndpoint((clientRegistration) ->
+															clientRegistration
+																	.authenticationProviders(scopePermissiveValidatorCustomizer())
+													)
 									)
 					)
 					.authorizeHttpRequests((authorize) ->

--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientRegistrationAuthenticationContext.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientRegistrationAuthenticationContext.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.authorization.authentication;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * An {@link OAuth2AuthenticationContext} that holds an
+ * {@link OAuth2ClientRegistrationAuthenticationToken} and additional information and is
+ * used when validating the OAuth 2.0 Client Registration Request parameters.
+ *
+ * @author addcontent
+ * @since 7.0
+ * @see OAuth2AuthenticationContext
+ * @see OAuth2ClientRegistrationAuthenticationToken
+ * @see OAuth2ClientRegistrationAuthenticationProvider#setAuthenticationValidator(Consumer)
+ */
+public final class OAuth2ClientRegistrationAuthenticationContext implements OAuth2AuthenticationContext {
+
+	private final Map<Object, Object> context;
+
+	private OAuth2ClientRegistrationAuthenticationContext(Map<Object, Object> context) {
+		this.context = Collections.unmodifiableMap(new HashMap<>(context));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Nullable
+	@Override
+	public <V> V get(Object key) {
+		return hasKey(key) ? (V) this.context.get(key) : null;
+	}
+
+	@Override
+	public boolean hasKey(Object key) {
+		Assert.notNull(key, "key cannot be null");
+		return this.context.containsKey(key);
+	}
+
+	/**
+	 * Constructs a new {@link Builder} with the provided
+	 * {@link OAuth2ClientRegistrationAuthenticationToken}.
+	 * @param authentication the {@link OAuth2ClientRegistrationAuthenticationToken}
+	 * @return the {@link Builder}
+	 */
+	public static Builder with(OAuth2ClientRegistrationAuthenticationToken authentication) {
+		return new Builder(authentication);
+	}
+
+	/**
+	 * A builder for {@link OAuth2ClientRegistrationAuthenticationContext}.
+	 */
+	public static final class Builder
+			extends AbstractBuilder<OAuth2ClientRegistrationAuthenticationContext, Builder> {
+
+		private Builder(OAuth2ClientRegistrationAuthenticationToken authentication) {
+			super(authentication);
+		}
+
+		/**
+		 * Builds a new {@link OAuth2ClientRegistrationAuthenticationContext}.
+		 * @return the {@link OAuth2ClientRegistrationAuthenticationContext}
+		 */
+		@Override
+		public OAuth2ClientRegistrationAuthenticationContext build() {
+			return new OAuth2ClientRegistrationAuthenticationContext(getContext());
+		}
+
+	}
+
+}

--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientRegistrationAuthenticationProvider.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientRegistrationAuthenticationProvider.java
@@ -16,12 +16,10 @@
 
 package org.springframework.security.oauth2.server.authorization.authentication;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -35,12 +33,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
-import org.springframework.security.oauth2.server.authorization.OAuth2ClientMetadataClaimNames;
 import org.springframework.security.oauth2.server.authorization.OAuth2ClientRegistration;
 import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
@@ -49,7 +45,6 @@ import org.springframework.security.oauth2.server.authorization.converter.OAuth2
 import org.springframework.security.oauth2.server.authorization.converter.RegisteredClientOAuth2ClientRegistrationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
 import org.springframework.util.Assert;
-import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -67,8 +62,6 @@ import org.springframework.util.StringUtils;
  */
 public final class OAuth2ClientRegistrationAuthenticationProvider implements AuthenticationProvider {
 
-	private static final String ERROR_URI = "https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.2";
-
 	private static final String DEFAULT_CLIENT_REGISTRATION_AUTHORIZED_SCOPE = "client.create";
 
 	private final Log logger = LogFactory.getLog(getClass());
@@ -84,6 +77,8 @@ public final class OAuth2ClientRegistrationAuthenticationProvider implements Aut
 	private PasswordEncoder passwordEncoder;
 
 	private boolean openRegistrationAllowed;
+
+	private Consumer<OAuth2ClientRegistrationAuthenticationContext> authenticationValidator = new OAuth2ClientRegistrationAuthenticationValidator();
 
 	/**
 	 * Constructs an {@code OAuth2ClientRegistrationAuthenticationProvider} using the
@@ -197,14 +192,34 @@ public final class OAuth2ClientRegistrationAuthenticationProvider implements Aut
 		this.openRegistrationAllowed = openRegistrationAllowed;
 	}
 
+	/**
+	 * Sets the {@code Consumer} providing access to the
+	 * {@link OAuth2ClientRegistrationAuthenticationContext} and is responsible for
+	 * validating specific OAuth 2.0 Client Registration Request parameters associated in
+	 * the {@link OAuth2ClientRegistrationAuthenticationToken}. The default authentication
+	 * validator is {@link OAuth2ClientRegistrationAuthenticationValidator}.
+	 *
+	 * <p>
+	 * <b>NOTE:</b> The authentication validator MUST throw
+	 * {@link OAuth2AuthenticationException} if validation fails.
+	 * @param authenticationValidator the {@code Consumer} providing access to the
+	 * {@link OAuth2ClientRegistrationAuthenticationContext} and is responsible for
+	 * validating specific OAuth 2.0 Client Registration Request parameters
+	 */
+	public void setAuthenticationValidator(
+			Consumer<OAuth2ClientRegistrationAuthenticationContext> authenticationValidator) {
+		Assert.notNull(authenticationValidator, "authenticationValidator cannot be null");
+		this.authenticationValidator = authenticationValidator;
+	}
+
 	private OAuth2ClientRegistrationAuthenticationToken registerClient(
 			OAuth2ClientRegistrationAuthenticationToken clientRegistrationAuthentication,
 			OAuth2Authorization authorization) {
 
-		if (!isValidRedirectUris(clientRegistrationAuthentication.getClientRegistration().getRedirectUris())) {
-			throwInvalidClientRegistration(OAuth2ErrorCodes.INVALID_REDIRECT_URI,
-					OAuth2ClientMetadataClaimNames.REDIRECT_URIS);
-		}
+		OAuth2ClientRegistrationAuthenticationContext authenticationContext = OAuth2ClientRegistrationAuthenticationContext
+			.with(clientRegistrationAuthentication)
+			.build();
+		this.authenticationValidator.accept(authenticationContext);
 
 		if (this.logger.isTraceEnabled()) {
 			this.logger.trace("Validated client registration request parameters");
@@ -275,31 +290,6 @@ public final class OAuth2ClientRegistrationAuthenticationProvider implements Aut
 			// Restrict the access token to only contain the required scope
 			throw new OAuth2AuthenticationException(OAuth2ErrorCodes.INVALID_TOKEN);
 		}
-	}
-
-	private static boolean isValidRedirectUris(List<String> redirectUris) {
-		if (CollectionUtils.isEmpty(redirectUris)) {
-			return true;
-		}
-
-		for (String redirectUri : redirectUris) {
-			try {
-				URI validRedirectUri = new URI(redirectUri);
-				if (validRedirectUri.getFragment() != null) {
-					return false;
-				}
-			}
-			catch (URISyntaxException ex) {
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	private static void throwInvalidClientRegistration(String errorCode, String fieldName) {
-		OAuth2Error error = new OAuth2Error(errorCode, "Invalid Client Registration: " + fieldName, ERROR_URI);
-		throw new OAuth2AuthenticationException(error);
 	}
 
 }

--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientRegistrationAuthenticationValidator.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientRegistrationAuthenticationValidator.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.authorization.authentication;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.core.log.LogMessage;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.server.authorization.OAuth2ClientMetadataClaimNames;
+import org.springframework.security.oauth2.server.authorization.OAuth2ClientRegistration;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * A {@code Consumer} providing access to the
+ * {@link OAuth2ClientRegistrationAuthenticationContext} containing an
+ * {@link OAuth2ClientRegistrationAuthenticationToken} and is the default
+ * {@link OAuth2ClientRegistrationAuthenticationProvider#setAuthenticationValidator(Consumer)
+ * authentication validator} used for validating specific OAuth 2.0 Dynamic Client
+ * Registration Request parameters (RFC 7591).
+ *
+ * <p>
+ * The default implementation validates
+ * {@link OAuth2ClientRegistration#getRedirectUris() redirect_uris},
+ * {@link OAuth2ClientRegistration#getJwkSetUrl() jwks_uri}, and
+ * {@link OAuth2ClientRegistration#getScopes() scope}. If validation fails, an
+ * {@link OAuth2AuthenticationException} is thrown.
+ *
+ * <p>
+ * Each validated field is backed by two public constants:
+ * <ul>
+ * <li>{@code DEFAULT_*_VALIDATOR} — strict validation that rejects unsafe values. This is
+ * the default behavior and may reject input that was previously accepted.</li>
+ * <li>{@code SIMPLE_*_VALIDATOR} — lenient validation preserving the behavior from prior
+ * releases. Use only when strictly required for backward compatibility and with full
+ * understanding that it may accept values that enable attacks against the authorization
+ * server.</li>
+ * </ul>
+ *
+ * @author addcontent
+ * @since 7.0
+ * @see OAuth2ClientRegistrationAuthenticationContext
+ * @see OAuth2ClientRegistrationAuthenticationToken
+ * @see OAuth2ClientRegistrationAuthenticationProvider#setAuthenticationValidator(Consumer)
+ */
+public final class OAuth2ClientRegistrationAuthenticationValidator
+		implements Consumer<OAuth2ClientRegistrationAuthenticationContext> {
+
+	private static final String ERROR_URI = "https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.2";
+
+	private static final Log LOGGER = LogFactory.getLog(OAuth2ClientRegistrationAuthenticationValidator.class);
+
+	/**
+	 * The default validator for
+	 * {@link OAuth2ClientRegistration#getRedirectUris() redirect_uris}. Rejects URIs that
+	 * contain a fragment, have no scheme (e.g. protocol-relative {@code //host/path}), or
+	 * use an unsafe scheme ({@code javascript}, {@code data}, {@code vbscript}).
+	 */
+	public static final Consumer<OAuth2ClientRegistrationAuthenticationContext> DEFAULT_REDIRECT_URI_VALIDATOR = OAuth2ClientRegistrationAuthenticationValidator::validateRedirectUris;
+
+	/**
+	 * The simple validator for
+	 * {@link OAuth2ClientRegistration#getRedirectUris() redirect_uris} that preserves
+	 * prior behavior (fragment-only check). Use only when backward compatibility is
+	 * required; values that enable open redirect and XSS attacks may be accepted.
+	 */
+	public static final Consumer<OAuth2ClientRegistrationAuthenticationContext> SIMPLE_REDIRECT_URI_VALIDATOR = OAuth2ClientRegistrationAuthenticationValidator::validateRedirectUrisSimple;
+
+	/**
+	 * The default validator for {@link OAuth2ClientRegistration#getJwkSetUrl() jwks_uri}.
+	 * Rejects URIs that do not use the {@code https} scheme.
+	 */
+	public static final Consumer<OAuth2ClientRegistrationAuthenticationContext> DEFAULT_JWK_SET_URI_VALIDATOR = OAuth2ClientRegistrationAuthenticationValidator::validateJwkSetUri;
+
+	/**
+	 * The simple validator for {@link OAuth2ClientRegistration#getJwkSetUrl() jwks_uri}
+	 * that preserves prior behavior (no validation). Use only when backward compatibility
+	 * is required; values that enable SSRF attacks may be accepted.
+	 */
+	public static final Consumer<OAuth2ClientRegistrationAuthenticationContext> SIMPLE_JWK_SET_URI_VALIDATOR = OAuth2ClientRegistrationAuthenticationValidator::validateJwkSetUriSimple;
+
+	/**
+	 * The default validator for {@link OAuth2ClientRegistration#getScopes() scope}.
+	 * Rejects any request that includes a non-empty scope value. Deployers that need to
+	 * accept scopes during Dynamic Client Registration must configure their own validator
+	 * (for example by chaining on top of {@link #SIMPLE_SCOPE_VALIDATOR}).
+	 *
+	 * <p>
+	 * <b>NOTE:</b> This default behavior is tentative and may be adjusted prior to
+	 * release based on the final fix design.
+	 */
+	public static final Consumer<OAuth2ClientRegistrationAuthenticationContext> DEFAULT_SCOPE_VALIDATOR = OAuth2ClientRegistrationAuthenticationValidator::validateScope;
+
+	/**
+	 * The simple validator for {@link OAuth2ClientRegistration#getScopes() scope} that
+	 * preserves prior behavior (accepts any scope). Use only when backward compatibility
+	 * is required; values that enable arbitrary scope injection may be accepted.
+	 */
+	public static final Consumer<OAuth2ClientRegistrationAuthenticationContext> SIMPLE_SCOPE_VALIDATOR = OAuth2ClientRegistrationAuthenticationValidator::validateScopeSimple;
+
+	private final Consumer<OAuth2ClientRegistrationAuthenticationContext> authenticationValidator = DEFAULT_REDIRECT_URI_VALIDATOR
+		.andThen(DEFAULT_JWK_SET_URI_VALIDATOR)
+		.andThen(DEFAULT_SCOPE_VALIDATOR);
+
+	@Override
+	public void accept(OAuth2ClientRegistrationAuthenticationContext authenticationContext) {
+		this.authenticationValidator.accept(authenticationContext);
+	}
+
+	private static void validateRedirectUris(OAuth2ClientRegistrationAuthenticationContext authenticationContext) {
+		OAuth2ClientRegistrationAuthenticationToken clientRegistrationAuthentication = authenticationContext
+			.getAuthentication();
+		List<String> redirectUris = clientRegistrationAuthentication.getClientRegistration().getRedirectUris();
+		if (CollectionUtils.isEmpty(redirectUris)) {
+			return;
+		}
+		for (String redirectUri : redirectUris) {
+			URI parsed;
+			try {
+				parsed = new URI(redirectUri);
+			}
+			catch (URISyntaxException ex) {
+				if (LOGGER.isDebugEnabled()) {
+					LOGGER.debug(LogMessage.format("Invalid request: redirect_uri is not parseable ('%s')", redirectUri));
+				}
+				throwInvalidClientRegistration(OAuth2ErrorCodes.INVALID_REDIRECT_URI,
+						OAuth2ClientMetadataClaimNames.REDIRECT_URIS);
+				return;
+			}
+			if (parsed.getFragment() != null) {
+				if (LOGGER.isDebugEnabled()) {
+					LOGGER.debug(LogMessage.format("Invalid request: redirect_uri contains a fragment ('%s')",
+							redirectUri));
+				}
+				throwInvalidClientRegistration(OAuth2ErrorCodes.INVALID_REDIRECT_URI,
+						OAuth2ClientMetadataClaimNames.REDIRECT_URIS);
+			}
+			String scheme = parsed.getScheme();
+			if (scheme == null) {
+				if (LOGGER.isDebugEnabled()) {
+					LOGGER.debug(LogMessage.format("Invalid request: redirect_uri has no scheme ('%s')", redirectUri));
+				}
+				throwInvalidClientRegistration(OAuth2ErrorCodes.INVALID_REDIRECT_URI,
+						OAuth2ClientMetadataClaimNames.REDIRECT_URIS);
+			}
+			if (isUnsafeScheme(scheme)) {
+				if (LOGGER.isDebugEnabled()) {
+					LOGGER.debug(LogMessage.format("Invalid request: redirect_uri uses unsafe scheme ('%s')",
+							redirectUri));
+				}
+				throwInvalidClientRegistration(OAuth2ErrorCodes.INVALID_REDIRECT_URI,
+						OAuth2ClientMetadataClaimNames.REDIRECT_URIS);
+			}
+		}
+	}
+
+	private static void validateRedirectUrisSimple(
+			OAuth2ClientRegistrationAuthenticationContext authenticationContext) {
+		OAuth2ClientRegistrationAuthenticationToken clientRegistrationAuthentication = authenticationContext
+			.getAuthentication();
+		List<String> redirectUris = clientRegistrationAuthentication.getClientRegistration().getRedirectUris();
+		if (CollectionUtils.isEmpty(redirectUris)) {
+			return;
+		}
+		for (String redirectUri : redirectUris) {
+			try {
+				URI parsed = new URI(redirectUri);
+				if (parsed.getFragment() != null) {
+					throwInvalidClientRegistration(OAuth2ErrorCodes.INVALID_REDIRECT_URI,
+							OAuth2ClientMetadataClaimNames.REDIRECT_URIS);
+				}
+			}
+			catch (URISyntaxException ex) {
+				throwInvalidClientRegistration(OAuth2ErrorCodes.INVALID_REDIRECT_URI,
+						OAuth2ClientMetadataClaimNames.REDIRECT_URIS);
+			}
+		}
+	}
+
+	private static void validateJwkSetUri(OAuth2ClientRegistrationAuthenticationContext authenticationContext) {
+		OAuth2ClientRegistrationAuthenticationToken clientRegistrationAuthentication = authenticationContext
+			.getAuthentication();
+		URL jwkSetUrl = clientRegistrationAuthentication.getClientRegistration().getJwkSetUrl();
+		if (jwkSetUrl == null) {
+			return;
+		}
+		if (!"https".equalsIgnoreCase(jwkSetUrl.getProtocol())) {
+			if (LOGGER.isDebugEnabled()) {
+				LOGGER.debug(LogMessage.format("Invalid request: jwks_uri does not use https ('%s')", jwkSetUrl));
+			}
+			throwInvalidClientRegistration("invalid_client_metadata", OAuth2ClientMetadataClaimNames.JWKS_URI);
+		}
+	}
+
+	private static void validateJwkSetUriSimple(
+			OAuth2ClientRegistrationAuthenticationContext authenticationContext) {
+		// No validation. Preserves prior behavior.
+	}
+
+	private static void validateScope(OAuth2ClientRegistrationAuthenticationContext authenticationContext) {
+		OAuth2ClientRegistrationAuthenticationToken clientRegistrationAuthentication = authenticationContext
+			.getAuthentication();
+		List<String> scopes = clientRegistrationAuthentication.getClientRegistration().getScopes();
+		if (!CollectionUtils.isEmpty(scopes)) {
+			if (LOGGER.isDebugEnabled()) {
+				LOGGER.debug(LogMessage.format(
+						"Invalid request: scope must not be set during Dynamic Client Registration ('%s')", scopes));
+			}
+			throwInvalidClientRegistration(OAuth2ErrorCodes.INVALID_SCOPE, OAuth2ClientMetadataClaimNames.SCOPE);
+		}
+	}
+
+	private static void validateScopeSimple(OAuth2ClientRegistrationAuthenticationContext authenticationContext) {
+		// No validation. Preserves prior behavior.
+	}
+
+	private static boolean isUnsafeScheme(String scheme) {
+		return "javascript".equalsIgnoreCase(scheme) || "data".equalsIgnoreCase(scheme)
+				|| "vbscript".equalsIgnoreCase(scheme);
+	}
+
+	private static void throwInvalidClientRegistration(String errorCode, String fieldName) {
+		OAuth2Error error = new OAuth2Error(errorCode, "Invalid Client Registration: " + fieldName, ERROR_URI);
+		throw new OAuth2AuthenticationException(error);
+	}
+
+}

--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/oidc/authentication/OidcClientRegistrationAuthenticationContext.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/oidc/authentication/OidcClientRegistrationAuthenticationContext.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.authorization.oidc.authentication;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.springframework.lang.Nullable;
+import org.springframework.security.oauth2.server.authorization.authentication.OAuth2AuthenticationContext;
+import org.springframework.util.Assert;
+
+/**
+ * An {@link OAuth2AuthenticationContext} that holds an
+ * {@link OidcClientRegistrationAuthenticationToken} and additional information and is
+ * used when validating the OpenID Connect 1.0 Client Registration Request parameters.
+ *
+ * @author addcontent
+ * @since 7.0
+ * @see OAuth2AuthenticationContext
+ * @see OidcClientRegistrationAuthenticationToken
+ * @see OidcClientRegistrationAuthenticationProvider#setAuthenticationValidator(Consumer)
+ */
+public final class OidcClientRegistrationAuthenticationContext implements OAuth2AuthenticationContext {
+
+	private final Map<Object, Object> context;
+
+	private OidcClientRegistrationAuthenticationContext(Map<Object, Object> context) {
+		this.context = Collections.unmodifiableMap(new HashMap<>(context));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Nullable
+	@Override
+	public <V> V get(Object key) {
+		return hasKey(key) ? (V) this.context.get(key) : null;
+	}
+
+	@Override
+	public boolean hasKey(Object key) {
+		Assert.notNull(key, "key cannot be null");
+		return this.context.containsKey(key);
+	}
+
+	/**
+	 * Constructs a new {@link Builder} with the provided
+	 * {@link OidcClientRegistrationAuthenticationToken}.
+	 * @param authentication the {@link OidcClientRegistrationAuthenticationToken}
+	 * @return the {@link Builder}
+	 */
+	public static Builder with(OidcClientRegistrationAuthenticationToken authentication) {
+		return new Builder(authentication);
+	}
+
+	/**
+	 * A builder for {@link OidcClientRegistrationAuthenticationContext}.
+	 */
+	public static final class Builder
+			extends AbstractBuilder<OidcClientRegistrationAuthenticationContext, Builder> {
+
+		private Builder(OidcClientRegistrationAuthenticationToken authentication) {
+			super(authentication);
+		}
+
+		/**
+		 * Builds a new {@link OidcClientRegistrationAuthenticationContext}.
+		 * @return the {@link OidcClientRegistrationAuthenticationContext}
+		 */
+		@Override
+		public OidcClientRegistrationAuthenticationContext build() {
+			return new OidcClientRegistrationAuthenticationContext(getContext());
+		}
+
+	}
+
+}

--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/oidc/authentication/OidcClientRegistrationAuthenticationProvider.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/oidc/authentication/OidcClientRegistrationAuthenticationProvider.java
@@ -16,14 +16,12 @@
 
 package org.springframework.security.oauth2.server.authorization.oidc.authentication;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -60,7 +58,6 @@ import org.springframework.security.oauth2.server.authorization.token.OAuth2Toke
 import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenGenerator;
 import org.springframework.security.oauth2.server.resource.authentication.AbstractOAuth2TokenAuthenticationToken;
 import org.springframework.util.Assert;
-import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -101,6 +98,8 @@ public final class OidcClientRegistrationAuthenticationProvider implements Authe
 	private Converter<OidcClientRegistration, RegisteredClient> registeredClientConverter;
 
 	private PasswordEncoder passwordEncoder;
+
+	private Consumer<OidcClientRegistrationAuthenticationContext> authenticationValidator = new OidcClientRegistrationAuthenticationValidator();
 
 	/**
 	 * Constructs an {@code OidcClientRegistrationAuthenticationProvider} using the
@@ -206,20 +205,34 @@ public final class OidcClientRegistrationAuthenticationProvider implements Authe
 		this.passwordEncoder = passwordEncoder;
 	}
 
+	/**
+	 * Sets the {@code Consumer} providing access to the
+	 * {@link OidcClientRegistrationAuthenticationContext} and is responsible for
+	 * validating specific OpenID Connect 1.0 Client Registration Request parameters
+	 * associated in the {@link OidcClientRegistrationAuthenticationToken}. The default
+	 * authentication validator is {@link OidcClientRegistrationAuthenticationValidator}.
+	 *
+	 * <p>
+	 * <b>NOTE:</b> The authentication validator MUST throw
+	 * {@link OAuth2AuthenticationException} if validation fails.
+	 * @param authenticationValidator the {@code Consumer} providing access to the
+	 * {@link OidcClientRegistrationAuthenticationContext} and is responsible for
+	 * validating specific OpenID Connect 1.0 Client Registration Request parameters
+	 */
+	public void setAuthenticationValidator(
+			Consumer<OidcClientRegistrationAuthenticationContext> authenticationValidator) {
+		Assert.notNull(authenticationValidator, "authenticationValidator cannot be null");
+		this.authenticationValidator = authenticationValidator;
+	}
+
 	private OidcClientRegistrationAuthenticationToken registerClient(
 			OidcClientRegistrationAuthenticationToken clientRegistrationAuthentication,
 			OAuth2Authorization authorization) {
 
-		if (!isValidRedirectUris(clientRegistrationAuthentication.getClientRegistration().getRedirectUris())) {
-			throwInvalidClientRegistration(OAuth2ErrorCodes.INVALID_REDIRECT_URI,
-					OidcClientMetadataClaimNames.REDIRECT_URIS);
-		}
-
-		if (!isValidRedirectUris(
-				clientRegistrationAuthentication.getClientRegistration().getPostLogoutRedirectUris())) {
-			throwInvalidClientRegistration("invalid_client_metadata",
-					OidcClientMetadataClaimNames.POST_LOGOUT_REDIRECT_URIS);
-		}
+		OidcClientRegistrationAuthenticationContext authenticationContext = OidcClientRegistrationAuthenticationContext
+			.with(clientRegistrationAuthentication)
+			.build();
+		this.authenticationValidator.accept(authenticationContext);
 
 		if (!isValidTokenEndpointAuthenticationMethod(clientRegistrationAuthentication.getClientRegistration())) {
 			throwInvalidClientRegistration("invalid_client_metadata",
@@ -349,26 +362,6 @@ public final class OidcClientRegistrationAuthenticationProvider implements Authe
 			// Restrict the access token to only contain the required scope
 			throw new OAuth2AuthenticationException(OAuth2ErrorCodes.INVALID_TOKEN);
 		}
-	}
-
-	private static boolean isValidRedirectUris(List<String> redirectUris) {
-		if (CollectionUtils.isEmpty(redirectUris)) {
-			return true;
-		}
-
-		for (String redirectUri : redirectUris) {
-			try {
-				URI validRedirectUri = new URI(redirectUri);
-				if (validRedirectUri.getFragment() != null) {
-					return false;
-				}
-			}
-			catch (URISyntaxException ex) {
-				return false;
-			}
-		}
-
-		return true;
 	}
 
 	private static boolean isValidTokenEndpointAuthenticationMethod(OidcClientRegistration clientRegistration) {

--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/oidc/authentication/OidcClientRegistrationAuthenticationValidator.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/oidc/authentication/OidcClientRegistrationAuthenticationValidator.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.authorization.oidc.authentication;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.core.log.LogMessage;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.server.authorization.oidc.OidcClientMetadataClaimNames;
+import org.springframework.security.oauth2.server.authorization.oidc.OidcClientRegistration;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * A {@code Consumer} providing access to the
+ * {@link OidcClientRegistrationAuthenticationContext} containing an
+ * {@link OidcClientRegistrationAuthenticationToken} and is the default
+ * {@link OidcClientRegistrationAuthenticationProvider#setAuthenticationValidator(Consumer)
+ * authentication validator} used for validating specific OpenID Connect 1.0 Dynamic
+ * Client Registration Request parameters.
+ *
+ * <p>
+ * The default implementation validates
+ * {@link OidcClientRegistration#getRedirectUris() redirect_uris},
+ * {@link OidcClientRegistration#getPostLogoutRedirectUris() post_logout_redirect_uris},
+ * {@link OidcClientRegistration#getJwkSetUrl() jwks_uri}, and
+ * {@link OidcClientRegistration#getScopes() scope}. If validation fails, an
+ * {@link OAuth2AuthenticationException} is thrown.
+ *
+ * <p>
+ * Each validated field is backed by two public constants:
+ * <ul>
+ * <li>{@code DEFAULT_*_VALIDATOR} — strict validation that rejects unsafe values. This is
+ * the default behavior and may reject input that was previously accepted.</li>
+ * <li>{@code SIMPLE_*_VALIDATOR} — lenient validation preserving the behavior from prior
+ * releases. Use only when strictly required for backward compatibility and with full
+ * understanding that it may accept values that enable attacks against the authorization
+ * server.</li>
+ * </ul>
+ *
+ * @author addcontent
+ * @since 7.0
+ * @see OidcClientRegistrationAuthenticationContext
+ * @see OidcClientRegistrationAuthenticationToken
+ * @see OidcClientRegistrationAuthenticationProvider#setAuthenticationValidator(Consumer)
+ */
+public final class OidcClientRegistrationAuthenticationValidator
+		implements Consumer<OidcClientRegistrationAuthenticationContext> {
+
+	private static final String ERROR_URI = "https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationError";
+
+	private static final Log LOGGER = LogFactory.getLog(OidcClientRegistrationAuthenticationValidator.class);
+
+	/**
+	 * The default validator for
+	 * {@link OidcClientRegistration#getRedirectUris() redirect_uris}. Rejects URIs that
+	 * contain a fragment, have no scheme (e.g. protocol-relative {@code //host/path}), or
+	 * use an unsafe scheme ({@code javascript}, {@code data}, {@code vbscript}).
+	 */
+	public static final Consumer<OidcClientRegistrationAuthenticationContext> DEFAULT_REDIRECT_URI_VALIDATOR = OidcClientRegistrationAuthenticationValidator::validateRedirectUris;
+
+	/**
+	 * The simple validator for
+	 * {@link OidcClientRegistration#getRedirectUris() redirect_uris} that preserves prior
+	 * behavior (fragment-only check). Use only when backward compatibility is required;
+	 * values that enable open redirect and XSS attacks may be accepted.
+	 */
+	public static final Consumer<OidcClientRegistrationAuthenticationContext> SIMPLE_REDIRECT_URI_VALIDATOR = OidcClientRegistrationAuthenticationValidator::validateRedirectUrisSimple;
+
+	/**
+	 * The default validator for
+	 * {@link OidcClientRegistration#getPostLogoutRedirectUris() post_logout_redirect_uris}.
+	 * Applies the same rules as
+	 * {@link #DEFAULT_REDIRECT_URI_VALIDATOR}.
+	 */
+	public static final Consumer<OidcClientRegistrationAuthenticationContext> DEFAULT_POST_LOGOUT_REDIRECT_URI_VALIDATOR = OidcClientRegistrationAuthenticationValidator::validatePostLogoutRedirectUris;
+
+	/**
+	 * The simple validator for
+	 * {@link OidcClientRegistration#getPostLogoutRedirectUris() post_logout_redirect_uris}
+	 * that preserves prior behavior (fragment-only check). Use only when backward
+	 * compatibility is required; values that enable XSS attacks on the authorization
+	 * server origin may be accepted.
+	 */
+	public static final Consumer<OidcClientRegistrationAuthenticationContext> SIMPLE_POST_LOGOUT_REDIRECT_URI_VALIDATOR = OidcClientRegistrationAuthenticationValidator::validatePostLogoutRedirectUrisSimple;
+
+	/**
+	 * The default validator for {@link OidcClientRegistration#getJwkSetUrl() jwks_uri}.
+	 * Rejects URIs that do not use the {@code https} scheme.
+	 */
+	public static final Consumer<OidcClientRegistrationAuthenticationContext> DEFAULT_JWK_SET_URI_VALIDATOR = OidcClientRegistrationAuthenticationValidator::validateJwkSetUri;
+
+	/**
+	 * The simple validator for {@link OidcClientRegistration#getJwkSetUrl() jwks_uri}
+	 * that preserves prior behavior (no validation). Use only when backward compatibility
+	 * is required; values that enable SSRF attacks may be accepted.
+	 */
+	public static final Consumer<OidcClientRegistrationAuthenticationContext> SIMPLE_JWK_SET_URI_VALIDATOR = OidcClientRegistrationAuthenticationValidator::validateJwkSetUriSimple;
+
+	/**
+	 * The default validator for {@link OidcClientRegistration#getScopes() scope}. Rejects
+	 * any request that includes a non-empty scope value. Deployers that need to accept
+	 * scopes during Dynamic Client Registration must configure their own validator (for
+	 * example by chaining on top of {@link #SIMPLE_SCOPE_VALIDATOR}).
+	 *
+	 * <p>
+	 * <b>NOTE:</b> This default behavior is tentative and may be adjusted prior to
+	 * release based on the final fix design.
+	 */
+	public static final Consumer<OidcClientRegistrationAuthenticationContext> DEFAULT_SCOPE_VALIDATOR = OidcClientRegistrationAuthenticationValidator::validateScope;
+
+	/**
+	 * The simple validator for {@link OidcClientRegistration#getScopes() scope} that
+	 * preserves prior behavior (accepts any scope). Use only when backward compatibility
+	 * is required; values that enable arbitrary scope injection may be accepted.
+	 */
+	public static final Consumer<OidcClientRegistrationAuthenticationContext> SIMPLE_SCOPE_VALIDATOR = OidcClientRegistrationAuthenticationValidator::validateScopeSimple;
+
+	private final Consumer<OidcClientRegistrationAuthenticationContext> authenticationValidator = DEFAULT_REDIRECT_URI_VALIDATOR
+		.andThen(DEFAULT_POST_LOGOUT_REDIRECT_URI_VALIDATOR)
+		.andThen(DEFAULT_JWK_SET_URI_VALIDATOR)
+		.andThen(DEFAULT_SCOPE_VALIDATOR);
+
+	@Override
+	public void accept(OidcClientRegistrationAuthenticationContext authenticationContext) {
+		this.authenticationValidator.accept(authenticationContext);
+	}
+
+	private static void validateRedirectUris(OidcClientRegistrationAuthenticationContext authenticationContext) {
+		OidcClientRegistrationAuthenticationToken clientRegistrationAuthentication = authenticationContext
+			.getAuthentication();
+		List<String> redirectUris = clientRegistrationAuthentication.getClientRegistration().getRedirectUris();
+		validateRedirectUrisStrict(redirectUris, OAuth2ErrorCodes.INVALID_REDIRECT_URI,
+				OidcClientMetadataClaimNames.REDIRECT_URIS);
+	}
+
+	private static void validatePostLogoutRedirectUris(
+			OidcClientRegistrationAuthenticationContext authenticationContext) {
+		OidcClientRegistrationAuthenticationToken clientRegistrationAuthentication = authenticationContext
+			.getAuthentication();
+		List<String> postLogoutRedirectUris = clientRegistrationAuthentication.getClientRegistration()
+			.getPostLogoutRedirectUris();
+		validateRedirectUrisStrict(postLogoutRedirectUris, "invalid_client_metadata",
+				OidcClientMetadataClaimNames.POST_LOGOUT_REDIRECT_URIS);
+	}
+
+	private static void validateRedirectUrisStrict(List<String> redirectUris, String errorCode, String fieldName) {
+		if (CollectionUtils.isEmpty(redirectUris)) {
+			return;
+		}
+		for (String redirectUri : redirectUris) {
+			URI parsed;
+			try {
+				parsed = new URI(redirectUri);
+			}
+			catch (URISyntaxException ex) {
+				if (LOGGER.isDebugEnabled()) {
+					LOGGER.debug(LogMessage.format("Invalid request: %s is not parseable ('%s')", fieldName,
+							redirectUri));
+				}
+				throwInvalidClientRegistration(errorCode, fieldName);
+				return;
+			}
+			if (parsed.getFragment() != null) {
+				if (LOGGER.isDebugEnabled()) {
+					LOGGER.debug(LogMessage.format("Invalid request: %s contains a fragment ('%s')", fieldName,
+							redirectUri));
+				}
+				throwInvalidClientRegistration(errorCode, fieldName);
+			}
+			String scheme = parsed.getScheme();
+			if (scheme == null) {
+				if (LOGGER.isDebugEnabled()) {
+					LOGGER.debug(LogMessage.format("Invalid request: %s has no scheme ('%s')", fieldName, redirectUri));
+				}
+				throwInvalidClientRegistration(errorCode, fieldName);
+			}
+			if (isUnsafeScheme(scheme)) {
+				if (LOGGER.isDebugEnabled()) {
+					LOGGER.debug(LogMessage.format("Invalid request: %s uses unsafe scheme ('%s')", fieldName,
+							redirectUri));
+				}
+				throwInvalidClientRegistration(errorCode, fieldName);
+			}
+		}
+	}
+
+	private static void validateRedirectUrisSimple(OidcClientRegistrationAuthenticationContext authenticationContext) {
+		OidcClientRegistrationAuthenticationToken clientRegistrationAuthentication = authenticationContext
+			.getAuthentication();
+		List<String> redirectUris = clientRegistrationAuthentication.getClientRegistration().getRedirectUris();
+		validateRedirectUrisFragmentOnly(redirectUris, OAuth2ErrorCodes.INVALID_REDIRECT_URI,
+				OidcClientMetadataClaimNames.REDIRECT_URIS);
+	}
+
+	private static void validatePostLogoutRedirectUrisSimple(
+			OidcClientRegistrationAuthenticationContext authenticationContext) {
+		OidcClientRegistrationAuthenticationToken clientRegistrationAuthentication = authenticationContext
+			.getAuthentication();
+		List<String> postLogoutRedirectUris = clientRegistrationAuthentication.getClientRegistration()
+			.getPostLogoutRedirectUris();
+		validateRedirectUrisFragmentOnly(postLogoutRedirectUris, "invalid_client_metadata",
+				OidcClientMetadataClaimNames.POST_LOGOUT_REDIRECT_URIS);
+	}
+
+	private static void validateRedirectUrisFragmentOnly(List<String> redirectUris, String errorCode, String fieldName) {
+		if (CollectionUtils.isEmpty(redirectUris)) {
+			return;
+		}
+		for (String redirectUri : redirectUris) {
+			try {
+				URI parsed = new URI(redirectUri);
+				if (parsed.getFragment() != null) {
+					throwInvalidClientRegistration(errorCode, fieldName);
+				}
+			}
+			catch (URISyntaxException ex) {
+				throwInvalidClientRegistration(errorCode, fieldName);
+			}
+		}
+	}
+
+	private static void validateJwkSetUri(OidcClientRegistrationAuthenticationContext authenticationContext) {
+		OidcClientRegistrationAuthenticationToken clientRegistrationAuthentication = authenticationContext
+			.getAuthentication();
+		URL jwkSetUrl = clientRegistrationAuthentication.getClientRegistration().getJwkSetUrl();
+		if (jwkSetUrl == null) {
+			return;
+		}
+		if (!"https".equalsIgnoreCase(jwkSetUrl.getProtocol())) {
+			if (LOGGER.isDebugEnabled()) {
+				LOGGER.debug(LogMessage.format("Invalid request: jwks_uri does not use https ('%s')", jwkSetUrl));
+			}
+			throwInvalidClientRegistration("invalid_client_metadata", OidcClientMetadataClaimNames.JWKS_URI);
+		}
+	}
+
+	private static void validateJwkSetUriSimple(OidcClientRegistrationAuthenticationContext authenticationContext) {
+		// No validation. Preserves prior behavior.
+	}
+
+	private static void validateScope(OidcClientRegistrationAuthenticationContext authenticationContext) {
+		OidcClientRegistrationAuthenticationToken clientRegistrationAuthentication = authenticationContext
+			.getAuthentication();
+		List<String> scopes = clientRegistrationAuthentication.getClientRegistration().getScopes();
+		if (!CollectionUtils.isEmpty(scopes)) {
+			if (LOGGER.isDebugEnabled()) {
+				LOGGER.debug(LogMessage.format(
+						"Invalid request: scope must not be set during Dynamic Client Registration ('%s')", scopes));
+			}
+			throwInvalidClientRegistration(OAuth2ErrorCodes.INVALID_SCOPE, OidcClientMetadataClaimNames.SCOPE);
+		}
+	}
+
+	private static void validateScopeSimple(OidcClientRegistrationAuthenticationContext authenticationContext) {
+		// No validation. Preserves prior behavior.
+	}
+
+	private static boolean isUnsafeScheme(String scheme) {
+		return "javascript".equalsIgnoreCase(scheme) || "data".equalsIgnoreCase(scheme)
+				|| "vbscript".equalsIgnoreCase(scheme);
+	}
+
+	private static void throwInvalidClientRegistration(String errorCode, String fieldName) {
+		OAuth2Error error = new OAuth2Error(errorCode, "Invalid Client Registration: " + fieldName, ERROR_URI);
+		throw new OAuth2AuthenticationException(error);
+	}
+
+}

--- a/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientRegistrationAuthenticationProviderTests.java
+++ b/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientRegistrationAuthenticationProviderTests.java
@@ -360,6 +360,12 @@ public class OAuth2ClientRegistrationAuthenticationProviderTests {
 
 	@Test
 	public void authenticateWhenValidAccessTokenThenReturnClientRegistration() {
+		// Allow scopes via composition so the happy path can assert scope flow-through
+		this.authenticationProvider.setAuthenticationValidator(
+				OAuth2ClientRegistrationAuthenticationValidator.DEFAULT_REDIRECT_URI_VALIDATOR
+					.andThen(OAuth2ClientRegistrationAuthenticationValidator.DEFAULT_JWK_SET_URI_VALIDATOR)
+					.andThen(OAuth2ClientRegistrationAuthenticationValidator.SIMPLE_SCOPE_VALIDATOR));
+
 		Jwt jwt = createJwtClientRegistration();
 		OAuth2AccessToken jwtAccessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
 				jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaim(OAuth2ParameterNames.SCOPE));
@@ -412,6 +418,11 @@ public class OAuth2ClientRegistrationAuthenticationProviderTests {
 	@Test
 	public void authenticateWhenOpenRegistrationThenReturnClientRegistration() {
 		this.authenticationProvider.setOpenRegistrationAllowed(true);
+		// Allow scopes via composition so the happy path can assert scope flow-through
+		this.authenticationProvider.setAuthenticationValidator(
+				OAuth2ClientRegistrationAuthenticationValidator.DEFAULT_REDIRECT_URI_VALIDATOR
+					.andThen(OAuth2ClientRegistrationAuthenticationValidator.DEFAULT_JWK_SET_URI_VALIDATOR)
+					.andThen(OAuth2ClientRegistrationAuthenticationValidator.SIMPLE_SCOPE_VALIDATOR));
 
 		// @formatter:off
 		OAuth2ClientRegistration clientRegistration = OAuth2ClientRegistration.builder()

--- a/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientRegistrationAuthenticationValidatorTests.java
+++ b/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2ClientRegistrationAuthenticationValidatorTests.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.authorization.authentication;
+
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.server.authorization.OAuth2ClientMetadataClaimNames;
+import org.springframework.security.oauth2.server.authorization.OAuth2ClientRegistration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+/**
+ * Tests for {@link OAuth2ClientRegistrationAuthenticationValidator}. Exercises the
+ * payloads from GHSA-qmmm-qvv5-j353 against the new {@code DEFAULT_*} validators and
+ * confirms that the {@code SIMPLE_*} validators preserve the pre-fix behavior.
+ *
+ * @author addcontent
+ */
+public class OAuth2ClientRegistrationAuthenticationValidatorTests {
+
+	private final OAuth2ClientRegistrationAuthenticationValidator validator = new OAuth2ClientRegistrationAuthenticationValidator();
+
+	// --- redirect_uri: DEFAULT rejects CVE payloads ---
+
+	@Test
+	public void defaultRedirectUriValidatorWhenProtocolRelativeThenRejected() {
+		assertRejected(context("//evil.example.com/steal", null),
+				OAuth2ErrorCodes.INVALID_REDIRECT_URI, OAuth2ClientMetadataClaimNames.REDIRECT_URIS);
+	}
+
+	@Test
+	public void defaultRedirectUriValidatorWhenJavascriptSchemeThenRejected() {
+		assertRejected(context("javascript:alert(document.cookie)", null),
+				OAuth2ErrorCodes.INVALID_REDIRECT_URI, OAuth2ClientMetadataClaimNames.REDIRECT_URIS);
+	}
+
+	@Test
+	public void defaultRedirectUriValidatorWhenDataSchemeThenRejected() {
+		assertRejected(context("data:text/html,<h1>xss</h1>", null),
+				OAuth2ErrorCodes.INVALID_REDIRECT_URI, OAuth2ClientMetadataClaimNames.REDIRECT_URIS);
+	}
+
+	@Test
+	public void defaultRedirectUriValidatorWhenVbscriptSchemeThenRejected() {
+		assertRejected(context("vbscript:msgbox(\"xss\")", null),
+				OAuth2ErrorCodes.INVALID_REDIRECT_URI, OAuth2ClientMetadataClaimNames.REDIRECT_URIS);
+	}
+
+	@Test
+	public void defaultRedirectUriValidatorWhenFragmentThenRejected() {
+		assertRejected(context("https://client.example.com/cb#evil", null),
+				OAuth2ErrorCodes.INVALID_REDIRECT_URI, OAuth2ClientMetadataClaimNames.REDIRECT_URIS);
+	}
+
+	// --- redirect_uri: DEFAULT accepts legitimate URIs ---
+
+	@Test
+	public void defaultRedirectUriValidatorWhenHttpsThenAccepted() {
+		assertThatNoException().isThrownBy(() -> validator.accept(context("https://client.example.com/cb", null)));
+	}
+
+	@Test
+	public void defaultRedirectUriValidatorWhenCustomSchemeForNativeAppThenAccepted() {
+		assertThatNoException().isThrownBy(() -> validator.accept(context("myapp://callback", null)));
+	}
+
+	@Test
+	public void defaultRedirectUriValidatorWhenHttpLoopbackThenAccepted() {
+		assertThatNoException().isThrownBy(() -> validator.accept(context("http://127.0.0.1:8080/cb", null)));
+	}
+
+	// --- jwks_uri: DEFAULT rejects http (SSRF vector) ---
+
+	@Test
+	public void defaultJwkSetUriValidatorWhenHttpThenRejected() {
+		assertRejected(context("https://client.example.com/cb", "http://169.254.169.254/latest/meta-data/"),
+				"invalid_client_metadata", OAuth2ClientMetadataClaimNames.JWKS_URI);
+	}
+
+	@Test
+	public void defaultJwkSetUriValidatorWhenHttpsThenAccepted() {
+		assertThatNoException().isThrownBy(() -> validator
+			.accept(context("https://client.example.com/cb", "https://client.example.com/jwks")));
+	}
+
+	@Test
+	public void defaultJwkSetUriValidatorWhenAbsentThenAccepted() {
+		assertThatNoException().isThrownBy(() -> validator.accept(context("https://client.example.com/cb", null)));
+	}
+
+	// --- scope: DEFAULT rejects any non-empty scope (tentative, pending jgrandja
+	// confirmation) ---
+
+	@Test
+	public void defaultScopeValidatorWhenNonEmptyThenRejected() {
+		OAuth2ClientRegistrationAuthenticationContext ctx = OAuth2ClientRegistrationAuthenticationContext
+			.with(new OAuth2ClientRegistrationAuthenticationToken(null,
+					OAuth2ClientRegistration.builder().redirectUri("https://client.example.com/cb").scope("admin").build()))
+			.build();
+		assertThatExceptionOfType(OAuth2AuthenticationException.class).isThrownBy(() -> validator.accept(ctx))
+			.extracting(OAuth2AuthenticationException::getError)
+			.satisfies((error) -> assertThat(error.getErrorCode()).isEqualTo(OAuth2ErrorCodes.INVALID_SCOPE));
+	}
+
+	@Test
+	public void defaultScopeValidatorWhenEmptyThenAccepted() {
+		assertThatNoException().isThrownBy(() -> validator.accept(context("https://client.example.com/cb", null)));
+	}
+
+	// --- SIMPLE validators preserve pre-fix behavior ---
+
+	@Test
+	public void simpleRedirectUriValidatorWhenProtocolRelativeThenAccepted() {
+		OAuth2ClientRegistrationAuthenticationContext ctx = context("//evil.example.com/steal", null);
+		assertThatNoException().isThrownBy(
+				() -> OAuth2ClientRegistrationAuthenticationValidator.SIMPLE_REDIRECT_URI_VALIDATOR.accept(ctx));
+	}
+
+	@Test
+	public void simpleRedirectUriValidatorWhenJavascriptThenAccepted() {
+		OAuth2ClientRegistrationAuthenticationContext ctx = context("javascript:alert(1)", null);
+		assertThatNoException().isThrownBy(
+				() -> OAuth2ClientRegistrationAuthenticationValidator.SIMPLE_REDIRECT_URI_VALIDATOR.accept(ctx));
+	}
+
+	@Test
+	public void simpleJwkSetUriValidatorWhenHttpThenAccepted() {
+		OAuth2ClientRegistrationAuthenticationContext ctx = context("https://client.example.com/cb",
+				"http://169.254.169.254/latest/meta-data/");
+		assertThatNoException().isThrownBy(
+				() -> OAuth2ClientRegistrationAuthenticationValidator.SIMPLE_JWK_SET_URI_VALIDATOR.accept(ctx));
+	}
+
+	@Test
+	public void simpleScopeValidatorWhenNonEmptyThenAccepted() {
+		OAuth2ClientRegistrationAuthenticationContext ctx = OAuth2ClientRegistrationAuthenticationContext
+			.with(new OAuth2ClientRegistrationAuthenticationToken(null,
+					OAuth2ClientRegistration.builder().redirectUri("https://client.example.com/cb").scope("admin").build()))
+			.build();
+		assertThatNoException().isThrownBy(
+				() -> OAuth2ClientRegistrationAuthenticationValidator.SIMPLE_SCOPE_VALIDATOR.accept(ctx));
+	}
+
+	// --- Composition: DEFAULT URIs + SIMPLE scope allows legitimate DCR ---
+
+	@Test
+	public void composedValidatorWhenDefaultUrisAndSimpleScopeThenAcceptsLegitimateRequest() {
+		Consumer<OAuth2ClientRegistrationAuthenticationContext> composed = OAuth2ClientRegistrationAuthenticationValidator.DEFAULT_REDIRECT_URI_VALIDATOR
+			.andThen(OAuth2ClientRegistrationAuthenticationValidator.DEFAULT_JWK_SET_URI_VALIDATOR)
+			.andThen(OAuth2ClientRegistrationAuthenticationValidator.SIMPLE_SCOPE_VALIDATOR);
+		OAuth2ClientRegistrationAuthenticationContext ctx = OAuth2ClientRegistrationAuthenticationContext
+			.with(new OAuth2ClientRegistrationAuthenticationToken(null,
+					OAuth2ClientRegistration.builder()
+						.redirectUri("https://client.example.com/cb")
+						.jwkSetUrl("https://client.example.com/jwks")
+						.scope("openid")
+						.scope("profile")
+						.build()))
+			.build();
+		assertThatNoException().isThrownBy(() -> composed.accept(ctx));
+	}
+
+	// --- helpers ---
+
+	private static OAuth2ClientRegistrationAuthenticationContext context(String redirectUri, String jwkSetUrl) {
+		OAuth2ClientRegistration.Builder builder = OAuth2ClientRegistration.builder();
+		if (redirectUri != null) {
+			builder.redirectUri(redirectUri);
+		}
+		if (jwkSetUrl != null) {
+			builder.jwkSetUrl(jwkSetUrl);
+		}
+		return OAuth2ClientRegistrationAuthenticationContext
+			.with(new OAuth2ClientRegistrationAuthenticationToken(null, builder.build()))
+			.build();
+	}
+
+	private void assertRejected(OAuth2ClientRegistrationAuthenticationContext ctx, String errorCode,
+			String fieldName) {
+		assertThatExceptionOfType(OAuth2AuthenticationException.class).isThrownBy(() -> validator.accept(ctx))
+			.extracting(OAuth2AuthenticationException::getError)
+			.satisfies((error) -> {
+				assertThat(error.getErrorCode()).isEqualTo(errorCode);
+				assertThat(error.getDescription()).contains(fieldName);
+			});
+	}
+
+}

--- a/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/oidc/authentication/OidcClientRegistrationAuthenticationProviderTests.java
+++ b/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/oidc/authentication/OidcClientRegistrationAuthenticationProviderTests.java
@@ -561,6 +561,12 @@ public class OidcClientRegistrationAuthenticationProviderTests {
 
 	@Test
 	public void authenticateWhenTokenEndpointAuthenticationSigningAlgorithmNotProvidedThenDefaults() {
+		// Allow scopes via composition so the happy path can assert scope flow-through
+		this.authenticationProvider.setAuthenticationValidator(
+				OidcClientRegistrationAuthenticationValidator.DEFAULT_REDIRECT_URI_VALIDATOR
+					.andThen(OidcClientRegistrationAuthenticationValidator.DEFAULT_POST_LOGOUT_REDIRECT_URI_VALIDATOR)
+					.andThen(OidcClientRegistrationAuthenticationValidator.DEFAULT_JWK_SET_URI_VALIDATOR)
+					.andThen(OidcClientRegistrationAuthenticationValidator.SIMPLE_SCOPE_VALIDATOR));
 		Jwt jwt = createJwtClientRegistration();
 		OAuth2AccessToken jwtAccessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
 				jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaim(OAuth2ParameterNames.SCOPE));
@@ -612,6 +618,12 @@ public class OidcClientRegistrationAuthenticationProviderTests {
 
 	@Test
 	public void authenticateWhenRegistrationAccessTokenNotGeneratedThenThrowOAuth2AuthenticationException() {
+		// Allow scopes via composition so this test exercises the post-validation path
+		this.authenticationProvider.setAuthenticationValidator(
+				OidcClientRegistrationAuthenticationValidator.DEFAULT_REDIRECT_URI_VALIDATOR
+					.andThen(OidcClientRegistrationAuthenticationValidator.DEFAULT_POST_LOGOUT_REDIRECT_URI_VALIDATOR)
+					.andThen(OidcClientRegistrationAuthenticationValidator.DEFAULT_JWK_SET_URI_VALIDATOR)
+					.andThen(OidcClientRegistrationAuthenticationValidator.SIMPLE_SCOPE_VALIDATOR));
 		Jwt jwt = createJwtClientRegistration();
 		OAuth2AccessToken jwtAccessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
 				jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaim(OAuth2ParameterNames.SCOPE));
@@ -653,6 +665,12 @@ public class OidcClientRegistrationAuthenticationProviderTests {
 
 	@Test
 	public void authenticateWhenValidAccessTokenThenReturnClientRegistration() {
+		// Allow scopes via composition so the happy path can assert scope flow-through
+		this.authenticationProvider.setAuthenticationValidator(
+				OidcClientRegistrationAuthenticationValidator.DEFAULT_REDIRECT_URI_VALIDATOR
+					.andThen(OidcClientRegistrationAuthenticationValidator.DEFAULT_POST_LOGOUT_REDIRECT_URI_VALIDATOR)
+					.andThen(OidcClientRegistrationAuthenticationValidator.DEFAULT_JWK_SET_URI_VALIDATOR)
+					.andThen(OidcClientRegistrationAuthenticationValidator.SIMPLE_SCOPE_VALIDATOR));
 		Jwt jwt = createJwtClientRegistration();
 		OAuth2AccessToken jwtAccessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER,
 				jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaim(OAuth2ParameterNames.SCOPE));

--- a/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/oidc/authentication/OidcClientRegistrationAuthenticationValidatorTests.java
+++ b/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/oidc/authentication/OidcClientRegistrationAuthenticationValidatorTests.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.authorization.oidc.authentication;
+
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.server.authorization.oidc.OidcClientMetadataClaimNames;
+import org.springframework.security.oauth2.server.authorization.oidc.OidcClientRegistration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+/**
+ * Tests for {@link OidcClientRegistrationAuthenticationValidator}. Exercises the payloads
+ * from GHSA-qmmm-qvv5-j353 against the new {@code DEFAULT_*} validators and confirms
+ * that the {@code SIMPLE_*} validators preserve the pre-fix behavior.
+ *
+ * @author addcontent
+ */
+public class OidcClientRegistrationAuthenticationValidatorTests {
+
+	private final OidcClientRegistrationAuthenticationValidator validator = new OidcClientRegistrationAuthenticationValidator();
+
+	// --- redirect_uri ---
+
+	@Test
+	public void defaultRedirectUriValidatorWhenProtocolRelativeThenRejected() {
+		assertRejected(context("//evil.example.com/steal", null, null),
+				OAuth2ErrorCodes.INVALID_REDIRECT_URI, OidcClientMetadataClaimNames.REDIRECT_URIS);
+	}
+
+	@Test
+	public void defaultRedirectUriValidatorWhenJavascriptSchemeThenRejected() {
+		assertRejected(context("javascript:alert(document.cookie)", null, null),
+				OAuth2ErrorCodes.INVALID_REDIRECT_URI, OidcClientMetadataClaimNames.REDIRECT_URIS);
+	}
+
+	@Test
+	public void defaultRedirectUriValidatorWhenHttpsThenAccepted() {
+		assertThatNoException()
+			.isThrownBy(() -> validator.accept(context("https://client.example.com/cb", null, null)));
+	}
+
+	// --- post_logout_redirect_uri ---
+
+	@Test
+	public void defaultPostLogoutRedirectUriValidatorWhenJavascriptSchemeThenRejected() {
+		assertRejected(context("https://client.example.com/cb", "javascript:alert(document.cookie)", null),
+				"invalid_client_metadata", OidcClientMetadataClaimNames.POST_LOGOUT_REDIRECT_URIS);
+	}
+
+	@Test
+	public void defaultPostLogoutRedirectUriValidatorWhenProtocolRelativeThenRejected() {
+		assertRejected(context("https://client.example.com/cb", "//evil.example.com/post-logout", null),
+				"invalid_client_metadata", OidcClientMetadataClaimNames.POST_LOGOUT_REDIRECT_URIS);
+	}
+
+	@Test
+	public void defaultPostLogoutRedirectUriValidatorWhenHttpsThenAccepted() {
+		assertThatNoException().isThrownBy(
+				() -> validator.accept(context("https://client.example.com/cb",
+						"https://client.example.com/post-logout", null)));
+	}
+
+	// --- jwks_uri ---
+
+	@Test
+	public void defaultJwkSetUriValidatorWhenHttpThenRejected() {
+		assertRejected(context("https://client.example.com/cb", null, "http://169.254.169.254/latest/meta-data/"),
+				"invalid_client_metadata", OidcClientMetadataClaimNames.JWKS_URI);
+	}
+
+	@Test
+	public void defaultJwkSetUriValidatorWhenHttpsThenAccepted() {
+		assertThatNoException().isThrownBy(() -> validator
+			.accept(context("https://client.example.com/cb", null, "https://client.example.com/jwks")));
+	}
+
+	// --- scope ---
+
+	@Test
+	public void defaultScopeValidatorWhenNonEmptyThenRejected() {
+		OidcClientRegistrationAuthenticationContext ctx = OidcClientRegistrationAuthenticationContext
+			.with(new OidcClientRegistrationAuthenticationToken(principal(),
+					OidcClientRegistration.builder().redirectUri("https://client.example.com/cb").scope("admin").build()))
+			.build();
+		assertThatExceptionOfType(OAuth2AuthenticationException.class).isThrownBy(() -> validator.accept(ctx))
+			.extracting(OAuth2AuthenticationException::getError)
+			.satisfies((error) -> assertThat(error.getErrorCode()).isEqualTo(OAuth2ErrorCodes.INVALID_SCOPE));
+	}
+
+	// --- SIMPLE validators preserve pre-fix behavior ---
+
+	@Test
+	public void simpleRedirectUriValidatorWhenJavascriptThenAccepted() {
+		OidcClientRegistrationAuthenticationContext ctx = context("javascript:alert(1)", null, null);
+		assertThatNoException().isThrownBy(
+				() -> OidcClientRegistrationAuthenticationValidator.SIMPLE_REDIRECT_URI_VALIDATOR.accept(ctx));
+	}
+
+	@Test
+	public void simplePostLogoutRedirectUriValidatorWhenJavascriptThenAccepted() {
+		OidcClientRegistrationAuthenticationContext ctx = context("https://client.example.com/cb",
+				"javascript:alert(1)", null);
+		assertThatNoException().isThrownBy(() -> OidcClientRegistrationAuthenticationValidator.SIMPLE_POST_LOGOUT_REDIRECT_URI_VALIDATOR
+			.accept(ctx));
+	}
+
+	@Test
+	public void simpleJwkSetUriValidatorWhenHttpThenAccepted() {
+		OidcClientRegistrationAuthenticationContext ctx = context("https://client.example.com/cb", null,
+				"http://169.254.169.254/latest/meta-data/");
+		assertThatNoException().isThrownBy(
+				() -> OidcClientRegistrationAuthenticationValidator.SIMPLE_JWK_SET_URI_VALIDATOR.accept(ctx));
+	}
+
+	@Test
+	public void simpleScopeValidatorWhenNonEmptyThenAccepted() {
+		OidcClientRegistrationAuthenticationContext ctx = OidcClientRegistrationAuthenticationContext
+			.with(new OidcClientRegistrationAuthenticationToken(principal(),
+					OidcClientRegistration.builder().redirectUri("https://client.example.com/cb").scope("admin").build()))
+			.build();
+		assertThatNoException().isThrownBy(
+				() -> OidcClientRegistrationAuthenticationValidator.SIMPLE_SCOPE_VALIDATOR.accept(ctx));
+	}
+
+	// --- Composition ---
+
+	@Test
+	public void composedValidatorWhenDefaultUrisAndSimpleScopeThenAcceptsLegitimateRequest() {
+		Consumer<OidcClientRegistrationAuthenticationContext> composed = OidcClientRegistrationAuthenticationValidator.DEFAULT_REDIRECT_URI_VALIDATOR
+			.andThen(OidcClientRegistrationAuthenticationValidator.DEFAULT_POST_LOGOUT_REDIRECT_URI_VALIDATOR)
+			.andThen(OidcClientRegistrationAuthenticationValidator.DEFAULT_JWK_SET_URI_VALIDATOR)
+			.andThen(OidcClientRegistrationAuthenticationValidator.SIMPLE_SCOPE_VALIDATOR);
+		OidcClientRegistrationAuthenticationContext ctx = OidcClientRegistrationAuthenticationContext
+			.with(new OidcClientRegistrationAuthenticationToken(principal(),
+					OidcClientRegistration.builder()
+						.redirectUri("https://client.example.com/cb")
+						.postLogoutRedirectUri("https://client.example.com/post-logout")
+						.jwkSetUrl("https://client.example.com/jwks")
+						.scope("openid")
+						.scope("profile")
+						.build()))
+			.build();
+		assertThatNoException().isThrownBy(() -> composed.accept(ctx));
+	}
+
+	// --- helpers ---
+
+	private static Authentication principal() {
+		TestingAuthenticationToken principal = new TestingAuthenticationToken("user", "password", "SCOPE_client.create");
+		principal.setAuthenticated(true);
+		return principal;
+	}
+
+	private static OidcClientRegistrationAuthenticationContext context(String redirectUri,
+			String postLogoutRedirectUri, String jwkSetUrl) {
+		OidcClientRegistration.Builder builder = OidcClientRegistration.builder();
+		if (redirectUri != null) {
+			builder.redirectUri(redirectUri);
+		}
+		if (postLogoutRedirectUri != null) {
+			builder.postLogoutRedirectUri(postLogoutRedirectUri);
+		}
+		if (jwkSetUrl != null) {
+			builder.jwkSetUrl(jwkSetUrl);
+		}
+		return OidcClientRegistrationAuthenticationContext
+			.with(new OidcClientRegistrationAuthenticationToken(principal(), builder.build()))
+			.build();
+	}
+
+	private void assertRejected(OidcClientRegistrationAuthenticationContext ctx, String errorCode, String fieldName) {
+		assertThatExceptionOfType(OAuth2AuthenticationException.class).isThrownBy(() -> validator.accept(ctx))
+			.extracting(OAuth2AuthenticationException::getError)
+			.satisfies((error) -> {
+				assertThat(error.getErrorCode()).isEqualTo(errorCode);
+				assertThat(error.getDescription()).contains(fieldName);
+			});
+	}
+
+}


### PR DESCRIPTION
Applies the existing `AuthenticationValidator` pattern (as used in `OAuth2AuthorizationCodeRequestAuthenticationValidator`, `OAuth2ClientCredentialsAuthenticationValidator`, and `OidcLogoutAuthenticationValidator`)