### PR TITLE
Fix CVE-2026-22732: Track Content-Length for setHeader, setIntHeader,…

### DIFF
--- a/web/src/main/java/org/springframework/security/web/util/OnCommittedResponseWrapper.java
+++ b/web/src/main/java/org/springframework/security/web/util/OnCommittedResponseWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-present the original author or authors.
+ * Copyright 2002-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,10 +58,38 @@ public abstract class OnCommittedResponseWrapper extends HttpServletResponseWrap
 
 	@Override
 	public void addHeader(String name, String value) {
+		checkContentLengthHeader(name, value);
+		super.addHeader(name, value);
+	}
+
+	@Override
+	public void addIntHeader(String name, int value) {
+		checkContentLengthHeader(name, value);
+		super.addIntHeader(name, value);
+	}
+
+	@Override
+	public void setHeader(String name, String value) {
+		checkContentLengthHeader(name, value);
+		super.setHeader(name, value);
+	}
+
+	@Override
+	public void setIntHeader(String name, int value) {
+		checkContentLengthHeader(name, value);
+		super.setIntHeader(name, value);
+	}
+
+	private void checkContentLengthHeader(String name, int value) {
+		if ("Content-Length".equalsIgnoreCase(name)) {
+			setContentLength(value);
+		}
+	}
+
+	private void checkContentLengthHeader(String name, String value) {
 		if ("Content-Length".equalsIgnoreCase(name)) {
 			setContentLength(Long.parseLong(value));
 		}
-		super.addHeader(name, value);
 	}
 
 	@Override


### PR DESCRIPTION
> … Backport

… addIntHeader

When applications specify HTTP response headers for servlet applications using Spring Security, there is the possibility that the HTTP Headers will not be written. This can open up applications to various attacks including exposing sensitive data via caching mechanisms.

Add Content-Length tracking to setHeader, setIntHeader, and addIntHeader methods in OnCommittedResponseWrapper to ensure HTTP headers are properly written.


<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
