### PR TITLE
Support pepper in Password4j encoders

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/password4j/Argon2Password4jPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password4j/Argon2Password4jPasswordEncoder.java
@@ -18,6 +18,7 @@ package org.springframework.security.crypto.password4j;
 
 import com.password4j.AlgorithmFinder;
 import com.password4j.Argon2Function;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Implementation of {@link org.springframework.security.crypto.password.PasswordEncoder}
@@ -47,6 +48,7 @@ import com.password4j.Argon2Function;
  * }</pre>
  *
  * @author Mehrdad Bozorgmehr
+ * @author Andrey Litvitski
  * @since 7.0
  * @see Argon2Function
  * @see AlgorithmFinder#getArgon2Instance()
@@ -58,7 +60,7 @@ public class Argon2Password4jPasswordEncoder extends Password4jPasswordEncoder {
 	 * Password4j's AlgorithmFinder.
 	 */
 	public Argon2Password4jPasswordEncoder() {
-		super(AlgorithmFinder.getArgon2Instance());
+		this(AlgorithmFinder.getArgon2Instance());
 	}
 
 	/**
@@ -68,7 +70,20 @@ public class Argon2Password4jPasswordEncoder extends Password4jPasswordEncoder {
 	 * @throws IllegalArgumentException if argon2Function is null
 	 */
 	public Argon2Password4jPasswordEncoder(Argon2Function argon2Function) {
-		super(argon2Function);
+		this(argon2Function, null);
+	}
+
+	/**
+	 * Constructs an Argon2 password encoder with a custom Argon2 function and a pepper.
+	 * @param argon2Function the Argon2 function to use for encoding passwords, must not
+	 * be null
+	 * @param pepper the pepper to be used in the hashing process. If null, no pepper will
+	 * be applied.
+	 * @throws IllegalArgumentException if argon2Function is null
+	 * @since 7.0
+	 */
+	public Argon2Password4jPasswordEncoder(Argon2Function argon2Function, @Nullable String pepper) {
+		super(argon2Function, pepper);
 	}
 
 }

--- a/crypto/src/main/java/org/springframework/security/crypto/password4j/BalloonHashingPassword4jPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password4j/BalloonHashingPassword4jPasswordEncoder.java
@@ -21,8 +21,9 @@ import java.util.Base64;
 
 import com.password4j.AlgorithmFinder;
 import com.password4j.BalloonHashingFunction;
-import com.password4j.Hash;
+import com.password4j.HashBuilder;
 import com.password4j.Password;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.security.crypto.password.AbstractValidatingPasswordEncoder;
 import org.springframework.util.Assert;
@@ -60,6 +61,7 @@ import org.springframework.util.Assert;
  * }</pre>
  *
  * @author Mehrdad Bozorgmehr
+ * @author Andrey Litvitski
  * @since 7.0
  * @see BalloonHashingFunction
  * @see AlgorithmFinder#getBalloonHashingInstance()
@@ -75,6 +77,8 @@ public class BalloonHashingPassword4jPasswordEncoder extends AbstractValidatingP
 	private final SecureRandom secureRandom;
 
 	private final int saltLength;
+
+	@Nullable private final String pepper;
 
 	/**
 	 * Constructs a Balloon hashing password encoder using the default Balloon hashing
@@ -105,11 +109,29 @@ public class BalloonHashingPassword4jPasswordEncoder extends AbstractValidatingP
 	 * not positive
 	 */
 	public BalloonHashingPassword4jPasswordEncoder(BalloonHashingFunction balloonHashingFunction, int saltLength) {
+		this(balloonHashingFunction, saltLength, null);
+	}
+
+	/**
+	 * Constructs a Balloon hashing password encoder with a custom Balloon hashing
+	 * function, salt length, and a pepper.
+	 * @param balloonHashingFunction the Balloon hashing function to use for encoding
+	 * passwords, must not be null
+	 * @param saltLength the length of the salt in bytes, must be positive
+	 * @param pepper the pepper to be used in the hashing process. If null, no pepper will
+	 * be applied.
+	 * @throws IllegalArgumentException if balloonHashingFunction is null or saltLength is
+	 * not positive
+	 * @since 7.0
+	 */
+	public BalloonHashingPassword4jPasswordEncoder(BalloonHashingFunction balloonHashingFunction, int saltLength,
+			@Nullable String pepper) {
 		Assert.notNull(balloonHashingFunction, "balloonHashingFunction cannot be null");
 		Assert.isTrue(saltLength > 0, "saltLength must be positive");
 		this.balloonHashingFunction = balloonHashingFunction;
 		this.saltLength = saltLength;
 		this.secureRandom = new SecureRandom();
+		this.pepper = pepper;
 	}
 
 	@Override
@@ -117,9 +139,12 @@ public class BalloonHashingPassword4jPasswordEncoder extends AbstractValidatingP
 		byte[] salt = new byte[this.saltLength];
 		this.secureRandom.nextBytes(salt);
 
-		Hash hash = Password.hash(rawPassword).addSalt(salt).with(this.balloonHashingFunction);
+		HashBuilder hashBuilder = Password.hash(rawPassword).addSalt(salt);
+		if (this.pepper != null) {
+			hashBuilder.addPepper(this.pepper);
+		}
 		String encodedSalt = Base64.getEncoder().encodeToString(salt);
-		String encodedHash = hash.getResult();
+		String encodedHash = hashBuilder.with(this.balloonHashingFunction).getResult();
 
 		return encodedSalt + DELIMITER + encodedHash;
 	}
@@ -139,8 +164,11 @@ public class BalloonHashingPassword4jPasswordEncoder extends AbstractValidatingP
 			byte[] salt = Base64.getDecoder().decode(parts[0]);
 			String expectedHash = parts[1];
 
-			Hash hash = Password.hash(rawPassword).addSalt(salt).with(this.balloonHashingFunction);
-			return expectedHash.equals(hash.getResult());
+			HashBuilder hashBuilder = Password.hash(rawPassword).addSalt(salt);
+			if (this.pepper != null) {
+				hashBuilder.addPepper(this.pepper);
+			}
+			return expectedHash.equals(hashBuilder.with(this.balloonHashingFunction).getResult());
 		}
 		catch (IllegalArgumentException ex) {
 			// Invalid Base64 encoding

--- a/crypto/src/main/java/org/springframework/security/crypto/password4j/BcryptPassword4jPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password4j/BcryptPassword4jPasswordEncoder.java
@@ -18,6 +18,7 @@ package org.springframework.security.crypto.password4j;
 
 import com.password4j.AlgorithmFinder;
 import com.password4j.BcryptFunction;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Implementation of {@link org.springframework.security.crypto.password.PasswordEncoder}
@@ -45,6 +46,7 @@ import com.password4j.BcryptFunction;
  * }</pre>
  *
  * @author Mehrdad Bozorgmehr
+ * @author Andrey Litvitski
  * @since 7.0
  * @see BcryptFunction
  * @see AlgorithmFinder#getBcryptInstance()
@@ -56,7 +58,7 @@ public class BcryptPassword4jPasswordEncoder extends Password4jPasswordEncoder {
 	 * Password4j's AlgorithmFinder.
 	 */
 	public BcryptPassword4jPasswordEncoder() {
-		super(AlgorithmFinder.getBcryptInstance());
+		this(AlgorithmFinder.getBcryptInstance());
 	}
 
 	/**
@@ -66,7 +68,20 @@ public class BcryptPassword4jPasswordEncoder extends Password4jPasswordEncoder {
 	 * @throws IllegalArgumentException if bcryptFunction is null
 	 */
 	public BcryptPassword4jPasswordEncoder(BcryptFunction bcryptFunction) {
-		super(bcryptFunction);
+		this(bcryptFunction, null);
+	}
+
+	/**
+	 * Constructs a BCrypt password encoder with a custom BCrypt function and a pepper.
+	 * @param bcryptFunction the BCrypt function to use for encoding passwords, must not
+	 * be null
+	 * @param pepper the pepper to be used in the hashing process. If null, no pepper will
+	 * be applied.
+	 * @throws IllegalArgumentException if bcryptFunction is null
+	 * @since 7.0
+	 */
+	public BcryptPassword4jPasswordEncoder(BcryptFunction bcryptFunction, @Nullable String pepper) {
+		super(bcryptFunction, pepper);
 	}
 
 }

--- a/crypto/src/main/java/org/springframework/security/crypto/password4j/Password4jPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password4j/Password4jPasswordEncoder.java
@@ -16,9 +16,11 @@
 
 package org.springframework.security.crypto.password4j;
 
-import com.password4j.Hash;
+import com.password4j.HashBuilder;
+import com.password4j.HashChecker;
 import com.password4j.HashingFunction;
 import com.password4j.Password;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.security.crypto.password.AbstractValidatingPasswordEncoder;
 import org.springframework.util.Assert;
@@ -39,11 +41,14 @@ import org.springframework.util.Assert;
  * </p>
  *
  * @author Mehrdad Bozorgmehr
+ * @author Andrey Litvitski
  * @since 7.0
  */
 abstract class Password4jPasswordEncoder extends AbstractValidatingPasswordEncoder {
 
 	private final HashingFunction hashingFunction;
+
+	@Nullable private final String pepper;
 
 	/**
 	 * Constructs a Password4j password encoder with the specified hashing function. This
@@ -53,19 +58,41 @@ abstract class Password4jPasswordEncoder extends AbstractValidatingPasswordEncod
 	 * @throws IllegalArgumentException if hashingFunction is null
 	 */
 	Password4jPasswordEncoder(HashingFunction hashingFunction) {
+		this(hashingFunction, null);
+	}
+
+	/**
+	 * Constructs a Password4j password encoder with the specified hashing function and a
+	 * pepper. This constructor is package-private and intended for use by subclasses
+	 * only.
+	 * @param hashingFunction the hashing function to use for encoding passwords, must not
+	 * be null
+	 * @param pepper the pepper to be used in the hashing process. If null, no pepper will
+	 * be applied.
+	 * @throws IllegalArgumentException if hashingFunction is null
+	 */
+	Password4jPasswordEncoder(HashingFunction hashingFunction, @Nullable String pepper) {
 		Assert.notNull(hashingFunction, "hashingFunction cannot be null");
 		this.hashingFunction = hashingFunction;
+		this.pepper = pepper;
 	}
 
 	@Override
 	protected String encodeNonNullPassword(String rawPassword) {
-		Hash hash = Password.hash(rawPassword).with(this.hashingFunction);
-		return hash.getResult();
+		HashBuilder hashBuilder = Password.hash(rawPassword);
+		if (this.pepper != null) {
+			hashBuilder = hashBuilder.addPepper(this.pepper);
+		}
+		return hashBuilder.with(this.hashingFunction).getResult();
 	}
 
 	@Override
 	protected boolean matchesNonNull(String rawPassword, String encodedPassword) {
-		return Password.check(rawPassword, encodedPassword).with(this.hashingFunction);
+		HashChecker hashChecker = Password.check(rawPassword, encodedPassword);
+		if (this.pepper != null) {
+			hashChecker = hashChecker.addPepper(this.pepper);
+		}
+		return hashChecker.with(this.hashingFunction);
 	}
 
 	@Override

--- a/crypto/src/main/java/org/springframework/security/crypto/password4j/Pbkdf2Password4jPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password4j/Pbkdf2Password4jPasswordEncoder.java
@@ -20,9 +20,10 @@ import java.security.SecureRandom;
 import java.util.Base64;
 
 import com.password4j.AlgorithmFinder;
-import com.password4j.Hash;
+import com.password4j.HashBuilder;
 import com.password4j.PBKDF2Function;
 import com.password4j.Password;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.security.crypto.password.AbstractValidatingPasswordEncoder;
 import org.springframework.util.Assert;
@@ -60,6 +61,7 @@ import org.springframework.util.Assert;
  * }</pre>
  *
  * @author Mehrdad Bozorgmehr
+ * @author Andrey Litvitski
  * @since 7.0
  * @see PBKDF2Function
  * @see AlgorithmFinder#getPBKDF2Instance()
@@ -75,6 +77,8 @@ public class Pbkdf2Password4jPasswordEncoder extends AbstractValidatingPasswordE
 	private final SecureRandom secureRandom;
 
 	private final int saltLength;
+
+	@Nullable private final String pepper;
 
 	/**
 	 * Constructs a PBKDF2 password encoder using the default PBKDF2 configuration from
@@ -103,11 +107,28 @@ public class Pbkdf2Password4jPasswordEncoder extends AbstractValidatingPasswordE
 	 * positive
 	 */
 	public Pbkdf2Password4jPasswordEncoder(PBKDF2Function pbkdf2Function, int saltLength) {
+		this(pbkdf2Function, saltLength, null);
+	}
+
+	/**
+	 * Constructs a PBKDF2 password encoder with a custom PBKDF2 function, salt length,
+	 * and a pepper.
+	 * @param pbkdf2Function the PBKDF2 function to use for encoding passwords, must not
+	 * be null
+	 * @param saltLength the length of the salt in bytes, must be positive
+	 * @param pepper the pepper to be used in the hashing process. If null, no pepper will
+	 * be applied.
+	 * @throws IllegalArgumentException if pbkdf2Function is null or saltLength is not
+	 * positive
+	 * @since 7.0
+	 */
+	public Pbkdf2Password4jPasswordEncoder(PBKDF2Function pbkdf2Function, int saltLength, @Nullable String pepper) {
 		Assert.notNull(pbkdf2Function, "pbkdf2Function cannot be null");
 		Assert.isTrue(saltLength > 0, "saltLength must be positive");
 		this.pbkdf2Function = pbkdf2Function;
 		this.saltLength = saltLength;
 		this.secureRandom = new SecureRandom();
+		this.pepper = pepper;
 	}
 
 	@Override
@@ -115,9 +136,12 @@ public class Pbkdf2Password4jPasswordEncoder extends AbstractValidatingPasswordE
 		byte[] salt = new byte[this.saltLength];
 		this.secureRandom.nextBytes(salt);
 
-		Hash hash = Password.hash(rawPassword).addSalt(salt).with(this.pbkdf2Function);
+		HashBuilder hashBuilder = Password.hash(rawPassword).addSalt(salt);
+		if (this.pepper != null) {
+			hashBuilder.addPepper(this.pepper);
+		}
 		String encodedSalt = Base64.getEncoder().encodeToString(salt);
-		String encodedHash = hash.getResult();
+		String encodedHash = hashBuilder.with(this.pbkdf2Function).getResult();
 
 		return encodedSalt + DELIMITER + encodedHash;
 	}
@@ -137,8 +161,11 @@ public class Pbkdf2Password4jPasswordEncoder extends AbstractValidatingPasswordE
 			byte[] salt = Base64.getDecoder().decode(parts[0]);
 			String expectedHash = parts[1];
 
-			Hash hash = Password.hash(rawPassword).addSalt(salt).with(this.pbkdf2Function);
-			return expectedHash.equals(hash.getResult());
+			HashBuilder hashBuilder = Password.hash(rawPassword).addSalt(salt);
+			if (this.pepper != null) {
+				hashBuilder.addPepper(this.pepper);
+			}
+			return expectedHash.equals(hashBuilder.with(this.pbkdf2Function).getResult());
 		}
 		catch (IllegalArgumentException ex) {
 			// Invalid Base64 encoding

--- a/crypto/src/main/java/org/springframework/security/crypto/password4j/ScryptPassword4jPasswordEncoder.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/password4j/ScryptPassword4jPasswordEncoder.java
@@ -18,6 +18,7 @@ package org.springframework.security.crypto.password4j;
 
 import com.password4j.AlgorithmFinder;
 import com.password4j.ScryptFunction;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Implementation of {@link org.springframework.security.crypto.password.PasswordEncoder}
@@ -47,6 +48,7 @@ import com.password4j.ScryptFunction;
  * }</pre>
  *
  * @author Mehrdad Bozorgmehr
+ * @author Andrey Litvitski
  * @since 7.0
  * @see ScryptFunction
  * @see AlgorithmFinder#getScryptInstance()
@@ -58,7 +60,7 @@ public class ScryptPassword4jPasswordEncoder extends Password4jPasswordEncoder {
 	 * Password4j's AlgorithmFinder.
 	 */
 	public ScryptPassword4jPasswordEncoder() {
-		super(AlgorithmFinder.getScryptInstance());
+		this(AlgorithmFinder.getScryptInstance());
 	}
 
 	/**
@@ -68,7 +70,20 @@ public class ScryptPassword4jPasswordEncoder extends Password4jPasswordEncoder {
 	 * @throws IllegalArgumentException if scryptFunction is null
 	 */
 	public ScryptPassword4jPasswordEncoder(ScryptFunction scryptFunction) {
-		super(scryptFunction);
+		this(scryptFunction, null);
+	}
+
+	/**
+	 * Constructs an SCrypt password encoder with a custom SCrypt function and a pepper.
+	 * @param scryptFunction the SCrypt function to use for encoding passwords, must not
+	 * be null
+	 * @param pepper the pepper to be used in the hashing process. If null, no pepper will
+	 * be applied.
+	 * @throws IllegalArgumentException if scryptFunction is null
+	 * @since 7.0
+	 */
+	public ScryptPassword4jPasswordEncoder(ScryptFunction scryptFunction, @Nullable String pepper) {
+		super(scryptFunction, pepper);
 	}
 
 }

--- a/crypto/src/test/java/org/springframework/security/crypto/password4j/Argon2Password4jPasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/password4j/Argon2Password4jPasswordEncoderTests.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  * Tests for {@link Argon2Password4jPasswordEncoder}.
  *
  * @author Mehrdad Bozorgmehr
+ * @author Andrey Litvitski
  */
 class Argon2Password4jPasswordEncoderTests {
 
@@ -68,6 +69,20 @@ class Argon2Password4jPasswordEncoderTests {
 		assertThat(encoded).isNotNull();
 		assertThat(encoded).startsWith("$argon2id");
 		assertThat(encoder.matches(PASSWORD, encoded)).isTrue();
+	}
+
+	@Test
+	void constructorWithPepperShouldWork() {
+		String pepper = "argon-pepper";
+		String wrongPepper = "wrong-pepper";
+		Argon2Function function = AlgorithmFinder.getArgon2Instance();
+		Argon2Password4jPasswordEncoder encoderWithPepper = new Argon2Password4jPasswordEncoder(
+				AlgorithmFinder.getArgon2Instance(), pepper);
+		String encoded = encoderWithPepper.encode(PASSWORD);
+		assertThat(encoderWithPepper.matches(PASSWORD, encoded)).isTrue();
+		Argon2Password4jPasswordEncoder encoderWithWrongPepper = new Argon2Password4jPasswordEncoder(function,
+				wrongPepper);
+		assertThat(encoderWithWrongPepper.matches(PASSWORD, encoded)).isFalse();
 	}
 
 	@ParameterizedTest

--- a/crypto/src/test/java/org/springframework/security/crypto/password4j/BalloonHashingPassword4jPasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/password4j/BalloonHashingPassword4jPasswordEncoderTests.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  * Tests for {@link BalloonHashingPassword4jPasswordEncoder}.
  *
  * @author Mehrdad Bozorgmehr
+ * @author Andrey Litvitski
  */
 class BalloonHashingPassword4jPasswordEncoderTests {
 
@@ -70,6 +71,20 @@ class BalloonHashingPassword4jPasswordEncoderTests {
 		assertThat(encoded).isNotNull().isNotEqualTo(PASSWORD);
 		assertThat(encoded).contains(":");
 		assertThat(encoder.matches(PASSWORD, encoded)).isTrue();
+	}
+
+	@Test
+	void constructorWithPepperShouldWork() {
+		String pepper = "balloon-pepper";
+		String wrongPepper = "wrong-pepper";
+		BalloonHashingFunction function = AlgorithmFinder.getBalloonHashingInstance();
+		BalloonHashingPassword4jPasswordEncoder encoderWithPepper = new BalloonHashingPassword4jPasswordEncoder(
+				function, 16, pepper);
+		String encoded = encoderWithPepper.encode(PASSWORD);
+		assertThat(encoderWithPepper.matches(PASSWORD, encoded)).isTrue();
+		BalloonHashingPassword4jPasswordEncoder encoderWithWrongPepper = new BalloonHashingPassword4jPasswordEncoder(
+				function, 16, wrongPepper);
+		assertThat(encoderWithWrongPepper.matches(PASSWORD, encoded)).isFalse();
 	}
 
 	@Test

--- a/crypto/src/test/java/org/springframework/security/crypto/password4j/BcryptPassword4jPasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/password4j/BcryptPassword4jPasswordEncoderTests.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  * Tests for {@link BcryptPassword4jPasswordEncoder}.
  *
  * @author Mehrdad Bozorgmehr
+ * @author Andrey Litvitski
  */
 class BcryptPassword4jPasswordEncoderTests {
 
@@ -68,6 +69,19 @@ class BcryptPassword4jPasswordEncoderTests {
 
 		assertThat(encoded).isNotNull().contains("$06$"); // 6 rounds
 		assertThat(encoder.matches(PASSWORD, encoded)).isTrue();
+	}
+
+	@Test
+	void constructorWithPepperShouldWork() {
+		String pepper = "bcrypt-pepper";
+		String wrongPepper = "wrong-pepper";
+		BcryptFunction function = BcryptFunction.getInstance(6);
+		BcryptPassword4jPasswordEncoder encoderWithPepper = new BcryptPassword4jPasswordEncoder(function, pepper);
+		String encoded = encoderWithPepper.encode(PASSWORD);
+		assertThat(encoderWithPepper.matches(PASSWORD, encoded)).isTrue();
+		BcryptPassword4jPasswordEncoder encoderWithWrongPepper = new BcryptPassword4jPasswordEncoder(function,
+				wrongPepper);
+		assertThat(encoderWithWrongPepper.matches(PASSWORD, encoded)).isFalse();
 	}
 
 	@ParameterizedTest

--- a/crypto/src/test/java/org/springframework/security/crypto/password4j/Password4jPasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/password4j/Password4jPasswordEncoderTests.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * tests verify the common behavior across all concrete password encoder subclasses.
  *
  * @author Mehrdad Bozorgmehr
+ * @author Andrey Litvitski
  */
 class Password4jPasswordEncoderTests {
 
@@ -100,6 +101,38 @@ class Password4jPasswordEncoderTests {
 		assertThat(encoder.matches("", encoded)).isFalse();
 		assertThat(encoder.matches(PASSWORD, null)).isFalse();
 		assertThat(encoder.matches(PASSWORD, "")).isFalse();
+	}
+
+	@Test
+	void matchesShouldReturnTrueWhenSamePepperIsUsed() {
+		String pepper = "secret-pepper";
+		BcryptPassword4jPasswordEncoder encoderWithPepper = new BcryptPassword4jPasswordEncoder(
+				BcryptFunction.getInstance(4), pepper);
+		String encoded = encoderWithPepper.encode(PASSWORD);
+		assertThat(encoderWithPepper.matches(PASSWORD, encoded)).isTrue();
+	}
+
+	@Test
+	void matchesShouldReturnFalseWhenDifferentPepperIsUsed() {
+		String pepper = "secret-pepper";
+		String wrongPepper = "wrong-pepper";
+		BcryptPassword4jPasswordEncoder encoderWithPepper = new BcryptPassword4jPasswordEncoder(
+				BcryptFunction.getInstance(4), pepper);
+		BcryptPassword4jPasswordEncoder encoderWithWrongPepper = new BcryptPassword4jPasswordEncoder(
+				BcryptFunction.getInstance(6), wrongPepper);
+		String encoded = encoderWithPepper.encode(PASSWORD);
+		assertThat(encoderWithWrongPepper.matches(PASSWORD, encoded)).isFalse();
+	}
+
+	@Test
+	void matchesShouldReturnFalseWhenPepperIsMissing() {
+		String pepper = "secret-pepper";
+		BcryptPassword4jPasswordEncoder encoderWithPepper = new BcryptPassword4jPasswordEncoder(
+				BcryptFunction.getInstance(6), pepper);
+		BcryptPassword4jPasswordEncoder encoderWithoutPepper = new BcryptPassword4jPasswordEncoder(
+				BcryptFunction.getInstance(6));
+		String encoded = encoderWithPepper.encode(PASSWORD);
+		assertThat(encoderWithoutPepper.matches(PASSWORD, encoded)).isFalse();
 	}
 
 }

--- a/crypto/src/test/java/org/springframework/security/crypto/password4j/Pbkdf2Password4jPasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/password4j/Pbkdf2Password4jPasswordEncoderTests.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  * Tests for {@link Pbkdf2Password4jPasswordEncoder}.
  *
  * @author Mehrdad Bozorgmehr
+ * @author Andrey Litvitski
  */
 class Pbkdf2Password4jPasswordEncoderTests {
 
@@ -79,6 +80,19 @@ class Pbkdf2Password4jPasswordEncoderTests {
 
 		assertThat(encoded).isNotNull().isNotEqualTo(PASSWORD).contains(":");
 		assertThat(encoder.matches(PASSWORD, encoded)).isTrue();
+	}
+
+	@Test
+	void constructorWithPepperShouldWork() {
+		String pepper = "pbkdf2-pepper";
+		String wrongPepper = "wrong-pepper";
+		PBKDF2Function function = AlgorithmFinder.getPBKDF2Instance();
+		Pbkdf2Password4jPasswordEncoder encoderWithPepper = new Pbkdf2Password4jPasswordEncoder(function, 16, pepper);
+		String encoded = encoderWithPepper.encode(PASSWORD);
+		assertThat(encoderWithPepper.matches(PASSWORD, encoded)).isTrue();
+		Pbkdf2Password4jPasswordEncoder encoderWithWrongPepper = new Pbkdf2Password4jPasswordEncoder(function, 16,
+				wrongPepper);
+		assertThat(encoderWithWrongPepper.matches(PASSWORD, encoded)).isFalse();
 	}
 
 	@Test

--- a/crypto/src/test/java/org/springframework/security/crypto/password4j/ScryptPassword4jPasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/password4j/ScryptPassword4jPasswordEncoderTests.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  * Tests for {@link ScryptPassword4jPasswordEncoder}.
  *
  * @author Mehrdad Bozorgmehr
+ * @author Andrey Litvitski
  */
 class ScryptPassword4jPasswordEncoderTests {
 
@@ -69,6 +70,19 @@ class ScryptPassword4jPasswordEncoderTests {
 		assertThat(encoded).isNotNull();
 		assertThat(encoded.split("\\$").length).isGreaterThanOrEqualTo(3);
 		assertThat(encoder.matches(PASSWORD, encoded)).isTrue();
+	}
+
+	@Test
+	void constructorWithPepperShouldWork() {
+		String pepper = "scrypt-pepper";
+		String wrongPepper = "wrong-pepper";
+		ScryptFunction function = AlgorithmFinder.getScryptInstance();
+		ScryptPassword4jPasswordEncoder encoderWithPepper = new ScryptPassword4jPasswordEncoder(function, pepper);
+		String encoded = encoderWithPepper.encode(PASSWORD);
+		assertThat(encoderWithPepper.matches(PASSWORD, encoded)).isTrue();
+		ScryptPassword4jPasswordEncoder encoderWithWrongPepper = new ScryptPassword4jPasswordEncoder(function,
+				wrongPepper);
+		assertThat(encoderWithWrongPepper.matches(PASSWORD, encoded)).isFalse();
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
Currently, we can't forward pepper unless we encounter an anti-pattern and implement our own encoder.

To solve this problem, we need to provide pepper support out of the box, specifically in `Password4jPasswordEncoder` and all its subclasses, as well as `BalloonHashingPassword4jPasswordEncoder` and `Pbkdf2Password4jPasswordEncoder`, which aren't direct implementations of `Password4jPasswordEncoder` but also use `password4j` and require pepper support.

Closes: gh-18299

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
