### PR TITLE
Fix HeaderWriterFilter race condition during async requests

### DIFF
--- a/web/src/main/java/org/springframework/security/web/header/HeaderWriterFilter.java
+++ b/web/src/main/java/org/springframework/security/web/header/HeaderWriterFilter.java
@@ -18,6 +18,7 @@ package org.springframework.security.web.header;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.RequestDispatcher;
@@ -114,6 +115,8 @@ public class HeaderWriterFilter extends OncePerRequestFilter {
 
 		private final HttpServletRequest request;
 
+		private final AtomicBoolean headersWritten = new AtomicBoolean(false);
+
 		HeaderWriterResponse(HttpServletRequest request, HttpServletResponse response) {
 			super(response);
 			this.request = request;
@@ -129,7 +132,9 @@ public class HeaderWriterFilter extends OncePerRequestFilter {
 			if (isDisableOnResponseCommitted()) {
 				return;
 			}
-			HeaderWriterFilter.this.writeHeaders(this.request, getHttpResponse());
+			if (this.headersWritten.compareAndSet(false, true)) {
+				HeaderWriterFilter.this.writeHeaders(this.request, getHttpResponse());
+			}
 		}
 
 		private HttpServletResponse getHttpResponse() {

--- a/web/src/test/java/org/springframework/security/web/header/HeaderWriterFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/header/HeaderWriterFilterTests.java
@@ -113,6 +113,26 @@ public class HeaderWriterFilterTests {
 		verifyNoMoreInteractions(this.writer1);
 	}
 
+	// gh-9175
+	@Test
+	public void doFilterWhenWriteHeadersCalledConcurrentlyThenHeadersWrittenOnlyOnce() throws Exception {
+		List<HeaderWriter> headerWriters = new ArrayList<>();
+		headerWriters.add(this.writer1);
+		HeaderWriterFilter filter = new HeaderWriterFilter(headerWriters);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		filter.doFilter(request, response, (req, resp) -> {
+			// Calling writeHeaders() directly simulates the race window where an
+			// async thread enters writeHeaders() via onResponseCommitted() but has
+			// not yet called disableOnResponseCommitted().
+			((HeaderWriterFilter.HeaderWriterResponse) resp).writeHeaders();
+		});
+		// The finally block in doHeadersAfter also calls writeHeaders().
+		// Without the fix, the header writers would be invoked twice.
+		verify(this.writer1).writeHeaders(any(HttpServletRequest.class), any(HttpServletResponse.class));
+		verifyNoMoreInteractions(this.writer1);
+	}
+
 	@Test
 	public void headersWrittenAtBeginningOfRequest() throws Exception {
 		HeaderWriterFilter filter = new HeaderWriterFilter(Collections.singletonList(this.writer1));

--- a/web/src/test/java/org/springframework/security/web/header/HeaderWriterFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/header/HeaderWriterFilterTests.java
@@ -121,12 +121,11 @@ public class HeaderWriterFilterTests {
 		HeaderWriterFilter filter = new HeaderWriterFilter(headerWriters);
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		MockHttpServletResponse response = new MockHttpServletResponse();
-		filter.doFilter(request, response, (req, resp) -> {
-			// Calling writeHeaders() directly simulates the race window where an
-			// async thread enters writeHeaders() via onResponseCommitted() but has
-			// not yet called disableOnResponseCommitted().
-			((HeaderWriterFilter.HeaderWriterResponse) resp).writeHeaders();
-		});
+		filter.doFilter(request, response, (req, resp) ->
+		// Calling writeHeaders() directly simulates the race window where an
+		// async thread enters writeHeaders() via onResponseCommitted() but has
+		// not yet called disableOnResponseCommitted().
+		((HeaderWriterFilter.HeaderWriterResponse) resp).writeHeaders());
 		// The finally block in doHeadersAfter also calls writeHeaders().
 		// Without the fix, the header writers would be invoked twice.
 		verify(this.writer1).writeHeaders(any(HttpServletRequest.class), any(HttpServletResponse.class));


### PR DESCRIPTION
Closes gh-9175

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
