### PR TITLE
Update jwt.adoc

### DIFF
--- a/docs/modules/ROOT/pages/reactive/oauth2/resource-server/jwt.adoc
+++ b/docs/modules/ROOT/pages/reactive/oauth2/resource-server/jwt.adoc
@@ -967,7 +967,7 @@ Java::
 @Bean
 JwtDecoder jwtDecoder() {
     NimbusReactiveJwtDecoder jwtDecoder = NimbusReactiveJwtDecoder.withIssuerLocation(issuerUri)
-            .validateTypes(false).build();
+            .validateType(false).build();
     jwtDecoder.setJwtValidator(JwtValidators.createAtJwtValidator()
             .audience("https://audience.example.org")
             .clientId("client-identifier")
@@ -983,7 +983,7 @@ Kotlin::
 @Bean
 fun jwtDecoder(): JwtDecoder {
     val jwtDecoder = NimbusReactiveJwtDecoder.withIssuerLocation(issuerUri)
-            .validateTypes(false).build()
+            .validateType(false).build()
     jwtDecoder.setJwtValidator(JwtValidators.createAtJwtValidator()
             .audience("https://audience.example.org")
             .clientId("client-identifier")


### PR DESCRIPTION
Fix: typo validateTypes -> validateType

https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/oauth2/jwt/NimbusReactiveJwtDecoder.JwkSetUriReactiveJwtDecoderBuilder.html#validateType(boolean)

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
