### PR TITLE
Clarify CORS Javadoc on HttpSecurity#cors

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/HttpSecurity.java
@@ -285,9 +285,23 @@ public final class HttpSecurity extends AbstractConfiguredSecurityBuilder<Defaul
 	}
 
 	/**
-	 * Adds a {@link CorsFilter} to be used. If a bean by the name of corsFilter is
-	 * provided, that {@link CorsFilter} is used. Else if corsConfigurationSource is
-	 * defined, then that {@link CorsConfiguration} is used. You can enable CORS using:
+	 * Configures Cross-Origin Resource Sharing (CORS).
+	 *
+	 * <p>A {@link CorsFilter} is added to the security filter chain in either of
+	 * the following cases:
+	 * <ul>
+	 * <li>a single {@link org.springframework.web.cors.UrlBasedCorsConfigurationSource}
+	 * bean is present in the application context, in which case it is added
+	 * automatically without invoking this method;
+	 * <li>this method is invoked explicitly. When invoked, a bean named
+	 * {@code corsFilter} is used if available; otherwise a bean named
+	 * {@code corsConfigurationSource} is used.
+	 * </ul>
+	 *
+	 * <p>Invoke this method when you need to customize the {@link CorsConfigurer},
+	 * for example to use a {@link CorsFilter} or a
+	 * {@link org.springframework.web.cors.CorsConfigurationSource} bean with a
+	 * different name:
 	 *
 	 * <pre>
 	 * &#064;Configuration


### PR DESCRIPTION
The Javadoc on `HttpSecurity#cors(Customizer<CorsConfigurer<HttpSecurity>>)` reads as if calling `.cors(...)` is what enables CORS, but since the changes for gh-5011 and gh-15444 a single `UrlBasedCorsConfigurationSource` bean is enough on its own. The new wording lists the two cases that add a `CorsFilter` (auto-detected bean vs. explicit invocation) and frames `.cors(...)` as the path for customizing the `CorsConfigurer`, not the only way to opt in.

The `corsFilter` / `corsConfigurationSource` bean-name lookup chain and the existing `withDefaults()` example are kept so readers can still find the bean-name behavior.

Closes gh-19139
