### PR TITLE
Make OAuth2AuthorizationCodeGenerator public

### DIFF
--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeGenerator.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2AuthorizationCodeGenerator.java
@@ -38,7 +38,7 @@ import org.springframework.security.oauth2.server.authorization.token.OAuth2Toke
  * @see OAuth2AuthorizationCodeRequestAuthenticationProvider
  * @see OAuth2AuthorizationConsentAuthenticationProvider
  */
-final class OAuth2AuthorizationCodeGenerator implements OAuth2TokenGenerator<OAuth2AuthorizationCode> {
+public final class OAuth2AuthorizationCodeGenerator implements OAuth2TokenGenerator<OAuth2AuthorizationCode> {
 
 	private final StringKeyGenerator authorizationCodeGenerator = new Base64StringKeyGenerator(
 			Base64.getUrlEncoder().withoutPadding(), 96);


### PR DESCRIPTION
`OAuth2AuthorizationCodeGenerator` currently has package-private access. This makes it impossible to use it to manually generate an authorization code. There does not seem to be a particular reason for this class to be package-private, because other `OAuth2TokenGenerator` implementations, like `JwtGenerator`, `OAuth2AccessTokenGenerator`, and `OAuth2RefreshTokenGenerator`, are public already. 

My proposed fix changes: 

```java
final class OAuth2AuthorizationCodeGenerator implements OAuth2TokenGenerator<OAuth2AuthorizationCode>
```

To: 

```java
public final class OAuth2AuthorizationCodeGenerator implements OAuth2TokenGenerator<OAuth2AuthorizationCode
```
