### PR TITLE
Mark matchingRequestParameterName as @Nullable

### DIFF
--- a/web/src/main/java/org/springframework/security/web/savedrequest/HttpSessionRequestCache.java
+++ b/web/src/main/java/org/springframework/security/web/savedrequest/HttpSessionRequestCache.java
@@ -51,7 +51,7 @@ public class HttpSessionRequestCache implements RequestCache {
 
 	private String sessionAttrName = SAVED_REQUEST;
 
-	private String matchingRequestParameterName = "continue";
+	private @Nullable String matchingRequestParameterName = "continue";
 
 	/**
 	 * Stores the current request, provided the configuration properties allow it.
@@ -172,9 +172,12 @@ public class HttpSessionRequestCache implements RequestCache {
 	 * {@link #getMatchingRequest(HttpServletRequest, HttpServletResponse)}
 	 * @param matchingRequestParameterName the parameter name that must be in the request
 	 * for {@link #getMatchingRequest(HttpServletRequest, HttpServletResponse)} to check
-	 * the session. Default is "continue".
+	 * the session. Default is "continue". Set to {@code null} to disable the
+	 * query-parameter requirement, in which case
+	 * {@link #getMatchingRequest(HttpServletRequest, HttpServletResponse)} always
+	 * consults the session.
 	 */
-	public void setMatchingRequestParameterName(String matchingRequestParameterName) {
+	public void setMatchingRequestParameterName(@Nullable String matchingRequestParameterName) {
 		this.matchingRequestParameterName = matchingRequestParameterName;
 	}
 

--- a/web/src/main/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCache.java
+++ b/web/src/main/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCache.java
@@ -119,9 +119,11 @@ public class WebSessionServerRequestCache implements ServerRequestCache {
 	 * {@link #removeMatchingRequest(ServerWebExchange)} to look up the
 	 * {@link ServerHttpRequest}.
 	 * @param matchingRequestParameterName the parameter name that must be in the request
-	 * for {@link #removeMatchingRequest(ServerWebExchange)} to check the session.
+	 * for {@link #removeMatchingRequest(ServerWebExchange)} to check the session, or
+	 * {@code null} (the default) to disable the query-parameter requirement, in which
+	 * case {@link #removeMatchingRequest(ServerWebExchange)} always consults the session.
 	 */
-	public void setMatchingRequestParameterName(String matchingRequestParameterName) {
+	public void setMatchingRequestParameterName(@Nullable String matchingRequestParameterName) {
 		this.matchingRequestParameterName = matchingRequestParameterName;
 	}
 


### PR DESCRIPTION
This change marks `matchingRequestParameterName` as `@Nullable` in `HttpSessionRequestCache` (field and setter parameter) and in `WebSessionServerRequestCache` (setter parameter; the field is already `@Nullable`). The Javadoc is updated to state that passing `null` disables the `?continue` query-parameter requirement.

Rationale and the contract/implementation mismatch are described in the issue.

Closes gh-19153