### PR TITLE
Return REQUEST dispatcher type from FilterInvocation dummy request

### DIFF
--- a/web/src/main/java/org/springframework/security/web/FilterInvocation.java
+++ b/web/src/main/java/org/springframework/security/web/FilterInvocation.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.servlet.DispatcherType;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletRequest;
@@ -186,6 +187,11 @@ public class FilterInvocation {
 		@Override
 		public String getCharacterEncoding() {
 			return "UTF-8";
+		}
+
+		@Override
+		public DispatcherType getDispatcherType() {
+			return DispatcherType.REQUEST;
 		}
 
 		@Override

--- a/web/src/test/java/org/springframework/security/web/FilterInvocationTests.java
+++ b/web/src/test/java/org/springframework/security/web/FilterInvocationTests.java
@@ -19,6 +19,7 @@ package org.springframework.security.web;
 import java.util.Enumeration;
 import java.util.NoSuchElementException;
 
+import jakarta.servlet.DispatcherType;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -145,6 +146,11 @@ public class FilterInvocationTests {
 		Enumeration<String> headers = request.getHeaders("unknown");
 		assertThat(headers.hasMoreElements()).isFalse();
 		assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(headers::nextElement);
+	}
+
+	@Test
+	public void dummyRequestDispatcherTypeIsRequest() {
+		assertThat(new DummyRequest().getDispatcherType()).isEqualTo(DispatcherType.REQUEST);
 	}
 
 }


### PR DESCRIPTION
After moving to Spring Security 7, injecting `WebInvocationPrivilegeEvaluator` blows up when the filter chain uses `authorizeHttpRequests(...).dispatcherTypeMatchers(...)`. `AuthorizationManagerWebInvocationPrivilegeEvaluator` feeds URL checks through `FilterInvocation`'s synthetic request. That stub never implemented `getDispatcherType()`, so `DispatcherTypeRequestMatcher` consulted the unsupported servlet proxy and surfaced `UnsupportedOperationException` before authorization ran.

The synthetic path used to behave like a normal request dispatch because the introspector transformer wrapped calls with a dummy dispatcher type. Restoring `DispatcherType.REQUEST` on `DummyRequest` puts synthetic evaluations back in line with that expectation.

`FilterInvocationTests` now pins the dispatcher type so this cannot regress quietly.

Closes gh-19131
