### PR TITLE
Add getName to SecurityFilterChain for trace logging

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configuration/CompositeFilterChainProxyTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configuration/CompositeFilterChainProxyTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.config.annotation.web.configuration;
+
+import java.util.List;
+
+import jakarta.servlet.Filter;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository;
+import org.springframework.security.web.util.matcher.AnyRequestMatcher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression tests for the reflective {@code getFilters(HttpServletRequest)} contract
+ * that {@code WebTestUtils.findFilter} relies on when invoked against a
+ * {@link WebSecurityConfiguration.CompositeFilterChainProxy}.
+ */
+class CompositeFilterChainProxyTests {
+
+	@Test
+	void getFiltersWhenCompositeFilterChainProxyThenResolvesFilters() {
+		CsrfFilter sentinel = new CsrfFilter(new HttpSessionCsrfTokenRepository());
+		DefaultSecurityFilterChain inner = new DefaultSecurityFilterChain(AnyRequestMatcher.INSTANCE, sentinel);
+		FilterChainProxy innerProxy = new FilterChainProxy(inner);
+		WebSecurityConfiguration.CompositeFilterChainProxy composite = new WebSecurityConfiguration.CompositeFilterChainProxy(
+				List.<Filter>of(innerProxy));
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+
+		// Mirrors the exact reflective call WebTestUtils.findFilter makes at WebTestUtils.java:158.
+		// We invoke getFilters directly rather than via WebTestUtils.findFilter because that method
+		// is package-private and the CompositeFilterChainProxy class lives in a different package.
+		List<Filter> filters = ReflectionTestUtils.invokeMethod(composite, "getFilters", request);
+
+		assertThat(filters).contains(sentinel);
+	}
+
+}

--- a/test/src/test/java/org/springframework/security/test/web/support/WebTestUtilsTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/support/WebTestUtilsTests.java
@@ -171,6 +171,18 @@ public class WebTestUtilsTests {
 		assertThat(WebTestUtils.findFilter(this.request, toFind.getClass())).isSameAs(toFind);
 	}
 
+	@Test
+	void findFilterWhenFilterChainProxyThenResolvesFilters() {
+		CsrfFilter sentinel = new CsrfFilter(new HttpSessionCsrfTokenRepository());
+		DefaultSecurityFilterChain chain = new DefaultSecurityFilterChain(AnyRequestMatcher.INSTANCE, sentinel);
+		FilterChainProxy fcp = new FilterChainProxy(chain);
+		this.request.getServletContext().setAttribute(BeanIds.SPRING_SECURITY_FILTER_CHAIN, fcp);
+
+		CsrfFilter resolved = WebTestUtils.findFilter(this.request, CsrfFilter.class);
+
+		assertThat(resolved).isSameAs(sentinel);
+	}
+
 	private void loadConfig(Class<?> config) {
 		AnnotationConfigWebApplicationContext context = new AnnotationConfigWebApplicationContext();
 		context.register(config);

--- a/web/spring-security-web.gradle
+++ b/web/spring-security-web.gradle
@@ -54,6 +54,7 @@ dependencies {
 	provided 'jakarta.servlet:jakarta.servlet-api'
 
 	testImplementation project(path: ':spring-security-core', configuration: 'tests')
+	testImplementation 'ch.qos.logback:logback-classic'
 	testImplementation 'io.projectreactor:reactor-test'
 	testImplementation 'jakarta.xml.bind:jakarta.xml.bind-api'
 	testImplementation 'jakarta.websocket:jakarta.websocket-api'

--- a/web/src/main/java/org/springframework/security/web/DefaultSecurityFilterChain.java
+++ b/web/src/main/java/org/springframework/security/web/DefaultSecurityFilterChain.java
@@ -90,6 +90,17 @@ public final class DefaultSecurityFilterChain implements SecurityFilterChain, Be
 		return this.requestMatcher.matches(request);
 	}
 
+	/**
+	 * Returns the Spring bean name of this chain when registered as a bean
+	 * (via {@link BeanNameAware}); otherwise {@code null}.
+	 * @return the bean name, or {@code null} if not registered as a bean
+	 * @since 7.1
+	 */
+	@Override
+	public @Nullable String getName() {
+		return this.beanName;
+	}
+
 	@Override
 	public String toString() {
 		List<String> filterNames = new ArrayList<>();

--- a/web/src/main/java/org/springframework/security/web/FilterChainProxy.java
+++ b/web/src/main/java/org/springframework/security/web/FilterChainProxy.java
@@ -238,22 +238,37 @@ public class FilterChainProxy extends GenericFilterBean {
 	}
 
 	/**
-	 * Returns the first filter chain matching the supplied URL.
+	 * Returns the first filter chain matching the supplied request.
 	 * @param request the request to match
-	 * @return an ordered array of Filters defining the filter chain
+	 * @return the matching {@link SecurityFilterChain}, or {@code null} if none matches
 	 */
-	private @Nullable List<Filter> getFilters(HttpServletRequest request) {
+	private @Nullable SecurityFilterChain matchChain(HttpServletRequest request) {
 		int count = 0;
-		for (SecurityFilterChain chain : this.filterChains) {
+		for (SecurityFilterChain candidate : this.filterChains) {
 			if (logger.isTraceEnabled()) {
-				logger.trace(LogMessage.format("Trying to match request against %s (%d/%d)", chain, ++count,
+				logger.trace(LogMessage.format("Trying to match request against %s (%d/%d)", candidate, ++count,
 						this.filterChains.size()));
 			}
-			if (chain.matches(request)) {
-				return chain.getFilters();
+			if (candidate.matches(request)) {
+				return candidate;
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Returns the filters of the first chain matching the supplied request.
+	 * <p>
+	 * NOTE: this method is invoked reflectively by Spring Security's test support
+	 * (see {@code WebTestUtils.findFilter}). Renaming or changing its signature
+	 * is a breaking change to that contract.
+	 * @param request the request to match
+	 * @return an ordered list of Filters defining the matched filter chain, or
+	 * {@code null} if no chain matches
+	 */
+	private @Nullable List<Filter> getFilters(HttpServletRequest request) {
+		SecurityFilterChain matched = matchChain(request);
+		return (matched != null) ? matched.getFilters() : null;
 	}
 
 	/**

--- a/web/src/main/java/org/springframework/security/web/FilterChainProxy.java
+++ b/web/src/main/java/org/springframework/security/web/FilterChainProxy.java
@@ -214,8 +214,8 @@ public class FilterChainProxy extends GenericFilterBean {
 			throws IOException, ServletException {
 		FirewalledRequest firewallRequest = this.firewall.getFirewalledRequest((HttpServletRequest) request);
 		HttpServletResponse firewallResponse = this.firewall.getFirewalledResponse((HttpServletResponse) response);
-		List<Filter> filters = getFilters(firewallRequest);
-		if (filters == null || filters.isEmpty()) {
+		SecurityFilterChain matched = matchChain(firewallRequest);
+		if (matched == null || matched.getFilters().isEmpty()) {
 			if (logger.isTraceEnabled()) {
 				logger.trace(LogMessage.of(() -> "No security for " + requestLine(firewallRequest)));
 			}
@@ -223,12 +223,15 @@ public class FilterChainProxy extends GenericFilterBean {
 			this.filterChainDecorator.decorate(chain).doFilter(firewallRequest, firewallResponse);
 			return;
 		}
+		List<Filter> filters = matched.getFilters();
+		String chainName = matched.getName();
+		String suffix = (chainName != null) ? " [" + chainName + "]" : "";
 		if (logger.isDebugEnabled()) {
-			logger.debug(LogMessage.of(() -> "Securing " + requestLine(firewallRequest)));
+			logger.debug(LogMessage.of(() -> "Securing " + requestLine(firewallRequest) + suffix));
 		}
 		FilterChain reset = (req, res) -> {
 			if (logger.isDebugEnabled()) {
-				logger.debug(LogMessage.of(() -> "Secured " + requestLine(firewallRequest)));
+				logger.debug(LogMessage.of(() -> "Secured " + requestLine(firewallRequest) + suffix));
 			}
 			// Deactivate path stripping as we exit the security filter chain
 			firewallRequest.reset();

--- a/web/src/main/java/org/springframework/security/web/SecurityFilterChain.java
+++ b/web/src/main/java/org/springframework/security/web/SecurityFilterChain.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import jakarta.servlet.Filter;
 import jakarta.servlet.http.HttpServletRequest;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Defines a filter chain which is capable of being matched against an
@@ -35,5 +36,26 @@ public interface SecurityFilterChain {
 	boolean matches(HttpServletRequest request);
 
 	List<Filter> getFilters();
+
+	/**
+	 * Returns a human-readable name identifying this chain, intended for
+	 * diagnostics such as log messages. May be {@code null} when no
+	 * meaningful name is available.
+	 * <p>
+	 * The returned value is intended for diagnostics only; it is not
+	 * stable across implementations and MUST NOT be used as a key for
+	 * authorization, routing, or any other functional decision.
+	 * <p>
+	 * Implementations should return quickly and should not throw exceptions.
+	 * Implementations that wrap or delegate to another {@code SecurityFilterChain}
+	 * are responsible for forwarding {@code getName()} appropriately when chain
+	 * identity matters to consumers.
+	 *
+	 * @return the chain name, or {@code null} if unavailable
+	 * @since 7.1
+	 */
+	default @Nullable String getName() {
+		return null;
+	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/DefaultSecurityFilterChainTests.java
+++ b/web/src/test/java/org/springframework/security/web/DefaultSecurityFilterChainTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.security.web.util.matcher.AnyRequestMatcher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DefaultSecurityFilterChain}.
+ */
+class DefaultSecurityFilterChainTests {
+
+	@Test
+	void getNameWhenBeanNameNotSetThenReturnsNull() {
+		DefaultSecurityFilterChain chain = new DefaultSecurityFilterChain(AnyRequestMatcher.INSTANCE,
+				Collections.emptyList());
+		assertThat(chain.getName()).isNull();
+	}
+
+	@Test
+	void getNameWhenBeanNameSetThenReturnsBeanName() {
+		DefaultSecurityFilterChain chain = new DefaultSecurityFilterChain(AnyRequestMatcher.INSTANCE,
+				Collections.emptyList());
+		chain.setBeanName("apiSecurity");
+		assertThat(chain.getName()).isEqualTo("apiSecurity");
+	}
+
+}

--- a/web/src/test/java/org/springframework/security/web/FilterChainProxyTests.java
+++ b/web/src/test/java/org/springframework/security/web/FilterChainProxyTests.java
@@ -22,6 +22,10 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
@@ -38,7 +42,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
+import org.slf4j.LoggerFactory;
 
+import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.TestingAuthenticationToken;
@@ -49,6 +55,7 @@ import org.springframework.security.web.firewall.HttpFirewall;
 import org.springframework.security.web.firewall.RequestRejectedException;
 import org.springframework.security.web.firewall.RequestRejectedHandler;
 import org.springframework.security.web.servlet.TestMockHttpServletMappings;
+import org.springframework.security.web.util.matcher.AnyRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -499,6 +506,59 @@ public class FilterChainProxyTests {
 		assertFilterChainObservation(contexts.next(), "after", 3);
 	}
 
+	@Test
+	void doFilterWhenChainHasNameThenDebugLogIncludesNameSuffix() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/users");
+		// MockHttpServletRequest.servletPath defaults to "" not null; UrlUtils.buildRequestUrl prefers it
+		request.setServletPath("/api/users");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockFilterChain mockChain = new MockFilterChain();
+
+		DefaultSecurityFilterChain named = new DefaultSecurityFilterChain(AnyRequestMatcher.INSTANCE,
+				new MockFilter());
+		named.setBeanName("apiSecurity");
+		FilterChainProxy fcp = new FilterChainProxy(named);
+
+		ListAppender<ILoggingEvent> appender = attachAppender(Level.DEBUG);
+		try {
+			fcp.doFilter(request, response, mockChain);
+			assertThat(appender.list)
+				.extracting(ILoggingEvent::getFormattedMessage)
+				.anyMatch((msg) -> msg.equals("Securing GET /api/users [apiSecurity]"))
+				.anyMatch((msg) -> msg.equals("Secured GET /api/users [apiSecurity]"));
+		}
+		finally {
+			detachAppender(appender);
+		}
+	}
+
+	@Test
+	void doFilterWhenChainHasNoNameThenDebugLogOmitsSuffix() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/users");
+		// MockHttpServletRequest.servletPath defaults to "" not null; UrlUtils.buildRequestUrl prefers it
+		request.setServletPath("/api/users");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockFilterChain mockChain = new MockFilterChain();
+
+		DefaultSecurityFilterChain unnamed = new DefaultSecurityFilterChain(AnyRequestMatcher.INSTANCE,
+				new MockFilter());
+		// beanName intentionally not set
+		FilterChainProxy fcp = new FilterChainProxy(unnamed);
+
+		ListAppender<ILoggingEvent> appender = attachAppender(Level.DEBUG);
+		try {
+			fcp.doFilter(request, response, mockChain);
+			assertThat(appender.list)
+				.extracting(ILoggingEvent::getFormattedMessage)
+				.anyMatch((msg) -> msg.equals("Securing GET /api/users"))
+				.anyMatch((msg) -> msg.equals("Secured GET /api/users"))
+				.noneMatch((msg) -> msg.contains("["));
+		}
+		finally {
+			detachAppender(appender);
+		}
+	}
+
 	static void assertFilterChainObservation(Observation.Context context, String filterSection, int chainPosition) {
 		assertThat(context).isInstanceOf(ObservationFilterChainDecorator.FilterChainObservationContext.class);
 		ObservationFilterChainDecorator.FilterChainObservationContext filterChainObservationContext = (ObservationFilterChainDecorator.FilterChainObservationContext) context;
@@ -506,6 +566,23 @@ public class FilterChainProxyTests {
 			.isEqualTo(ObservationFilterChainDecorator.FilterChainObservationConvention.CHAIN_OBSERVATION_NAME);
 		assertThat(context.getContextualName()).endsWith(filterSection);
 		assertThat(filterChainObservationContext.getChainPosition()).isEqualTo(chainPosition);
+	}
+
+	private ListAppender<ILoggingEvent> attachAppender(Level level) {
+		ListAppender<ILoggingEvent> appender = new ListAppender<>();
+		appender.start();
+		Logger fcpLogger = (Logger) LoggerFactory.getLogger(FilterChainProxy.class);
+		fcpLogger.setLevel(level);
+		fcpLogger.addAppender(appender);
+		return appender;
+	}
+
+	private void detachAppender(ListAppender<ILoggingEvent> appender) {
+		Logger fcpLogger = (Logger) LoggerFactory.getLogger(FilterChainProxy.class);
+		fcpLogger.detachAppender(appender);
+		// Reset to no explicit level so it inherits from the parent
+		// (org.springframework.security = WARN per logback-test.xml).
+		fcpLogger.setLevel(null);
 	}
 
 	static Filter mockFilter() throws Exception {

--- a/web/src/test/java/org/springframework/security/web/SecurityFilterChainTests.java
+++ b/web/src/test/java/org/springframework/security/web/SecurityFilterChainTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web;
+
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the {@link SecurityFilterChain} interface default behavior.
+ */
+class SecurityFilterChainTests {
+
+	@Test
+	void getNameWhenInterfaceDefaultThenReturnsNull() {
+		SecurityFilterChain chain = new SecurityFilterChain() {
+			@Override
+			public boolean matches(HttpServletRequest request) {
+				return true;
+			}
+
+			@Override
+			public List<Filter> getFilters() {
+				return Collections.emptyList();
+			}
+		};
+		assertThat(chain.getName()).isNull();
+	}
+
+}


### PR DESCRIPTION
Closes gh-6274

## Background

This issue has had two prior attempts at resolution:

- #6288 (BeanNameAware on `DefaultSecurityFilterChain`) — closed, not merged
- #6308 (`getId()` on `RequestMatcher`) — closed, not merged

Since then, in commit f46e56de78 (gh-15874), `BeanNameAware` was added to
`DefaultSecurityFilterChain` to improve error messages. The bean name is now
captured and surfaced through `toString()`, but the `SecurityFilterChain`
interface itself still has no name accessor, so consumers like
`FilterChainProxy` cannot include the matched chain identity in
"Securing/Secured" debug logs without `instanceof` checks.

## Change

- Add `default @Nullable String getName()` to `SecurityFilterChain`
  (returns `null` by default — fully backward compatible).
- Override in `DefaultSecurityFilterChain` to return the bean name
  captured by the existing `BeanNameAware` integration.
- Update `FilterChainProxy.doFilterInternal` to include `[<name>]` in
  DEBUG logs when a name is available; omit when null.

## Commit-by-commit reviewability

The PR is split into six small commits so each can be reviewed in isolation:

1. `Add getName default to SecurityFilterChain` — interface change only
2. `Override getName in DefaultSecurityFilterChain` — bean-name override
3. `Extract matchChain helper in FilterChainProxy` — pure refactor, no behavior change
4. `Include chain name in FilterChainProxy DEBUG log` — the visible behavioral change
5. `Add WebTestUtils.findFilter regression test for FilterChainProxy`
6. `Add getFilters(HttpServletRequest) regression test for CompositeFilterChainProxy`

Happy to squash if the team prefers a single commit, but kept separate so the
"no behavior change" refactor (3) can be verified independently from the
behavioral change (4).

## Preservation of the reflective `getFilters(HttpServletRequest)` contract

The existing private `FilterChainProxy.getFilters(HttpServletRequest)` is
**preserved verbatim** (name and signature). It is invoked reflectively by
`WebTestUtils.findFilter` at `WebTestUtils.java:158` via
`ReflectionTestUtils.invokeMethod(springSecurityFilterChain, "getFilters", request)`,
and an analogous private method exists on `CompositeFilterChainProxy` for the
same reason. The new `matchChain` helper is added alongside it, and
`getFilters(HttpServletRequest)` now delegates to `matchChain`. Two regression
tests lock this contract for both `FilterChainProxy` and
`CompositeFilterChainProxy`.

## Why `@Nullable String` rather than `Optional<String>`

Return type is `@Nullable String` rather than `Optional<String>` for
consistency with the existing `@Nullable beanName` field on
`DefaultSecurityFilterChain`, and following Brian Goetz's guidance that
`Optional` is awkward as a property-style return type. The new method's
Javadoc explicitly marks the returned value as for diagnostic use only.

## Out of scope (deliberately)

- **No setter on the interface.** `BeanNameAware` covers the common path;
  custom implementations can return their own identity by overriding
  `getName()`.
- **No reactive parity.** `SecurityWebFilterChain` lacks `BeanNameAware`
  groundwork (no equivalent of `f46e56de78` on the reactive side yet), so
  that change is meaningfully different. If this lands, I will open a
  separate issue for `SecurityWebFilterChain` parity.
- **No changes to `DebugFilter` or `DefaultFilterChainValidator`.** Those
  consumers can adopt `getName()` in follow-up PRs once the interface
  change lands.

## Alternative considered

If the team prefers to avoid an interface change, the same DEBUG output
can be achieved via an `instanceof DefaultSecurityFilterChain` cast in
`FilterChainProxy`. Happy to switch to that diff if a cast-based approach
is preferred.

## Testing

- `SecurityFilterChainTests` — interface default returns null.
- `DefaultSecurityFilterChainTests` — `getName()` returns the bean name when
  set; null otherwise.
- `FilterChainProxyTests` — DEBUG log includes `[<name>]` suffix when the
  matched chain has a name; suffix omitted when null. Uses logback
  `ListAppender` for log capture.
- `WebTestUtilsTests` — regression test for the reflective contract on
  plain `FilterChainProxy`.
- `CompositeFilterChainProxyTests` — regression test for the same contract
  on `WebSecurityConfiguration.CompositeFilterChainProxy` (the package-private
  composite path used by Spring Boot annotation-based config).

## Notes

- No try/catch around `getName()` in `FilterChainProxy`, consistent with how
  `matches()` and `getFilters()` are already invoked. Diagnostics should
  not silently swallow exceptions.
- Existing log scrapers using prefix matching (`startsWith("Securing")`)
  are unaffected. End-anchored regexes (`^Securing .* /\S+$`) may need
  adjustment.