### PR TITLE
Update reactive/authentication/logout.adoc to use include-code

### DIFF
--- a/docs/modules/ROOT/pages/reactive/authentication/logout.adoc
+++ b/docs/modules/ROOT/pages/reactive/authentication/logout.adoc
@@ -11,44 +11,4 @@ This will:
 Often, you will want to also invalidate the session on logout.
 To achieve this, you can add the `WebSessionServerLogoutHandler` to your logout configuration, like so:
 
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-@Bean
-SecurityWebFilterChain http(ServerHttpSecurity http) throws Exception {
-    DelegatingServerLogoutHandler logoutHandler = new DelegatingServerLogoutHandler(
-            new SecurityContextServerLogoutHandler(), new WebSessionServerLogoutHandler()
-    );
-
-    http
-        .authorizeExchange((authorize) -> authorize.anyExchange().authenticated())
-        .logout((logout) -> logout.logoutHandler(logoutHandler));
-
-    return http.build();
-}
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-@Bean
-fun http(http: ServerHttpSecurity): SecurityWebFilterChain {
-    val customLogoutHandler = DelegatingServerLogoutHandler(
-        SecurityContextServerLogoutHandler(), WebSessionServerLogoutHandler()
-    )
-
-    return http {
-        authorizeExchange {
-            authorize(anyExchange, authenticated)
-        }
-        logout {
-            logoutHandler = customLogoutHandler
-        }
-    }
-}
-----
-======
+include-code::./CustomLogoutHandlerConfiguration[tag=customLogoutHandler,indent=0]

--- a/docs/src/test/java/org/springframework/security/docs/reactive/authentication/reactivelogout/CustomLogoutHandlerConfiguration.java
+++ b/docs/src/test/java/org/springframework/security/docs/reactive/authentication/reactivelogout/CustomLogoutHandlerConfiguration.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.docs.reactive.authentication.reactivelogout;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.authentication.logout.DelegatingServerLogoutHandler;
+import org.springframework.security.web.server.authentication.logout.SecurityContextServerLogoutHandler;
+import org.springframework.security.web.server.authentication.logout.WebSessionServerLogoutHandler;
+
+/**
+ * Demonstrates a reactive logout configuration that invalidates the {@code WebSession}
+ * on logout in addition to clearing the security context.
+ *
+ * @author lu1tr0n
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableWebFluxSecurity
+public class CustomLogoutHandlerConfiguration {
+
+	// tag::customLogoutHandler[]
+	@Bean
+	SecurityWebFilterChain http(ServerHttpSecurity http) throws Exception {
+		DelegatingServerLogoutHandler logoutHandler = new DelegatingServerLogoutHandler(
+				new SecurityContextServerLogoutHandler(), new WebSessionServerLogoutHandler()
+		);
+
+		http
+			.authorizeExchange((authorize) -> authorize.anyExchange().authenticated())
+			.logout((logout) -> logout.logoutHandler(logoutHandler));
+
+		return http.build();
+	}
+	// end::customLogoutHandler[]
+
+}

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/reactive/authentication/reactivelogout/CustomLogoutHandlerConfiguration.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/reactive/authentication/reactivelogout/CustomLogoutHandlerConfiguration.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.kt.docs.reactive.authentication.reactivelogout
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
+import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.config.web.server.invoke
+import org.springframework.security.web.server.SecurityWebFilterChain
+import org.springframework.security.web.server.authentication.logout.DelegatingServerLogoutHandler
+import org.springframework.security.web.server.authentication.logout.SecurityContextServerLogoutHandler
+import org.springframework.security.web.server.authentication.logout.WebSessionServerLogoutHandler
+import org.springframework.web.reactive.config.EnableWebFlux
+
+/**
+ * Demonstrates a reactive logout configuration that invalidates the `WebSession`
+ * on logout in addition to clearing the security context.
+ *
+ * @author lu1tr0n
+ */
+@EnableWebFlux
+@EnableWebFluxSecurity
+@Configuration(proxyBeanMethods = false)
+class CustomLogoutHandlerConfiguration {
+
+    // tag::customLogoutHandler[]
+    @Bean
+    fun http(http: ServerHttpSecurity): SecurityWebFilterChain {
+        val customLogoutHandler = DelegatingServerLogoutHandler(
+            SecurityContextServerLogoutHandler(), WebSessionServerLogoutHandler()
+        )
+
+        return http {
+            authorizeExchange {
+                authorize(anyExchange, authenticated)
+            }
+            logout {
+                logoutHandler = customLogoutHandler
+            }
+        }
+    }
+    // end::customLogoutHandler[]
+
+}


### PR DESCRIPTION
This PR updates `docs/modules/ROOT/pages/reactive/authentication/logout.adoc` to use the `include-code` macro for its Java and Kotlin samples.

The custom logout handler sample is now sourced from `CustomLogoutHandlerConfiguration` (Java and Kotlin), tagged as `customLogoutHandler`, and pulled into the rendered docs via `include-code::./CustomLogoutHandlerConfiguration[tag=customLogoutHandler,indent=0]`.

Verification:
- `./gradlew :spring-security-docs:compileTestJava :spring-security-docs:compileTestKotlin` passes.
- `./gradlew :spring-security-docs:antora` renders the page; the resulting `reactive/authentication/logout.html` shows the Java/Kotlin tabs with the expected snippets and no unprocessed `include-code` macros.

References https://github.com/spring-projects/spring-security/issues/16226