### PR TITLE
Use List.of in test collection factories

### DIFF
--- a/config/src/test/java/org/springframework/security/config/http/HttpCorsConfigTests.java
+++ b/config/src/test/java/org/springframework/security/config/http/HttpCorsConfigTests.java
@@ -16,7 +16,7 @@
 
 package org.springframework.security.config.http;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -151,8 +151,8 @@ public class HttpCorsConfigTests {
 
 		MyCorsConfigurationSource() {
 			CorsConfiguration configuration = new CorsConfiguration();
-			configuration.setAllowedOrigins(Arrays.asList("*"));
-			configuration.setAllowedMethods(Arrays.asList(RequestMethod.GET.name(), RequestMethod.POST.name()));
+			configuration.setAllowedOrigins(List.of("*"));
+			configuration.setAllowedMethods(List.of(RequestMethod.GET.name(), RequestMethod.POST.name()));
 			super.registerCorsConfiguration("/**", configuration);
 		}
 

--- a/test/src/test/java/org/springframework/security/test/web/reactive/server/SecurityMockServerConfigurersJwtTests.java
+++ b/test/src/test/java/org/springframework/security/test/web/reactive/server/SecurityMockServerConfigurersJwtTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.security.test.web.reactive.server;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -115,7 +114,7 @@ public class SecurityMockServerConfigurersJwtTests extends AbstractMockServerCon
 		this.client
 			.mutateWith(SecurityMockServerConfigurers.mockJwt()
 				.jwt((jwt) -> jwt.claim("scope", "ignored authorities"))
-				.authorities((jwt) -> Arrays.asList(this.authority1)))
+				.authorities((jwt) -> List.of(this.authority1)))
 			.get()
 			.exchange()
 			.expectStatus()


### PR DESCRIPTION
## Summary

Replace simple `Arrays.asList(...)` usages with `List.of(...)` in tests where the created lists are not mutated.

## Verification

- `./gradlew :spring-security-config:checkstyleTest`
- `./gradlew :spring-security-test:checkstyleTest`
- `./gradlew :spring-security-config:test --tests org.springframework.security.config.http.HttpCorsConfigTests`
- `./gradlew :spring-security-test:test --tests org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurersJwtTests`