### PR TITLE
7:28Add debug logging for parent AuthenticationManager

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
@@ -222,6 +222,7 @@ public class ProviderManager implements AuthenticationManager, MessageSourceAwar
 				// handled the request
 			}
 			catch (AuthenticationException ex) {
+				logger.debug(LogMessage.format("Authentication failed: %s", ex.getMessage()));
 				parentException = ex;
 				lastException = ex;
 			}


### PR DESCRIPTION
When a parent AuthenticationManager fails with an
AuthenticationException, the exception is currently caught and stored silently, making it difficult to diagnose authentication failures that originate in the parent manager at runtime.

Add a debug log message consistent with the existing logging throughout the authenticate method to aid
debugging.

The affected code path is already covered by existing tests in ProviderManagerTests.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
