### PR TITLE
Use switch for context holder strategy

### DIFF
--- a/core/src/main/java/org/springframework/security/core/context/SecurityContextHolder.java
+++ b/core/src/main/java/org/springframework/security/core/context/SecurityContextHolder.java
@@ -87,26 +87,27 @@ public class SecurityContextHolder {
 			// Set default
 			strategyName = MODE_THREADLOCAL;
 		}
-		if (strategyName.equals(MODE_THREADLOCAL)) {
-			strategy = new ThreadLocalSecurityContextHolderStrategy();
-			return;
-		}
-		if (strategyName.equals(MODE_INHERITABLETHREADLOCAL)) {
-			strategy = new InheritableThreadLocalSecurityContextHolderStrategy();
-			return;
-		}
-		if (strategyName.equals(MODE_GLOBAL)) {
-			strategy = new GlobalSecurityContextHolderStrategy();
-			return;
-		}
-		// Try to load a custom strategy
-		try {
-			Class<?> clazz = Class.forName(strategyName);
-			Constructor<?> customStrategy = clazz.getConstructor();
-			strategy = (SecurityContextHolderStrategy) customStrategy.newInstance();
-		}
-		catch (Exception ex) {
-			ReflectionUtils.handleReflectionException(ex);
+		switch (strategyName) {
+			case MODE_THREADLOCAL -> {
+				strategy = new ThreadLocalSecurityContextHolderStrategy();
+			}
+			case MODE_INHERITABLETHREADLOCAL -> {
+				strategy = new InheritableThreadLocalSecurityContextHolderStrategy();
+			}
+			case MODE_GLOBAL -> {
+				strategy = new GlobalSecurityContextHolderStrategy();
+			}
+			default -> {
+				// Try to load a custom strategy
+				try {
+					Class<?> clazz = Class.forName(strategyName);
+					Constructor<?> customStrategy = clazz.getConstructor();
+					strategy = (SecurityContextHolderStrategy) customStrategy.newInstance();
+				}
+				catch (Exception ex) {
+					ReflectionUtils.handleReflectionException(ex);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary  
Refactor `SecurityContextHolder.initializeStrategy()` to use a switch statement for strategy mode selection.

## What changed
The existing chain of `if` statements for `MODE_THREADLOCAL`, `MODE_INHERITABLETHREADLOCAL`, and `MODE_GLOBAL` was replaced with a switch statement.

## Why
This makes the strategy selection logic easier to read by grouping all `strategyName`-based branches in one switch statement. The behavior remains unchanged.
