### PR TITLE
docs: fix successful spelling in docs

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authentication/kerberos/samples.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/kerberos/samples.adoc
@@ -209,7 +209,7 @@ Or use a `user2` with a keytab file.
 $ java -jar sec-client-rest-template-{spring-security-version}.jar
 ----
 
-If operation is succesful you should see below output with `user2@EXAMPLE.ORG`.
+If operation is successful you should see below output with `user2@EXAMPLE.ORG`.
 [source,text]
 ----
 <html xmlns="https://www.w3.org/1999/xhtml"


### PR DESCRIPTION
Changes:
- `succesful` -> `successful` in `docs/modules/ROOT/pages/servlet/authentication/kerberos/samples.adoc` (1 occurrence(s), preserving capitalization where applicable)

Verification:
- Applied an exact spelling-only replacement against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked open PR titles and my open PRs before opening this PR.
