### PR TITLE
Remove BeanResolver Null Checks

### DIFF
--- a/core/src/main/java/org/springframework/security/access/expression/AbstractSecurityExpressionHandler.java
+++ b/core/src/main/java/org/springframework/security/access/expression/AbstractSecurityExpressionHandler.java
@@ -78,9 +78,7 @@ public abstract class AbstractSecurityExpressionHandler<T>
 	public final EvaluationContext createEvaluationContext(@Nullable Authentication authentication, T invocation) {
 		SecurityExpressionOperations root = createSecurityExpressionRoot(authentication, invocation);
 		StandardEvaluationContext ctx = createEvaluationContextInternal(authentication, invocation);
-		if (this.beanResolver != null) {
-			ctx.setBeanResolver(this.beanResolver);
-		}
+		ctx.setBeanResolver(this.beanResolver);
 		ctx.setRootObject(root);
 		return ctx;
 	}

--- a/core/src/main/java/org/springframework/security/access/expression/method/DefaultMethodSecurityExpressionHandler.java
+++ b/core/src/main/java/org/springframework/security/access/expression/method/DefaultMethodSecurityExpressionHandler.java
@@ -23,7 +23,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -95,7 +94,7 @@ public class DefaultMethodSecurityExpressionHandler extends AbstractSecurityExpr
 		MethodSecurityExpressionOperations root = createSecurityExpressionRoot(authentication, mi);
 		MethodSecurityEvaluationContext ctx = new MethodSecurityEvaluationContext(root, mi,
 				getParameterNameDiscoverer());
-		Optional.ofNullable(getBeanResolver()).ifPresent(ctx::setBeanResolver);
+		ctx.setBeanResolver(getBeanResolver());
 		return ctx;
 	}
 

--- a/messaging/src/main/java/org/springframework/security/messaging/access/expression/DefaultMessageSecurityExpressionHandler.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/access/expression/DefaultMessageSecurityExpressionHandler.java
@@ -20,7 +20,6 @@ import java.util.function.Supplier;
 
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.expression.BeanResolver;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.messaging.Message;
@@ -47,11 +46,7 @@ public class DefaultMessageSecurityExpressionHandler<T> extends AbstractSecurity
 			Message<T> message) {
 		MessageSecurityExpressionRoot<T> root = createSecurityExpressionRoot(authentication, message);
 		StandardEvaluationContext ctx = new StandardEvaluationContext(root);
-		BeanResolver beanResolver = getBeanResolver();
-		if (beanResolver != null) {
-			// https://github.com/spring-projects/spring-framework/issues/35371
-			ctx.setBeanResolver(beanResolver);
-		}
+		ctx.setBeanResolver(getBeanResolver());
 		return ctx;
 	}
 

--- a/messaging/src/main/java/org/springframework/security/messaging/handler/invocation/reactive/CurrentSecurityContextArgumentResolver.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/handler/invocation/reactive/CurrentSecurityContextArgumentResolver.java
@@ -175,10 +175,7 @@ public class CurrentSecurityContextArgumentResolver implements HandlerMethodArgu
 			StandardEvaluationContext context = new StandardEvaluationContext();
 			context.setRootObject(securityContext);
 			context.setVariable("this", securityContext);
-			if (this.beanResolver != null) {
-				// https://github.com/spring-projects/spring-framework/issues/35371
-				context.setBeanResolver(this.beanResolver);
-			}
+			context.setBeanResolver(this.beanResolver);
 			Expression expression = this.parser.parseExpression(expressionToParse);
 			securityContext = expression.getValue(context);
 		}

--- a/web/src/main/java/org/springframework/security/web/access/expression/DefaultHttpSecurityExpressionHandler.java
+++ b/web/src/main/java/org/springframework/security/web/access/expression/DefaultHttpSecurityExpressionHandler.java
@@ -48,7 +48,6 @@ public class DefaultHttpSecurityExpressionHandler extends AbstractSecurityExpres
 	private String defaultRolePrefix = DEFAULT_ROLE_PREFIX;
 
 	@Override
-	@SuppressWarnings("NullAway") // https://github.com/spring-projects/spring-framework/issues/35371
 	public EvaluationContext createEvaluationContext(Supplier<? extends @Nullable Authentication> authentication,
 			RequestAuthorizationContext context) {
 		WebSecurityExpressionRoot root = createSecurityExpressionRoot(authentication, context);

--- a/web/src/main/java/org/springframework/security/web/method/annotation/AuthenticationPrincipalArgumentResolver.java
+++ b/web/src/main/java/org/springframework/security/web/method/annotation/AuthenticationPrincipalArgumentResolver.java
@@ -126,10 +126,7 @@ public final class AuthenticationPrincipalArgumentResolver implements HandlerMet
 			StandardEvaluationContext context = new StandardEvaluationContext();
 			context.setRootObject(principal);
 			context.setVariable("this", principal);
-			// https://github.com/spring-projects/spring-framework/issues/35371
-			if (this.beanResolver != null) {
-				context.setBeanResolver(this.beanResolver);
-			}
+			context.setBeanResolver(this.beanResolver);
 			Expression expression = this.parser.parseExpression(expressionToParse);
 			principal = expression.getValue(context);
 		}

--- a/web/src/main/java/org/springframework/security/web/method/annotation/CurrentSecurityContextArgumentResolver.java
+++ b/web/src/main/java/org/springframework/security/web/method/annotation/CurrentSecurityContextArgumentResolver.java
@@ -160,10 +160,7 @@ public final class CurrentSecurityContextArgumentResolver implements HandlerMeth
 			StandardEvaluationContext context = new StandardEvaluationContext();
 			context.setRootObject(securityContext);
 			context.setVariable("this", securityContext);
-			// https://github.com/spring-projects/spring-framework/issues/35371
-			if (this.beanResolver != null) {
-				context.setBeanResolver(this.beanResolver);
-			}
+			context.setBeanResolver(this.beanResolver);
 			Expression expression = this.parser.parseExpression(expressionToParse);
 			securityContextResult = expression.getValue(context);
 		}

--- a/web/src/main/java/org/springframework/security/web/reactive/result/method/annotation/AuthenticationPrincipalArgumentResolver.java
+++ b/web/src/main/java/org/springframework/security/web/reactive/result/method/annotation/AuthenticationPrincipalArgumentResolver.java
@@ -95,7 +95,6 @@ public class AuthenticationPrincipalArgumentResolver extends HandlerMethodArgume
 			});
 	}
 
-	@SuppressWarnings("NullAway") // https://github.com/spring-projects/spring-framework/issues/35371
 	private @Nullable Object resolvePrincipal(MethodParameter parameter, @Nullable Object principal) {
 		AuthenticationPrincipal annotation = findMethodAnnotation(parameter);
 		if (annotation == null) {

--- a/web/src/main/java/org/springframework/security/web/reactive/result/method/annotation/CurrentSecurityContextArgumentResolver.java
+++ b/web/src/main/java/org/springframework/security/web/reactive/result/method/annotation/CurrentSecurityContextArgumentResolver.java
@@ -141,7 +141,6 @@ public class CurrentSecurityContextArgumentResolver extends HandlerMethodArgumen
 		return securityContext;
 	}
 
-	@SuppressWarnings("NullAway") // https://github.com/spring-projects/spring-framework/issues/35371
 	private @Nullable Object resolveSecurityContextFromAnnotation(CurrentSecurityContext annotation,
 			MethodParameter parameter, Object securityContext) {
 		Object securityContextResult = securityContext;


### PR DESCRIPTION
Resolves gh-17816.

Spring Framework updated `StandardEvaluationContext.setBeanResolver`
to accept a `@Nullable BeanResolver`
(spring-projects/spring-framework#35371, included in 6.2.11 and 7.0.x).

Since Spring Security now depends on Spring Framework 7.0.7,
the temporary NullAway workarounds around `setBeanResolver`
can be removed.

## Changes

Removed temporary workarounds from the following locations.

### Removed `@SuppressWarnings("NullAway")`

- `DefaultHttpSecurityExpressionHandler`
- reactive `CurrentSecurityContextArgumentResolver`
- reactive `AuthenticationPrincipalArgumentResolver`

### Removed unnecessary null guards

- servlet `AuthenticationPrincipalArgumentResolver`
- servlet `CurrentSecurityContextArgumentResolver`
- messaging reactive `CurrentSecurityContextArgumentResolver`
- `DefaultMessageSecurityExpressionHandler`

Also removed obsolete comments referencing
spring-projects/spring-framework#35371 and cleaned up
unused imports/local variables where applicable.

## Behavior

No behavior change.

`StandardEvaluationContext.beanResolver` defaults to `null`,
so calling `setBeanResolver(null)` is equivalent to not invoking
the setter.

## Verification

- `./gradlew :spring-security-web:compileJava :spring-security-messaging:compileJava`
- `./gradlew :spring-security-web:test --tests "*AuthenticationPrincipalArgumentResolver*" --tests "*CurrentSecurityContextArgumentResolver*" --tests "*DefaultHttpSecurityExpressionHandler*"`
- `./gradlew :spring-security-messaging:test --tests "*CurrentSecurityContextArgumentResolver*" --tests "*DefaultMessageSecurityExpressionHandler*"`
- `grep -rn "35371" --include="*.java"`