### PR TITLE
AuthenticatorTransport#values should include SMART_CARD

### DIFF
--- a/webauthn/src/main/java/org/springframework/security/web/webauthn/api/AuthenticatorTransport.java
+++ b/webauthn/src/main/java/org/springframework/security/web/webauthn/api/AuthenticatorTransport.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
  * order to obtain an assertion for a specific credential.
  *
  * @author Rob Winch
+ * @author Andrey Litvitski
  * @since 6.4
  */
 public final class AuthenticatorTransport implements Serializable {
@@ -118,7 +119,7 @@ public final class AuthenticatorTransport implements Serializable {
 	}
 
 	public static AuthenticatorTransport[] values() {
-		return new AuthenticatorTransport[] { USB, NFC, BLE, HYBRID, INTERNAL };
+		return new AuthenticatorTransport[] { USB, NFC, BLE, SMART_CARD, HYBRID, INTERNAL };
 	}
 
 }

--- a/webauthn/src/main/java/org/springframework/security/web/webauthn/api/AuthenticatorTransport.java
+++ b/webauthn/src/main/java/org/springframework/security/web/webauthn/api/AuthenticatorTransport.java
@@ -27,6 +27,7 @@ import java.io.Serializable;
  * order to obtain an assertion for a specific credential.
  *
  * @author Rob Winch
+ * @author Andrey Litvitski
  * @since 6.4
  */
 public final class AuthenticatorTransport implements Serializable {
@@ -119,7 +120,7 @@ public final class AuthenticatorTransport implements Serializable {
 	}
 
 	public static AuthenticatorTransport[] values() {
-		return new AuthenticatorTransport[] { USB, NFC, BLE, HYBRID, INTERNAL };
+		return new AuthenticatorTransport[] { USB, NFC, BLE, SMART_CARD, HYBRID, INTERNAL };
 	}
 
 	@Override


### PR DESCRIPTION
We do not specify the SMART_CARD constant in
`AuthenticatorTransport#values`, even though it is processed in `AuthenticatorTransport#valueOf`.

Closes: gh-19232

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
