### PR TITLE
Validate authorization-code token parameters

### DIFF
--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/authentication/OAuth2EndpointUtils.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/web/authentication/OAuth2EndpointUtils.java
@@ -18,6 +18,7 @@ package org.springframework.security.oauth2.server.authorization.web.authenticat
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -85,6 +86,9 @@ final class OAuth2EndpointUtils {
 		}
 		MultiValueMap<String, String> multiValueParameters = "GET".equals(request.getMethod())
 				? getQueryParameters(request) : getFormParameters(request);
+		validateSingleParameter(multiValueParameters, OAuth2ParameterNames.GRANT_TYPE);
+		validateSingleParameter(multiValueParameters, OAuth2ParameterNames.CODE);
+		validateSingleParameter(multiValueParameters, PkceParameterNames.CODE_VERIFIER);
 		for (String exclusion : exclusions) {
 			multiValueParameters.remove(exclusion);
 		}
@@ -94,6 +98,13 @@ final class OAuth2EndpointUtils {
 				(key, value) -> parameters.put(key, (value.size() == 1) ? value.get(0) : value.toArray(new String[0])));
 
 		return parameters;
+	}
+
+	private static void validateSingleParameter(MultiValueMap<String, String> parameters, String parameterName) {
+		List<String> values = parameters.get(parameterName);
+		if (values != null && values.size() != 1) {
+			throwError(OAuth2ErrorCodes.INVALID_REQUEST, parameterName, ACCESS_TOKEN_REQUEST_ERROR_URI);
+		}
 	}
 
 	static boolean matchesAuthorizationCodeGrantRequest(HttpServletRequest request) {

--- a/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/authentication/ClientSecretBasicAuthenticationConverterTests.java
+++ b/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/authentication/ClientSecretBasicAuthenticationConverterTests.java
@@ -123,6 +123,28 @@ public class ClientSecretBasicAuthenticationConverterTests {
 				entry("custom-param", new String[] { "custom-value-1", "custom-value-2" }));
 	}
 
+	@Test
+	public void convertWhenConfidentialClientWithMultipleCodeThenInvalidRequestError() throws Exception {
+		MockHttpServletRequest request = createPkceTokenRequest();
+		request.addParameter(OAuth2ParameterNames.CODE, "code-2");
+		request.addHeader(HttpHeaders.AUTHORIZATION, "Basic " + encodeBasicAuth("clientId", "secret"));
+		assertThatExceptionOfType(OAuth2AuthenticationException.class).isThrownBy(() -> this.converter.convert(request))
+			.extracting(OAuth2AuthenticationException::getError)
+			.extracting("errorCode")
+			.isEqualTo(OAuth2ErrorCodes.INVALID_REQUEST);
+	}
+
+	@Test
+	public void convertWhenConfidentialClientWithMultipleCodeVerifierThenInvalidRequestError() throws Exception {
+		MockHttpServletRequest request = createPkceTokenRequest();
+		request.addParameter(PkceParameterNames.CODE_VERIFIER, "code-verifier-2");
+		request.addHeader(HttpHeaders.AUTHORIZATION, "Basic " + encodeBasicAuth("clientId", "secret"));
+		assertThatExceptionOfType(OAuth2AuthenticationException.class).isThrownBy(() -> this.converter.convert(request))
+			.extracting(OAuth2AuthenticationException::getError)
+			.extracting("errorCode")
+			.isEqualTo(OAuth2ErrorCodes.INVALID_REQUEST);
+	}
+
 	private static String encodeBasicAuth(String clientId, String secret) throws Exception {
 		clientId = URLEncoder.encode(clientId, StandardCharsets.UTF_8.name());
 		secret = URLEncoder.encode(secret, StandardCharsets.UTF_8.name());

--- a/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/authentication/ClientSecretPostAuthenticationConverterTests.java
+++ b/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/web/authentication/ClientSecretPostAuthenticationConverterTests.java
@@ -110,6 +110,30 @@ public class ClientSecretPostAuthenticationConverterTests {
 				entry("custom-param", new String[] { "custom-value-1", "custom-value-2" }));
 	}
 
+	@Test
+	public void convertWhenConfidentialClientWithMultipleCodeThenInvalidRequestError() {
+		MockHttpServletRequest request = createPkceTokenRequest();
+		request.addParameter(OAuth2ParameterNames.CLIENT_ID, "client-1");
+		request.addParameter(OAuth2ParameterNames.CLIENT_SECRET, "client-secret");
+		request.addParameter(OAuth2ParameterNames.CODE, "code-2");
+		assertThatExceptionOfType(OAuth2AuthenticationException.class).isThrownBy(() -> this.converter.convert(request))
+			.extracting(OAuth2AuthenticationException::getError)
+			.extracting("errorCode")
+			.isEqualTo(OAuth2ErrorCodes.INVALID_REQUEST);
+	}
+
+	@Test
+	public void convertWhenConfidentialClientWithMultipleCodeVerifierThenInvalidRequestError() {
+		MockHttpServletRequest request = createPkceTokenRequest();
+		request.addParameter(OAuth2ParameterNames.CLIENT_ID, "client-1");
+		request.addParameter(OAuth2ParameterNames.CLIENT_SECRET, "client-secret");
+		request.addParameter(PkceParameterNames.CODE_VERIFIER, "code-verifier-2");
+		assertThatExceptionOfType(OAuth2AuthenticationException.class).isThrownBy(() -> this.converter.convert(request))
+			.extracting(OAuth2AuthenticationException::getError)
+			.extracting("errorCode")
+			.isEqualTo(OAuth2ErrorCodes.INVALID_REQUEST);
+	}
+
 	private static MockHttpServletRequest createPkceTokenRequest() {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addParameter(OAuth2ParameterNames.GRANT_TYPE, AuthorizationGrantType.AUTHORIZATION_CODE.getValue());


### PR DESCRIPTION
Closes gh-19227

This validates the authorization-code token request parameters that are copied into confidential client authentication before they are stored as additional parameters.

Duplicate code or code_verifier values now fail with invalid_request instead of being carried as String[] values into PKCE validation. Repeated custom extension parameters are still preserved.



**Tests:**

./gradlew :spring-security-oauth2-authorization-server:test --tests ClientSecretBasicAuthenticationConverterTests --tests ClientSecretPostAuthenticationConverterTests
./gradlew --no-build-cache --rerun-tasks :spring-security-oauth2-authorization-server:test
./gradlew format && ./gradlew check

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
