### PR TITLE
Add allowIfSubType for URL and Instant in OAuth2ClientJacksonModule 

### DIFF
--- a/core/src/main/java/org/springframework/security/jackson/CoreJacksonModule.java
+++ b/core/src/main/java/org/springframework/security/jackson/CoreJacksonModule.java
@@ -16,6 +16,7 @@
 
 package org.springframework.security.jackson;
 
+import java.net.URL;
 import java.time.Duration;
 import java.time.Instant;
 
@@ -73,6 +74,7 @@ public class CoreJacksonModule extends SecurityJacksonModule {
 	public void configurePolymorphicTypeValidator(BasicPolymorphicTypeValidator.Builder builder) {
 		builder.allowIfSubType(Instant.class)
 			.allowIfSubType(Duration.class)
+			.allowIfSubType(URL.class)
 			.allowIfSubType(SimpleGrantedAuthority.class)
 			.allowIfSubType(FactorGrantedAuthority.class)
 			.allowIfSubType(UsernamePasswordAuthenticationToken.class)

--- a/core/src/test/java/org/springframework/security/jackson/SecurityJacksonModulesTests.java
+++ b/core/src/test/java/org/springframework/security/jackson/SecurityJacksonModulesTests.java
@@ -16,7 +16,11 @@
 
 package org.springframework.security.jackson;
 
+import java.net.URI;
+import java.net.URL;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.junit.jupiter.api.Test;
@@ -70,6 +74,18 @@ public class SecurityJacksonModulesTests {
 		String json = mapper.writeValueAsString(user);
 		User deserializedUer = mapper.readerFor(User.class).readValue(json);
 		assertThat(deserializedUer).isEqualTo(user);
+	}
+
+	@Test
+	public void deserializeWhenMapContainsUrlThenDeserializes() throws Exception {
+		ClassLoader loader = getClass().getClassLoader();
+		List<JacksonModule> modules = SecurityJacksonModules.getModules(loader);
+		JsonMapper mapper = JsonMapper.builder().addModules(modules).build();
+		Map<String, Object> map = new LinkedHashMap<>();
+		map.put("url", URI.create("https://example.com").toURL());
+		String json = mapper.writeValueAsString(map);
+		Map<String, Object> deserialized = mapper.readerFor(Map.class).readValue(json);
+		assertThat(deserialized.get("url")).isInstanceOf(URL.class).hasToString("https://example.com");
 	}
 
 	@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthenticationTokenMixinTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/jackson/OAuth2AuthenticationTokenMixinTests.java
@@ -16,11 +16,15 @@
 
 package org.springframework.security.oauth2.client.jackson;
 
+import java.net.URI;
+import java.net.URL;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.datatype.jsr310.DecimalUtils;
@@ -169,6 +173,27 @@ public class OAuth2AuthenticationTokenMixinTests {
 		assertThat(idToken.getExpiresAt()).isEqualTo(expectedIdToken.getExpiresAt());
 		assertThat(idToken.getClaims()).containsExactlyEntriesOf(expectedIdToken.getClaims());
 		assertThat(principal.getUserInfo()).isNull();
+	}
+
+	@Test
+	public void deserializeWhenClaimsContainUrlThenDeserializes() throws Exception {
+		Instant issuedAt = Instant.now();
+		Instant expiresAt = issuedAt.plusSeconds(3600);
+		Map<String, Object> claims = new HashMap<>();
+		claims.put(IdTokenClaimNames.ISS, URI.create("https://example.com/issuer").toURL());
+		claims.put(IdTokenClaimNames.SUB, "subject");
+		claims.put(IdTokenClaimNames.IAT, issuedAt);
+		claims.put(IdTokenClaimNames.EXP, expiresAt);
+		OidcIdToken idToken = new OidcIdToken("id-token", issuedAt, expiresAt, claims);
+		Collection<GrantedAuthority> authorities = Collections.singleton(new OidcUserAuthority(idToken));
+		DefaultOidcUser principal = new DefaultOidcUser(authorities, idToken);
+		OAuth2AuthenticationToken authentication = new OAuth2AuthenticationToken(principal, authorities,
+				"registration-id");
+		String json = this.mapper.writeValueAsString(authentication);
+		OAuth2AuthenticationToken deserialized = this.mapper.readValue(json, OAuth2AuthenticationToken.class);
+		DefaultOidcUser deserializedUser = (DefaultOidcUser) deserialized.getPrincipal();
+		assertThat(deserializedUser.getIdToken().getClaims().get(IdTokenClaimNames.ISS)).isInstanceOf(URL.class)
+				.hasToString("https://example.com/issuer");
 	}
 
 	private static String asJson(OAuth2AuthenticationToken authentication) {


### PR DESCRIPTION
Fixes gh-19241

## Problem

Deserializing an `OAuth2AuthenticationToken` from a Redis session fails
with a `SerializationException`, because `OidcIdToken` stores `iss` as a
`java.net.URL` inside its claims map and the configured
`PolymorphicTypeValidator` denies it.

`java.net.URL` is present in the Jackson 2 allowlist
(`AllowlistTypeIdResolver.ALLOWLIST_CLASS_NAMES`) but missing from the
Jackson 3 modules.

## Fix

Added `allowIfSubType(URL.class)` to `CoreJacksonModule`.
`SecurityJacksonModules` passes a single shared builder to every
`SecurityJacksonModule`, so the entry applies to the OAuth2 modules as
well.

## Tests

- `deserializeWhenMapContainsUrlThenDeserializes` in
  `SecurityJacksonModulesTests` — a `Map` value of type `URL` round-trips
- `deserializeWhenClaimsContainUrlThenDeserializes` in
  `OAuth2AuthenticationTokenMixinTests` — regression test for the
  originally reported scenario