### PR TITLE
Update permissions policy header in SecurityFilterChain

### DIFF
--- a/docs/modules/ROOT/pages/servlet/exploits/headers.adoc
+++ b/docs/modules/ROOT/pages/servlet/exploits/headers.adoc
@@ -946,7 +946,7 @@ public class WebSecurityConfig {
 		http
 			// ...
 			.headers((headers) -> headers
-				.permissionsPolicy((permissions) -> permissions
+				.permissionsPolicyHeader((permissions) -> permissions
 					.policy("geolocation=(self)")
 				)
 			);


### PR DESCRIPTION
Replace `.permissionsPolicy` with `.permissionsPolicyHeader` as `.permissionsPolicy` is marked as deprecated.

> Deprecated. For removal in 7.0. Use permissionsPolicyHeader(Customizer) instead
