### PR TITLE
Fix device authorization flow without requested scopes

### DIFF
--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2DeviceAuthorizationConsentAuthenticationProvider.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2DeviceAuthorizationConsentAuthenticationProvider.java
@@ -50,6 +50,7 @@ import org.springframework.util.Assert;
  * used in the OAuth 2.0 Device Authorization Grant.
  *
  * @author Steve Riesenberg
+ * @author Andrey Litvitski
  * @since 7.0
  * @see OAuth2DeviceAuthorizationConsentAuthenticationToken
  * @see OAuth2AuthorizationConsent
@@ -183,7 +184,7 @@ public final class OAuth2DeviceAuthorizationConsentAuthenticationProvider implem
 		OAuth2Authorization.Token<OAuth2UserCode> userCodeToken = authorization.getToken(OAuth2UserCode.class);
 		Assert.notNull(userCodeToken, "userCode cannot be null");
 
-		if (authorities.isEmpty()) {
+		if (authorities.isEmpty() && !requestedScopes.isEmpty()) {
 			// Authorization consent denied (or revoked)
 			if (currentAuthorizationConsent != null) {
 				this.authorizationConsentService.remove(currentAuthorizationConsent);
@@ -203,11 +204,13 @@ public final class OAuth2DeviceAuthorizationConsentAuthenticationProvider implem
 			throw createException(OAuth2ErrorCodes.ACCESS_DENIED, OAuth2ParameterNames.CLIENT_ID);
 		}
 
-		OAuth2AuthorizationConsent authorizationConsent = authorizationConsentBuilder.build();
-		if (currentAuthorizationConsent == null || !authorizationConsent.equals(currentAuthorizationConsent)) {
-			this.authorizationConsentService.save(authorizationConsent);
-			if (this.logger.isTraceEnabled()) {
-				this.logger.trace("Saved authorization consent");
+		if (!authorities.isEmpty()) {
+			OAuth2AuthorizationConsent authorizationConsent = authorizationConsentBuilder.build();
+			if (currentAuthorizationConsent == null || !authorizationConsent.equals(currentAuthorizationConsent)) {
+				this.authorizationConsentService.save(authorizationConsent);
+				if (this.logger.isTraceEnabled()) {
+					this.logger.trace("Saved authorization consent");
+				}
 			}
 		}
 

--- a/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2DeviceAuthorizationConsentAuthenticationProviderTests.java
+++ b/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2DeviceAuthorizationConsentAuthenticationProviderTests.java
@@ -63,6 +63,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
  * Tests for {@link OAuth2DeviceAuthorizationConsentAuthenticationProvider}.
  *
  * @author Steve Riesenberg
+ * @author Andrey Litvitski
  */
 public class OAuth2DeviceAuthorizationConsentAuthenticationProviderTests {
 
@@ -274,9 +275,12 @@ public class OAuth2DeviceAuthorizationConsentAuthenticationProviderTests {
 	@Test
 	public void authenticateWhenAuthoritiesIsEmptyThenThrowOAuth2AuthenticationException() {
 		RegisteredClient registeredClient = TestRegisteredClients.registeredClient().build();
-		RegisteredClient registeredClient2 = TestRegisteredClients.registeredClient().scopes(Set::clear).build();
-		OAuth2Authorization authorization = createAuthorization(registeredClient2);
-		Authentication authentication = createAuthentication(registeredClient2);
+		OAuth2Authorization authorization = createAuthorization(registeredClient);
+		TestingAuthenticationToken principal = new TestingAuthenticationToken("principal", null,
+				Collections.emptyList());
+		Authentication authentication = new OAuth2DeviceAuthorizationConsentAuthenticationToken(AUTHORIZATION_URI,
+				registeredClient.getClientId(), principal, USER_CODE, STATE, Collections.emptySet(),
+				Collections.emptyMap());
 		given(this.authorizationService.findByToken(anyString(), any(OAuth2TokenType.class))).willReturn(authorization);
 		given(this.registeredClientRepository.findByClientId(anyString())).willReturn(registeredClient);
 		// @formatter:off


### PR DESCRIPTION
The main issue is inconsistent behavior. A `device_authorization` request without a `scope` is always accepted, but then, during the `consent` phase, if `authorities` is empty, we always get an `access_denied` error. However, would not it make sense to continue processing when both `scope` and `authorities` are empty?

The `scope` parameter itself is optional according to [RFC-8628](https://datatracker.ietf.org/doc/html/rfc8628#section-3.1). There is also a note attached to it that refers to [Section 3.3 in RFC-6749](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3). It states that if `scope` is empty, then we must either handle it with a default value or throw an error.

And here’s the interesting part. I propose two solutions to the problem; I’ve implemented the first one in the current commit, and in the future we can pivot to the other solution. The first is to directly handle the case at the `consent` stage when `scope` and `authorities` are empty and allow the event to proceed. The second is to throw an error on a `device_authorization` request if `scope` is empty.

I think the first solution is better because it’s also easier to maintain. With the first solution, the test breaks, but that’s because it handles all cases and is abstract, so I refined it for the case where `authorities` is empty but `scope` is not empty. The second solution breaks the specific test case `OAuth2DeviceAuthorizationRequestAuthenticationProviderTests#authenticateWhenNoScopesRequestedThenReturnDeviceCodeAndUserCode`.

Closes: gh-19238
Ref: gh-19256

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
