### PR TITLE
Use `SCOPE` instead of `CLIENT_ID` for access_denied in device authorization consent

### DIFF
--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2DeviceAuthorizationConsentAuthenticationProvider.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2DeviceAuthorizationConsentAuthenticationProvider.java
@@ -50,6 +50,7 @@ import org.springframework.util.Assert;
  * used in the OAuth 2.0 Device Authorization Grant.
  *
  * @author Steve Riesenberg
+ * @author Andrey Litvitski
  * @since 7.0
  * @see OAuth2DeviceAuthorizationConsentAuthenticationToken
  * @see OAuth2AuthorizationConsent
@@ -200,7 +201,7 @@ public final class OAuth2DeviceAuthorizationConsentAuthenticationProvider implem
 			if (this.logger.isTraceEnabled()) {
 				this.logger.trace("Invalidated device code and user code because authorization consent was denied");
 			}
-			throw createException(OAuth2ErrorCodes.ACCESS_DENIED, OAuth2ParameterNames.CLIENT_ID);
+			throw createException(OAuth2ErrorCodes.ACCESS_DENIED, OAuth2ParameterNames.SCOPE);
 		}
 
 		OAuth2AuthorizationConsent authorizationConsent = authorizationConsentBuilder.build();


### PR DESCRIPTION
The current behavior is misleading (for example, as in gh-19238). It was likely implemented by accident as a result of copy-pasting, since the `client_id` check was performed earlier in the
`OAuth2DeviceAuthorizationConsentAuthenticationProvider#authenticate` method, and the current behavior has nothing to do with `client_id`, but rather with checking authorities, i.e., scope.

Ref: gh-19238
Ref: gh-19256

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
