### PR TITLE
Add XML configuration guidance to authorizeRequests deprecation warning

### DIFF
--- a/config/src/main/java/org/springframework/security/config/http/DefaultFilterChainValidator.java
+++ b/config/src/main/java/org/springframework/security/config/http/DefaultFilterChainValidator.java
@@ -126,7 +126,9 @@ public class DefaultFilterChainValidator implements FilterChainProxy.FilterChain
 			}
 			if (filterSecurityInterceptor != null) {
 				this.logger.warn(
-						"Usage of authorizeRequests is deprecated. Please use authorizeHttpRequests in the configuration");
+						"Usage of authorizeRequests is deprecated. Please use authorizeHttpRequests in the configuration. "
+								+ "If you are using XML configuration with <intercept-url>, "
+								+ "add use-authorization-manager=\"true\" to your <http> element.");
 			}
 			authorizationFilter = null;
 			filterSecurityInterceptor = null;

--- a/config/src/test/java/org/springframework/security/config/http/DefaultFilterChainValidatorTests.java
+++ b/config/src/test/java/org/springframework/security/config/http/DefaultFilterChainValidatorTests.java
@@ -132,6 +132,15 @@ public class DefaultFilterChainValidatorTests {
 				+ "access to the configured login page. (Simulated access was rejected)");
 	}
 
+	@Test
+	void validateWhenOnlyFilterSecurityInterceptorThenWarnWithXmlGuidance() {
+		this.validator.validate(this.chain);
+		verify(this.logger).warn(
+				"Usage of authorizeRequests is deprecated. Please use authorizeHttpRequests in the configuration. "
+						+ "If you are using XML configuration with <intercept-url>, "
+						+ "add use-authorization-manager=\"true\" to your <http> element.");
+	}
+
 	// SEC-1957
 	@Test
 	public void validateCustomMetadataSource() {


### PR DESCRIPTION
## Problem

When using XML configuration with `<intercept-url>`, Spring Security internally registers a `FilterSecurityInterceptor`, which triggers the `authorizeRequests` deprecation warning in `DefaultFilterChainValidator`. However, the previous warning message provided no actionable guidance for XML users:

```
Usage of authorizeRequests is deprecated. Please use authorizeHttpRequests in the configuration
```

XML users cannot directly replace `<intercept-url>` with `authorizeHttpRequests()` — they need to add `use-authorization-manager="true"` to their `<http>` element. Without this guidance, the warning is confusing and leaves XML users with no clear path forward.

## Fix

Added XML-specific guidance to the deprecation warning message:

```
Usage of authorizeRequests is deprecated. Please use authorizeHttpRequests in the configuration.
If you are using XML configuration with <intercept-url>, add use-authorization-manager="true" to your <http> element.
```

## Testing

Added `validateWhenOnlyFilterSecurityInterceptorThenWarnWithXmlGuidance()` to `DefaultFilterChainValidatorTests` to verify the updated warning message.

Closes gh-17259