### PR TITLE
Validate Parameter in setPostAuthenticationChecks

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/AbstractUserDetailsReactiveAuthenticationManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/AbstractUserDetailsReactiveAuthenticationManager.java
@@ -184,7 +184,7 @@ public abstract class AbstractUserDetailsReactiveAuthenticationManager
 	 * @since 5.2
 	 */
 	public void setPostAuthenticationChecks(UserDetailsChecker postAuthenticationChecks) {
-		Assert.notNull(this.postAuthenticationChecks, "postAuthenticationChecks cannot be null");
+		Assert.notNull(postAuthenticationChecks, "postAuthenticationChecks cannot be null");
 		this.postAuthenticationChecks = postAuthenticationChecks;
 	}
 

--- a/core/src/test/java/org/springframework/security/authentication/UserDetailsRepositoryReactiveAuthenticationManagerTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/UserDetailsRepositoryReactiveAuthenticationManagerTests.java
@@ -91,6 +91,12 @@ public class UserDetailsRepositoryReactiveAuthenticationManagerTests {
 	}
 
 	@Test
+	public void setPostAuthenticationChecksWhenNullThenIllegalArgumentException() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+			.isThrownBy(() -> this.manager.setPostAuthenticationChecks(null));
+	}
+
+	@Test
 	public void authenticateWhenCustomSchedulerThenUsed() {
 		given(this.scheduler.schedule(any())).willAnswer((a) -> {
 			Runnable r = a.getArgument(0);


### PR DESCRIPTION
# Overview
The null check in `AbstractUserDetailsReactiveAuthenticationManager#setPostAuthenticationChecks` asserts the current field value instead of the method parameter:

```java
public void setPostAuthenticationChecks(UserDetailsChecker postAuthenticationChecks) {
	Assert.notNull(this.postAuthenticationChecks, "postAuthenticationChecks cannot be null");
	this.postAuthenticationChecks = postAuthenticationChecks;
}
```

Since the field is initialized to a default and can never be null at that point, the assertion always passes and `null` is silently accepted. The next `authenticate(...)` call then fails with a raw `NullPointerException` at `.doOnNext(this.postAuthenticationChecks::check)` instead of failing fast with a clear message:

```java
manager.setPostAuthenticationChecks(null); // no exception — should throw IllegalArgumentException
manager.authenticate(token).block();       // NullPointerException
```

All other setters in the same class (`setPasswordEncoder`, `setScheduler`, `setUserDetailsPasswordService`, `setMessageSource`) validate the parameter. This change fixes the assertion to validate the parameter and adds a regression test.

# Related Issue
Closes gh-19276