### PR TITLE
Add setPreAuthenticationChecks to Reactive Manager

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/AbstractUserDetailsReactiveAuthenticationManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/AbstractUserDetailsReactiveAuthenticationManager.java
@@ -179,6 +179,17 @@ public abstract class AbstractUserDetailsReactiveAuthenticationManager
 
 	/**
 	 * Sets the strategy which will be used to validate the loaded <tt>UserDetails</tt>
+	 * object before authentication occurs.
+	 * @param preAuthenticationChecks The {@link UserDetailsChecker}
+	 * @since 7.1
+	 */
+	public void setPreAuthenticationChecks(UserDetailsChecker preAuthenticationChecks) {
+		Assert.notNull(preAuthenticationChecks, "preAuthenticationChecks cannot be null");
+		this.preAuthenticationChecks = preAuthenticationChecks;
+	}
+
+	/**
+	 * Sets the strategy which will be used to validate the loaded <tt>UserDetails</tt>
 	 * object after authentication occurs.
 	 * @param postAuthenticationChecks The {@link UserDetailsChecker}
 	 * @since 5.2

--- a/core/src/test/java/org/springframework/security/authentication/UserDetailsRepositoryReactiveAuthenticationManagerTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/UserDetailsRepositoryReactiveAuthenticationManagerTests.java
@@ -70,6 +70,9 @@ public class UserDetailsRepositoryReactiveAuthenticationManagerTests {
 	private Scheduler scheduler;
 
 	@Mock
+	private UserDetailsChecker preAuthenticationChecks;
+
+	@Mock
 	private UserDetailsChecker postAuthenticationChecks;
 
 	// @formatter:off
@@ -147,6 +150,25 @@ public class UserDetailsRepositoryReactiveAuthenticationManagerTests {
 				this.user.getPassword());
 		Authentication result = this.manager.authenticate(token).block();
 		verifyNoMoreInteractions(this.userDetailsPasswordService);
+	}
+
+	@Test
+	public void setPreAuthenticationChecksWhenNullThenIllegalArgumentException() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+			.isThrownBy(() -> this.manager.setPreAuthenticationChecks(null));
+	}
+
+	@Test
+	public void authenticateWhenPreAuthenticationChecksFail() {
+		given(this.userDetailsService.findByUsername(any())).willReturn(Mono.just(this.user));
+		willThrow(new LockedException("account is locked")).given(this.preAuthenticationChecks).check(any());
+		this.manager.setPreAuthenticationChecks(this.preAuthenticationChecks);
+		assertThatExceptionOfType(LockedException.class)
+			.isThrownBy(() -> this.manager
+				.authenticate(UsernamePasswordAuthenticationToken.unauthenticated(this.user, this.user.getPassword()))
+				.block())
+			.withMessage("account is locked");
+		verify(this.preAuthenticationChecks).check(eq(this.user));
 	}
 
 	@Test


### PR DESCRIPTION
# Overview
`AbstractUserDetailsReactiveAuthenticationManager` runs pre-authentication checks (locked/disabled/expired) before validating the password, but unlike the post-authentication checks they cannot be customized:

```java
manager.setPostAuthenticationChecks(customChecker); // available since 5.2
manager.setPreAuthenticationChecks(customChecker);  // does not exist
```

The servlet counterpart (`AbstractUserDetailsAuthenticationProvider`) allows customizing both. This PR adds the missing `setPreAuthenticationChecks` setter (`@since 7.1`) along with tests for null validation and for a custom checker being invoked during authentication.

# Related Issue
Closes gh-19275