### PR TITLE
Remove Unnecessary `AuthorizationDecision` Cast

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/WebSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/WebSecurity.java
@@ -379,9 +379,8 @@ public final class WebSecurity extends AbstractConfiguredSecurityBuilder<Filter,
 			}
 			if (filter instanceof AuthorizationFilter authorization) {
 				AuthorizationManager<HttpServletRequest> authorizationManager = authorization.getAuthorizationManager();
-				builder.add(securityFilterChain::matches,
-						(authentication, context) -> (AuthorizationDecision) authorizationManager
-							.authorize(authentication, context.getRequest()));
+				builder.add(securityFilterChain::matches, (authentication, context) -> authorizationManager
+					.authorize(authentication, context.getRequest()));
 				mappings = true;
 			}
 		}


### PR DESCRIPTION
Closes gh-19282

The method was deprecated in 6.5.x and removed in 7.0.x, so I don't think this cast is necessary.

https://github.com/spring-projects/spring-security/blob/fe2e52f646f6beb534de2e49152c183c6e5a1529/core/src/main/java/org/springframework/security/authorization/AuthorizationManager.java#L48-L57