### PR TITLE
Allow non-AuthorizationDecision results in WebSecurity

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/WebSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/WebSecurity.java
@@ -379,9 +379,8 @@ public final class WebSecurity extends AbstractConfiguredSecurityBuilder<Filter,
 			}
 			if (filter instanceof AuthorizationFilter authorization) {
 				AuthorizationManager<HttpServletRequest> authorizationManager = authorization.getAuthorizationManager();
-				builder.add(securityFilterChain::matches,
-						(authentication, context) -> (AuthorizationDecision) authorizationManager
-							.authorize(authentication, context.getRequest()));
+				builder.add(securityFilterChain::matches, (authentication, context) -> authorizationManager
+					.authorize(authentication, context.getRequest()));
 				mappings = true;
 			}
 		}

--- a/config/src/test/java/org/springframework/security/config/annotation/web/builders/WebSecurityTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/builders/WebSecurityTests.java
@@ -17,6 +17,7 @@
 package org.springframework.security.config.annotation.web.builders;
 
 import java.io.IOException;
+import java.util.List;
 
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.ObservationTextPublisher;
@@ -35,13 +36,19 @@ import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletContext;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.authorization.FactorAuthorizationDecision;
+import org.springframework.security.authorization.RequiredFactor;
+import org.springframework.security.authorization.RequiredFactorError;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.web.PathPatternRequestMatcherBuilderFactoryBean;
+import org.springframework.security.core.authority.FactorGrantedAuthority;
 import org.springframework.security.core.userdetails.PasswordEncodedUser;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.WebInvocationPrivilegeEvaluator;
 import org.springframework.security.web.firewall.HttpStatusRequestRejectedHandler;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -109,6 +116,19 @@ public class WebSecurityTests {
 		this.request.setRequestURI("/spring/\u0019path");
 		this.springSecurityFilterChain.doFilter(this.request, this.response, this.chain);
 		assertThat(this.response.getStatus()).isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
+	}
+
+	// gh-19282
+	@Test
+	public void privilegeEvaluatorWhenAuthorizationManagerReturnsFactorDecisionThenIsAllowedReturnsFalseWithoutClassCastException() {
+		loadConfig(FactorDecisionConfig.class);
+		WebInvocationPrivilegeEvaluator evaluator = this.context.getBean(WebInvocationPrivilegeEvaluator.class);
+		TestingAuthenticationToken authentication = new TestingAuthenticationToken("user", "password", "ROLE_USER");
+		// Before gh-19282 the lambda registered in WebSecurity#addAuthorizationManager
+		// cast the result of AuthorizationManager#authorize to AuthorizationDecision,
+		// which fails for AuthorizationResult subtypes such as
+		// FactorAuthorizationDecision.
+		assertThat(evaluator.isAllowed("/secure", authentication)).isFalse();
 	}
 
 	// gh-19128
@@ -259,6 +279,25 @@ public class WebSecurityTests {
 				return "path";
 			}
 
+		}
+
+	}
+
+	// gh-19282
+	@Configuration
+	@EnableWebSecurity
+	static class FactorDecisionConfig {
+
+		@Bean
+		SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+			// @formatter:off
+			http
+				.authorizeHttpRequests((requests) -> requests
+					.anyRequest().access((authentication, context) -> new FactorAuthorizationDecision(
+							List.of(RequiredFactorError.createMissing(
+									RequiredFactor.withAuthority(FactorGrantedAuthority.OTT_AUTHORITY).build())))));
+			// @formatter:on
+			return http.build();
 		}
 
 	}


### PR DESCRIPTION
Closes gh-19282

## Root cause

`WebSecurity#addAuthorizationManager` registers, for every `AuthorizationFilter` in a `SecurityFilterChain`, a lambda that delegates to the filter's `AuthorizationManager#authorize` so that `WebInvocationPrivilegeEvaluator` can use the same authorization rules. The lambda casts the returned `AuthorizationResult` to `AuthorizationDecision`:

```java
builder.add(securityFilterChain::matches,
        (authentication, context) -> (AuthorizationDecision) authorizationManager
            .authorize(authentication, context.getRequest()));
```

The cast was added in `0ab01eac1` while migrating from the deprecated `AuthorizationManager#check` (which returned `AuthorizationDecision`) to `#authorize` (which returns the broader `AuthorizationResult`). The narrowing was carried over unconditionally, which violates the new return-type contract for any `AuthorizationResult` that is not an `AuthorizationDecision`.

In Spring Security 7.0 this is reachable through the multi-factor authorization manager produced by `AuthorizationManagerFactories`. Its underlying `AllRequiredFactorsAuthorizationManager#authorize` returns a `FactorAuthorizationDecision`, which `implements AuthorizationResult` directly and is a sibling of `AuthorizationDecision`, not a subtype. The stack trace in the issue ends in this lambda:

```
java.lang.ClassCastException: class FactorAuthorizationDecision cannot be cast to class AuthorizationDecision
    at WebSecurity.lambda$addAuthorizationManager$2(WebSecurity.java:384)
    at RequestMatcherDelegatingAuthorizationManager.authorize(...)
    at AuthorizationManagerWebInvocationPrivilegeEvaluator.isAllowed(...)
```

The cast is also unnecessary: `RequestMatcherDelegatingAuthorizationManager.Builder#add` accepts an `AuthorizationManager<? super RequestAuthorizationContext>`, whose `authorize` already returns `AuthorizationResult`.

## Change

Remove the cast. The lambda now returns the `AuthorizationResult` directly, matching the contract of `AuthorizationManager#authorize` and the type expected by `Builder#add`.

## Tests

Added `WebSecurityTests.privilegeEvaluatorWhenAuthorizationManagerReturnsFactorDecisionThenIsAllowedReturnsFalseWithoutClassCastException`. It registers a `SecurityFilterChain` whose authorization manager returns a `FactorAuthorizationDecision` and asserts that `WebInvocationPrivilegeEvaluator#isAllowed` reports `false` without throwing. With the cast still present, this test fails with `ClassCastException at WebSecurityTests.java:131`; with the cast removed it passes.

`./gradlew :spring-security-config:test --tests 'org.springframework.security.config.annotation.web.builders.WebSecurityTests'` is green, and `./gradlew :spring-security-config:checkstyleMain :spring-security-config:checkstyleTest` reports no violations.

Verification done: (1) `gh pr list --search "FactorAuthorizationDecision in:title,body"` returns no in-flight PRs; (2) the linked issue has zero comments and no self-claims; (3) the fix is in `.java` files only; (4) the buggy cast is present on `origin/main` at `WebSecurity.java:383`; (5) the issue is a stand-alone bug report, not a sub-issue of an umbrella; (6) the stack trace in the issue terminates inside the framework lambda this PR rewrites.