### PR TITLE
Add missing nullability annotations in `AbstractConfiguredSecurityBuilder`

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/AbstractConfiguredSecurityBuilder.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/AbstractConfiguredSecurityBuilder.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.ObjectPostProcessor;
@@ -51,6 +52,7 @@ import org.springframework.web.filter.DelegatingFilterProxy;
  * @param <B> The type of this builder (that is returned by the base class)
  * @author Rob Winch
  * @author DingHao
+ * @author Andrey Litvitski
  * @see WebSecurity
  */
 public abstract class AbstractConfiguredSecurityBuilder<O, B extends SecurityBuilder<O>>
@@ -101,7 +103,7 @@ public abstract class AbstractConfiguredSecurityBuilder<O, B extends SecurityBui
 	 * @return the result of {@link SecurityBuilder#build()} or {@link #getObject()}. If
 	 * an error occurs while building, returns null.
 	 */
-	public O getOrBuild() {
+	public @Nullable O getOrBuild() {
 		if (!isUnbuilt()) {
 			return getObject();
 		}
@@ -182,7 +184,7 @@ public abstract class AbstractConfiguredSecurityBuilder<O, B extends SecurityBui
 	 * @return the shared Object or null if it is not found
 	 */
 	@SuppressWarnings("unchecked")
-	public <C> C getSharedObject(Class<C> sharedType) {
+	public <C> @Nullable C getSharedObject(Class<C> sharedType) {
 		return (C) this.sharedObjects.get(sharedType);
 	}
 
@@ -276,7 +278,7 @@ public abstract class AbstractConfiguredSecurityBuilder<O, B extends SecurityBui
 	 * @return
 	 */
 	@SuppressWarnings("unchecked")
-	public <C extends SecurityConfigurer<O, B>> C removeConfigurer(Class<C> clazz) {
+	public <C extends SecurityConfigurer<O, B>> @Nullable C removeConfigurer(Class<C> clazz) {
 		List<SecurityConfigurer<O, B>> configs = this.configurers.remove(clazz);
 		if (configs == null) {
 			return null;

--- a/config/src/main/kotlin/org/springframework/security/config/annotation/web/HttpSecurityDsl.kt
+++ b/config/src/main/kotlin/org/springframework/security/config/annotation/web/HttpSecurityDsl.kt
@@ -73,6 +73,7 @@ operator fun HttpSecurity.invoke(httpConfiguration: HttpSecurityDsl.() -> Unit) 
  * in order to configure [HttpSecurity] using idiomatic Kotlin code.
  *
  * @author Eleftheria Stein
+ * @author Andrey Litvitski
  * @since 5.3
  * @param http the [HttpSecurity] which all configurations will be applied to
  * @param init the configurations to apply to the provided [HttpSecurity]
@@ -82,7 +83,7 @@ operator fun HttpSecurity.invoke(httpConfiguration: HttpSecurityDsl.() -> Unit) 
 class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecurityDsl.() -> Unit) {
 
     var authenticationManager: AuthenticationManager? = null
-    val context: ApplicationContext = http.getSharedObject(ApplicationContext::class.java)
+    val context: ApplicationContext = http.getSharedObject(ApplicationContext::class.java)!!
 
     init {
         applyFunction1HttpSecurityDslBeans(this.context, this)


### PR DESCRIPTION
Since the package containing `AbstractConfiguredSecurityBuilder` is annotated with `@NullMarked`, we should annotate the methods that return null with `@Nullable`.

Closes: gh-19304

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
