### PR TITLE
Allow nullable objects in authorization managers

### DIFF
--- a/config/src/test/kotlin/org/springframework/security/config/annotation/web/session/SessionConcurrencyDslTests.kt
+++ b/config/src/test/kotlin/org/springframework/security/config/annotation/web/session/SessionConcurrencyDslTests.kt
@@ -214,12 +214,12 @@ class SessionConcurrencyDslTests {
 
         @Bean
         open fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-            val isAdmin: AuthorizationManager<Any> = AuthorityAuthorizationManager.hasRole("ADMIN")
+            val isAdmin: AuthorizationManager<Any?> = AuthorityAuthorizationManager.hasRole("ADMIN")
             http {
                 sessionManagement {
                     sessionConcurrency {
                         maximumSessions {
-                            authentication -> if (isAdmin.authorize({ authentication }, "")!!.isGranted) -1 else 1
+                            authentication -> if (isAdmin.authorize({ authentication }, null)!!.isGranted) -1 else 1
                         }
                         maxSessionsPreventsLogin = true
                     }

--- a/core/src/main/java/org/springframework/security/authorization/AllAuthoritiesAuthorizationManager.java
+++ b/core/src/main/java/org/springframework/security/authorization/AllAuthoritiesAuthorizationManager.java
@@ -39,7 +39,7 @@ import org.springframework.util.Assert;
  * @since 7.0
  * @see AuthorityAuthorizationManager
  */
-public final class AllAuthoritiesAuthorizationManager<T> implements AuthorizationManager<T> {
+public final class AllAuthoritiesAuthorizationManager<T extends @Nullable Object> implements AuthorizationManager<T> {
 
 	private static final String ROLE_PREFIX = "ROLE_";
 
@@ -101,7 +101,7 @@ public final class AllAuthoritiesAuthorizationManager<T> implements Authorizatio
 	 * @param <T> the type of object being authorized
 	 * @return the new instance
 	 */
-	public static <T> AllAuthoritiesAuthorizationManager<T> hasAllRoles(String... roles) {
+	public static <T extends @Nullable Object> AllAuthoritiesAuthorizationManager<T> hasAllRoles(String... roles) {
 		return hasAllPrefixedAuthorities(ROLE_PREFIX, roles);
 	}
 
@@ -113,8 +113,8 @@ public final class AllAuthoritiesAuthorizationManager<T> implements Authorizatio
 	 * @param <T> the type of object being authorized
 	 * @return the new instance
 	 */
-	public static <T> AllAuthoritiesAuthorizationManager<T> hasAllPrefixedAuthorities(String prefix,
-			String... authorities) {
+	public static <T extends @Nullable Object> AllAuthoritiesAuthorizationManager<T> hasAllPrefixedAuthorities(
+			String prefix, String... authorities) {
 		Assert.notNull(prefix, "rolePrefix cannot be null");
 		Assert.notEmpty(authorities, "roles cannot be empty");
 		Assert.noNullElements(authorities, "roles cannot contain null values");
@@ -128,7 +128,8 @@ public final class AllAuthoritiesAuthorizationManager<T> implements Authorizatio
 	 * @param <T> the type of object being authorized
 	 * @return the new instance
 	 */
-	public static <T> AllAuthoritiesAuthorizationManager<T> hasAllAuthorities(String... authorities) {
+	public static <T extends @Nullable Object> AllAuthoritiesAuthorizationManager<T> hasAllAuthorities(
+			String... authorities) {
 		Assert.notEmpty(authorities, "authorities cannot be empty");
 		Assert.noNullElements(authorities, "authorities cannot contain null values");
 		return new AllAuthoritiesAuthorizationManager<>(authorities);
@@ -141,7 +142,8 @@ public final class AllAuthoritiesAuthorizationManager<T> implements Authorizatio
 	 * @param <T> the type of object being authorized
 	 * @return the new instance
 	 */
-	public static <T> AllAuthoritiesAuthorizationManager<T> hasAllAuthorities(List<String> authorities) {
+	public static <T extends @Nullable Object> AllAuthoritiesAuthorizationManager<T> hasAllAuthorities(
+			List<String> authorities) {
 		Assert.notEmpty(authorities, "authorities cannot be empty");
 		Assert.noNullElements(authorities, "authorities cannot contain null values");
 		return new AllAuthoritiesAuthorizationManager<>(authorities.toArray(new String[0]));

--- a/core/src/main/java/org/springframework/security/authorization/AllRequiredFactorsAuthorizationManager.java
+++ b/core/src/main/java/org/springframework/security/authorization/AllRequiredFactorsAuthorizationManager.java
@@ -46,7 +46,8 @@ import org.springframework.util.Assert;
  * @since 7.0
  * @see AuthorityAuthorizationManager
  */
-public final class AllRequiredFactorsAuthorizationManager<T> implements AuthorizationManager<T> {
+public final class AllRequiredFactorsAuthorizationManager<T extends @Nullable Object>
+		implements AuthorizationManager<T> {
 
 	private Clock clock = Clock.systemUTC();
 
@@ -64,7 +65,8 @@ public final class AllRequiredFactorsAuthorizationManager<T> implements Authoriz
 	 * @see AuthorizationManagers#anyOf(AuthorizationManager[])
 	 */
 	@SafeVarargs
-	public static <T> AuthorizationManager<T> anyOf(AllRequiredFactorsAuthorizationManager<T>... managers) {
+	public static <T extends @Nullable Object> AuthorizationManager<T> anyOf(
+			AllRequiredFactorsAuthorizationManager<T>... managers) {
 		Assert.notEmpty(managers, "managers cannot be empty");
 		Assert.noNullElements(managers, "managers cannot contain null elements");
 		if (managers.length == 1) {
@@ -170,7 +172,7 @@ public final class AllRequiredFactorsAuthorizationManager<T> implements Authoriz
 	 * Creates a new {@link Builder}
 	 * @return
 	 */
-	public static <T> Builder<T> builder() {
+	public static <T extends @Nullable Object> Builder<T> builder() {
 		return new Builder<>();
 	}
 
@@ -181,7 +183,8 @@ public final class AllRequiredFactorsAuthorizationManager<T> implements Authoriz
 	 *
 	 * @param <T> the type of object being authorized
 	 */
-	private static final class AnyOfFactorsAuthorizationManager<T> implements AuthorizationManager<T> {
+	private static final class AnyOfFactorsAuthorizationManager<T extends @Nullable Object>
+			implements AuthorizationManager<T> {
 
 		private final AllRequiredFactorsAuthorizationManager<T>[] managers;
 
@@ -212,7 +215,7 @@ public final class AllRequiredFactorsAuthorizationManager<T> implements Authoriz
 	 * @author Rob Winch
 	 * @since 7.0
 	 */
-	public static final class Builder<T> {
+	public static final class Builder<T extends @Nullable Object> {
 
 		private List<RequiredFactor> requiredFactors = new ArrayList<>();
 

--- a/core/src/main/java/org/springframework/security/authorization/AuthenticatedAuthorizationManager.java
+++ b/core/src/main/java/org/springframework/security/authorization/AuthenticatedAuthorizationManager.java
@@ -32,7 +32,7 @@ import org.springframework.util.Assert;
  * @author Evgeniy Cheban
  * @since 5.5
  */
-public final class AuthenticatedAuthorizationManager<T> implements AuthorizationManager<T> {
+public final class AuthenticatedAuthorizationManager<T extends @Nullable Object> implements AuthorizationManager<T> {
 
 	private final AbstractAuthorizationStrategy authorizationStrategy;
 
@@ -69,7 +69,7 @@ public final class AuthenticatedAuthorizationManager<T> implements Authorization
 	 * @param <T> the type of object being authorized
 	 * @return the new instance
 	 */
-	public static <T> AuthenticatedAuthorizationManager<T> authenticated() {
+	public static <T extends @Nullable Object> AuthenticatedAuthorizationManager<T> authenticated() {
 		return new AuthenticatedAuthorizationManager<>();
 	}
 
@@ -80,7 +80,7 @@ public final class AuthenticatedAuthorizationManager<T> implements Authorization
 	 * @return the new instance
 	 * @since 5.8
 	 */
-	public static <T> AuthenticatedAuthorizationManager<T> fullyAuthenticated() {
+	public static <T extends @Nullable Object> AuthenticatedAuthorizationManager<T> fullyAuthenticated() {
 		return new AuthenticatedAuthorizationManager<>(new FullyAuthenticatedAuthorizationStrategy());
 	}
 
@@ -91,7 +91,7 @@ public final class AuthenticatedAuthorizationManager<T> implements Authorization
 	 * @return the new instance
 	 * @since 5.8
 	 */
-	public static <T> AuthenticatedAuthorizationManager<T> rememberMe() {
+	public static <T extends @Nullable Object> AuthenticatedAuthorizationManager<T> rememberMe() {
 		return new AuthenticatedAuthorizationManager<>(new RememberMeAuthorizationStrategy());
 	}
 
@@ -102,7 +102,7 @@ public final class AuthenticatedAuthorizationManager<T> implements Authorization
 	 * @return the new instance
 	 * @since 5.8
 	 */
-	public static <T> AuthenticatedAuthorizationManager<T> anonymous() {
+	public static <T extends @Nullable Object> AuthenticatedAuthorizationManager<T> anonymous() {
 		return new AuthenticatedAuthorizationManager<>(new AnonymousAuthorizationStrategy());
 	}
 

--- a/core/src/main/java/org/springframework/security/authorization/AuthorityAuthorizationManager.java
+++ b/core/src/main/java/org/springframework/security/authorization/AuthorityAuthorizationManager.java
@@ -35,7 +35,7 @@ import org.springframework.util.Assert;
  * @since 5.5
  * @see AllAuthoritiesAuthorizationManager
  */
-public final class AuthorityAuthorizationManager<T> implements AuthorizationManager<T> {
+public final class AuthorityAuthorizationManager<T extends @Nullable Object> implements AuthorizationManager<T> {
 
 	private static final String ROLE_PREFIX = "ROLE_";
 
@@ -65,7 +65,7 @@ public final class AuthorityAuthorizationManager<T> implements AuthorizationMana
 	 * @param <T> the type of object being authorized
 	 * @return the new instance
 	 */
-	public static <T> AuthorityAuthorizationManager<T> hasRole(String role) {
+	public static <T extends @Nullable Object> AuthorityAuthorizationManager<T> hasRole(String role) {
 		Assert.notNull(role, "role cannot be null");
 		Assert.isTrue(!role.startsWith(ROLE_PREFIX), () -> role + " should not start with " + ROLE_PREFIX + " since "
 				+ ROLE_PREFIX + " is automatically prepended when using hasRole. Consider using hasAuthority instead.");
@@ -79,7 +79,7 @@ public final class AuthorityAuthorizationManager<T> implements AuthorizationMana
 	 * @param <T> the type of object being authorized
 	 * @return the new instance
 	 */
-	public static <T> AuthorityAuthorizationManager<T> hasAuthority(String authority) {
+	public static <T extends @Nullable Object> AuthorityAuthorizationManager<T> hasAuthority(String authority) {
 		Assert.notNull(authority, "authority cannot be null");
 		return new AuthorityAuthorizationManager<>(authority);
 	}
@@ -92,7 +92,7 @@ public final class AuthorityAuthorizationManager<T> implements AuthorizationMana
 	 * @param <T> the type of object being authorized
 	 * @return the new instance
 	 */
-	public static <T> AuthorityAuthorizationManager<T> hasAnyRole(String... roles) {
+	public static <T extends @Nullable Object> AuthorityAuthorizationManager<T> hasAnyRole(String... roles) {
 		return hasAnyRole(ROLE_PREFIX, roles);
 	}
 
@@ -104,7 +104,8 @@ public final class AuthorityAuthorizationManager<T> implements AuthorizationMana
 	 * @param <T> the type of object being authorized
 	 * @return the new instance
 	 */
-	public static <T> AuthorityAuthorizationManager<T> hasAnyRole(String rolePrefix, String[] roles) {
+	public static <T extends @Nullable Object> AuthorityAuthorizationManager<T> hasAnyRole(String rolePrefix,
+			String[] roles) {
 		Assert.notNull(rolePrefix, "rolePrefix cannot be null");
 		Assert.notEmpty(roles, "roles cannot be empty");
 		Assert.noNullElements(roles, "roles cannot contain null values");
@@ -118,7 +119,7 @@ public final class AuthorityAuthorizationManager<T> implements AuthorizationMana
 	 * @param <T> the type of object being authorized
 	 * @return the new instance
 	 */
-	public static <T> AuthorityAuthorizationManager<T> hasAnyAuthority(String... authorities) {
+	public static <T extends @Nullable Object> AuthorityAuthorizationManager<T> hasAnyAuthority(String... authorities) {
 		Assert.notEmpty(authorities, "authorities cannot be empty");
 		Assert.noNullElements(authorities, "authorities cannot contain null values");
 		return new AuthorityAuthorizationManager<>(authorities);

--- a/core/src/main/java/org/springframework/security/authorization/AuthorizationManagerFactories.java
+++ b/core/src/main/java/org/springframework/security/authorization/AuthorizationManagerFactories.java
@@ -47,7 +47,7 @@ public final class AuthorizationManagerFactories {
 	 * @param <T> the secured object type
 	 * @return a factory configured with the required authorities
 	 */
-	public static <T> AdditionalRequiredFactorsBuilder<T> multiFactor() {
+	public static <T extends @Nullable Object> AdditionalRequiredFactorsBuilder<T> multiFactor() {
 		return new AdditionalRequiredFactorsBuilder<>();
 	}
 
@@ -58,7 +58,7 @@ public final class AuthorizationManagerFactories {
 	 * @param <T> the type for the {@link DefaultAuthorizationManagerFactory}
 	 * @author Rob Winch
 	 */
-	public static final class AdditionalRequiredFactorsBuilder<T> {
+	public static final class AdditionalRequiredFactorsBuilder<T extends @Nullable Object> {
 
 		private final AllRequiredFactorsAuthorizationManager.Builder<T> factors = AllRequiredFactorsAuthorizationManager
 			.builder();

--- a/core/src/main/java/org/springframework/security/authorization/AuthorizationManagers.java
+++ b/core/src/main/java/org/springframework/security/authorization/AuthorizationManagers.java
@@ -42,7 +42,7 @@ public final class AuthorizationManagers {
 	 * @return the {@link AuthorizationManager} to use
 	 */
 	@SafeVarargs
-	public static <T> AuthorizationManager<T> anyOf(AuthorizationManager<T>... managers) {
+	public static <T extends @Nullable Object> AuthorizationManager<T> anyOf(AuthorizationManager<T>... managers) {
 		return anyOf(new AuthorizationDecision(false), managers);
 	}
 
@@ -58,8 +58,8 @@ public final class AuthorizationManagers {
 	 * @since 6.3
 	 */
 	@SafeVarargs
-	public static <T> AuthorizationManager<T> anyOf(AuthorizationDecision allAbstainDefaultDecision,
-			AuthorizationManager<T>... managers) {
+	public static <T extends @Nullable Object> AuthorizationManager<T> anyOf(
+			AuthorizationDecision allAbstainDefaultDecision, AuthorizationManager<T>... managers) {
 		return (AuthorizationManagerCheckAdapter<T>) (Supplier<? extends @Nullable Authentication> authentication,
 				T object) -> {
 			List<AuthorizationResult> results = new ArrayList<>();
@@ -89,7 +89,7 @@ public final class AuthorizationManagers {
 	 * @return the {@link AuthorizationManager} to use
 	 */
 	@SafeVarargs
-	public static <T> AuthorizationManager<T> allOf(AuthorizationManager<T>... managers) {
+	public static <T extends @Nullable Object> AuthorizationManager<T> allOf(AuthorizationManager<T>... managers) {
 		return allOf(new AuthorizationDecision(true), managers);
 	}
 
@@ -105,8 +105,8 @@ public final class AuthorizationManagers {
 	 * @since 6.3
 	 */
 	@SafeVarargs
-	public static <T> AuthorizationManager<T> allOf(AuthorizationDecision allAbstainDefaultDecision,
-			AuthorizationManager<T>... managers) {
+	public static <T extends @Nullable Object> AuthorizationManager<T> allOf(
+			AuthorizationDecision allAbstainDefaultDecision, AuthorizationManager<T>... managers) {
 		return (AuthorizationManagerCheckAdapter<T>) (Supplier<? extends @Nullable Authentication> authentication,
 				T object) -> {
 			List<AuthorizationResult> results = new ArrayList<>();
@@ -136,7 +136,7 @@ public final class AuthorizationManagers {
 	 * @return the reversing {@link AuthorizationManager}
 	 * @since 6.3
 	 */
-	public static <T> AuthorizationManager<T> not(AuthorizationManager<T> manager) {
+	public static <T extends @Nullable Object> AuthorizationManager<T> not(AuthorizationManager<T> manager) {
 		return (Supplier<? extends @Nullable Authentication> authentication, T object) -> {
 			AuthorizationResult result = manager.authorize(authentication, object);
 			if (result == null) {
@@ -183,7 +183,7 @@ public final class AuthorizationManagers {
 
 	}
 
-	private interface AuthorizationManagerCheckAdapter<T> extends AuthorizationManager<T> {
+	private interface AuthorizationManagerCheckAdapter<T extends @Nullable Object> extends AuthorizationManager<T> {
 
 		@Override
 		AuthorizationResult authorize(Supplier<? extends @Nullable Authentication> authentication, T object);

--- a/core/src/main/java/org/springframework/security/authorization/ConditionalAuthorizationManager.java
+++ b/core/src/main/java/org/springframework/security/authorization/ConditionalAuthorizationManager.java
@@ -41,7 +41,7 @@ import org.springframework.util.Assert;
  * @author Rob Winch
  * @since 7.1
  */
-public final class ConditionalAuthorizationManager<T> implements AuthorizationManager<T> {
+public final class ConditionalAuthorizationManager<T extends @Nullable Object> implements AuthorizationManager<T> {
 
 	private final Predicate<Authentication> condition;
 
@@ -76,7 +76,7 @@ public final class ConditionalAuthorizationManager<T> implements AuthorizationMa
 	 * not be null)
 	 * @return the builder
 	 */
-	public static <T> Builder<T> when(Predicate<Authentication> condition) {
+	public static <T extends @Nullable Object> Builder<T> when(Predicate<Authentication> condition) {
 		Assert.notNull(condition, "condition cannot be null");
 		return new Builder<>(condition);
 	}
@@ -98,7 +98,7 @@ public final class ConditionalAuthorizationManager<T> implements AuthorizationMa
 	 * @author Rob Winch
 	 * @since 7.1
 	 */
-	public static final class Builder<T> {
+	public static final class Builder<T extends @Nullable Object> {
 
 		private final Predicate<Authentication> condition;
 

--- a/core/src/main/java/org/springframework/security/authorization/RequiredAuthoritiesAuthorizationManager.java
+++ b/core/src/main/java/org/springframework/security/authorization/RequiredAuthoritiesAuthorizationManager.java
@@ -33,7 +33,7 @@ import org.springframework.util.Assert;
  * @since 7.0
  * @see AllAuthoritiesAuthorizationManager
  */
-public class RequiredAuthoritiesAuthorizationManager<T> implements AuthorizationManager<T> {
+public class RequiredAuthoritiesAuthorizationManager<T extends @Nullable Object> implements AuthorizationManager<T> {
 
 	private final RequiredAuthoritiesRepository authorities;
 

--- a/core/src/main/java/org/springframework/security/authorization/SingleResultAuthorizationManager.java
+++ b/core/src/main/java/org/springframework/security/authorization/SingleResultAuthorizationManager.java
@@ -30,7 +30,7 @@ import org.springframework.util.Assert;
  * @author Max Batischev
  * @since 6.5
  */
-public final class SingleResultAuthorizationManager<C> implements AuthorizationManager<C> {
+public final class SingleResultAuthorizationManager<C extends @Nullable Object> implements AuthorizationManager<C> {
 
 	private static final SingleResultAuthorizationManager<?> DENY_MANAGER = new SingleResultAuthorizationManager<>(
 			new AuthorizationDecision(false));
@@ -54,12 +54,12 @@ public final class SingleResultAuthorizationManager<C> implements AuthorizationM
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <C> SingleResultAuthorizationManager<C> denyAll() {
+	public static <C extends @Nullable Object> SingleResultAuthorizationManager<C> denyAll() {
 		return (SingleResultAuthorizationManager<C>) DENY_MANAGER;
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <C> SingleResultAuthorizationManager<C> permitAll() {
+	public static <C extends @Nullable Object> SingleResultAuthorizationManager<C> permitAll() {
 		return (SingleResultAuthorizationManager<C>) PERMIT_MANAGER;
 	}
 

--- a/core/src/test/kotlin/org/springframework/security/authorization/AuthorizationManagerKotlinNullabilityTests.kt
+++ b/core/src/test/kotlin/org/springframework/security/authorization/AuthorizationManagerKotlinNullabilityTests.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authorization
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.security.authentication.TestingAuthenticationToken
+import org.springframework.security.core.Authentication
+
+class AuthorizationManagerKotlinNullabilityTests {
+
+    private val authentication: Authentication = TestingAuthenticationToken("user", "password", "ROLE_ADMIN")
+
+    @Test
+    fun `authority authorization manager allows nullable object type`() {
+        val manager: AuthorizationManager<Any?> = AuthorityAuthorizationManager.hasRole("ADMIN")
+
+        assertThat(manager.authorize({ authentication }, null)!!.isGranted).isTrue()
+    }
+
+    @Test
+    fun `authenticated authorization manager allows nullable object type`() {
+        val manager: AuthorizationManager<Any?> = AuthenticatedAuthorizationManager.authenticated()
+
+        assertThat(manager.authorize({ authentication }, null)!!.isGranted).isTrue()
+    }
+
+    @Test
+    fun `single result authorization manager allows nullable object type`() {
+        val manager: AuthorizationManager<Any?> = SingleResultAuthorizationManager.permitAll()
+
+        assertThat(manager.authorize({ authentication }, null)!!.isGranted).isTrue()
+    }
+
+    @Test
+    fun `all authorities authorization manager allows nullable object type`() {
+        val manager: AuthorizationManager<Any?> = AllAuthoritiesAuthorizationManager.hasAllRoles("ADMIN")
+
+        assertThat(manager.authorize({ authentication }, null)!!.isGranted).isTrue()
+    }
+
+    @Test
+    fun `required authorities authorization manager allows nullable object type`() {
+        val manager: AuthorizationManager<Any?> = RequiredAuthoritiesAuthorizationManager { listOf("ROLE_ADMIN") }
+
+        assertThat(manager.authorize({ authentication }, null)!!.isGranted).isTrue()
+    }
+
+    @Test
+    fun `all required factors authorization manager allows nullable object type`() {
+        val manager: AuthorizationManager<Any?> = AllRequiredFactorsAuthorizationManager.builder<Any?>()
+            .requireFactor { it.passwordAuthority() }
+            .build()
+
+        assertThat(manager.authorize({ authentication }, null)!!.isGranted).isFalse()
+    }
+
+    @Test
+    fun `conditional authorization manager allows nullable object type`() {
+        val manager: AuthorizationManager<Any?> = ConditionalAuthorizationManager.`when`<Any?> { true }
+            .whenTrue(SingleResultAuthorizationManager.permitAll<Any?>())
+            .build()
+
+        assertThat(manager.authorize({ authentication }, null)!!.isGranted).isTrue()
+    }
+
+    @Test
+    fun `authorization manager compositions allow nullable object type`() {
+        val manager: AuthorizationManager<Any?> = AuthorizationManagers.anyOf(
+            SingleResultAuthorizationManager.denyAll(),
+            SingleResultAuthorizationManager.permitAll(),
+        )
+
+        assertThat(manager.authorize({ authentication }, null)!!.isGranted).isTrue()
+    }
+
+    @Test
+    fun `authorization managers allOf allows nullable object type`() {
+        val manager: AuthorizationManager<Any?> = AuthorizationManagers.allOf(
+            SingleResultAuthorizationManager.permitAll(),
+            SingleResultAuthorizationManager.permitAll(),
+        )
+
+        assertThat(manager.authorize({ authentication }, null)!!.isGranted).isTrue()
+    }
+
+    @Test
+    fun `authorization managers not allows nullable object type`() {
+        val manager: AuthorizationManager<Any?> = AuthorizationManagers.not(
+            SingleResultAuthorizationManager.denyAll()
+        )
+
+        assertThat(manager.authorize({ authentication }, null)!!.isGranted).isTrue()
+    }
+
+    @Test
+    fun `authorization manager factories multiFactor allows nullable object type`() {
+        val factory: DefaultAuthorizationManagerFactory<Any?> = AuthorizationManagerFactories.multiFactor<Any?>()
+            .requireFactor { it.passwordAuthority() }
+            .build()
+        val manager: AuthorizationManager<Any?> = factory.authenticated()
+
+        assertThat(manager.authorize({ authentication }, null)!!.isGranted).isFalse()
+    }
+
+}

--- a/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/authorization/OAuth2AuthorizationManagers.java
+++ b/oauth2/oauth2-core/src/main/java/org/springframework/security/oauth2/core/authorization/OAuth2AuthorizationManagers.java
@@ -16,6 +16,8 @@
 
 package org.springframework.security.oauth2.core.authorization;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.security.authorization.AllAuthoritiesAuthorizationManager;
 import org.springframework.security.authorization.AuthorityAuthorizationManager;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -53,7 +55,7 @@ public final class OAuth2AuthorizationManagers {
 	 * @return an {@link AuthorizationManager} that requires a {@code "SCOPE_scope"}
 	 * authority
 	 */
-	public static <T> AuthorizationManager<T> hasScope(String scope) {
+	public static <T extends @Nullable Object> AuthorizationManager<T> hasScope(String scope) {
 		assertScope(scope);
 		return AuthorityAuthorizationManager.hasAuthority("SCOPE_" + scope);
 	}
@@ -78,7 +80,7 @@ public final class OAuth2AuthorizationManagers {
 	 * {@code "SCOPE_scope1"}, {@code SCOPE_scope2}, ... {@code SCOPE_scopeN}.
 	 *
 	 */
-	public static <T> AuthorizationManager<T> hasAnyScope(String... scopes) {
+	public static <T extends @Nullable Object> AuthorizationManager<T> hasAnyScope(String... scopes) {
 		String[] mappedScopes = new String[scopes.length];
 		for (int i = 0; i < scopes.length; i++) {
 			assertScope(scopes[i]);
@@ -106,7 +108,7 @@ public final class OAuth2AuthorizationManagers {
 	 * {@code SCOPE_scope1}, {@code SCOPE_scope2}, ... {@code SCOPE_scopeN}.
 	 * @since 7.1
 	 */
-	public static <T> AuthorizationManager<T> hasAllScopes(String... scopes) {
+	public static <T extends @Nullable Object> AuthorizationManager<T> hasAllScopes(String... scopes) {
 		String[] mappedScopes = new String[scopes.length];
 		for (int i = 0; i < scopes.length; i++) {
 			assertScope(scopes[i]);


### PR DESCRIPTION
Several `AuthorizationManager` implementations and factory methods declared
plain `<T>` type parameters. Under package-level `@NullMarked`, JSpecify treats
a plain `<T>` as `<T extends @NonNull Object>`, so Kotlin callers could not use
these implementations as `AuthorizationManager<Any?>` or invoke them with a
`null` object, even though `AuthorizationManager` itself already declares
`<T extends @Nullable Object>` (gh-17667).

This adds `<T extends @Nullable Object>` bounds to the implementations and
factory methods that do not depend on a non-null authorization object:

- `AuthorityAuthorizationManager`
- `AuthenticatedAuthorizationManager`
- `SingleResultAuthorizationManager`
- `AllAuthoritiesAuthorizationManager`
- `RequiredAuthoritiesAuthorizationManager`
- `AllRequiredFactorsAuthorizationManager`
- `ConditionalAuthorizationManager`
- `AuthorizationManagers`
- `AuthorizationManagerFactories`
- `OAuth2AuthorizationManagers`

`ObservationAuthorizationManager` is intentionally left unchanged because it
passes the authorization object to `AuthorizationObservationContext`, whose
constructor requires a non-null value.

Closes gh-17537