### PR TITLE
Add hook for adding authentication filters

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/AbstractAuthenticationFilterConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/AbstractAuthenticationFilterConfigurer.java
@@ -56,6 +56,7 @@ import org.springframework.web.accept.HeaderContentNegotiationStrategy;
  * @param <F> refers to the {@link AbstractAuthenticationProcessingFilter} that is being
  * built
  * @author Rob Winch
+ * @author Andrey Litvitski
  * @since 3.2
  * @see FormLoginConfigurer
  */
@@ -300,6 +301,15 @@ public abstract class AbstractAuthenticationFilterConfigurer<B extends HttpSecur
 		}
 		this.authFilter.setSecurityContextHolderStrategy(getSecurityContextHolderStrategy());
 		F filter = postProcess(this.authFilter);
+		addAuthenticationFilter(http, filter);
+	}
+
+	/**
+	 * Adds the authentication filter
+	 * @param http the {@link HttpSecurityBuilder}
+	 * @param filter the authentication filter
+	 */
+	protected void addAuthenticationFilter(B http, F filter) {
 		http.addFilter(filter);
 	}
 


### PR DESCRIPTION
This change will allow us to directly add authentication filters without resorting to various hacks by directly overriding the protected `addAuthenticationFilter` method.

Closes: gh-19319

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
