### PR TITLE
Skip @PostFilter when method returns null

### DIFF
--- a/core/src/main/java/org/springframework/security/authorization/method/PostFilterAuthorizationMethodInterceptor.java
+++ b/core/src/main/java/org/springframework/security/authorization/method/PostFilterAuthorizationMethodInterceptor.java
@@ -21,6 +21,8 @@ import java.util.function.Supplier;
 import org.aopalliance.aop.Advice;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.aop.Pointcut;
@@ -43,6 +45,8 @@ import org.springframework.security.core.context.SecurityContextHolderStrategy;
  * @since 5.6
  */
 public final class PostFilterAuthorizationMethodInterceptor implements AuthorizationAdvisor {
+
+	private final Log logger = LogFactory.getLog(getClass());
 
 	private Supplier<SecurityContextHolderStrategy> securityContextHolderStrategy = SecurityContextHolder::getContextHolderStrategy;
 
@@ -132,6 +136,10 @@ public final class PostFilterAuthorizationMethodInterceptor implements Authoriza
 		ExpressionAttribute attribute = this.registry.getAttribute(mi);
 		if (attribute == null) {
 			return returnedObject;
+		}
+		if (returnedObject == null) {
+			this.logger.debug("Returned object is null, filtering will be skipped");
+			return null;
 		}
 		MethodSecurityExpressionHandler expressionHandler = this.registry.getExpressionHandler();
 		EvaluationContext ctx = expressionHandler.createEvaluationContext(this::getAuthentication, mi);

--- a/core/src/test/java/org/springframework/security/authorization/method/PostFilterAuthorizationMethodInterceptorTests.java
+++ b/core/src/test/java/org/springframework/security/authorization/method/PostFilterAuthorizationMethodInterceptorTests.java
@@ -109,6 +109,20 @@ public class PostFilterAuthorizationMethodInterceptorTests {
 		assertThat(result).asInstanceOf(InstanceOfAssertFactories.array(String[].class)).containsOnly("john");
 	}
 
+	// gh-19280
+	@Test
+	public void invokeWhenReturnedObjectIsNullThenSkipsFilteringAndReturnsNull() throws Throwable {
+		MockMethodInvocation methodInvocation = new MockMethodInvocation(new TestClass(), TestClass.class,
+				"doSomethingArray", new Class[] { String[].class }, new Object[] { null }) {
+			@Override
+			public Object proceed() {
+				return null;
+			}
+		};
+		PostFilterAuthorizationMethodInterceptor advice = new PostFilterAuthorizationMethodInterceptor();
+		assertThat(advice.invoke(methodInvocation)).isNull();
+	}
+
 	@Test
 	public void checkInheritedAnnotationsWhenConflictingThenAnnotationConfigurationException() throws Exception {
 		MockMethodInvocation methodInvocation = new MockMethodInvocation(new ConflictingAnnotations(),


### PR DESCRIPTION
Closes gh-19280

## Background

When a `@PostFilter`-annotated method returns `null`, the legacy `@EnableGlobalMethodSecurity` pipeline returned `null` to the caller. After migrating the same method to `@EnableMethodSecurity`, it now throws `IllegalArgumentException: Filter target must be a collection, array, map or stream type, but was null`. The issue suggests this is either a behavioural bug in the new interceptor or a documentation gap; this PR takes the first option and restores the legacy behaviour.

## Root cause

`PostFilterAuthorizationMethodInterceptor#invoke` calls `MethodSecurityExpressionHandler#filter` unconditionally with whatever the intercepted method returned. `DefaultMethodSecurityExpressionHandler#filter` requires the filter target to be a `Collection`, array, `Map`, or `Stream` and otherwise throws `IllegalArgumentException`. `null` does not satisfy any of those `instanceof` checks (the array check is explicitly null-guarded), so the handler always throws when the method returns `null`.

The deprecated legacy implementation, [`ExpressionBasedPostInvocationAdvice#after`](https://github.com/spring-projects/spring-security/blob/main/access/src/main/java/org/springframework/security/access/expression/method/ExpressionBasedPostInvocationAdvice.java), guards the call explicitly:

```java
if (returnedObject != null) {
    returnedObject = this.expressionHandler.filter(returnedObject, postFilter, ctx);
}
else {
    this.logger.debug("Return object is null, filtering will be skipped");
}
```

That guard was not carried over to the new `AuthorizationManager`-based interceptor, which is what made the migration a behavioural breaking change for any service that returns `null` as a "nothing to filter" signal.

## Change

`PostFilterAuthorizationMethodInterceptor#invoke` now short-circuits when the intercepted method returns `null`: it logs the same debug message as the legacy advice and returns `null` to the caller without consulting the expression handler. The `MethodSecurityExpressionHandler#filter` contract is intentionally left unchanged — semantically `null` is not a collection, so the handler should still reject it; the interceptor is the right layer to decide that `@PostFilter` over a `null` return is a no-op.

## Tests

Added `invokeWhenReturnedObjectIsNullThenSkipsFilteringAndReturnsNull` in `PostFilterAuthorizationMethodInterceptorTests` covering the scenario from the issue: an intercepted invocation whose `proceed()` returns `null` now resolves to `null` instead of throwing. Before the fix this test fails with `IllegalArgumentException` from `DefaultMethodSecurityExpressionHandler#filter`; after, it passes.

`./gradlew :spring-security-core:test --tests 'org.springframework.security.authorization.method.*'` runs all 117 method-authorization tests green, so no other consumer of the interceptor is affected. `:spring-security-core:checkstyleMain` and `:checkstyleTest` also pass.

## Verification done

1. **No in-flight PR / claim**: `gh pr list --repo spring-projects/spring-security --search "PostFilter null"` and `... "PostFilterAuthorizationMethodInterceptor"` returned no open PRs touching this code path; the issue thread has no "I'll work on this" claim.
2. **Code still on `main`**: confirmed `PostFilterAuthorizationMethodInterceptor#invoke` on `main` (HEAD `bf06d19225`) still calls `expressionHandler.filter` without a null guard.
3. **Legacy implementation present**: confirmed `ExpressionBasedPostInvocationAdvice#after` in `access/src/main/java/...` still has the explicit `if (returnedObject != null)` branch this PR mirrors.
4. **Behavioural impact**: reproduced the IAE via the new regression test before applying the fix; after the fix the test passes and all sibling tests in the package remain green.