### PR TITLE
Avoid reflective final field mutation in BasicLookupStrategy

### DIFF
--- a/acl/src/main/java/org/springframework/security/acls/jdbc/BasicLookupStrategy.java
+++ b/acl/src/main/java/org/springframework/security/acls/jdbc/BasicLookupStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004, 2005, 2006, 2017 Acegi Technology Pty Limited
+ * Copyright 2004, 2005, 2006, 2017, 2026 Acegi Technology Pty Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,8 +127,6 @@ public class BasicLookupStrategy implements LookupStrategy {
 
 	private final Field fieldAces = FieldUtils.getField(AclImpl.class, "aces");
 
-	private final Field fieldAcl = FieldUtils.getField(AccessControlEntryImpl.class, "acl");
-
 	// SQL Customization fields
 	private String selectClause = DEFAULT_SELECT_CLAUSE;
 
@@ -171,7 +169,6 @@ public class BasicLookupStrategy implements LookupStrategy {
 		this.objectIdentityGenerator = new ObjectIdentityRetrievalStrategyImpl();
 		this.aclClassIdUtils = new AclClassIdUtils();
 		this.fieldAces.setAccessible(true);
-		this.fieldAcl.setAccessible(true);
 	}
 
 	private String computeRepeatingSql(String repeatingSql, int requiredRepetitions) {
@@ -201,22 +198,11 @@ public class BasicLookupStrategy implements LookupStrategy {
 		}
 	}
 
-	private void setAclOnAce(AccessControlEntryImpl ace, AclImpl acl) {
-		try {
-			this.fieldAcl.set(ace, acl);
-		}
-		catch (IllegalAccessException ex) {
-			throw new IllegalStateException("Could not or set AclImpl on AccessControlEntryImpl fields", ex);
-		}
-	}
-
-	private void setAces(AclImpl acl, List<AccessControlEntryImpl> aces) {
-		try {
-			this.fieldAces.set(acl, aces);
-		}
-		catch (IllegalAccessException ex) {
-			throw new IllegalStateException("Could not set AclImpl entries", ex);
-		}
+	private void addAces(AclImpl acl, List<AccessControlEntryImpl> aces) {
+		// Populate the existing aces list in place rather than replacing the
+		// (final) field reference via reflection, which Java 26+ blocks. The
+		// list itself is mutable; only the field that holds it is final.
+		readAces(acl).addAll(aces);
 	}
 
 	/**
@@ -407,25 +393,19 @@ public class BasicLookupStrategy implements LookupStrategy {
 		AclImpl result = new AclImpl(inputAcl.getObjectIdentity(), inputAcl.getId(), this.aclAuthorizationStrategy,
 				this.grantingStrategy, parent, null, inputAcl.isEntriesInheriting(), owner);
 
-		// Copy the "aces" from the input to the destination
-
-		// Obtain the "aces" from the input ACL
+		// Copy the "aces" from the input to the destination.
+		//
+		// Re-create each AccessControlEntryImpl rather than mutating its final
+		// "acl" back-reference via reflection, so that StubAclParent references
+		// are replaced with the new "result" AclImpl instance (as per SEC-951).
+		// Java 26+ blocks reflective mutation of final fields.
 		List<AccessControlEntryImpl> aces = readAces(inputAcl);
-
-		// Create a list in which to store the "aces" for the "result" AclImpl instance
-		List<AccessControlEntryImpl> acesNew = new ArrayList<>();
-
-		// Iterate over the "aces" input and replace each nested
-		// AccessControlEntryImpl.getAcl() with the new "result" AclImpl instance
-		// This ensures StubAclParent instances are removed, as per SEC-951
+		List<AccessControlEntryImpl> acesNew = new ArrayList<>(aces.size());
 		for (AccessControlEntryImpl ace : aces) {
-			setAclOnAce(ace, result);
-			acesNew.add(ace);
+			acesNew.add(new AccessControlEntryImpl(ace.getId(), result, ace.getSid(), ace.getPermission(),
+					ace.isGranting(), ace.isAuditSuccess(), ace.isAuditFailure()));
 		}
-
-		// Finally, now that the "aces" have been converted to have the "result" AclImpl
-		// instance, modify the "result" AclImpl instance
-		setAces(result, acesNew);
+		addAces(result, acesNew);
 
 		return result;
 	}

--- a/acl/src/test/java/org/springframework/security/acls/jdbc/AbstractBasicLookupStrategyTests.java
+++ b/acl/src/test/java/org/springframework/security/acls/jdbc/AbstractBasicLookupStrategyTests.java
@@ -46,6 +46,7 @@ import org.springframework.security.acls.domain.GrantedAuthoritySid;
 import org.springframework.security.acls.domain.ObjectIdentityImpl;
 import org.springframework.security.acls.domain.PrincipalSid;
 import org.springframework.security.acls.domain.SpringCacheBasedAclCache;
+import org.springframework.security.acls.model.AccessControlEntry;
 import org.springframework.security.acls.model.Acl;
 import org.springframework.security.acls.model.AuditableAccessControlEntry;
 import org.springframework.security.acls.model.MutableAcl;
@@ -318,6 +319,21 @@ public abstract class AbstractBasicLookupStrategyTests {
 		Sid result = this.strategy.createSid(false, "sid");
 		assertThat(result.getClass()).isEqualTo(GrantedAuthoritySid.class);
 		assertThat(((GrantedAuthoritySid) result).getGrantedAuthority()).isEqualTo("sid");
+	}
+
+	// gh-19127
+	@Test
+	public void readAclsByIdWhenChildLoadedThenAcesPointToConvertedAcl() {
+		ObjectIdentity topParentOid = new ObjectIdentityImpl(TARGET_CLASS, 100L);
+		ObjectIdentity middleParentOid = new ObjectIdentityImpl(TARGET_CLASS, 101L);
+		ObjectIdentity childOid = new ObjectIdentityImpl(TARGET_CLASS, 102L);
+		Map<ObjectIdentity, Acl> map = this.strategy
+			.readAclsById(Arrays.asList(topParentOid, middleParentOid, childOid), null);
+		for (Acl acl : map.values()) {
+			for (AccessControlEntry ace : acl.getEntries()) {
+				assertThat(ace.getAcl()).isSameAs(acl);
+			}
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Closes gh-19127

## Background

On Java 26 the JVM warns whenever ACLs are loaded through `BasicLookupStrategy`:

```
WARNING: Final field aces in class org.springframework.security.acls.domain.AclImpl has been mutated reflectively
by class org.springframework.security.acls.jdbc.BasicLookupStrategy in unnamed module ...
WARNING: Use --enable-final-field-mutation=ALL-UNNAMED to avoid a warning
WARNING: Mutating final fields will be blocked in a future release unless final field mutation is enabled
```

`BasicLookupStrategy.convert(...)` is responsible for re-parenting a loaded `AclImpl` onto a freshly constructed one: stub parent references are resolved and the back-reference on every `AccessControlEntryImpl` is rewritten to point at the new ACL (per SEC-951). The previous implementation did this by reflectively rewriting two `final` fields:

- `AclImpl.aces` was replaced through `Field.set(...)` (`setAces`).
- `AccessControlEntryImpl.acl` was replaced through `Field.set(...)` (`setAclOnAce`).

Both writes trigger the Java 26 warning today and will be rejected outright on the JVMs that flip the default. Reading the `aces` field reflectively is not affected — only mutation is.

## Change

Neither final field actually needs to be replaced:

- The new `AclImpl` is created with an empty, mutable `aces` list (initialised inline as `new ArrayList<>()`). Adding to that existing list in place achieves the same end state without touching the field reference. `addAces` (replacing `setAces`) reuses the existing read helper and calls `addAll` on the list.
- `AccessControlEntryImpl` is documented as immutable and exposes a public constructor that takes every field. Re-creating each ACE with the converted `Acl` lets us substitute the `StubAclParent`-bearing ACE for an equivalent one without mutating any final field. `setAclOnAce` and the cached `Field` for `AccessControlEntryImpl.acl` go away entirely.

The reflective *read* of `AclImpl.aces` is preserved — it is necessary to populate the result list and is unaffected by the upcoming JVM restriction. The internal `ProcessResultSet.mapRow` path is unchanged: it already uses the same read-then-`add` idiom to populate the input ACLs.

## Tests

Added `readAclsByIdWhenChildLoadedThenAcesPointToConvertedAcl` to `AbstractBasicLookupStrategyTests`, which asserts the SEC-951 invariant directly: after `readAclsById(...)`, every ACE returned by `acl.getEntries()` reports the converted `Acl` (not a `StubAclParent`) via `getAcl()`. Both `BasicLookupStrategyTests` and `BasicLookupStrategyWithAclClassTypeTests` extend the abstract class, so the new test runs against both class-id strategies.

`./gradlew :spring-security-acl:check` passes (test, checkFormat, checkstyle, license, jacoco).

## Verification done

1. **No in-flight PR**: `gh pr list --repo spring-projects/spring-security --search "AclImpl OR \"final field\" OR \"Java 26\""` returns nothing related, and `gh pr list --search "19127"` is empty.
2. **No claim in the issue thread**: gh-19127 has zero comments at the time of writing.
3. **Code-focused fix**: touches `acl/src/main/java/.../BasicLookupStrategy.java` and the existing abstract test class.
4. **Pattern still present on main**: confirmed `fieldAces.set(...)` and `fieldAcl.set(...)` still live in `BasicLookupStrategy` at HEAD (`5594fc018f`).
5. **Reproducer matches**: the warning text in gh-19127 names `BasicLookupStrategy` mutating `AclImpl.aces`, which is the call this change removes.