### PR TITLE
Exclude anonymous from additionalAuthorization

### DIFF
--- a/core/src/main/java/org/springframework/security/authorization/DefaultAuthorizationManagerFactory.java
+++ b/core/src/main/java/org/springframework/security/authorization/DefaultAuthorizationManagerFactory.java
@@ -146,7 +146,12 @@ public final class DefaultAuthorizationManagerFactory<T extends @Nullable Object
 
 	@Override
 	public AuthorizationManager<T> anonymous() {
-		return createManager(AuthenticatedAuthorizationManager.anonymous());
+		// Unlike authenticated()/fullyAuthenticated()/rememberMe(), anonymous() does not
+		// apply additionalAuthorization, consistent with the permitAll()/denyAll()
+		// defaults.
+		AuthenticatedAuthorizationManager<T> manager = AuthenticatedAuthorizationManager.anonymous();
+		manager.setTrustResolver(this.trustResolver);
+		return manager;
 	}
 
 	private AuthorizationManager<T> createManager(AuthorityAuthorizationManager<T> authorizationManager) {

--- a/core/src/test/java/org/springframework/security/authorization/AuthorizationManagerFactoryTests.java
+++ b/core/src/test/java/org/springframework/security/authorization/AuthorizationManagerFactoryTests.java
@@ -128,8 +128,9 @@ public class AuthorizationManagerFactoryTests {
 		DefaultAuthorizationManagerFactory<String> factory = new DefaultAuthorizationManagerFactory<>();
 		factory.setAdditionalAuthorization(additional);
 
-		factory.anonymous();
+		AuthorizationManager<String> anonymous = factory.anonymous();
 
+		assertThat(anonymous.authorize(() -> TestAuthentication.anonymousUser(), "").isGranted()).isTrue();
 		verifyNoInteractions(additional);
 	}
 


### PR DESCRIPTION
## Overview

`DefaultAuthorizationManagerFactory.anonymous()` applies the configured `additionalAuthorization`, contradicting the documented contract of `setAdditionalAuthorization(...)`:

> This does not affect `anonymous`, `permitAll`, or `denyAll`.

## Problem

`anonymous()` routes through the same `createManager(AuthenticatedAuthorizationManager)` path as `authenticated()`, `fullyAuthenticated()`, and `rememberMe()`, which wraps the manager via `withAdditionalAuthorization(...)`:

```java
return AuthorizationManagers.allOf(new AuthorizationDecision(false), this.additionalAuthorization, manager);
```

`permitAll()` and `denyAll()` are inherited interface defaults and never go through this path, so they correctly stay unaffected. `anonymous()` does not.

As a result, when an `additionalAuthorization` is configured (for example via `AuthorizationManagerFactories.multiFactor().requireFactors(...)`), an anonymous request is **denied** because an anonymous user holds none of the required factors — even though the Javadoc promises `anonymous` is unaffected.

The existing test `anonymousWhenAdditionalAuthorizationThenNotInvoked` only called `factory.anonymous()` and asserted `verifyNoInteractions(...)`. Because the `allOf` wrapping is lazy, that assertion passed at construction time even with the bug, so the regression was not caught.

## Fix

Have `anonymous()` construct the `AuthenticatedAuthorizationManager` directly (still setting the `trustResolver`) and return it without `withAdditionalAuthorization`, mirroring how `permitAll()`/`denyAll()` stay unaffected. `authenticated()`, `fullyAuthenticated()`, and `rememberMe()` continue to apply `additionalAuthorization`.

The existing test is strengthened to actually `authorize(...)` an anonymous authentication and assert it is granted, which fails on the previous code.

## Note on impact

This is a behavior change in the documented direction: an endpoint guarded only by `anonymous()` will now allow anonymous principals even when a configured `additionalAuthorization` (e.g. an MFA/IP/tenant gate) would fail. This matches the documented contract. Callers that intentionally want both conditions should compose them explicitly, e.g. `allOf(factory.anonymous(), extraCondition)`. `anonymous()` still denies authenticated users, so anonymous-only endpoints do not become open to logged-in users.

Closes gh-19334
