### PR TITLE
Find mixed-case usernames in InMemoryUserDetailsManager#changePassword

### DIFF
--- a/core/src/main/java/org/springframework/security/provisioning/InMemoryUserDetailsManager.java
+++ b/core/src/main/java/org/springframework/security/provisioning/InMemoryUserDetailsManager.java
@@ -150,7 +150,7 @@ public class InMemoryUserDetailsManager implements UserDetailsManager, UserDetai
 		else {
 			this.logger.debug("No authentication manager set. Password won't be re-checked.");
 		}
-		MutableUserDetails user = this.users.get(username);
+		MutableUserDetails user = this.users.get(username.toLowerCase(Locale.ROOT));
 		Assert.state(user != null, "Current user doesn't exist in database.");
 		user.setPassword(newPassword);
 	}

--- a/core/src/main/java/org/springframework/security/provisioning/InMemoryUserDetailsManager.java
+++ b/core/src/main/java/org/springframework/security/provisioning/InMemoryUserDetailsManager.java
@@ -149,7 +149,7 @@ public class InMemoryUserDetailsManager implements UserDetailsManager, UserDetai
 		else {
 			this.logger.debug("No authentication manager set. Password won't be re-checked.");
 		}
-		MutableUserDetails user = this.users.get(username);
+		MutableUserDetails user = this.users.get(username.toLowerCase(Locale.ROOT));
 		Assert.state(user != null, "Current user doesn't exist in database.");
 		user.setPassword(newPassword);
 	}

--- a/core/src/test/java/org/springframework/security/provisioning/InMemoryUserDetailsManagerTests.java
+++ b/core/src/test/java/org/springframework/security/provisioning/InMemoryUserDetailsManagerTests.java
@@ -124,6 +124,22 @@ public class InMemoryUserDetailsManagerTests {
 	}
 
 	@Test
+	public void changePasswordWhenCurrentUsernameIsNotInLowercaseThenChangesPassword() {
+		UserDetails userNotLowerCase = User.withUserDetails(PasswordEncodedUser.user()).username("User").build();
+		InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager(userNotLowerCase);
+		Authentication authentication = new UsernamePasswordAuthenticationToken("User", userNotLowerCase.getPassword(),
+				userNotLowerCase.getAuthorities());
+		SecurityContextHolderStrategy strategy = mock(SecurityContextHolderStrategy.class);
+		given(strategy.getContext()).willReturn(new SecurityContextImpl(authentication));
+		manager.setSecurityContextHolderStrategy(strategy);
+
+		String newPassword = "newPassword";
+		manager.changePassword(userNotLowerCase.getPassword(), newPassword);
+
+		assertThat(manager.loadUserByUsername("User").getPassword()).isEqualTo(newPassword);
+	}
+
+	@Test
 	public void createUserWhenUserAlreadyExistsThenException() {
 		assertThatIllegalArgumentException().isThrownBy(() -> this.manager.createUser(this.user))
 			.withMessage("user should not exist");


### PR DESCRIPTION
## Overview

`InMemoryUserDetailsManager.changePassword(...)` fails for users whose username contains uppercase letters.

## Problem

The manager keys its `Map<String, MutableUserDetails> users` on the lower-cased username in `createUser`, `updateUser`, `deleteUser`, `userExists`, `loadUserByUsername`, and `updatePassword`. Only `changePassword(...)` looked the current user up with the raw name:

```java
String username = currentUser.getName();
...
MutableUserDetails user = this.users.get(username); // not lower-cased
Assert.state(user != null, "Current user doesn't exist in database.");
```

So a user created as e.g. `User.withUsername("User")...` (stored under the key `"user"`) cannot change its password: `users.get("User")` is `null` and `IllegalStateException("Current user doesn't exist in database.")` is thrown, even though authentication and every other operation on that user succeed.

## Fix

Lower-case the lookup key, matching the rest of the class:

```java
MutableUserDetails user = this.users.get(username.toLowerCase(Locale.ROOT));
```

A regression test creates the manager with an uppercase username, authenticates as that user, and asserts `changePassword(...)` updates the password (observed through `loadUserByUsername`).

Closes gh-19336
