### PR TITLE
Make InMemoryReactiveSessionRegistry updates atomic

### DIFF
--- a/core/src/main/java/org/springframework/security/core/session/InMemoryReactiveSessionRegistry.java
+++ b/core/src/main/java/org/springframework/security/core/session/InMemoryReactiveSessionRegistry.java
@@ -59,8 +59,16 @@ public class InMemoryReactiveSessionRegistry implements ReactiveSessionRegistry 
 	@Override
 	public Mono<Void> saveSessionInformation(ReactiveSessionInformation information) {
 		this.sessionById.put(information.getSessionId(), information);
-		this.sessionIdsByPrincipal.computeIfAbsent(information.getPrincipal(), (key) -> new CopyOnWriteArraySet<>())
-			.add(information.getSessionId());
+		// Add the session id inside the compute so that it cannot race with the key
+		// removal performed by removeSessionInformation (which could otherwise drop a
+		// concurrently added session). This mirrors the blocking SessionRegistryImpl.
+		this.sessionIdsByPrincipal.compute(information.getPrincipal(), (key, sessionsUsedByPrincipal) -> {
+			if (sessionsUsedByPrincipal == null) {
+				sessionsUsedByPrincipal = new CopyOnWriteArraySet<>();
+			}
+			sessionsUsedByPrincipal.add(information.getSessionId());
+			return sessionsUsedByPrincipal;
+		});
 		return Mono.empty();
 	}
 
@@ -73,13 +81,14 @@ public class InMemoryReactiveSessionRegistry implements ReactiveSessionRegistry 
 	public Mono<ReactiveSessionInformation> removeSessionInformation(String sessionId) {
 		return getSessionInformation(sessionId).doOnNext((sessionInformation) -> {
 			this.sessionById.remove(sessionId);
-			Set<String> sessionsUsedByPrincipal = this.sessionIdsByPrincipal.get(sessionInformation.getPrincipal());
-			if (sessionsUsedByPrincipal != null) {
-				sessionsUsedByPrincipal.remove(sessionId);
-				if (sessionsUsedByPrincipal.isEmpty()) {
-					this.sessionIdsByPrincipal.remove(sessionInformation.getPrincipal());
-				}
-			}
+			// Remove and prune atomically so the principal key is dropped only while its
+			// set is empty; otherwise a session added concurrently could be lost. Mirrors
+			// the blocking SessionRegistryImpl.
+			this.sessionIdsByPrincipal.computeIfPresent(sessionInformation.getPrincipal(),
+					(key, sessionsUsedByPrincipal) -> {
+						sessionsUsedByPrincipal.remove(sessionId);
+						return sessionsUsedByPrincipal.isEmpty() ? null : sessionsUsedByPrincipal;
+					});
 		});
 	}
 

--- a/web/src/test/java/org/springframework/security/web/server/authentication/session/InMemoryReactiveSessionRegistryTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/authentication/session/InMemoryReactiveSessionRegistryTests.java
@@ -117,35 +117,38 @@ class InMemoryReactiveSessionRegistryTests {
 		ExecutorService executor = Executors.newFixedThreadPool(2);
 		try {
 			for (int i = 0; i < 1000; i++) {
-				String existing = "existing-" + i;
-				String added = "added-" + i;
-				this.sessionRegistry
-					.saveSessionInformation(new ReactiveSessionInformation(principal, existing, this.now))
-					.block();
-				CountDownLatch start = new CountDownLatch(1);
-				Future<?> remove = executor.submit(() -> {
-					awaitUninterruptibly(start);
-					this.sessionRegistry.removeSessionInformation(existing).block();
-				});
-				Future<?> save = executor.submit(() -> {
-					awaitUninterruptibly(start);
-					this.sessionRegistry
-						.saveSessionInformation(new ReactiveSessionInformation(principal, added, this.now))
-						.block();
-				});
-				start.countDown();
-				remove.get();
-				save.get();
-				List<ReactiveSessionInformation> sessions = this.sessionRegistry.getAllSessions(principal)
-					.collectList()
-					.block();
-				assertThat(sessions).extracting(ReactiveSessionInformation::getSessionId).contains(added);
-				this.sessionRegistry.removeSessionInformation(added).block();
+				assertAddedSessionSurvivesConcurrentSaveAndRemove(principal, "existing-" + i, "added-" + i, executor);
 			}
 		}
 		finally {
 			executor.shutdownNow();
 		}
+	}
+
+	// Runs one concurrent save/remove race for the principal and asserts the
+	// concurrently added session is not lost.
+	private void assertAddedSessionSurvivesConcurrentSaveAndRemove(Object principal, String existing, String added,
+			ExecutorService executor) throws Exception {
+		this.sessionRegistry.saveSessionInformation(new ReactiveSessionInformation(principal, existing, this.now))
+			.block();
+		CountDownLatch start = new CountDownLatch(1);
+		Future<?> remove = executor.submit(() -> {
+			awaitUninterruptibly(start);
+			this.sessionRegistry.removeSessionInformation(existing).block();
+		});
+		Future<?> save = executor.submit(() -> {
+			awaitUninterruptibly(start);
+			this.sessionRegistry.saveSessionInformation(new ReactiveSessionInformation(principal, added, this.now))
+				.block();
+		});
+		start.countDown();
+		remove.get();
+		save.get();
+		List<ReactiveSessionInformation> sessions = this.sessionRegistry.getAllSessions(principal)
+			.collectList()
+			.block();
+		assertThat(sessions).extracting(ReactiveSessionInformation::getSessionId).contains(added);
+		this.sessionRegistry.removeSessionInformation(added).block();
 	}
 
 	private static void awaitUninterruptibly(CountDownLatch latch) {

--- a/web/src/test/java/org/springframework/security/web/server/authentication/session/InMemoryReactiveSessionRegistryTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/authentication/session/InMemoryReactiveSessionRegistryTests.java
@@ -20,6 +20,10 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.junit.jupiter.api.Test;
 
@@ -101,6 +105,57 @@ class InMemoryReactiveSessionRegistryTests {
 		saved = this.sessionRegistry.getSessionInformation("1234").block();
 		assertThat(saved.getLastAccessTime()).isNotNull();
 		assertThat(saved.getLastAccessTime()).isAfter(lastAccessTimeBefore);
+	}
+
+	// Removing the last session of a principal must not race with a concurrent save for
+	// the same principal. Previously remove pruned the principal key with a non-atomic
+	// isEmpty()-then-remove, which could drop a session added concurrently.
+	@Test
+	void saveAndRemoveConcurrentlyThenAddedSessionNotLost() throws Exception {
+		Authentication authentication = TestAuthentication.authenticatedUser();
+		Object principal = authentication.getPrincipal();
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		try {
+			for (int i = 0; i < 1000; i++) {
+				String existing = "existing-" + i;
+				String added = "added-" + i;
+				this.sessionRegistry
+					.saveSessionInformation(new ReactiveSessionInformation(principal, existing, this.now))
+					.block();
+				CountDownLatch start = new CountDownLatch(1);
+				Future<?> remove = executor.submit(() -> {
+					awaitUninterruptibly(start);
+					this.sessionRegistry.removeSessionInformation(existing).block();
+				});
+				Future<?> save = executor.submit(() -> {
+					awaitUninterruptibly(start);
+					this.sessionRegistry
+						.saveSessionInformation(new ReactiveSessionInformation(principal, added, this.now))
+						.block();
+				});
+				start.countDown();
+				remove.get();
+				save.get();
+				List<ReactiveSessionInformation> sessions = this.sessionRegistry.getAllSessions(principal)
+					.collectList()
+					.block();
+				assertThat(sessions).extracting(ReactiveSessionInformation::getSessionId).contains(added);
+				this.sessionRegistry.removeSessionInformation(added).block();
+			}
+		}
+		finally {
+			executor.shutdownNow();
+		}
+	}
+
+	private static void awaitUninterruptibly(CountDownLatch latch) {
+		try {
+			latch.await();
+		}
+		catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException(ex);
+		}
 	}
 
 }


### PR DESCRIPTION
## Overview

`InMemoryReactiveSessionRegistry` can lose a session when `saveSessionInformation` and `removeSessionInformation` run concurrently for the same principal.

## Problem

The per-principal session set was updated non-atomically:

- `saveSessionInformation` added the session id **outside** the `computeIfAbsent` mapping function.
- `removeSessionInformation` pruned the principal key with a non-atomic `get` → `isEmpty()` → `remove(principal)`.

Interleaving (principal `P` owns one session `S1`):

1. Thread A removes `S1`; the set becomes empty and A is about to remove key `P`.
2. Thread B saves `S2`: `computeIfAbsent(P)` still sees key `P`, returns the same set, and adds `S2`.
3. Thread A removes key `P` → the set `{S2}` is orphaned; `getAllSessions(P)` is empty and `S2` is lost.

The blocking `SessionRegistryImpl` already avoids this by performing both updates atomically with `compute`/`computeIfPresent` (on the same `ConcurrentMap` field shape and constructor); the reactive registry did not.

## Fix

Mirror the blocking `SessionRegistryImpl`: perform the add inside `compute`, and the remove-and-prune inside `computeIfPresent` (returning `null` to drop the key only while the set is empty). This makes the per-principal updates atomic.

A 1000-iteration, latch-synchronized concurrent save/remove stress test is added; it fails on the previous code and passes with the fix.

Closes gh-19338
