### PR TITLE
Update servlet/test/mockmvc/http-basic.adoc to use include-code

### DIFF
--- a/docs/modules/ROOT/pages/servlet/test/mockmvc/http-basic.adoc
+++ b/docs/modules/ROOT/pages/servlet/test/mockmvc/http-basic.adoc
@@ -4,25 +4,7 @@ While it has always been possible to authenticate with HTTP Basic, it was a bit 
 Now this can be done using Spring Security's `httpBasic` xref:servlet/test/mockmvc/request-post-processors.adoc[`RequestPostProcessor`].
 For example, the snippet below:
 
-[tabs]
-======
-Java::
-+
-[source,java,role="primary"]
-----
-mvc
-	.perform(get("/").with(httpBasic("user","password")))
-----
-
-Kotlin::
-+
-[source,kotlin,role="secondary"]
-----
-mvc.get("/") {
-    with(httpBasic("user","password"))
-}
-----
-======
+include-code::./HttpBasicAuthenticationTests[tag=http-basic,indent=0]
 
 will attempt to use HTTP Basic to authenticate a user with the username "user" and the password "password" by ensuring the following header is populated on the HTTP Request:
 

--- a/docs/src/test/java/org/springframework/security/docs/servlet/test/mockmvc/HttpBasicAuthenticationTests.java
+++ b/docs/src/test/java/org/springframework/security/docs/servlet/test/mockmvc/HttpBasicAuthenticationTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.docs.servlet.test.mockmvc;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+class HttpBasicAuthenticationTests {
+
+	@Test
+	void basicAuthentication() throws Exception {
+		MockMvc mvc = MockMvcBuilders.standaloneSetup(new TestController()).build();
+
+		MvcResult result =
+				// tag::http-basic[]
+				mvc
+					.perform(get("/").with(httpBasic("user", "password")))
+				// end::http-basic[]
+					.andReturn();
+
+		assertThat(result.getRequest().getHeader(HttpHeaders.AUTHORIZATION))
+				.isEqualTo("Basic dXNlcjpwYXNzd29yZA==");
+	}
+
+	@RestController
+	static class TestController {
+
+		@GetMapping("/")
+		String index() {
+			return "ok";
+		}
+
+	}
+
+}

--- a/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/mockmvc/HttpBasicAuthenticationTests.kt
+++ b/docs/src/test/kotlin/org/springframework/security/kt/docs/servlet/test/mockmvc/HttpBasicAuthenticationTests.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.kt.docs.servlet.test.mockmvc
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+class HttpBasicAuthenticationTests {
+
+    @Test
+    fun `http basic`() {
+        val mvc = MockMvcBuilders.standaloneSetup(TestController()).build()
+
+        val result =
+            // tag::http-basic[]
+            mvc.get("/") {
+                with(httpBasic("user", "password"))
+            }
+            // end::http-basic[]
+                .andReturn()
+
+        assertThat(result.request.getHeader(HttpHeaders.AUTHORIZATION))
+            .isEqualTo("Basic dXNlcjpwYXNzd29yZA==")
+    }
+
+    @RestController
+    class TestController {
+
+        @GetMapping("/")
+        fun index(): String {
+            return "ok"
+        }
+
+    }
+
+}


### PR DESCRIPTION
This PR updates `docs/modules/ROOT/pages/servlet/test/mockmvc/http-basic.adoc` to use the `include-code` macro for its Java and Kotlin samples.

The HTTP Basic MockMvc sample is now sourced from `HttpBasicAuthenticationTests` (Java and Kotlin), tagged as `http-basic`, and pulled into the rendered docs via `include-code::./HttpBasicAuthenticationTests[tag=http-basic,indent=0]`.

Verification:
- `git diff --check` passes.
- `./gradlew :spring-security-docs:compileTestJava :spring-security-docs:compileTestKotlin :spring-security-docs:test --tests '*HttpBasicAuthenticationTests' --console=plain` passes.
- `./gradlew :spring-security-docs:antora --console=plain` renders the page; the resulting `servlet/test/mockmvc/http-basic.html` shows the Java/Kotlin tabs with the expected snippets and no unprocessed `include-code` macros or tag comments.
- `./gradlew :spring-security-docs:check --console=plain` passes.

References https://github.com/spring-projects/spring-security/issues/16226
