### PR TITLE
Fix JwtAuthenticationToken builder principal type

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationToken.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationToken.java
@@ -135,13 +135,17 @@ public class JwtAuthenticationToken extends AbstractOAuth2TokenAuthenticationTok
 		}
 
 		/**
-		 * A synonym for {@link #token(Jwt)}
+		 * Use this {@code principal} as the principal. If it is an
+		 * {@link AuthenticatedPrincipal}, also uses its name.
 		 * @return the {@link Builder} for further configurations
 		 */
 		@Override
 		public B principal(@Nullable Object principal) {
-			Assert.isInstanceOf(Jwt.class, principal, "principal must be of type Jwt");
-			return token((Jwt) principal);
+			super.principal(principal);
+			if (principal instanceof AuthenticatedPrincipal authenticatedPrincipal) {
+				name(authenticatedPrincipal.getName());
+			}
+			return (B) this;
 		}
 
 		/**

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationTokenTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationTokenTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.security.core.AuthenticatedPrincipal;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.oauth2.jose.jws.JwsAlgorithms;
@@ -131,6 +132,30 @@ public class JwtAuthenticationTokenTests {
 		assertThat(result.getPrincipal()).isSameAs(factorTwo.getPrincipal());
 		assertThat(result.getName()).isSameAs(factorTwo.getName());
 		assertThat(authorities).containsExactlyInAnyOrder("FACTOR_ONE", "FACTOR_TWO");
+	}
+
+	@Test
+	public void toBuilderWhenPrincipalIsCustomObjectThenBuilds() {
+		Jwt jwt = builder().subject("Hayden").build();
+		Object principal = new Object();
+		JwtAuthenticationToken result = new JwtAuthenticationToken(jwt, AuthorityUtils.NO_AUTHORITIES).toBuilder()
+			.principal(principal)
+			.build();
+		assertThat(result.getPrincipal()).isSameAs(principal);
+		assertThat(result.getCredentials()).isSameAs(jwt);
+		assertThat(result.getToken()).isSameAs(jwt);
+		assertThat(result.getName()).isEqualTo("Hayden");
+	}
+
+	@Test
+	public void toBuilderWhenPrincipalIsAuthenticatedPrincipalThenUsesPrincipalName() {
+		Jwt jwt = builder().subject("Hayden").build();
+		AuthenticatedPrincipal principal = () -> "Samantha";
+		JwtAuthenticationToken result = new JwtAuthenticationToken(jwt, AuthorityUtils.NO_AUTHORITIES).toBuilder()
+			.principal(principal)
+			.build();
+		assertThat(result.getPrincipal()).isSameAs(principal);
+		assertThat(result.getName()).isEqualTo("Samantha");
 	}
 
 	private Jwt.Builder builder() {


### PR DESCRIPTION
## Summary

- Allow `JwtAuthenticationToken.Builder.principal` to accept the same principal types as the matching constructor
- Preserve the JWT as the token and credentials when setting a custom principal
- Use an `AuthenticatedPrincipal` name when supplied to the builder

Closes gh-19333

## Testing

- `./gradlew :spring-security-oauth2-resource-server:test --tests 'org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationTokenTests.toBuilderWhenPrincipalIsCustomObjectThenBuilds' --tests 'org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationTokenTests.toBuilderWhenPrincipalIsAuthenticatedPrincipalThenUsesPrincipalName' --no-daemon`
- `./gradlew :spring-security-oauth2-resource-server:test --tests 'org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationTokenTests' --no-daemon`
- `./gradlew :spring-security-oauth2-resource-server:test --no-daemon`
