### PR TITLE
Fix JwtClaimValidator null claim handling

### DIFF
--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtClaimValidator.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/JwtClaimValidator.java
@@ -62,10 +62,8 @@ public final class JwtClaimValidator<T> implements OAuth2TokenValidator<Jwt> {
 	public OAuth2TokenValidatorResult validate(Jwt token) {
 		Assert.notNull(token, "token cannot be null");
 		T claimValue = token.getClaim(this.claim);
-		if (claimValue != null) {
-			if (this.test.test(claimValue)) {
-				return OAuth2TokenValidatorResult.success();
-			}
+		if (this.test.test(claimValue)) {
+			return OAuth2TokenValidatorResult.success();
 		}
 		this.logger.debug(this.error.getDescription());
 		return OAuth2TokenValidatorResult.failure(this.error);

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtClaimValidatorTests.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jwt/JwtClaimValidatorTests.java
@@ -55,6 +55,14 @@ public class JwtClaimValidatorTests {
 	}
 
 	@Test
+	public void validateWhenClaimIsMissingAndTestAcceptsNullThenReturnsSuccess() {
+		JwtClaimValidator<String> validator = new JwtClaimValidator<>("loa", Objects::isNull);
+		Jwt jwt = TestJwts.jwt().build();
+
+		assertThat(validator.validate(jwt)).isEqualTo(OAuth2TokenValidatorResult.success());
+	}
+
+	@Test
 	public void validateWhenClaimIsNullThenThrowsIllegalArgumentException() {
 		assertThatIllegalArgumentException().isThrownBy(() -> new JwtClaimValidator<>(null, test));
 	}


### PR DESCRIPTION
## Summary

- Restore `JwtClaimValidator` behavior so custom claim predicates receive `null` for missing or null-valued claims.
- Add regression coverage for a missing `loa` claim where the configured predicate accepts `null`.

Fixes gh-19346

## Testing

- `./gradlew :spring-security-oauth2-jose:test --tests org.springframework.security.oauth2.jwt.JwtClaimValidatorTests.validateWhenClaimIsMissingAndTestAcceptsNullThenReturnsSuccess --no-daemon`
- `./gradlew :spring-security-oauth2-jose:test --tests org.springframework.security.oauth2.jwt.JwtClaimValidatorTests --no-daemon`
- `./gradlew :spring-security-oauth2-jose:test --no-daemon`
- `git diff --check`
