### PR TITLE
Restore Java 17 compatible CAS client

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,7 +58,7 @@ org-apache-maven-maven-resolver-provider = "org.apache.maven:maven-resolver-prov
 org-apache-maven-resolver-maven-resolver-connector-basic = { module = "org.apache.maven.resolver:maven-resolver-connector-basic", version.ref = "org-apache-maven-resolver" }
 org-apache-maven-resolver-maven-resolver-impl = { module = "org.apache.maven.resolver:maven-resolver-impl", version.ref = "org-apache-maven-resolver" }
 org-apache-maven-resolver-maven-resolver-transport-http = { module = "org.apache.maven.resolver:maven-resolver-transport-http", version.ref = "org-apache-maven-resolver" }
-org-apereo-cas-client-cas-client-core = "org.apereo.cas.client:cas-client-core:4.1.1"
+org-apereo-cas-client-cas-client-core = "org.apereo.cas.client:cas-client-core:4.0.4"
 io-freefair-gradle-aspectj-plugin = "io.freefair.gradle:aspectj-plugin:8.14.4"
 org-aspectj-aspectjrt = { module = "org.aspectj:aspectjrt", version.ref = "org-aspectj" }
 org-aspectj-aspectjweaver = { module = "org.aspectj:aspectjweaver", version.ref = "org-aspectj" }


### PR DESCRIPTION
Fixes gh-19325.

`cas-client-core` 4.1.x is built with Java 21 bytecode (class file major 65), which is above Spring Security's Java 17 baseline. This restores 4.0.4, whose artifacts are Java 17 bytecode (major 61).

Verification:
- confirmed `cas-client-core` 4.1.1 has max class file major 65 and 4.0.4 has max class file major 61
- `./gradlew :spring-security-cas:dependencyInsight --configuration runtimeClasspath --dependency org.apereo.cas.client:cas-client-core --no-daemon`
- `./gradlew :spring-security-cas:test --no-daemon`
- `git diff --check`
