### PR TITLE
Support OIDC discovery path insertion for multi-issuer configurations

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OidcProviderConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/oauth2/server/authorization/OidcProviderConfigurationTests.java
@@ -112,6 +112,24 @@ public class OidcProviderConfigurationTests {
 			.andExpectAll(defaultConfigurationMatchers(issuer));
 	}
 
+	@Test
+	public void requestWhenConfigurationRequestUsesPathInsertionThenConfigurationResponseHasIssuerPath()
+			throws Exception {
+		this.spring.register(AuthorizationServerConfigurationWithMultipleIssuersAllowed.class).autowire();
+
+		String issuer = "https://example.com:8443/issuer1";
+		String requestUri = "https://example.com:8443" + DEFAULT_OIDC_PROVIDER_CONFIGURATION_ENDPOINT_URI + "/issuer1";
+		this.mvc.perform(get(requestUri))
+			.andExpect(status().is2xxSuccessful())
+			.andExpectAll(defaultConfigurationMatchers(issuer));
+
+		issuer = "https://example.com:8443/path1/issuer2";
+		requestUri = "https://example.com:8443" + DEFAULT_OIDC_PROVIDER_CONFIGURATION_ENDPOINT_URI + "/path1/issuer2";
+		this.mvc.perform(get(requestUri))
+			.andExpect(status().is2xxSuccessful())
+			.andExpectAll(defaultConfigurationMatchers(issuer));
+	}
+
 	// gh-632
 	@Test
 	public void requestWhenConfigurationRequestAndUserAuthenticatedThenReturnConfigurationResponse() throws Exception {

--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/oidc/web/OidcProviderConfigurationEndpointFilter.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/oidc/web/OidcProviderConfigurationEndpointFilter.java
@@ -40,6 +40,7 @@ import org.springframework.security.oauth2.server.authorization.oidc.OidcProvide
 import org.springframework.security.oauth2.server.authorization.oidc.http.converter.OidcProviderConfigurationHttpMessageConverter;
 import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -132,8 +133,12 @@ public final class OidcProviderConfigurationEndpointFilter extends OncePerReques
 	private static RequestMatcher createRequestMatcher() {
 		final RequestMatcher defaultRequestMatcher = PathPatternRequestMatcher.withDefaults()
 			.matcher(HttpMethod.GET, DEFAULT_OIDC_PROVIDER_CONFIGURATION_ENDPOINT_URI);
-		final RequestMatcher multipleIssuersRequestMatcher = PathPatternRequestMatcher.withDefaults()
+		final RequestMatcher multipleIssuersPathInsertionRequestMatcher = PathPatternRequestMatcher.withDefaults()
+			.matcher(HttpMethod.GET, DEFAULT_OIDC_PROVIDER_CONFIGURATION_ENDPOINT_URI + "/**");
+		final RequestMatcher multipleIssuersPathAppendRequestMatcher = PathPatternRequestMatcher.withDefaults()
 			.matcher(HttpMethod.GET, "/**" + DEFAULT_OIDC_PROVIDER_CONFIGURATION_ENDPOINT_URI);
+		final RequestMatcher multipleIssuersRequestMatcher = new OrRequestMatcher(
+				multipleIssuersPathInsertionRequestMatcher, multipleIssuersPathAppendRequestMatcher);
 		return (request) -> AuthorizationServerContextHolder.getContext()
 			.getAuthorizationServerSettings()
 			.isMultipleIssuersAllowed() ? multipleIssuersRequestMatcher.matches(request)


### PR DESCRIPTION
Closes gh-19342

The OIDC provider configuration endpoint only matched the path-append multi-issuer discovery form (`/{issuer}/.well-known/openid-configuration`). This adds the matching path-insertion form (`/.well-known/openid-configuration/{issuer}`) while preserving the existing path-append behavior.

The added MockMvc regression coverage verifies issuer path resolution for both a single-segment issuer path and a nested issuer path.

Tests:
- `./gradlew :spring-security-config:test --tests org.springframework.security.config.annotation.web.configurers.oauth2.server.authorization.OidcProviderConfigurationTests.requestWhenConfigurationRequestUsesPathInsertionThenConfigurationResponseHasIssuerPath --no-daemon` (failed before the fix, passes after)
- `./gradlew :spring-security-config:test --tests org.springframework.security.config.annotation.web.configurers.oauth2.server.authorization.OidcProviderConfigurationTests --no-daemon`
- `./gradlew :spring-security-oauth2-authorization-server:test --tests org.springframework.security.oauth2.server.authorization.oidc.web.OidcProviderConfigurationEndpointFilterTests --no-daemon`
- `git diff --check`
