### PR TITLE
Fix incorrect example in SAML2 authentication docs

### DIFF
--- a/docs/modules/ROOT/pages/servlet/saml2/login/authentication.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/login/authentication.adoc
@@ -368,7 +368,7 @@ Java::
 @Bean
 ResponseAuthenticationConverter authenticationConverter() {
 	ResponseAuthenticationConverter authenticationConverter = new ResponseAuthenticationConverter();
-	authenticationConverter.setPrincipalNameConverter((assertion) -> {
+	authenticationConverter.setGrantedAuthoritiesConverter((assertion) -> {
 		// ... grant the needed authorities based on attributes in the assertion
 	});
 	return authenticationConverter;
@@ -382,7 +382,7 @@ Kotlin::
 @Bean
 fun authenticationConverter(): ResponseAuthenticationConverter {
     val authenticationConverter = ResponseAuthenticationConverter()
-    authenticationConverter.setPrincipalNameConverter{ assertion ->
+    authenticationConverter.setGrantedAuthoritiesConverter{ assertion ->
 		// ... grant the needed authorities based on attributes in the assertion
     }
     return authenticationConverter


### PR DESCRIPTION
In the 'Configuring a Principal's Granted Authorities' example, call setGrantedAuthoritiesConverter instead of setPrincipalNameConverter