### PR TITLE
Fix WebAuthn unknown transport deserialization

### DIFF
--- a/webauthn/src/main/java/org/springframework/security/web/webauthn/jackson/AuthenticatorTransportDeserializer.java
+++ b/webauthn/src/main/java/org/springframework/security/web/webauthn/jackson/AuthenticatorTransportDeserializer.java
@@ -41,12 +41,10 @@ class AuthenticatorTransportDeserializer extends StdDeserializer<AuthenticatorTr
 	public @Nullable AuthenticatorTransport deserialize(JsonParser parser, DeserializationContext ctxt)
 			throws JacksonException {
 		String transportValue = parser.readValueAs(String.class);
-		for (AuthenticatorTransport transport : AuthenticatorTransport.values()) {
-			if (transport.getValue().equals(transportValue)) {
-				return transport;
-			}
+		if (transportValue == null) {
+			return null;
 		}
-		return null;
+		return AuthenticatorTransport.valueOf(transportValue);
 	}
 
 }

--- a/webauthn/src/main/java/org/springframework/security/web/webauthn/jackson/AuthenticatorTransportJackson2Deserializer.java
+++ b/webauthn/src/main/java/org/springframework/security/web/webauthn/jackson/AuthenticatorTransportJackson2Deserializer.java
@@ -47,12 +47,10 @@ class AuthenticatorTransportJackson2Deserializer extends StdDeserializer<Authent
 	public @Nullable AuthenticatorTransport deserialize(JsonParser parser, DeserializationContext ctxt)
 			throws IOException, JacksonException {
 		String transportValue = parser.readValueAs(String.class);
-		for (AuthenticatorTransport transport : AuthenticatorTransport.values()) {
-			if (transport.getValue().equals(transportValue)) {
-				return transport;
-			}
+		if (transportValue == null) {
+			return null;
 		}
-		return null;
+		return AuthenticatorTransport.valueOf(transportValue);
 	}
 
 }

--- a/webauthn/src/test/java/org/springframework/security/web/webauthn/jackson/Jackson2Tests.java
+++ b/webauthn/src/test/java/org/springframework/security/web/webauthn/jackson/Jackson2Tests.java
@@ -63,6 +63,14 @@ class Jackson2Tests {
 	}
 
 	@Test
+	void readAuthenticatorTransportWhenUnknownThenPreservesValue() throws Exception {
+		AuthenticatorTransport transport = this.mapper.readValue("\"cable\"", AuthenticatorTransport.class);
+
+		assertThat(transport).isNotNull();
+		assertThat(transport.getValue()).isEqualTo("cable");
+	}
+
+	@Test
 	void readAuthenticatorAttachment() throws Exception {
 		AuthenticatorAttachment value = this.mapper.readValue("\"cross-platform\"", AuthenticatorAttachment.class);
 		assertThat(value).isEqualTo(AuthenticatorAttachment.CROSS_PLATFORM);

--- a/webauthn/src/test/java/org/springframework/security/web/webauthn/jackson/JacksonTests.java
+++ b/webauthn/src/test/java/org/springframework/security/web/webauthn/jackson/JacksonTests.java
@@ -61,6 +61,14 @@ class JacksonTests {
 	}
 
 	@Test
+	void readAuthenticatorTransportWhenUnknownThenPreservesValue() throws Exception {
+		AuthenticatorTransport transport = this.mapper.readValue("\"cable\"", AuthenticatorTransport.class);
+
+		assertThat(transport).isNotNull();
+		assertThat(transport.getValue()).isEqualTo("cable");
+	}
+
+	@Test
 	void readAuthenticatorAttachment() throws Exception {
 		AuthenticatorAttachment value = this.mapper.readValue("\"cross-platform\"", AuthenticatorAttachment.class);
 		assertThat(value).isEqualTo(AuthenticatorAttachment.CROSS_PLATFORM);


### PR DESCRIPTION
Fixes gh-19366

`AuthenticatorTransport` already preserves unknown transport names, but the Jackson deserializers returned `null` for transport strings outside the built-in constants. Registration payloads that include values such as `"cable"` could then fail later when the registration flow reads the transport value.

This updates both Jackson 3 and Jackson 2 deserializers to delegate to `AuthenticatorTransport.valueOf(...)`, preserving unknown transport values while still returning the existing constants for known values.

Tests:
- RED: `./gradlew :spring-security-webauthn:test --tests org.springframework.security.web.webauthn.jackson.JacksonTests.readAuthenticatorTransportWhenUnknownThenPreservesValue --tests org.springframework.security.web.webauthn.jackson.Jackson2Tests.readAuthenticatorTransportWhenUnknownThenPreservesValue --no-daemon`
- GREEN: `./gradlew :spring-security-webauthn:test --tests org.springframework.security.web.webauthn.jackson.JacksonTests.readAuthenticatorTransportWhenUnknownThenPreservesValue --tests org.springframework.security.web.webauthn.jackson.Jackson2Tests.readAuthenticatorTransportWhenUnknownThenPreservesValue --no-daemon`
- `./gradlew :spring-security-webauthn:test --tests org.springframework.security.web.webauthn.jackson.JacksonTests --tests org.springframework.security.web.webauthn.jackson.Jackson2Tests --no-daemon`
- `./gradlew :spring-security-webauthn:test --no-daemon`
- `git diff --check HEAD^ HEAD`
