### PR TITLE
fix: allow nullable uid in InetOrgPerson

### DIFF
--- a/ldap/src/main/java/org/springframework/security/ldap/userdetails/InetOrgPerson.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/userdetails/InetOrgPerson.java
@@ -77,8 +77,8 @@ public class InetOrgPerson extends Person {
 
 	private @Nullable String uid;
 
-	public String getUid() {
-		return Objects.requireNonNull(this.uid, "uid cannot be null");
+	public @Nullable String getUid() {
+		return this.uid;
 	}
 
 	public @Nullable String getMail() {
@@ -222,8 +222,9 @@ public class InetOrgPerson extends Person {
 			setStreet(ctx.getStringAttribute("street"));
 			setTitle(ctx.getStringAttribute("title"));
 			String uid = ctx.getStringAttribute("uid");
-			Assert.notNull(uid, "uid cannot be null");
-			setUid(uid);
+			if (uid != null) {
+				setUid(uid);
+			}
 		}
 
 		@Override
@@ -236,11 +237,10 @@ public class InetOrgPerson extends Person {
 			((InetOrgPerson) this.instance).mail = email;
 		}
 
-		public void setUid(String uid) {
+		public void setUid(@Nullable String uid) {
 			Assert.notNull(this.instance, "Essence can only be used to create a single instance");
 			((InetOrgPerson) this.instance).uid = uid;
-
-			if (this.username == null) {
+			if (this.username == null && uid != null) {
 				setUsername(uid);
 			}
 		}

--- a/ldap/src/test/java/org/springframework/security/ldap/userdetails/InetOrgPersonTests.java
+++ b/ldap/src/test/java/org/springframework/security/ldap/userdetails/InetOrgPersonTests.java
@@ -81,6 +81,14 @@ public class InetOrgPersonTests {
 		assertThat(p.getDisplayName()).isEqualTo("Ghengis McCann");
 		assertThat(p.getInitials()).isEqualTo("G");
 	}
+	@Test
+	public void testNullUidIsAllowed() {
+		DirContextAdapter ctx = createUserContext();
+		ctx.setAttributeValue("uid", null);
+		InetOrgPerson.Essence essence = new InetOrgPerson.Essence(ctx);
+		InetOrgPerson p = (InetOrgPerson) essence.createUserDetails();
+		assertThat(p.getUid()).isNull();
+	}
 
 	@Test
 	public void testPasswordIsSetFromContextUserPassword() {


### PR DESCRIPTION
Fixes #19370

## Problem
`uid` is marked `@Nullable` on the field but two places contradicted 
this:
- `getUid()` called `Objects.requireNonNull()`, throwing NPE if uid is null
- `Essence(DirContextOperations)` constructor called `Assert.notNull()`, 
  throwing IllegalArgumentException if uid is absent from LDAP context

According to the LDAP inetOrgPerson schema, `uid` is not a mandatory 
field. This behavior also regressed from pre-7.1.0 behavior (introduced 
in commit c5632cc).

## Changes
- `getUid()` now returns `@Nullable String` and returns the field directly
- Constructor no longer asserts uid is non-null; skips `setUid()` if absent
- `setUid()` now accepts `@Nullable String` and guards username mapping 
  with a null check

## Testing
- Added `testNullUidIsAllowed()` to verify null uid no longer throws