### PR TITLE
Add `@Nullable` to `OidcSessionRegistry#removeSessionInformation`

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/session/InMemoryOidcSessionRegistry.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/session/InMemoryOidcSessionRegistry.java
@@ -50,7 +50,7 @@ public final class InMemoryOidcSessionRegistry implements OidcSessionRegistry {
 	}
 
 	@Override
-	public OidcSessionInformation removeSessionInformation(String clientSessionId) {
+	public @Nullable OidcSessionInformation removeSessionInformation(String clientSessionId) {
 		OidcSessionInformation information = this.sessions.remove(clientSessionId);
 		if (information != null) {
 			this.logger.trace("Removed client session");

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/session/OidcSessionRegistry.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/session/OidcSessionRegistry.java
@@ -16,6 +16,7 @@
 
 package org.springframework.security.oauth2.client.oidc.session;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.security.oauth2.client.oidc.authentication.logout.OidcLogoutToken;
 
 /**
@@ -44,7 +45,7 @@ public interface OidcSessionRegistry {
 	 * @param clientSessionId the client session
 	 * @return any found {@link OidcSessionInformation}, could be {@code null}
 	 */
-	OidcSessionInformation removeSessionInformation(String clientSessionId);
+	@Nullable OidcSessionInformation removeSessionInformation(String clientSessionId);
 
 	/**
 	 * Deregister the OIDC Provider sessions referenced by the provided OIDC Logout Token

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/session/OidcSessionRegistry.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/oidc/session/OidcSessionRegistry.java
@@ -17,6 +17,7 @@
 package org.springframework.security.oauth2.client.oidc.session;
 
 import org.jspecify.annotations.Nullable;
+
 import org.springframework.security.oauth2.client.oidc.authentication.logout.OidcLogoutToken;
 
 /**


### PR DESCRIPTION
Closes gh-19403

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
