### PR TITLE
Use modern Spring LDAP APIs

### DIFF
--- a/ldap/src/main/java/org/springframework/security/ldap/authentication/ad/ActiveDirectoryLdapAuthenticationProvider.java
+++ b/ldap/src/main/java/org/springframework/security/ldap/authentication/ad/ActiveDirectoryLdapAuthenticationProvider.java
@@ -305,8 +305,7 @@ public final class ActiveDirectoryLdapAuthenticationProvider extends AbstractLda
 		String bindPrincipal = createBindPrincipal(username);
 		String searchRoot = (this.rootDn != null) ? this.rootDn : searchRootFromPrincipal(bindPrincipal);
 		SingleContextSource contextSource = new SingleContextSource(context);
-		LdapClient ldapClient = LdapClient.builder()
-			.contextSource(contextSource)
+		LdapClient ldapClient = LdapClient.withContextSource(contextSource)
 			.defaultSearchControls(() -> searchControls)
 			.ignorePartialResultException(true)
 			.build();
@@ -315,11 +314,10 @@ public final class ActiveDirectoryLdapAuthenticationProvider extends AbstractLda
 				.base(searchRoot)
 				.searchScope(SearchScope.SUBTREE)
 				.filter(this.searchFilter, bindPrincipal, username);
-			DirContextOperations result = ldapClient.search().query(query).toEntry();
-			if (result == null) {
-				throw new IncorrectResultSizeDataAccessException(1, 0);
-			}
-			return result;
+			return ldapClient.search()
+				.query(query)
+				.<DirContextOperations>optional()
+				.orElseThrow(() -> new IncorrectResultSizeDataAccessException(1, 0));
 		}
 		catch (CommunicationException ex) {
 			throw badLdapConnection(ex);


### PR DESCRIPTION
With the release of spring-ldap 4.1.0, the `LdapClient` API has been updated, so we should update our usage of it. See: https://github.com/spring-projects/spring-ldap/pull/1446

Closes: gh-19407

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
