### PR TITLE
Allow custom AuthenticationConverter in WebAuthnAuthenticationFilter

### DIFF
--- a/webauthn/src/main/java/org/springframework/security/web/webauthn/authentication/WebAuthnAuthenticationConverter.java
+++ b/webauthn/src/main/java/org/springframework/security/web/webauthn/authentication/WebAuthnAuthenticationConverter.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.webauthn.authentication;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.http.converter.SmartHttpMessageConverter;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.web.authentication.AuthenticationConverter;
+import org.springframework.security.web.webauthn.api.AuthenticatorAssertionResponse;
+import org.springframework.security.web.webauthn.api.PublicKeyCredential;
+import org.springframework.security.web.webauthn.api.PublicKeyCredentialRequestOptions;
+import org.springframework.security.web.webauthn.management.RelyingPartyAuthenticationRequest;
+import org.springframework.util.Assert;
+
+/**
+ * An {@link AuthenticationConverter} that generates a
+ * {@link WebAuthnAuthenticationRequestToken} from a WebAuthn authentication request.
+ *
+ * @author Andrey Litvitski
+ * @since 7.1.0
+ */
+public class WebAuthnAuthenticationConverter implements AuthenticationConverter {
+
+	private SmartHttpMessageConverter<Object> converter;
+
+	private PublicKeyCredentialRequestOptionsRepository requestOptionsRepository;
+
+	/**
+	 * Constructs a {@link WebAuthnAuthenticationConverter} given a strategy for reading
+	 * the {@code PublicKeyCredential} and loading the
+	 * {@code PublicKeyCredentialRequestOptions}.
+	 * @param converter the strategy for reading the {@code PublicKeyCredential} from the
+	 * request
+	 * @param requestOptionsRepository the strategy for loading the
+	 * {@code PublicKeyCredentialRequestOptions}
+	 */
+	public WebAuthnAuthenticationConverter(SmartHttpMessageConverter<Object> converter,
+			PublicKeyCredentialRequestOptionsRepository requestOptionsRepository) {
+		Assert.notNull(converter, "converter cannot be null");
+		Assert.notNull(requestOptionsRepository, "requestOptionsRepository cannot be null");
+		this.converter = converter;
+		this.requestOptionsRepository = requestOptionsRepository;
+	}
+
+	@Override
+	public @Nullable WebAuthnAuthenticationRequestToken convert(HttpServletRequest request) {
+		ServletServerHttpRequest httpRequest = new ServletServerHttpRequest(request);
+		ResolvableType resolvableType = ResolvableType.forClassWithGenerics(PublicKeyCredential.class,
+				AuthenticatorAssertionResponse.class);
+		PublicKeyCredential<AuthenticatorAssertionResponse> publicKeyCredential;
+		try {
+			publicKeyCredential = (PublicKeyCredential<AuthenticatorAssertionResponse>) this.converter
+				.read(resolvableType, httpRequest, null);
+		}
+		catch (Exception ex) {
+			throw new BadCredentialsException("Unable to authenticate the PublicKeyCredential", ex);
+		}
+		PublicKeyCredentialRequestOptions requestOptions = this.requestOptionsRepository.load(request);
+		if (requestOptions == null) {
+			throw new BadCredentialsException(
+					"Unable to authenticate the PublicKeyCredential. No PublicKeyCredentialRequestOptions found.");
+		}
+		RelyingPartyAuthenticationRequest authenticationRequest = new RelyingPartyAuthenticationRequest(requestOptions,
+				publicKeyCredential);
+		return new WebAuthnAuthenticationRequestToken(authenticationRequest);
+	}
+
+	/**
+	 * Sets the {@link SmartHttpMessageConverter} to use for reading
+	 * {@code PublicKeyCredential<AuthenticatorAssertionResponse>} from the request. The
+	 * default is {@link JacksonJsonHttpMessageConverter}.
+	 * @param converter the {@link SmartHttpMessageConverter} to use. Cannot be null.
+	 * @since 7.0
+	 */
+	public void setConverter(SmartHttpMessageConverter<Object> converter) {
+		Assert.notNull(converter, "converter cannot be null");
+		this.converter = converter;
+	}
+
+	/**
+	 * Sets the {@link PublicKeyCredentialRequestOptionsRepository} to use. The default is
+	 * {@link HttpSessionPublicKeyCredentialRequestOptionsRepository}.
+	 * @param requestOptionsRepository the
+	 * {@link PublicKeyCredentialRequestOptionsRepository} to use. Cannot be null.
+	 */
+	public void setRequestOptionsRepository(PublicKeyCredentialRequestOptionsRepository requestOptionsRepository) {
+		Assert.notNull(requestOptionsRepository, "requestOptionsRepository cannot be null");
+		this.requestOptionsRepository = requestOptionsRepository;
+	}
+
+}

--- a/webauthn/src/main/java/org/springframework/security/web/webauthn/authentication/WebAuthnAuthenticationFilter.java
+++ b/webauthn/src/main/java/org/springframework/security/web/webauthn/authentication/WebAuthnAuthenticationFilter.java
@@ -38,20 +38,15 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.http.converter.SmartHttpMessageConverter;
 import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
-import org.springframework.http.server.ServletServerHttpRequest;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.authentication.AuthenticationConverter;
 import org.springframework.security.web.authentication.AuthenticationEntryPointFailureHandler;
 import org.springframework.security.web.authentication.HttpMessageConverterAuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
-import org.springframework.security.web.webauthn.api.AuthenticatorAssertionResponse;
-import org.springframework.security.web.webauthn.api.PublicKeyCredential;
-import org.springframework.security.web.webauthn.api.PublicKeyCredentialRequestOptions;
 import org.springframework.security.web.webauthn.jackson.WebauthnJacksonModule;
-import org.springframework.security.web.webauthn.management.RelyingPartyAuthenticationRequest;
 import org.springframework.util.Assert;
 
 import static org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher.pathPattern;
@@ -78,6 +73,7 @@ import static org.springframework.security.web.servlet.util.matcher.PathPatternR
  * </pre>
  *
  * @author Rob Winch
+ * @author Andrey Litvitski
  * @since 6.4
  */
 public class WebAuthnAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
@@ -86,6 +82,11 @@ public class WebAuthnAuthenticationFilter extends AbstractAuthenticationProcessi
 			JsonMapper.builder().addModule(new WebauthnJacksonModule()).build());
 
 	private PublicKeyCredentialRequestOptionsRepository requestOptionsRepository = new HttpSessionPublicKeyCredentialRequestOptionsRepository();
+
+	private final WebAuthnAuthenticationConverter webAuthnAuthenticationConverter = new WebAuthnAuthenticationConverter(
+			this.converter, this.requestOptionsRepository);
+
+	private AuthenticationConverter authenticationConverter = this.webAuthnAuthenticationConverter;
 
 	public WebAuthnAuthenticationFilter() {
 		super(pathPattern(HttpMethod.POST, "/login/webauthn"));
@@ -96,29 +97,14 @@ public class WebAuthnAuthenticationFilter extends AbstractAuthenticationProcessi
 	}
 
 	@Override
-	public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+	public @Nullable Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
 			throws AuthenticationException, IOException, ServletException {
-		ServletServerHttpRequest httpRequest = new ServletServerHttpRequest(request);
-		ResolvableType resolvableType = ResolvableType.forClassWithGenerics(PublicKeyCredential.class,
-				AuthenticatorAssertionResponse.class);
-		PublicKeyCredential<AuthenticatorAssertionResponse> publicKeyCredential = null;
-		try {
-			publicKeyCredential = (PublicKeyCredential<AuthenticatorAssertionResponse>) this.converter
-				.read(resolvableType, httpRequest, null);
-		}
-		catch (Exception ex) {
-			throw new BadCredentialsException("Unable to authenticate the PublicKeyCredential", ex);
-		}
-		PublicKeyCredentialRequestOptions requestOptions = this.requestOptionsRepository.load(request);
-		if (requestOptions == null) {
-			throw new BadCredentialsException(
-					"Unable to authenticate the PublicKeyCredential. No PublicKeyCredentialRequestOptions found.");
+		Authentication authentication = this.authenticationConverter.convert(request);
+		if (authentication == null) {
+			return null;
 		}
 		this.requestOptionsRepository.save(request, response, null);
-		RelyingPartyAuthenticationRequest authenticationRequest = new RelyingPartyAuthenticationRequest(requestOptions,
-				publicKeyCredential);
-		WebAuthnAuthenticationRequestToken token = new WebAuthnAuthenticationRequestToken(authenticationRequest);
-		return getAuthenticationManager().authenticate(token);
+		return getAuthenticationManager().authenticate(authentication);
 	}
 
 	/**
@@ -132,6 +118,7 @@ public class WebAuthnAuthenticationFilter extends AbstractAuthenticationProcessi
 	public void setConverter(GenericHttpMessageConverter<Object> converter) {
 		Assert.notNull(converter, "converter cannot be null");
 		this.converter = new GenericHttpMessageConverterAdapter<>(converter);
+		this.webAuthnAuthenticationConverter.setConverter(this.converter);
 	}
 
 	/**
@@ -144,6 +131,21 @@ public class WebAuthnAuthenticationFilter extends AbstractAuthenticationProcessi
 	public void setConverter(SmartHttpMessageConverter<Object> converter) {
 		Assert.notNull(converter, "converter cannot be null");
 		this.converter = converter;
+		this.webAuthnAuthenticationConverter.setConverter(converter);
+	}
+
+	/**
+	 * Sets the {@link AuthenticationConverter} to use for converting the
+	 * {@link HttpServletRequest} into an {@link Authentication}.
+	 * @param authenticationConverter the {@link AuthenticationConverter} to use. Cannot
+	 * be null.
+	 * @since 7.1
+	 */
+	@Override
+	public void setAuthenticationConverter(AuthenticationConverter authenticationConverter) {
+		Assert.notNull(authenticationConverter, "authenticationConverter cannot be null");
+		this.authenticationConverter = authenticationConverter;
+		super.setAuthenticationConverter(authenticationConverter);
 	}
 
 	/**
@@ -155,6 +157,7 @@ public class WebAuthnAuthenticationFilter extends AbstractAuthenticationProcessi
 	public void setRequestOptionsRepository(PublicKeyCredentialRequestOptionsRepository requestOptionsRepository) {
 		Assert.notNull(requestOptionsRepository, "requestOptionsRepository cannot be null");
 		this.requestOptionsRepository = requestOptionsRepository;
+		this.webAuthnAuthenticationConverter.setRequestOptionsRepository(requestOptionsRepository);
 	}
 
 	/**


### PR DESCRIPTION
This change allows us to delegate the `attemptAuthentication` logic to the `AuthenticationConverter` interface and enables the definition of custom instances. Additionally, we have added a default implementation, `WebAuthnAuthenticationConverter`, whose behavior is fully deterministic with respect to the previous implementation.

Closes: gh-19411

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
