### PR TITLE
Use configured logout matcher for SAML logout

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/LogoutConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/LogoutConfigurer.java
@@ -349,7 +349,14 @@ public final class LogoutConfigurer<H extends HttpSecurityBuilder<H>>
 		return securityContextRepository;
 	}
 
-	private RequestMatcher getLogoutRequestMatcher(H http) {
+	/**
+	 * Gets the {@link RequestMatcher} that will be used to determine if logout should
+	 * occur.
+	 * @param http the builder to use
+	 * @return the {@link RequestMatcher} that will be used to determine if logout
+	 * should occur
+	 */
+	public RequestMatcher getLogoutRequestMatcher(H http) {
 		if (this.logoutRequestMatcher != null) {
 			return this.logoutRequestMatcher;
 		}

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurer.java
@@ -123,6 +123,8 @@ public final class Saml2LogoutConfigurer<H extends HttpSecurityBuilder<H>>
 
 	private LogoutSuccessHandler logoutSuccessHandler;
 
+	private RequestMatcher logoutRequestMatcher;
+
 	private LogoutRequestConfigurer logoutRequestConfigurer;
 
 	private LogoutResponseConfigurer logoutResponseConfigurer;
@@ -204,6 +206,7 @@ public final class Saml2LogoutConfigurer<H extends HttpSecurityBuilder<H>>
 		if (logout != null) {
 			this.logoutHandlers = logout.getLogoutHandlers();
 			this.logoutSuccessHandler = logout.getLogoutSuccessHandler();
+			this.logoutRequestMatcher = logout.getLogoutRequestMatcher(http);
 		}
 		RelyingPartyRegistrationRepository registrations = getRelyingPartyRegistrationRepository(http);
 		http.addFilterBefore(createLogoutRequestProcessingFilter(registrations), CsrfFilter.class);
@@ -271,7 +274,8 @@ public final class Saml2LogoutConfigurer<H extends HttpSecurityBuilder<H>>
 	}
 
 	private RequestMatcher createLogoutMatcher() {
-		RequestMatcher logout = getRequestMatcherBuilder().matcher(HttpMethod.POST, this.logoutUrl);
+		RequestMatcher logout = (this.logoutRequestMatcher != null) ? this.logoutRequestMatcher
+				: getRequestMatcherBuilder().matcher(HttpMethod.POST, this.logoutUrl);
 		RequestMatcher saml2 = new Saml2RequestMatcher(getSecurityContextHolderStrategy());
 		return new AndRequestMatcher(logout, saml2);
 	}

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/saml2/Saml2LogoutConfigurerTests.java
@@ -197,6 +197,19 @@ public class Saml2LogoutConfigurerTests {
 		verify(logoutHandler).logout(any(), any(), any());
 	}
 
+	// gh-10821
+	@Test
+	public void saml2LogoutWhenLogoutRequestMatcherConfiguredThenUses() throws Exception {
+		this.spring.register(Saml2LogoutRequestMatcherConfig.class).autowire();
+		MvcResult result = this.mvc.perform(post("/signout").with(authentication(this.user)).with(csrf()))
+			.andExpect(status().isFound())
+			.andReturn();
+		String location = result.getResponse().getHeader("Location");
+		LogoutHandler logoutHandler = this.spring.getContext().getBean(LogoutHandler.class);
+		assertThat(location).startsWith("https://ap.example.org/logout/saml2/request");
+		verify(logoutHandler).logout(any(), any(), any());
+	}
+
 	// gh-19128
 	@Test
 	public void saml2LogoutWhenBuilderBeanWithBasePathThenLogoutUrlIgnoresBasePath() throws Exception {
@@ -640,6 +653,35 @@ public class Saml2LogoutConfigurerTests {
 		@Bean
 		LogoutSuccessHandler logoutSuccessHandler() {
 			return this.mockLogoutSuccessHandler;
+		}
+
+	}
+
+	@Configuration
+	@EnableWebSecurity
+	@Import(Saml2LoginConfigBeans.class)
+	static class Saml2LogoutRequestMatcherConfig {
+
+		LogoutHandler mockLogoutHandler = mock(LogoutHandler.class);
+
+		@Bean
+		SecurityFilterChain web(HttpSecurity http) throws Exception {
+			// @formatter:off
+			http
+				.authorizeHttpRequests((authorize) -> authorize.anyRequest().authenticated())
+				.logout((logout) -> logout
+					.logoutRequestMatcher(pathPattern(HttpMethod.POST, "/signout"))
+					.addLogoutHandler(this.mockLogoutHandler)
+				)
+				.saml2Login(withDefaults())
+				.saml2Logout(withDefaults());
+			return http.build();
+			// @formatter:on
+		}
+
+		@Bean
+		LogoutHandler logoutHandler() {
+			return this.mockLogoutHandler;
 		}
 
 	}


### PR DESCRIPTION
Fixes gh-10821

This updates SAML relying-party-initiated logout to reuse the logout request matcher configured through `LogoutConfigurer`, while still requiring the existing SAML authentication matcher.

Previously, SAML logout always created its own POST matcher from `Saml2LogoutConfigurer#logoutUrl`, so a custom matcher configured through `logout().logoutRequestMatcher(...)` was ignored for SAML logout.

Verification:
- `./gradlew :spring-security-config:test --tests org.springframework.security.config.annotation.web.configurers.saml2.Saml2LogoutConfigurerTests.saml2LogoutWhenLogoutRequestMatcherConfiguredThenUses`
- `./gradlew :spring-security-config:test --tests org.springframework.security.config.annotation.web.configurers.saml2.Saml2LogoutConfigurerTests`
