### PR TITLE
Fix `OAuth2PushedAuthorizationRequestUri` parsing

### DIFF
--- a/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2PushedAuthorizationRequestUri.java
+++ b/oauth2/oauth2-authorization-server/src/main/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2PushedAuthorizationRequestUri.java
@@ -27,6 +27,7 @@ import org.springframework.security.crypto.keygen.StringKeyGenerator;
  * Requests.
  *
  * @author Joe Grandja
+ * @author Andrey Litvitski
  * @since 7.0
  */
 final class OAuth2PushedAuthorizationRequestUri {
@@ -60,7 +61,7 @@ final class OAuth2PushedAuthorizationRequestUri {
 
 	static OAuth2PushedAuthorizationRequestUri parse(String requestUri) {
 		int stateStartIndex = REQUEST_URI_PREFIX.length();
-		int expiresAtStartIndex = requestUri.indexOf(REQUEST_URI_DELIMITER) + REQUEST_URI_DELIMITER.length();
+		int expiresAtStartIndex = requestUri.lastIndexOf(REQUEST_URI_DELIMITER) + REQUEST_URI_DELIMITER.length();
 		OAuth2PushedAuthorizationRequestUri pushedAuthorizationRequestUri = new OAuth2PushedAuthorizationRequestUri();
 		pushedAuthorizationRequestUri.requestUri = requestUri;
 		pushedAuthorizationRequestUri.state = requestUri.substring(stateStartIndex);

--- a/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2PushedAuthorizationRequestUriTests.java
+++ b/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2PushedAuthorizationRequestUriTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.authorization.authentication;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link OAuth2PushedAuthorizationRequestUri}.
+ *
+ * @author Josh Cummings
+ */
+public class OAuth2PushedAuthorizationRequestUriTests {
+
+	@Test
+	public void parseWhenValidRequestUriThenReturnsExpectedValues() {
+		String state = "abcXYZ123-abcXYZ123";
+		long epochMilli = 1700000000000L;
+		String requestUri = "urn:ietf:params:oauth:request_uri:" + state + "___" + epochMilli;
+
+		OAuth2PushedAuthorizationRequestUri parsed = OAuth2PushedAuthorizationRequestUri.parse(requestUri);
+
+		assertThat(parsed.getRequestUri()).isEqualTo(requestUri);
+		assertThat(parsed.getState()).isEqualTo(state + "___" + epochMilli);
+		assertThat(parsed.getExpiresAt()).isEqualTo(Instant.ofEpochMilli(epochMilli));
+	}
+
+	@Test
+	public void createWhenParsedThenReturnsEquivalentValues() {
+		Instant expiresAt = Instant.ofEpochMilli(1700000000000L);
+
+		OAuth2PushedAuthorizationRequestUri created = OAuth2PushedAuthorizationRequestUri.create(expiresAt);
+		OAuth2PushedAuthorizationRequestUri parsed = OAuth2PushedAuthorizationRequestUri.parse(created.getRequestUri());
+
+		assertThat(parsed.getRequestUri()).isEqualTo(created.getRequestUri());
+		assertThat(parsed.getState()).isEqualTo(created.getState());
+		assertThat(parsed.getExpiresAt()).isEqualTo(created.getExpiresAt());
+	}
+
+}

--- a/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2PushedAuthorizationRequestUriTests.java
+++ b/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/authentication/OAuth2PushedAuthorizationRequestUriTests.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link OAuth2PushedAuthorizationRequestUri}.
  *
  * @author Josh Cummings
+ * @author Andrey Litvitski
  */
 public class OAuth2PushedAuthorizationRequestUriTests {
 
@@ -52,6 +53,19 @@ public class OAuth2PushedAuthorizationRequestUriTests {
 		assertThat(parsed.getRequestUri()).isEqualTo(created.getRequestUri());
 		assertThat(parsed.getState()).isEqualTo(created.getState());
 		assertThat(parsed.getExpiresAt()).isEqualTo(created.getExpiresAt());
+	}
+
+	@Test
+	public void parseWhenStateContainsDelimiterThenParsesSuccessfully() {
+		String state = "xXMGJTZwzXIFL8i_DFu_EM8IeWC___frCWjpiF2q-xs=";
+		long epochMillis = 1781670640281L;
+		String requestUri = "urn:ietf:params:oauth:request_uri:" + state + "___" + epochMillis;
+
+		OAuth2PushedAuthorizationRequestUri parsedUri = OAuth2PushedAuthorizationRequestUri.parse(requestUri);
+
+		assertThat(parsedUri.getRequestUri()).isEqualTo(requestUri);
+		assertThat(parsedUri.getState()).isEqualTo(state + "___" + epochMillis);
+		assertThat(parsedUri.getExpiresAt()).isEqualTo(Instant.ofEpochMilli(epochMillis));
 	}
 
 }


### PR DESCRIPTION
`OAuth2PushedAuthorizationRequestUri` uses Base64URL encoding for the state, which can produce a value containing `___`, the same sequence used as the delimiter. As a result, `indexOf` may locate a delimiter within the state instead of the delimiter preceding the expiration timestamp.

Use `lastIndexOf` to reliably locate the delimiter before the timestamp without changing the existing request URI format.

Closes gh-19444

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
