### PR TITLE
Correct ProviderManager exception comment

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
@@ -198,8 +198,7 @@ public class ProviderManager implements AuthenticationManager, MessageSourceAwar
 				prepareException(ex, authentication);
 				logger.debug(LogMessage.format("Authentication service failed internally for user '%s'",
 						authentication.getName()), ex);
-				// SEC-546: Avoid polling additional providers if auth failure is due to
-				// invalid account status
+                // Avoid polling additional providers after an internal authentication service failure
 				throw ex;
 			}
 			catch (AuthenticationException ex) {


### PR DESCRIPTION
The comment in the `InternalAuthenticationServiceException` catch block
incorrectly states that authentication failed because of an invalid account
status.

Update the comment to describe the actual reason for stopping further
authentication providers.

No functional changes.