### PR TITLE
Fix OIDC ID token exchange token type

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/TokenExchangeGrantRequest.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/endpoint/TokenExchangeGrantRequest.java
@@ -22,6 +22,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.OAuth2Token;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -48,6 +49,8 @@ import org.springframework.util.StringUtils;
 public class TokenExchangeGrantRequest extends AbstractOAuth2AuthorizationGrantRequest {
 
 	private static final String ACCESS_TOKEN_TYPE_VALUE = "urn:ietf:params:oauth:token-type:access_token";
+
+	private static final String ID_TOKEN_TYPE_VALUE = "urn:ietf:params:oauth:token-type:id_token";
 
 	private static final String JWT_TOKEN_TYPE_VALUE = "urn:ietf:params:oauth:token-type:jwt";
 
@@ -113,6 +116,9 @@ public class TokenExchangeGrantRequest extends AbstractOAuth2AuthorizationGrantR
 	}
 
 	private static String tokenType(OAuth2Token token) {
+		if (token instanceof OidcIdToken) {
+			return ID_TOKEN_TYPE_VALUE;
+		}
 		return (token instanceof Jwt) ? JWT_TOKEN_TYPE_VALUE : ACCESS_TOKEN_TYPE_VALUE;
 	}
 

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/DefaultOAuth2TokenRequestParametersConverterTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/DefaultOAuth2TokenRequestParametersConverterTests.java
@@ -220,4 +220,22 @@ public class DefaultOAuth2TokenRequestParametersConverterTests {
 		assertThat(parameters.get(OAuth2ParameterNames.SUBJECT_TOKEN_TYPE)).containsExactly(ID_TOKEN_TYPE_VALUE);
 	}
 
+	@Test
+	public void convertWhenGrantRequestIsTokenExchangeAndActorTokenIsOidcIdTokenThenActorTokenTypeIsIdToken() {
+		ClientRegistration clientRegistration = this.clientRegistration
+			.authorizationGrantType(AuthorizationGrantType.TOKEN_EXCHANGE)
+			.build();
+		OAuth2Token subjectToken = TestOAuth2AccessTokens.scopes("read", "write");
+		OidcIdToken actorToken = OidcIdToken.withTokenValue("id-token").claim("sub", "user").build();
+		TokenExchangeGrantRequest grantRequest = new TokenExchangeGrantRequest(clientRegistration, subjectToken,
+				actorToken);
+		// @formatter:off
+		DefaultOAuth2TokenRequestParametersConverter<TokenExchangeGrantRequest> parametersConverter =
+			new DefaultOAuth2TokenRequestParametersConverter<>();
+		// @formatter:on
+		MultiValueMap<String, String> parameters = parametersConverter.convert(grantRequest);
+		assertThat(parameters.get(OAuth2ParameterNames.ACTOR_TOKEN)).containsExactly(actorToken.getTokenValue());
+		assertThat(parameters.get(OAuth2ParameterNames.ACTOR_TOKEN_TYPE)).containsExactly(ID_TOKEN_TYPE_VALUE);
+	}
+
 }

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/DefaultOAuth2TokenRequestParametersConverterTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/endpoint/DefaultOAuth2TokenRequestParametersConverterTests.java
@@ -35,6 +35,7 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequ
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponse;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.TestJwts;
 import org.springframework.util.MultiValueMap;
@@ -50,6 +51,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DefaultOAuth2TokenRequestParametersConverterTests {
 
 	private static final String ACCESS_TOKEN_TYPE_VALUE = "urn:ietf:params:oauth:token-type:access_token";
+
+	private static final String ID_TOKEN_TYPE_VALUE = "urn:ietf:params:oauth:token-type:id_token";
 
 	private static final String JWT_TOKEN_TYPE_VALUE = "urn:ietf:params:oauth:token-type:jwt";
 
@@ -199,6 +202,22 @@ public class DefaultOAuth2TokenRequestParametersConverterTests {
 		assertThat(parameters.get(OAuth2ParameterNames.SUBJECT_TOKEN_TYPE)).containsExactly(ACCESS_TOKEN_TYPE_VALUE);
 		assertThat(parameters.get(OAuth2ParameterNames.ACTOR_TOKEN)).containsExactly(actorToken.getTokenValue());
 		assertThat(parameters.get(OAuth2ParameterNames.ACTOR_TOKEN_TYPE)).containsExactly(JWT_TOKEN_TYPE_VALUE);
+	}
+
+	@Test
+	public void convertWhenGrantRequestIsTokenExchangeAndSubjectTokenIsOidcIdTokenThenSubjectTokenTypeIsIdToken() {
+		ClientRegistration clientRegistration = this.clientRegistration
+			.authorizationGrantType(AuthorizationGrantType.TOKEN_EXCHANGE)
+			.build();
+		OidcIdToken subjectToken = OidcIdToken.withTokenValue("id-token").claim("sub", "user").build();
+		TokenExchangeGrantRequest grantRequest = new TokenExchangeGrantRequest(clientRegistration, subjectToken, null);
+		// @formatter:off
+		DefaultOAuth2TokenRequestParametersConverter<TokenExchangeGrantRequest> parametersConverter =
+			new DefaultOAuth2TokenRequestParametersConverter<>();
+		// @formatter:on
+		MultiValueMap<String, String> parameters = parametersConverter.convert(grantRequest);
+		assertThat(parameters.get(OAuth2ParameterNames.SUBJECT_TOKEN)).containsExactly(subjectToken.getTokenValue());
+		assertThat(parameters.get(OAuth2ParameterNames.SUBJECT_TOKEN_TYPE)).containsExactly(ID_TOKEN_TYPE_VALUE);
 	}
 
 }


### PR DESCRIPTION
Fixes gh-19448.

This maps `OidcIdToken` to `urn:ietf:params:oauth:token-type:id_token` when building token exchange request parameters. The default converter continues to use the existing fallback for other token classes.

Regression coverage checks OIDC ID tokens used as both `subject_token` and `actor_token`.