### PR TITLE
Initialize refresh token response client lazily

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/RefreshTokenOAuth2AuthorizedClientProvider.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/RefreshTokenOAuth2AuthorizedClientProvider.java
@@ -50,7 +50,7 @@ import org.springframework.util.Assert;
 public final class RefreshTokenOAuth2AuthorizedClientProvider
 		implements OAuth2AuthorizedClientProvider, ApplicationEventPublisherAware {
 
-	private OAuth2AccessTokenResponseClient<OAuth2RefreshTokenGrantRequest> accessTokenResponseClient = new RestClientRefreshTokenTokenResponseClient();
+	private @Nullable OAuth2AccessTokenResponseClient<OAuth2RefreshTokenGrantRequest> accessTokenResponseClient;
 
 	private @Nullable ApplicationEventPublisher applicationEventPublisher;
 
@@ -114,12 +114,19 @@ public final class RefreshTokenOAuth2AuthorizedClientProvider
 	private OAuth2AccessTokenResponse getTokenResponse(OAuth2AuthorizedClient authorizedClient,
 			OAuth2RefreshTokenGrantRequest refreshTokenGrantRequest) {
 		try {
-			return this.accessTokenResponseClient.getTokenResponse(refreshTokenGrantRequest);
+			return getAccessTokenResponseClient().getTokenResponse(refreshTokenGrantRequest);
 		}
 		catch (OAuth2AuthorizationException ex) {
 			throw new ClientAuthorizationException(ex.getError(),
 					authorizedClient.getClientRegistration().getRegistrationId(), ex);
 		}
+	}
+
+	private OAuth2AccessTokenResponseClient<OAuth2RefreshTokenGrantRequest> getAccessTokenResponseClient() {
+		if (this.accessTokenResponseClient == null) {
+			this.accessTokenResponseClient = new RestClientRefreshTokenTokenResponseClient();
+		}
+		return this.accessTokenResponseClient;
 	}
 
 	private boolean hasTokenExpired(OAuth2Token token) {

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/RefreshTokenOAuth2AuthorizedClientProviderTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/RefreshTokenOAuth2AuthorizedClientProviderTests.java
@@ -38,6 +38,7 @@ import org.springframework.security.oauth2.core.TestOAuth2AccessTokens;
 import org.springframework.security.oauth2.core.TestOAuth2RefreshTokens;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 import org.springframework.security.oauth2.core.endpoint.TestOAuth2AccessTokenResponses;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -158,6 +159,21 @@ public class RefreshTokenOAuth2AuthorizedClientProviderTests {
 				.build();
 		// @formatter:on
 		assertThat(this.authorizedClientProvider.authorize(authorizationContext)).isNull();
+	}
+
+	@Test
+	public void authorizeWhenAuthorizedAndAccessTokenNotExpiredThenDoesNotInitializeDefaultAccessTokenResponseClient() {
+		RefreshTokenOAuth2AuthorizedClientProvider authorizedClientProvider = new RefreshTokenOAuth2AuthorizedClientProvider();
+		OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(this.clientRegistration,
+				this.principal.getName(), TestOAuth2AccessTokens.noScopes(), this.authorizedClient.getRefreshToken());
+		// @formatter:off
+		OAuth2AuthorizationContext authorizationContext = OAuth2AuthorizationContext
+				.withAuthorizedClient(authorizedClient)
+				.principal(this.principal)
+				.build();
+		// @formatter:on
+		assertThat(authorizedClientProvider.authorize(authorizationContext)).isNull();
+		assertThat(ReflectionTestUtils.getField(authorizedClientProvider, "accessTokenResponseClient")).isNull();
 	}
 
 	// gh-7511


### PR DESCRIPTION
Fixes gh-19406

The default `RestClientRefreshTokenTokenResponseClient` is now created only when a refresh-token request is actually needed. This keeps `RefreshTokenOAuth2AuthorizedClientProvider` cheap to instantiate for applications where no refresh is attempted during startup.

A regression test verifies that an authorization attempt with a non-expired access token returns without initializing the default response client.

Tests:
- `./gradlew :spring-security-oauth2-client:test --tests 'org.springframework.security.oauth2.client.RefreshTokenOAuth2AuthorizedClientProviderTests' --no-daemon --console=plain`
- `./gradlew :spring-security-oauth2-client:check --no-daemon --console=plain`
