### PR TITLE
Fail fast when spring-security-access is missing

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecuritySelector.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecuritySelector.java
@@ -39,6 +39,8 @@ import org.springframework.util.ClassUtils;
 @Deprecated
 final class GlobalMethodSecuritySelector implements ImportSelector {
 
+	private static final String METHOD_SECURITY_METADATA_SOURCE_ADVISOR = "org.springframework.security.access.intercept.aopalliance.MethodSecurityMetadataSourceAdvisor";
+
 	@Override
 	public String[] selectImports(AnnotationMetadata importingClassMetadata) {
 		Class<EnableGlobalMethodSecurity> annoType = EnableGlobalMethodSecurity.class;
@@ -57,6 +59,16 @@ final class GlobalMethodSecuritySelector implements ImportSelector {
 		String autoProxyClassName = isProxy ? AutoProxyRegistrar.class.getName()
 				: GlobalMethodSecurityAspectJAutoProxyRegistrar.class.getName();
 		boolean jsr250Enabled = attributes.getBoolean("jsr250Enabled");
+		if (isProxy || !skipMethodSecurityConfiguration) {
+			// The proxy-mode advisor registrar and GlobalMethodSecurityConfiguration
+			// (imported for both proxy and aspectj modes) need types that only exist in
+			// the optional spring-security-access module.
+			Assert.state(
+					ClassUtils.isPresent(METHOD_SECURITY_METADATA_SOURCE_ADVISOR, ClassUtils.getDefaultClassLoader()),
+					() -> "@EnableGlobalMethodSecurity requires the spring-security-access dependency on the "
+							+ "classpath. Please add spring-security-access, or migrate to @EnableMethodSecurity "
+							+ "which does not require it.");
+		}
 		List<String> classNames = new ArrayList<>(4);
 		if (isProxy) {
 			classNames.add(MethodSecurityMetadataSourceAdvisorRegistrar.class.getName());

--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecuritySelector.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/GlobalMethodSecuritySelector.java
@@ -39,7 +39,8 @@ import org.springframework.util.ClassUtils;
 @Deprecated
 final class GlobalMethodSecuritySelector implements ImportSelector {
 
-	private static final String METHOD_SECURITY_METADATA_SOURCE_ADVISOR = "org.springframework.security.access.intercept.aopalliance.MethodSecurityMetadataSourceAdvisor";
+	private static final boolean isAccessPresent = ClassUtils.isPresent(
+			"org.springframework.security.access.intercept.aopalliance.MethodSecurityMetadataSourceAdvisor", null);
 
 	@Override
 	public String[] selectImports(AnnotationMetadata importingClassMetadata) {
@@ -59,28 +60,28 @@ final class GlobalMethodSecuritySelector implements ImportSelector {
 		String autoProxyClassName = isProxy ? AutoProxyRegistrar.class.getName()
 				: GlobalMethodSecurityAspectJAutoProxyRegistrar.class.getName();
 		boolean jsr250Enabled = attributes.getBoolean("jsr250Enabled");
-		if (isProxy || !skipMethodSecurityConfiguration) {
-			// The proxy-mode advisor registrar and GlobalMethodSecurityConfiguration
-			// (imported for both proxy and aspectj modes) need types that only exist in
-			// the optional spring-security-access module.
-			Assert.state(
-					ClassUtils.isPresent(METHOD_SECURITY_METADATA_SOURCE_ADVISOR, ClassUtils.getDefaultClassLoader()),
-					() -> "@EnableGlobalMethodSecurity requires the spring-security-access dependency on the "
-							+ "classpath. Please add spring-security-access, or migrate to @EnableMethodSecurity "
-							+ "which does not require it.");
-		}
 		List<String> classNames = new ArrayList<>(4);
 		if (isProxy) {
+			assertAccessModulePresent();
 			classNames.add(MethodSecurityMetadataSourceAdvisorRegistrar.class.getName());
 		}
 		classNames.add(autoProxyClassName);
 		if (!skipMethodSecurityConfiguration) {
+			assertAccessModulePresent();
 			classNames.add(GlobalMethodSecurityConfiguration.class.getName());
 		}
 		if (jsr250Enabled) {
+			assertAccessModulePresent();
 			classNames.add(Jsr250MetadataSourceConfiguration.class.getName());
 		}
 		return classNames.toArray(new String[0]);
+	}
+
+	private static void assertAccessModulePresent() {
+		Assert.state(isAccessPresent,
+				() -> "@EnableGlobalMethodSecurity requires the spring-security-access dependency on the "
+						+ "classpath. Please add spring-security-access, or migrate to @EnableMethodSecurity "
+						+ "which does not require it.");
 	}
 
 }

--- a/config/src/main/java/org/springframework/security/config/annotation/method/configuration/ReactiveMethodSecuritySelector.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/method/configuration/ReactiveMethodSecuritySelector.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.AutoProxyRegistrar;
 import org.springframework.context.annotation.ImportSelector;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.lang.NonNull;
+import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -34,6 +35,8 @@ import org.springframework.util.ClassUtils;
  * @since 5.0
  */
 class ReactiveMethodSecuritySelector implements ImportSelector {
+
+	private static final String METHOD_SECURITY_METADATA_SOURCE_ADVISOR = "org.springframework.security.access.intercept.aopalliance.MethodSecurityMetadataSourceAdvisor";
 
 	private static final boolean isDataPresent = ClassUtils
 		.isPresent("org.springframework.security.data.aot.hint.AuthorizeReturnObjectDataHintsRegistrar", null);
@@ -56,6 +59,11 @@ class ReactiveMethodSecuritySelector implements ImportSelector {
 			imports.add(ReactiveAuthorizationManagerMethodSecurityConfiguration.class.getName());
 		}
 		else {
+			Assert.state(
+					ClassUtils.isPresent(METHOD_SECURITY_METADATA_SOURCE_ADVISOR, ClassUtils.getDefaultClassLoader()),
+					() -> "@EnableReactiveMethodSecurity(useAuthorizationManager = false) requires the "
+							+ "spring-security-access dependency on the classpath. Please add spring-security-access, "
+							+ "or use the default useAuthorizationManager = true which does not require it.");
 			imports.add(ReactiveMethodSecurityConfiguration.class.getName());
 		}
 		if (isDataPresent) {

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/Gh19441Tests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/Gh19441Tests.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.config.annotation.method.configuration;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.context.annotation.AdviceMode;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.test.support.ClassPathExclusions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Tests for gh-19441: {@code spring-security-access} moved
+ * {@link org.springframework.security.access.intercept.aopalliance.MethodSecurityMetadataSourceAdvisor}
+ * out of {@code spring-security-core} and into the optional
+ * {@code spring-security-access} module. {@link EnableMethodSecurity} and
+ * {@link EnableReactiveMethodSecurity}'s default (AuthorizationManager-based) mode never
+ * needed that class and continue to work without {@code spring-security-access} on the
+ * classpath, but the deprecated legacy method security annotations do need it and
+ * previously failed with a confusing {@link NoClassDefFoundError} instead of an
+ * actionable message.
+ */
+@ClassPathExclusions("spring-security-access-*.jar")
+public class Gh19441Tests {
+
+	@Test
+	public void enableMethodSecurityWhenAccessModuleAbsentThenContextStartsCleanly() {
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+			context.register(EnableMethodSecurityConfig.class);
+			context.refresh();
+		}
+	}
+
+	@Test
+	public void enableReactiveMethodSecurityWhenAccessModuleAbsentThenContextStartsCleanly() {
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+			context.register(EnableReactiveMethodSecurityConfig.class);
+			context.refresh();
+		}
+	}
+
+	@Test
+	public void enableGlobalMethodSecurityWhenProxyModeAndAccessModuleAbsentThenClearException() {
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+			context.register(EnableGlobalMethodSecurityProxyConfig.class);
+			assertThatExceptionOfType(Exception.class).isThrownBy(context::refresh)
+				.havingRootCause()
+				.isInstanceOf(IllegalStateException.class)
+				.withMessageContaining("spring-security-access");
+		}
+	}
+
+	@Test
+	public void enableGlobalMethodSecurityWhenAspectJModeAndAccessModuleAbsentThenClearException() {
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+			context.register(EnableGlobalMethodSecurityAspectJConfig.class);
+			assertThatExceptionOfType(Exception.class).isThrownBy(context::refresh)
+				.havingRootCause()
+				.isInstanceOf(IllegalStateException.class)
+				.withMessageContaining("spring-security-access");
+		}
+	}
+
+	@Test
+	public void enableReactiveMethodSecurityWhenUseAuthorizationManagerFalseAndAccessModuleAbsentThenClearException() {
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+			context.register(EnableReactiveMethodSecurityLegacyConfig.class);
+			assertThatExceptionOfType(Exception.class).isThrownBy(context::refresh)
+				.havingRootCause()
+				.isInstanceOf(IllegalStateException.class)
+				.withMessageContaining("spring-security-access");
+		}
+	}
+
+	@Configuration
+	@EnableMethodSecurity
+	static class EnableMethodSecurityConfig {
+
+	}
+
+	@Configuration
+	@EnableReactiveMethodSecurity
+	static class EnableReactiveMethodSecurityConfig {
+
+	}
+
+	@Configuration
+	@EnableGlobalMethodSecurity(prePostEnabled = true)
+	static class EnableGlobalMethodSecurityProxyConfig {
+
+	}
+
+	@Configuration
+	@EnableGlobalMethodSecurity(prePostEnabled = true, mode = AdviceMode.ASPECTJ)
+	static class EnableGlobalMethodSecurityAspectJConfig {
+
+	}
+
+	@Configuration
+	@EnableReactiveMethodSecurity(useAuthorizationManager = false)
+	static class EnableReactiveMethodSecurityLegacyConfig {
+
+	}
+
+}

--- a/config/src/test/java/org/springframework/security/config/annotation/method/configuration/Gh19441Tests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/method/configuration/Gh19441Tests.java
@@ -88,6 +88,17 @@ public class Gh19441Tests {
 		}
 	}
 
+	@Test
+	public void enableGlobalMethodSecurityWhenAspectJModeAndJsr250EnabledAndConfigurationSubclassedAndAccessModuleAbsentThenClearException() {
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+			context.register(EnableGlobalMethodSecurityAspectJJsr250SubclassedConfig.class);
+			assertThatExceptionOfType(Exception.class).isThrownBy(context::refresh)
+				.havingRootCause()
+				.isInstanceOf(IllegalStateException.class)
+				.withMessageContaining("spring-security-access");
+		}
+	}
+
 	@Configuration
 	@EnableMethodSecurity
 	static class EnableMethodSecurityConfig {
@@ -115,6 +126,12 @@ public class Gh19441Tests {
 	@Configuration
 	@EnableReactiveMethodSecurity(useAuthorizationManager = false)
 	static class EnableReactiveMethodSecurityLegacyConfig {
+
+	}
+
+	@Configuration
+	@EnableGlobalMethodSecurity(jsr250Enabled = true, mode = AdviceMode.ASPECTJ)
+	static class EnableGlobalMethodSecurityAspectJJsr250SubclassedConfig extends GlobalMethodSecurityConfiguration {
 
 	}
 


### PR DESCRIPTION
## Summary

Fixes #19441.

`spring-security-config`'s deprecated legacy method-security support throws a raw `NoClassDefFoundError` at startup instead of a clear error when `spring-security-access` isn't on the classpath.

## Root cause

#17847 moved `MethodSecurityMetadataSourceAdvisor` and `MethodSecurityInterceptor` from `spring-security-core` (a mandatory dependency of `spring-security-config`) into the new `spring-security-access` module, which `spring-security-config` only depends on **optionally**. Several deprecated method-security paths still construct these types unconditionally:

- `GlobalMethodSecuritySelector` → `MethodSecurityMetadataSourceAdvisorRegistrar` (proxy mode) and `GlobalMethodSecurityConfiguration` (imported for **both** proxy and aspectj mode)
- `ReactiveMethodSecuritySelector` → `ReactiveMethodSecurityConfiguration` (`@EnableReactiveMethodSecurity(useAuthorizationManager = false)`)

`@EnableMethodSecurity` and `@EnableReactiveMethodSecurity`'s default mode — the non-deprecated replacements — never reference these classes and are unaffected.

## Fix

Added a `ClassUtils.isPresent(...)` guard (the same pattern already used for other optional dependencies in these selectors) so the legacy paths fail fast with a clear `IllegalStateException` naming the missing dependency, instead of a `NoClassDefFoundError` deep in Spring's configuration-processing machinery.

Chose this over making `spring-security-access` mandatory again, since that would silently reintroduce the footprint #17847 removed for the majority of apps using `@EnableMethodSecurity`. `@EnableGlobalMethodSecurity` stays deprecated; this adds no new investment in it beyond a clear diagnostic.

## Testing

Added `Gh19441Tests`, using the existing `@ClassPathExclusions` harness to simulate `spring-security-access` being absent:

- `@EnableMethodSecurity` and `@EnableReactiveMethodSecurity` default mode start cleanly (locks in that the modern paths are unaffected).
- `@EnableGlobalMethodSecurity` in proxy mode, aspectj mode, and `@EnableReactiveMethodSecurity(useAuthorizationManager = false)` all now fail with the clear message instead of `NoClassDefFoundError`/`ClassNotFoundException`.

Full `spring-security-config` suite passes (3640 tests; the only 3 failures are pre-existing, locale-related, and unrelated to this change). `./gradlew :spring-security-config:check` passes.
