### PR TITLE
Introduce Scoped Value-based SecurityContextHolderStrategy

### DIFF
--- a/buildSrc/src/main/groovy/java-toolchain.gradle
+++ b/buildSrc/src/main/groovy/java-toolchain.gradle
@@ -17,7 +17,8 @@ java {
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = "UTF-8"
 	options.compilerArgs.add("-parameters")
-	options.release = 17
+    sourceCompatibility = '17'
+    targetCompatibility = '17'
 }
 
 pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {

--- a/buildSrc/src/main/groovy/test-compile-target-jdk25.gradle
+++ b/buildSrc/src/main/groovy/test-compile-target-jdk25.gradle
@@ -25,6 +25,6 @@ tasks.withType(JavaCompile).configureEach { task ->
 
 tasks.withType(KotlinCompile).configureEach { task ->
 	if (task.name == 'compileTestKotlin' || task.name == 'compileIntegrationTestKotlin') {
-		task.kotlinOptions.jvmTarget = '25'
+		task.kotlinOptions.jvmTarget = '17'
 	}
 }

--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/FilterOrderRegistration.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/FilterOrderRegistration.java
@@ -40,6 +40,7 @@ import org.springframework.security.web.authentication.ui.DefaultOneTimeTokenSub
 import org.springframework.security.web.authentication.ui.DefaultResourcesFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.authentication.www.DigestAuthenticationFilter;
+import org.springframework.security.web.context.ScopedSecurityContextHolderFilter;
 import org.springframework.security.web.context.SecurityContextHolderFilter;
 import org.springframework.security.web.context.SecurityContextPersistenceFilter;
 import org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter;
@@ -82,6 +83,7 @@ final class FilterOrderRegistration {
 		put(WebAsyncManagerIntegrationFilter.class, order.next());
 		put(SecurityContextHolderFilter.class, order.next());
 		put(SecurityContextPersistenceFilter.class, order.next());
+		put(ScopedSecurityContextHolderFilter.class, order.next());
 		put(HeaderWriterFilter.class, order.next());
 		put(CorsFilter.class, order.next());
 		put(CsrfFilter.class, order.next());

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SecurityContextConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SecurityContextConfigurer.java
@@ -20,11 +20,14 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.HttpSecurityBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.context.ScopedSecurityContextHolderStrategy;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.web.context.DelegatingSecurityContextRepository;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.security.web.context.RequestAttributeSecurityContextRepository;
+import org.springframework.security.web.context.ScopedSecurityContextHolderFilter;
 import org.springframework.security.web.context.SecurityContextHolderFilter;
 import org.springframework.security.web.context.SecurityContextPersistenceFilter;
 import org.springframework.security.web.context.SecurityContextRepository;
@@ -69,6 +72,9 @@ public final class SecurityContextConfigurer<H extends HttpSecurityBuilder<H>>
 
 	private boolean requireExplicitSave = true;
 
+	private SecurityContextHolderStrategy securityContextHolderStrategy = SecurityContextHolder
+		.getContextHolderStrategy();
+
 	/**
 	 * Creates a new instance
 	 * @see HttpSecurity#securityContext(Customizer)
@@ -110,10 +116,18 @@ public final class SecurityContextConfigurer<H extends HttpSecurityBuilder<H>>
 	public void configure(H http) {
 		SecurityContextRepository securityContextRepository = getSecurityContextRepository();
 		if (this.requireExplicitSave) {
-			SecurityContextHolderFilter securityContextHolderFilter = postProcess(
-					new SecurityContextHolderFilter(securityContextRepository));
-			securityContextHolderFilter.setSecurityContextHolderStrategy(getSecurityContextHolderStrategy());
-			http.addFilter(securityContextHolderFilter);
+			if (this.securityContextHolderStrategy instanceof ScopedSecurityContextHolderStrategy) {
+				ScopedSecurityContextHolderFilter securityContextHolderFilter = postProcess(
+						new ScopedSecurityContextHolderFilter(securityContextRepository));
+				securityContextHolderFilter.setSecurityContextHolderStrategy(getSecurityContextHolderStrategy());
+				http.addFilter(securityContextHolderFilter);
+			}
+			else {
+				SecurityContextHolderFilter securityContextHolderFilter = postProcess(
+						new SecurityContextHolderFilter(securityContextRepository));
+				securityContextHolderFilter.setSecurityContextHolderStrategy(getSecurityContextHolderStrategy());
+				http.addFilter(securityContextHolderFilter);
+			}
 		}
 		else {
 			SecurityContextPersistenceFilter securityContextFilter = new SecurityContextPersistenceFilter(

--- a/core/src/main/java/org/springframework/security/core/context/ScopedSecurityContextHolderStrategy.java
+++ b/core/src/main/java/org/springframework/security/core/context/ScopedSecurityContextHolderStrategy.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.core.context;
+
+import java.util.function.Supplier;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.util.Assert;
+
+/**
+ * A <code>ScopedValue</code>-based implementation of
+ * {@link SecurityContextHolderStrategy}.
+ *
+ * <p>
+ * </p>
+ * Unlike {@link ThreadLocalSecurityContextHolderStrategy}, for example, this
+ * implementation cannot be used "out-of-the-box". Instead, {@link #SECURITY_CONTEXT}
+ * <code>ScopedValue</code> has to be bound to
+ * {@link ScopedSecurityContextHolderStrategy.SecurityContextScopedValueHolder
+ * SecurityContextScopedValueHolder} instance for the current thread. This could be
+ * achieved by invoking static {@link #runWhere(Supplier, Runnable)} or
+ * {@link #getSecuriyContextCarrier()} methods anywhere down-stack of the code which
+ * invokes any of the {@link SecurityContextHolderStrategy} methods, for example in a
+ * Spring Security Filter.
+ *
+ * <p>
+ * </p>
+ * See
+ * <code>org.springframework.security.web.context.ScopedSecurityContextHolderFilter</code>.
+ *
+ * @see ScopedValue
+ */
+public class ScopedSecurityContextHolderStrategy implements SecurityContextHolderStrategy {
+
+	/**
+	 * An instance of {@link ScopedValue} which has to be bound to an instance of
+	 * {@link SecurityContextScopedValueHolder}.
+	 */
+	private static final ScopedValue<SecurityContextScopedValueHolder> SECURITY_CONTEXT = ScopedValue.newInstance();
+
+	@Override
+	public void clearContext() {
+		if (SECURITY_CONTEXT.isBound()) {
+			retrieveSecurityContextScopedValueHolder().setSecurityContext(null);
+		}
+		// no action is needed if SECURITY_CONTEXT ScopedValue is not bound for the
+		// current thread.
+	}
+
+	@Override
+	public SecurityContext getContext() {
+		return getDeferredContext().get();
+	}
+
+	@Override
+	public Supplier<SecurityContext> getDeferredContext() {
+		final SecurityContextScopedValueHolder holder = retrieveSecurityContextScopedValueHolder();
+		@Nullable Supplier<SecurityContext> result = holder.getSecurityContext();
+		if (result == null) {
+			SecurityContext context = createEmptyContext();
+			result = () -> context;
+			holder.setSecurityContext(result);
+		}
+		return result;
+	}
+
+	@Override
+	public void setContext(SecurityContext context) {
+		Assert.notNull(context, "Only non-null SecurityContext instances are permitted");
+		retrieveSecurityContextScopedValueHolder().setSecurityContext(() -> context);
+	}
+
+	@Override
+	public SecurityContext createEmptyContext() {
+		return new SecurityContextImpl();
+	}
+
+	private SecurityContextScopedValueHolder retrieveSecurityContextScopedValueHolder() {
+		if (SECURITY_CONTEXT.isBound()) {
+			return SECURITY_CONTEXT.get();
+		}
+		else {
+			throw new IllegalStateException("Security Context Scoped Value not bound");
+		}
+	}
+
+	@Override
+	public void setDeferredContext(Supplier<SecurityContext> deferredContext) {
+		Assert.notNull(deferredContext, "Only non-null Supplier instances are permitted");
+		Supplier<SecurityContext> notNullDeferredContext = () -> {
+			SecurityContext result = deferredContext.get();
+			Assert.notNull(result, "A Supplier<SecurityContext> returned null and is not allowed.");
+			return result;
+		};
+		retrieveSecurityContextScopedValueHolder().setSecurityContext(notNullDeferredContext);
+	}
+
+	/**
+	 * Binds an instance of {@link ScopedValue},
+	 * {@link ScopedSecurityContextHolderStrategy#SECURITY_CONTEXT}, to an instance of
+	 * {@link SecurityContextScopedValueHolder} <i>for current thread</i>.
+	 */
+	public static void runWhere(Supplier<SecurityContext> deferredContext, Runnable r) {
+		ScopedValue.where(SECURITY_CONTEXT, new SecurityContextScopedValueHolder(deferredContext)).run(r);
+	}
+
+	/**
+	 * A convenience version of {@link #runWhere(Supplier, Runnable)} method.
+	 */
+	public static ScopedValue.Carrier getSecuriyContextCarrier() {
+		return ScopedValue.where(SECURITY_CONTEXT, new SecurityContextScopedValueHolder());
+	}
+
+	/**
+	 * A structure that holds {@link SecurityContext}. An instance of {@link ScopedValue},
+	 * {@link ScopedSecurityContextHolderStrategy#SECURITY_CONTEXT}, has to be bound to an
+	 * instance of this class.
+	 */
+	private static class SecurityContextScopedValueHolder {
+
+		@Nullable private Supplier<SecurityContext> securityContext;
+
+		SecurityContextScopedValueHolder() {
+		}
+
+		SecurityContextScopedValueHolder(Supplier<SecurityContext> securityContext) {
+			this.securityContext = securityContext;
+		}
+
+		@Nullable Supplier<SecurityContext> getSecurityContext() {
+			return this.securityContext;
+		}
+
+		void setSecurityContext(@Nullable Supplier<SecurityContext> securityContext) {
+			this.securityContext = securityContext;
+		}
+
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/core/context/SecurityContextHolder.java
+++ b/core/src/main/java/org/springframework/security/core/context/SecurityContextHolder.java
@@ -60,6 +60,8 @@ public class SecurityContextHolder {
 
 	private static final String MODE_PRE_INITIALIZED = "MODE_PRE_INITIALIZED";
 
+	private static final String MODE_SCOPEDVALUE = "MODE_SCOPEDVALUE";
+
 	public static final String SYSTEM_PROPERTY = "spring.security.strategy";
 
 	private static String strategyName = System.getProperty(SYSTEM_PROPERTY);
@@ -97,6 +99,10 @@ public class SecurityContextHolder {
 		}
 		if (strategyName.equals(MODE_GLOBAL)) {
 			strategy = new GlobalSecurityContextHolderStrategy();
+			return;
+		}
+		if (strategyName.equals(MODE_SCOPEDVALUE)) {
+			strategy = new ScopedSecurityContextHolderStrategy();
 			return;
 		}
 		// Try to load a custom strategy

--- a/core/src/test/java/org/springframework/security/core/context/ScopedSecurityContextHolderStrategyTests.java
+++ b/core/src/test/java/org/springframework/security/core/context/ScopedSecurityContextHolderStrategyTests.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.core.context;
+
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.security.core.Authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class ScopedSecurityContextHolderStrategyTests {
+
+	ScopedSecurityContextHolderStrategy strategy = new ScopedSecurityContextHolderStrategy();
+
+	@Test
+	void deferredNotInvoked() {
+		Supplier<SecurityContext> deferredContext = mock(Supplier.class);
+		ScopedSecurityContextHolderStrategy.getSecuriyContextCarrier().run(() -> {
+			try {
+				this.strategy.setDeferredContext(deferredContext);
+				verifyNoInteractions(deferredContext);
+			}
+			finally {
+				this.strategy.clearContext();
+			}
+		});
+	}
+
+	@Test
+	void deferredContext() {
+		Authentication authentication = mock(Authentication.class);
+		Supplier<SecurityContext> deferredContext = () -> new SecurityContextImpl(authentication);
+		ScopedSecurityContextHolderStrategy.runWhere(deferredContext, () -> {
+			try {
+				this.strategy.setDeferredContext(deferredContext);
+				assertThat(this.strategy.getDeferredContext().get()).isEqualTo(deferredContext.get());
+				assertThat(this.strategy.getContext()).isEqualTo(deferredContext.get());
+			}
+			finally {
+				this.strategy.clearContext();
+			}
+		});
+	}
+
+	@Test
+	void deferredContextValidates() {
+		ScopedSecurityContextHolderStrategy.getSecuriyContextCarrier().run(() -> {
+			try {
+				this.strategy.setDeferredContext(() -> null);
+				Supplier<SecurityContext> deferredContext = this.strategy.getDeferredContext();
+				assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(deferredContext::get);
+			}
+			finally {
+				this.strategy.clearContext();
+			}
+		});
+	}
+
+	@Test
+	void context() {
+		Authentication authentication = mock(Authentication.class);
+		SecurityContext context = new SecurityContextImpl(authentication);
+		ScopedSecurityContextHolderStrategy.getSecuriyContextCarrier().run(() -> {
+			try {
+				this.strategy.setContext(context);
+				assertThat(this.strategy.getContext()).isEqualTo(context);
+				assertThat(this.strategy.getDeferredContext().get()).isEqualTo(context);
+			}
+			finally {
+				this.strategy.clearContext();
+			}
+		});
+	}
+
+	@Test
+	void contextValidates() {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> this.strategy.setContext(null));
+	}
+
+	@Test
+	void getContextWhenEmptyThenReturnsSameInstance() {
+		Authentication authentication = mock(Authentication.class);
+		ScopedSecurityContextHolderStrategy.getSecuriyContextCarrier().run(() -> {
+			try {
+				this.strategy.getContext().setAuthentication(authentication);
+				assertThat(this.strategy.getContext().getAuthentication()).isEqualTo(authentication);
+			}
+			finally {
+				this.strategy.clearContext();
+			}
+		});
+	}
+
+	@Test
+	void unboundGetContext() {
+		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> this.strategy.getContext());
+	}
+
+	@Test
+	void unboundSetContext() {
+		Authentication authentication = mock(Authentication.class);
+		SecurityContext context = new SecurityContextImpl(authentication);
+		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> this.strategy.setContext(context));
+	}
+
+}

--- a/kerberos/kerberos-client/src/main/java/org/springframework/security/kerberos/client/KerberosRestTemplate.java
+++ b/kerberos/kerberos-client/src/main/java/org/springframework/security/kerberos/client/KerberosRestTemplate.java
@@ -228,6 +228,7 @@ public class KerberosRestTemplate extends RestTemplate {
 		return lc;
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	protected final <T> T doExecute(final URI url, final @Nullable String uriTemplate,
 			final @Nullable HttpMethod method, final @Nullable RequestCallback requestCallback,

--- a/kerberos/kerberos-client/src/main/java/org/springframework/security/kerberos/client/ldap/KerberosLdapContextSource.java
+++ b/kerberos/kerberos-client/src/main/java/org/springframework/security/kerberos/client/ldap/KerberosLdapContextSource.java
@@ -110,6 +110,7 @@ public class KerberosLdapContextSource extends DefaultSpringSecurityContextSourc
 		Subject serviceSubject = login();
 
 		final NamingException[] suppressedException = new NamingException[] { null };
+		@SuppressWarnings("removal")
 		DirContext dirContext = Subject.doAs(serviceSubject, new PrivilegedAction<@Nullable DirContext>() {
 
 			@Override

--- a/kerberos/kerberos-core/src/main/java/org/springframework/security/kerberos/authentication/KerberosMultiTier.java
+++ b/kerberos/kerberos-core/src/main/java/org/springframework/security/kerberos/authentication/KerberosMultiTier.java
@@ -53,6 +53,7 @@ public final class KerberosMultiTier {
 	 * @param targetService
 	 * @return
 	 */
+	@SuppressWarnings("removal")
 	public static Authentication authenticateService(Authentication authentication, final String username,
 			final int lifetimeInSeconds, final String targetService) {
 

--- a/kerberos/kerberos-core/src/main/java/org/springframework/security/kerberos/authentication/KerberosServiceRequestToken.java
+++ b/kerberos/kerberos-core/src/main/java/org/springframework/security/kerberos/authentication/KerberosServiceRequestToken.java
@@ -186,6 +186,7 @@ public class KerberosServiceRequestToken extends AbstractAuthenticationToken imp
 	 * @return the decrypted message
 	 * @throws PrivilegedActionException if jaas throws and error
 	 */
+	@SuppressWarnings("removal")
 	public byte[] decrypt(final byte[] data, final int offset, final int length) throws PrivilegedActionException {
 		KerberosTicketValidation validation = getTicketValidation();
 		if (validation == null) {
@@ -220,6 +221,7 @@ public class KerberosServiceRequestToken extends AbstractAuthenticationToken imp
 	 * @return the encrypted message
 	 * @throws PrivilegedActionException if jaas throws and error
 	 */
+	@SuppressWarnings("removal")
 	public byte[] encrypt(final byte[] data, final int offset, final int length) throws PrivilegedActionException {
 		KerberosTicketValidation validation = getTicketValidation();
 		if (validation == null) {

--- a/kerberos/kerberos-core/src/main/java/org/springframework/security/kerberos/authentication/sun/SunJaasKerberosTicketValidator.java
+++ b/kerberos/kerberos-core/src/main/java/org/springframework/security/kerberos/authentication/sun/SunJaasKerberosTicketValidator.java
@@ -77,6 +77,7 @@ public class SunJaasKerberosTicketValidator implements KerberosTicketValidator, 
 
 	private static final Log LOG = LogFactory.getLog(SunJaasKerberosTicketValidator.class);
 
+	@SuppressWarnings("removal")
 	@Override
 	public KerberosTicketValidation validateTicket(byte[] token) {
 		try {

--- a/web/src/main/java/org/springframework/security/web/context/ScopedSecurityContextHolderFilter.java
+++ b/web/src/main/java/org/springframework/security/web/context/ScopedSecurityContextHolderFilter.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2004, 2005, 2006 Acegi Technology Pty Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.context;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.context.DeferredSecurityContext;
+import org.springframework.security.core.context.ScopedSecurityContextHolderStrategy;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
+import org.springframework.util.Assert;
+import org.springframework.web.filter.GenericFilterBean;
+
+/**
+ * A {@link jakarta.servlet.Filter} that orchestrates the usage of
+ * {@link ScopedSecurityContextHolderStrategy}.
+ *
+ * <p>
+ * </p>
+ * The implementation is very similar to that of {@link SecurityContextHolderFilter},
+ * where from it has been adopted, except the delegating to the next filter has to be an
+ * operation passed to {@link ScopedValue.Carrier#run(Runnable)} method, so that for every
+ * code executed up-stack of this filter a {@link ScopedValue} is bound to a
+ * {@link org.springframework.security.core.context.SecurityContext SecurityContext}
+ * instance for the current thread.
+ *
+ * <p>
+ * </p>
+ * The other difference is that
+ * {@link #setSecurityContextHolderStrategy(SecurityContextHolderStrategy)} method can
+ * accept only {@link ScopedSecurityContextHolderStrategy} implementation of
+ * {@link SecurityContextHolderStrategy} interface.
+ *
+ * @see org.springframework.security.core.context.ScopedSecurityContextHolderStrategy
+ */
+public class ScopedSecurityContextHolderFilter extends GenericFilterBean {
+
+	private static final String FILTER_APPLIED = ScopedSecurityContextHolderFilter.class.getName() + ".APPLIED";
+
+	private final SecurityContextRepository securityContextRepository;
+
+	private ScopedSecurityContextHolderStrategy securityContextHolderStrategy;
+
+	public ScopedSecurityContextHolderFilter(SecurityContextRepository securityContextRepository) {
+		this.securityContextRepository = securityContextRepository;
+		final SecurityContextHolderStrategy contextHolderStrategy = SecurityContextHolder.getContextHolderStrategy();
+		this.securityContextHolderStrategy = (contextHolderStrategy instanceof ScopedSecurityContextHolderStrategy)
+				? (ScopedSecurityContextHolderStrategy) contextHolderStrategy
+				: new ScopedSecurityContextHolderStrategy();
+	}
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
+		doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+	}
+
+	private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+			throws ServletException, IOException {
+		if (request.getAttribute(FILTER_APPLIED) != null) {
+			chain.doFilter(request, response);
+			return;
+		}
+		request.setAttribute(FILTER_APPLIED, Boolean.TRUE);
+		DeferredSecurityContext deferredContext = this.securityContextRepository.loadDeferredContext(request);
+		try {
+			ScopedSecurityContextHolderStrategy.runWhere(deferredContext, () -> {
+				this.securityContextHolderStrategy.setDeferredContext(deferredContext);
+				try {
+					chain.doFilter(request, response);
+				}
+				catch (IOException | ServletException ex) {
+					throw new RuntimeException(ex);
+				}
+			});
+		}
+		catch (RuntimeException ex) {
+			final Throwable cause = ex.getCause();
+			if (cause instanceof ServletException) {
+				throw (ServletException) cause;
+			}
+			if (cause instanceof IOException) {
+				throw (IOException) cause;
+			}
+			throw ex;
+		}
+		finally {
+			// clearing the Context is unnecessary because ScopedValue is already unbound
+			request.removeAttribute(FILTER_APPLIED);
+		}
+	}
+
+	/**
+	 * Only {@link ScopedSecurityContextHolderStrategy} implementation of
+	 * {@link SecurityContextHolderStrategy} interface is acceptable, otherwise
+	 * {@link IllegalArgumentException} is thrown
+	 * @param securityContextHolderStrategy
+	 */
+	public void setSecurityContextHolderStrategy(SecurityContextHolderStrategy securityContextHolderStrategy) {
+		Assert.isInstanceOf(ScopedSecurityContextHolderStrategy.class, securityContextHolderStrategy,
+				"Security Context Holder Strategy is not of type "
+						+ ScopedSecurityContextHolderStrategy.class.getSimpleName());
+		this.securityContextHolderStrategy = (ScopedSecurityContextHolderStrategy) securityContextHolderStrategy;
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/jaasapi/JaasApiIntegrationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/jaasapi/JaasApiIntegrationFilter.java
@@ -77,6 +77,7 @@ public class JaasApiIntegrationFilter extends GenericFilterBean {
 	 * <code>Subject</code> obtained.
 	 * </p>
 	 */
+	@SuppressWarnings("removal")
 	@Override
 	public final void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
 			throws ServletException, IOException {

--- a/web/src/test/java/org/springframework/security/web/context/ScopedSecurityContextHolderFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/context/ScopedSecurityContextHolderFilterTests.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.web.context;
+
+import java.util.function.Supplier;
+
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.security.authentication.TestAuthentication;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ScopedSecurityContextHolderStrategy;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
+import org.springframework.security.core.context.SecurityContextImpl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class ScopedSecurityContextHolderFilterTests {
+
+	private static final String FILTER_APPLIED = ScopedSecurityContextHolderFilter.class.getName() + ".APPLIED";
+
+	@Mock
+	private SecurityContextRepository repository;
+
+	@Mock
+	private ScopedSecurityContextHolderStrategy strategy;
+
+	@Mock
+	private HttpServletRequest request;
+
+	@Mock
+	private HttpServletResponse response;
+
+	@Captor
+	private ArgumentCaptor<HttpServletRequest> requestArg;
+
+	private ScopedSecurityContextHolderFilter filter;
+
+	private SecurityContextHolderStrategy originalStrategy;
+
+	@BeforeEach
+	void setup() {
+		this.originalStrategy = SecurityContextHolder.getContextHolderStrategy();
+		SecurityContextHolder.setContextHolderStrategy(new ScopedSecurityContextHolderStrategy());
+		this.filter = new ScopedSecurityContextHolderFilter(this.repository);
+	}
+
+	@AfterEach
+	void cleanup() {
+		SecurityContextHolder.setContextHolderStrategy(this.originalStrategy);
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	void doFilterThenGetSecurityContextHolderOnUnbound() throws Exception {
+		Authentication authentication = TestAuthentication.authenticatedUser();
+		SecurityContext expectedContext = new SecurityContextImpl(authentication);
+		given(this.repository.loadDeferredContext(this.requestArg.capture()))
+			.willReturn(new SupplierDeferredSecurityContext(() -> expectedContext, this.strategy));
+		FilterChain filterChain = (request, response) -> assertThat(SecurityContextHolder.getContext())
+			.isEqualTo(expectedContext);
+
+		this.filter.doFilter(this.request, this.response, filterChain);
+
+		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> SecurityContextHolder.getContext());
+	}
+
+	@Test
+	void doFilterThenSetAndGetSecurityContext() throws Exception {
+		Authentication authentication = TestAuthentication.authenticatedUser();
+		SecurityContext expectedContext = new SecurityContextImpl(authentication);
+		given(this.repository.loadDeferredContext(this.requestArg.capture()))
+			.willReturn(new SupplierDeferredSecurityContext(() -> expectedContext, this.strategy));
+		FilterChain filterChain = (request, response) -> {
+		};
+
+		this.filter.setSecurityContextHolderStrategy(this.strategy);
+		this.filter.doFilter(this.request, this.response, filterChain);
+
+		ArgumentCaptor<Supplier<SecurityContext>> deferredContextArg = ArgumentCaptor.forClass(Supplier.class);
+		verify(this.strategy).setDeferredContext(deferredContextArg.capture());
+		assertThat(deferredContextArg.getValue().get()).isEqualTo(expectedContext);
+		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> SecurityContextHolder.getContext());
+	}
+
+	@Test
+	void doFilterWhenFilterAppliedThenDoNothing() throws Exception {
+		given(this.request.getAttribute(FILTER_APPLIED)).willReturn(true);
+		this.filter.doFilter(this.request, this.response, new MockFilterChain());
+		verify(this.request, times(1)).getAttribute(FILTER_APPLIED);
+		verifyNoInteractions(this.repository, this.response);
+	}
+
+	@Test
+	void doFilterWhenNotAppliedThenSetsAndRemovesAttribute() throws Exception {
+		given(this.repository.loadDeferredContext(this.requestArg.capture()))
+			.willReturn(new SupplierDeferredSecurityContext(SecurityContextHolder::createEmptyContext, this.strategy));
+
+		this.filter.doFilter(this.request, this.response, new MockFilterChain());
+
+		InOrder inOrder = inOrder(this.request, this.repository);
+		inOrder.verify(this.request).setAttribute(FILTER_APPLIED, true);
+		inOrder.verify(this.repository).loadDeferredContext(this.request);
+		inOrder.verify(this.request).removeAttribute(FILTER_APPLIED);
+	}
+
+	@ParameterizedTest
+	@EnumSource(DispatcherType.class)
+	void doFilterWhenAnyDispatcherTypeThenFilter(DispatcherType dispatcherType) throws Exception {
+		lenient().when(this.request.getDispatcherType()).thenReturn(dispatcherType);
+		Authentication authentication = TestAuthentication.authenticatedUser();
+		SecurityContext expectedContext = new SecurityContextImpl(authentication);
+		given(this.repository.loadDeferredContext(this.requestArg.capture()))
+			.willReturn(new SupplierDeferredSecurityContext(() -> expectedContext, this.strategy));
+		FilterChain filterChain = (request, response) -> assertThat(SecurityContextHolder.getContext())
+			.isEqualTo(expectedContext);
+
+		this.filter.doFilter(this.request, this.response, filterChain);
+	}
+
+}


### PR DESCRIPTION
Closes gh-19259.

The implementation of Scoped Value-based `SecurityContextHolderStrategy`, henceforth Strategy, is rather straightforward: 

-  a `ScopedValue` instance holds a reference to `SecurityContext` similar to that of `ThreadLocal`;

-  `SecurityContextHolder` is changed to be able to be configured with new `SecurityContextHolderStrategy`;

- a newly introduced `ScopedSecurityContextHolderFilter` orchestrates the usage of new Strategy, invoking upstack/downstream Security Filters in a Filter Chain with the `ScopedValue` instance bound to `SecurityContext` for the current thread;

- `SecurityContextConfigurer` is changed to replace `SecurityContextHolderFilter` with `ScopedSecurityContextHolderFilter` _if_ current, globally configured Strategy is Scoped Value-based one;

- it was unnecessary, IMHO, to alter XML-based configuration as custom Strategy can be set for a particular Filter Chain by `security-context-holder-strategy-ref` attribute of `http` XML element.

	
What is not that straightforward is the configuration of Java compiler to be able to access Java 25 features, `ScopedValue` class in this case. For that purpose, Java compiler option `--release` was replaced with `--source` and `--target` options in `java-toolchain.gradle`; it also turned out to be necessary to set JVM target to 17 for Kotlin test compilation in `test-compile-target-jdk25.gradle`. As a result of these changes, the project now builds, uses `ScopedValue`, and still can run under JVM 17.
	
It is impossible to replace `Subject.doAs` calls with its Java 18 replacement `Subject.callAs` due to the requirement of compatibility with Java 17, and the correspondent deprecation warnings are suppressed.  
	