### PR TITLE
Fix SAML extension URLs sample link

### DIFF
--- a/docs/modules/ROOT/pages/servlet/saml2/saml-extension-migration.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/saml-extension-migration.adoc
@@ -44,7 +44,7 @@ Both Spring Security and Spring Security SAML Extensions have examples for how t
 
 | Login & Logout | https://github.com/spring-projects/spring-security-samples/tree/main/servlet/spring-boot/java/saml2/login[Sample] |
 https://github.com/jzheaux/spring-security-saml-migrate/tree/main/login-logout[Sample]
-| Login using SAML Extension URLs | https://github.com/spring-projects/spring-security-samples/tree/main/servlet/spring-boot/java/saml2/custom-urls[Sample] | -
+| Login using SAML Extension URLs | https://github.com/spring-projects/spring-security-samples/tree/main/servlet/spring-boot/java/saml2/saml-extension-urls[Sample] | -
 | Metadata support | https://github.com/spring-projects/spring-security-samples/tree/main/servlet/spring-boot/java/saml2/refreshable-metadata[Sample] | -
 |===
 


### PR DESCRIPTION
The `custom-urls` sample was renamed to `saml-extension-urls` in spring-security-samples, so this link has returned a 404 since November 2024.

The reference docs were only partially updated for that rename: `servlet/saml2/login/overview.adoc` already points at `saml-extension-urls`, but this row of the migration guide's examples matrix was missed. This completes the update.
