### PR TITLE
Update saml-extension-migration.adoc

### DIFF
--- a/docs/modules/ROOT/pages/servlet/saml2/saml-extension-migration.adoc
+++ b/docs/modules/ROOT/pages/servlet/saml2/saml-extension-migration.adoc
@@ -1,6 +1,6 @@
 = SAML 2.0 Extension Migration
 
-This document contains guidance for moving SAML 2.0 Service Providers from Spring Security SAML Extensions 1.x to Spring Security Since Spring Security doesn’t provide Identity Provider support, migrating a Spring Security SAML Extensions Identity Provider is out of scope for this document.
+This document contains guidance for moving SAML 2.0 Service Providers from Spring Security SAML Extensions 1.x to Spring Security. Since Spring Security doesn’t provide Identity Provider support, migrating a Spring Security SAML Extensions Identity Provider is out of scope for this document.
 
 Because the two approaches are as different as they are, this document will tend to cover patterns more than precise search-and-replace steps.
 
@@ -22,17 +22,17 @@ xref:servlet/saml2/metadata.adoc[`saml2Metadata`]. It selects the correct filter
 
 ==== Stronger Encapsulation
 
-Like Spring Security SAML Extensions, Spring Security bases it’s SAML support on OpenSAML. The Extensions project exposes OpenSAML over public interfaces, blurring the lines between the two projects, effectively requiring OpenSAML, and making upgrades to later versions of OpenSAML more complicated.
+Like Spring Security SAML Extensions, Spring Security bases its SAML support on OpenSAML. The Extensions project exposes OpenSAML over public interfaces, blurring the lines between the two projects, effectively requiring OpenSAML, and making upgrades to later versions of OpenSAML more complicated.
 
-Spring Security provides stronger encapsulation. No public interfaces expose OpenSAML components and any class that exposes OpenSAML in its public API is named with an `OpenSaml` prefix for additional clarity.
+Spring Security provides stronger encapsulation. No public interfaces expose OpenSAML components, and any class that exposes OpenSAML in its public API is named with an `OpenSaml` prefix for additional clarity.
 
 ==== Out-of-the-box Multitenancy
 
-Spring Security SAML Extensions offered some lightweight support for declaring more than one Identity Provider and accessing it at login time using the `idp` request parameter. This was limiting as far as changing things at runtime was concerned and also doesn’t allow for a many-to-many relationship between relying and asserting parties.
+Spring Security SAML Extensions offered some lightweight support for declaring more than one Identity Provider and accessing it at login time using the `idp` request parameter. This was limiting when it came to runtime changes and also didn’t allow for a many-to-many relationship between relying and asserting parties.
 
 Spring Security builds SAML 2.0 multitenancy into its default URLs and basic components in the form of a `RelyingPartyRegistration`. This component acts as a link between a Relying Party’s metadata and an Asserting Party’s metadata, and all pairs are available for lookup in a `RelyingPartyRegistrationRepository`. Each URL represents a unique registration pair to be retrieved.
 
-Whether it’s AuthnRequests, Responses, LogoutRequests, LogoutResponses, or EntityDescriptors, each filter is based off of `RelyingPartyRegistrationRepository` and so is fundamentally multi-tenant.
+Whether it’s AuthnRequests, Responses, LogoutRequests, LogoutResponses, or EntityDescriptors, each filter is based on `RelyingPartyRegistrationRepository` and so is fundamentally multi-tenant.
 
 === Examples Matrix
 


### PR DESCRIPTION
Minor changes to improve the readability of the [SAML 2.0 Extension Migration](https://docs.spring.io/spring-security/reference/servlet/saml2/saml-extension-migration.html) chapter.