### PR TITLE
Differentiate Forwarded and X-Forwarded headers in proxy docs

### DIFF
--- a/docs/modules/ROOT/pages/features/exploits/http.adoc
+++ b/docs/modules/ROOT/pages/features/exploits/http.adoc
@@ -23,10 +23,28 @@ When using a proxy server, it is important to ensure that you have configured yo
 For example, many applications have a load balancer that responds to request for `\https://example.com/` by forwarding the request to an application server at `\https://192.168.0.107`
 Without proper configuration, the application server can not know that the load balancer exists and treats the request as though `\https://192.168.0.107:8080` was requested by the client.
 
-To fix this, you can use https://tools.ietf.org/html/rfc7239[RFC 7239] to specify that a load balancer is being used.
-To make the application aware of this, you need to configure your application server to be aware of the X-Forwarded headers.
+To fix this, the proxy needs to pass on the details of the original request, and the application needs to be configured to use them.
+Two kinds of headers are used for this, and it is important to know which of them applies in your deployment:
+
+* The standard `Forwarded` header, defined by https://tools.ietf.org/html/rfc7239[RFC 7239], which carries the original host, protocol, and client in a single header.
+* The non-standard `X-Forwarded-*` headers, such as `X-Forwarded-Host`, `X-Forwarded-Proto`, and `X-Forwarded-For`, which predate RFC 7239.
+
+Most proxies still send the `X-Forwarded-*` headers rather than the standard `Forwarded` header, while Spring Framework and servers such as Reactor Netty and Jetty understand both.
+Do not assume that only one of them is in use.
+
+[NOTE]
+====
+Both kinds of headers are supplied by the client unless a proxy overwrites them, so an application that trusts them without a trusted proxy in front of it can be made to believe a request arrived over a different host, protocol, or client address than it really did.
+====
+
+For this reason, the proxy at the edge of your network must be configured to remove or overwrite any forwarded headers that arrive from the outside, for _both_ kinds of headers.
+Dropping only the `Forwarded` header while passing through `X-Forwarded-*` (or the reverse) leaves the application open to the same spoofing through the other set.
+Only headers added by a proxy you control should reach the application.
+
+Once untrusted values are handled at the edge, the application server can be configured to apply the headers.
 For example, Tomcat uses https://tomcat.apache.org/tomcat-10.1-doc/api/org/apache/catalina/valves/RemoteIpValve.html[`RemoteIpValve`] and Jetty uses https://eclipse.dev/jetty/javadoc/jetty-11/org/eclipse/jetty/server/ForwardedRequestCustomizer.html[`ForwardedRequestCustomizer`].
 Alternatively, Spring users can use https://docs.spring.io/spring-framework/reference/web/webmvc/filters.html#filters-forwarded-headers[`ForwardedHeaderFilter`] with the Servlet stack or https://docs.spring.io/spring-framework/reference/web/webflux/reactive-spring.html#webflux-forwarded-headers[`ForwardedHeaderTransformer`] with the Reactive stack.
+Both handle the `Forwarded` header and the `X-Forwarded-*` headers, and both can be configured to remove the headers instead of applying them, which is useful when the application is not behind a proxy.
 
 Spring Boot users can use the `server.forward-headers-strategy` property to configure the application.
 See the https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto.webserver.use-behind-a-proxy-server[Spring Boot documentation] for further details.


### PR DESCRIPTION
See gh-19461.

The proxy server section currently says:

> To fix this, you can use RFC 7239 to specify that a load balancer is being used.
> To make the application aware of this, you need to configure your application server to be aware of the X-Forwarded headers.

which points at RFC 7239 and then, in the next sentence, refers to the `X-Forwarded-*` headers as though they were the same mechanism. They are not: RFC 7239 defines a single standard `Forwarded` header, while `X-Forwarded-Host` / `X-Forwarded-Proto` / `X-Forwarded-For` are the older non-standard set.

This change:

- describes the two kinds of headers separately, so a reader can tell which applies to their deployment;
- notes that most proxies still send `X-Forwarded-*` while Spring Framework and servers such as Reactor Netty and Jetty understand both, so neither can be assumed to be the only one in use;
- adds a note that both kinds are client-supplied unless a proxy overwrites them, and states that the edge proxy has to drop or overwrite untrusted values for **both** kinds — dropping only one set still leaves the application spoofable through the other;
- mentions that `ForwardedHeaderFilter` / `ForwardedHeaderTransformer` handle both kinds and can be configured to remove the headers instead of applying them.

The wording follows the framing in the issue. Only `features/exploits/http.adoc` needed changing — the servlet and reactive pages `xref` this section rather than repeating it.

Happy to adjust the emphasis or trim it if you had a different structure in mind; this is meant as a starting point rather than a finished opinion on the guidance.
