### PR TITLE
docs: correct failureUrl Javadoc for custom login page

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/AbstractAuthenticationFilterConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/AbstractAuthenticationFilterConfigurer.java
@@ -204,9 +204,16 @@ public abstract class AbstractAuthenticationFilterConfigurer<B extends HttpSecur
 	}
 
 	/**
-	 * The URL to send users if authentication fails. This is a shortcut for invoking
-	 * {@link #failureHandler(AuthenticationFailureHandler)}. The default is
-	 * "/login?error".
+	 * The URL to send users if authentication fails. The default is "/login?error".
+	 * <p>
+	 * When a custom {@link #loginPage(String) login page} is configured, the application
+	 * must process the specified URL to generate an error page.
+	 * </p>
+	 * <p>
+	 * When a custom login page is not configured, the framework processes the specified
+	 * URL and generates the default error page (the default login page with an error
+	 * message). Any application mapping for the specified URL is ignored.
+	 * </p>
 	 * @param authenticationFailureUrl the URL to send users if authentication fails (i.e.
 	 * "/login?error").
 	 * @return the {@link FormLoginConfigurer} for additional customization


### PR DESCRIPTION
## Description

Fixes #9229

The `failureUrl(String)` Javadoc stated that the method is a shortcut for
`failureHandler(AuthenticationFailureHandler)`, which is incorrect.

`failureUrl` behavior depends on whether a custom login page is configured:

- **Custom login page:** the application must process the failure URL to generate an error page.
- **No custom login page:** the framework processes the failure URL and generates the default error page (default login page with an error message); any application mapping for that URL is ignored.

This documentation applies to `formLogin`, `oauth2Login`, and `saml2Login` via `AbstractAuthenticationFilterConfigurer`.

## Related issues

- gh-9229