### PR TITLE
Add reactive protected resource metadata discovery

### DIFF
--- a/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java
@@ -108,6 +108,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoderFactory;
+import org.springframework.security.oauth2.server.resource.OAuth2ProtectedResourceMetadata;
 import org.springframework.security.oauth2.server.resource.authentication.JwtReactiveAuthenticationManager;
 import org.springframework.security.oauth2.server.resource.authentication.OpaqueTokenReactiveAuthenticationManager;
 import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverter;
@@ -116,6 +117,7 @@ import org.springframework.security.oauth2.server.resource.introspection.Reactiv
 import org.springframework.security.oauth2.server.resource.introspection.SpringReactiveOpaqueTokenIntrospector;
 import org.springframework.security.oauth2.server.resource.web.access.server.BearerTokenServerAccessDeniedHandler;
 import org.springframework.security.oauth2.server.resource.web.server.BearerTokenServerAuthenticationEntryPoint;
+import org.springframework.security.oauth2.server.resource.web.server.OAuth2ProtectedResourceMetadataWebFilter;
 import org.springframework.security.oauth2.server.resource.web.server.authentication.ServerBearerTokenAuthenticationConverter;
 import org.springframework.security.web.PortMapper;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
@@ -297,6 +299,7 @@ import org.springframework.web.util.pattern.PathPatternParser;
  * @author Ankur Pathak
  * @author Alexey Nesterov
  * @author Yanming Zhou
+ * @author Andrey Litvitski
  * @since 5.0
  */
 public class ServerHttpSecurity {
@@ -4150,6 +4153,8 @@ public class ServerHttpSecurity {
 
 		private ReactiveAuthenticationManagerResolver<ServerWebExchange> authenticationManagerResolver;
 
+		private final ProtectedResourceMetadataSpec protectedResourceMetadataConfigurer = new ProtectedResourceMetadataSpec();
+
 		/**
 		 * Configures the {@link ServerAccessDeniedHandler} to use for requests
 		 * authenticating with
@@ -4243,6 +4248,18 @@ public class ServerHttpSecurity {
 			return this;
 		}
 
+		/**
+		 * Configure OAuth 2.0 Protected Resource Metadata.
+		 * @param protectedResourceMetadataCustomizer the {@link Customizer} to provide
+		 * more options for the {@link ProtectedResourceMetadataSpec}
+		 * @return the {@link OAuth2ResourceServerSpec} for further customizations
+		 */
+		public OAuth2ResourceServerSpec protectedResourceMetadata(
+				Customizer<ProtectedResourceMetadataSpec> protectedResourceMetadataCustomizer) {
+			protectedResourceMetadataCustomizer.customize(this.protectedResourceMetadataConfigurer);
+			return this;
+		}
+
 		protected void configure(ServerHttpSecurity http) {
 			this.authenticationConverterServerWebExchangeMatcher = new AuthenticationConverterServerWebExchangeMatcher(
 					this.bearerTokenConverter);
@@ -4250,6 +4267,12 @@ public class ServerHttpSecurity {
 			registerDefaultAuthenticationEntryPoint(http);
 			registerDefaultCsrfOverride(http);
 			validateConfiguration();
+			OAuth2ProtectedResourceMetadataWebFilter protectedResourceMetadataFilter = new OAuth2ProtectedResourceMetadataWebFilter();
+			if (this.protectedResourceMetadataConfigurer.protectedResourceMetadataCustomizer != null) {
+				protectedResourceMetadataFilter.setProtectedResourceMetadataCustomizer(
+						this.protectedResourceMetadataConfigurer.protectedResourceMetadataCustomizer);
+			}
+			http.addFilterBefore(protectedResourceMetadataFilter, SecurityWebFiltersOrder.AUTHENTICATION);
 			if (this.authenticationManagerResolver != null) {
 				AuthenticationWebFilter oauth2 = new AuthenticationWebFilter(this.authenticationManagerResolver);
 				oauth2.setServerAuthenticationConverter(this.bearerTokenConverter);
@@ -5247,6 +5270,29 @@ public class ServerHttpSecurity {
 		public OneTimeTokenLoginSpec loginPage(String loginPage) {
 			Assert.hasText(loginPage, "loginPage cannot be empty");
 			this.loginPage = loginPage;
+			return this;
+		}
+
+	}
+
+	public static final class ProtectedResourceMetadataSpec {
+
+		private Consumer<OAuth2ProtectedResourceMetadata.Builder> protectedResourceMetadataCustomizer;
+
+		private ProtectedResourceMetadataSpec() {
+		}
+
+		/**
+		 * Sets the {@code Consumer} providing access to the
+		 * {@link OAuth2ProtectedResourceMetadata.Builder} allowing the ability to
+		 * customize the claims of the Resource Server's configuration.
+		 * @param protectedResourceMetadataCustomizer the {@code Consumer} providing
+		 * access to the {@link OAuth2ProtectedResourceMetadata.Builder}
+		 * @return the {@link ProtectedResourceMetadataSpec} for further configuration
+		 */
+		public ProtectedResourceMetadataSpec protectedResourceMetadataCustomizer(
+				Consumer<OAuth2ProtectedResourceMetadata.Builder> protectedResourceMetadataCustomizer) {
+			this.protectedResourceMetadataCustomizer = protectedResourceMetadataCustomizer;
 			return this;
 		}
 

--- a/config/src/test/java/org/springframework/security/config/web/server/OAuth2ProtectedResourceMetadataTests.java
+++ b/config/src/test/java/org/springframework/security/config/web/server/OAuth2ProtectedResourceMetadataTests.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.config.web.server;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.test.SpringTestContext;
+import org.springframework.security.config.test.SpringTestContextExtension;
+import org.springframework.security.oauth2.jose.TestKeys;
+import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder;
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
+import org.springframework.security.oauth2.server.resource.OAuth2ProtectedResourceMetadata;
+import org.springframework.security.oauth2.server.resource.OAuth2ProtectedResourceMetadataClaimNames;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.config.EnableWebFlux;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for OAuth 2.0 Protected Resource Metadata Requests.
+ *
+ * @author Andrey Litvitski
+ */
+@ExtendWith(SpringTestContextExtension.class)
+public class OAuth2ProtectedResourceMetadataTests {
+
+	private static final String DEFAULT_OAUTH2_PROTECTED_RESOURCE_METADATA_ENDPOINT_URI = "/.well-known/oauth-protected-resource";
+
+	private static final String RESOURCE = "https://resource.com:8443";
+
+	private static final String ISSUER_1 = "https://provider1.com";
+
+	private static final String ISSUER_2 = "https://provider2.com";
+
+	public final SpringTestContext spring = new SpringTestContext(this);
+
+	private WebTestClient client;
+
+	@Autowired
+	public void setApplicationContext(ApplicationContext context) {
+		this.client = WebTestClient.bindToApplicationContext(context).build();
+	}
+
+	@Test
+	public void requestWhenProtectedResourceMetadataRequestThenReturnMetadataResponse() {
+		this.spring.register(ResourceServerConfiguration.class).autowire();
+
+		this.client.get()
+			.uri(RESOURCE.concat(DEFAULT_OAUTH2_PROTECTED_RESOURCE_METADATA_ENDPOINT_URI))
+			.exchange()
+			.expectStatus()
+			.is2xxSuccessful()
+			.expectBody()
+			.jsonPath(OAuth2ProtectedResourceMetadataClaimNames.RESOURCE)
+			.isEqualTo(RESOURCE)
+			.jsonPath(OAuth2ProtectedResourceMetadataClaimNames.BEARER_METHODS_SUPPORTED)
+			.isArray()
+			.jsonPath(OAuth2ProtectedResourceMetadataClaimNames.BEARER_METHODS_SUPPORTED)
+			.value((List<Object> values) -> assertThat(values).hasSize(1).contains("header"))
+			.jsonPath(OAuth2ProtectedResourceMetadataClaimNames.TLS_CLIENT_CERTIFICATE_BOUND_ACCESS_TOKENS)
+			.isEqualTo(true);
+	}
+
+	@Test
+	public void requestWhenProtectedResourceMetadataRequestIncludesResourcePathThenMetadataResponseHasResourcePath() {
+		this.spring.register(ResourceServerConfiguration.class).autowire();
+
+		String host = RESOURCE;
+
+		String resourcePath = "/resource1";
+		String resource = host.concat(resourcePath);
+		this.client.get()
+			.uri(host.concat(DEFAULT_OAUTH2_PROTECTED_RESOURCE_METADATA_ENDPOINT_URI).concat(resourcePath))
+			.exchange()
+			.expectStatus()
+			.is2xxSuccessful()
+			.expectBody()
+			.jsonPath(OAuth2ProtectedResourceMetadataClaimNames.RESOURCE)
+			.isEqualTo(resource);
+
+		resourcePath = "/path1/resource2";
+		resource = host.concat(resourcePath);
+		this.client.get()
+			.uri(host.concat(DEFAULT_OAUTH2_PROTECTED_RESOURCE_METADATA_ENDPOINT_URI).concat(resourcePath))
+			.exchange()
+			.expectStatus()
+			.is2xxSuccessful()
+			.expectBody()
+			.jsonPath(OAuth2ProtectedResourceMetadataClaimNames.RESOURCE)
+			.isEqualTo(resource);
+
+		resourcePath = "/path1/path2/resource3";
+		resource = host.concat(resourcePath);
+		this.client.get()
+			.uri(host.concat(DEFAULT_OAUTH2_PROTECTED_RESOURCE_METADATA_ENDPOINT_URI).concat(resourcePath))
+			.exchange()
+			.expectStatus()
+			.is2xxSuccessful()
+			.expectBody()
+			.jsonPath(OAuth2ProtectedResourceMetadataClaimNames.RESOURCE)
+			.isEqualTo(resource);
+	}
+
+	@Test
+	public void requestWhenProtectedResourceMetadataRequestAndMetadataCustomizerSetThenReturnCustomMetadataResponse() {
+		this.spring.register(ResourceServerConfigurationWithMetadataCustomizer.class).autowire();
+
+		this.client.get()
+			.uri(RESOURCE.concat(DEFAULT_OAUTH2_PROTECTED_RESOURCE_METADATA_ENDPOINT_URI))
+			.exchange()
+			.expectStatus()
+			.is2xxSuccessful()
+			.expectBody()
+			.jsonPath(OAuth2ProtectedResourceMetadataClaimNames.RESOURCE)
+			.isEqualTo(RESOURCE)
+			.jsonPath(OAuth2ProtectedResourceMetadataClaimNames.AUTHORIZATION_SERVERS)
+			.isArray()
+			.jsonPath(OAuth2ProtectedResourceMetadataClaimNames.AUTHORIZATION_SERVERS)
+			.value((List<Object> values) -> assertThat(values).hasSize(2).contains(ISSUER_1, ISSUER_2))
+			.jsonPath(OAuth2ProtectedResourceMetadataClaimNames.SCOPES_SUPPORTED)
+			.isArray()
+			.jsonPath(OAuth2ProtectedResourceMetadataClaimNames.SCOPES_SUPPORTED)
+			.value((List<Object> values) -> assertThat(values).hasSize(2).contains("scope1", "scope2"))
+			.jsonPath(OAuth2ProtectedResourceMetadataClaimNames.BEARER_METHODS_SUPPORTED)
+			.isArray()
+			.jsonPath(OAuth2ProtectedResourceMetadataClaimNames.BEARER_METHODS_SUPPORTED)
+			.value((List<Object> values) -> assertThat(values).hasSize(1).contains("header"))
+			.jsonPath(OAuth2ProtectedResourceMetadataClaimNames.RESOURCE_NAME)
+			.isEqualTo("resourceName")
+			.jsonPath(OAuth2ProtectedResourceMetadataClaimNames.TLS_CLIENT_CERTIFICATE_BOUND_ACCESS_TOKENS)
+			.isEqualTo(true);
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@EnableWebFlux
+	@EnableWebFluxSecurity
+	static class ResourceServerConfiguration {
+
+		@Bean
+		SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+			// @formatter:off
+			http
+				.authorizeExchange((authorize) -> authorize
+					.anyExchange().authenticated()
+				)
+				.oauth2ResourceServer((oauth2) -> oauth2
+					.jwt(Customizer.withDefaults())
+				);
+			// @formatter:on
+			return http.build();
+		}
+
+		@Bean
+		ReactiveJwtDecoder jwtDecoder() {
+			return NimbusReactiveJwtDecoder.withPublicKey(TestKeys.DEFAULT_PUBLIC_KEY).build();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@EnableWebFlux
+	@EnableWebFluxSecurity
+	static class ResourceServerConfigurationWithMetadataCustomizer extends ResourceServerConfiguration {
+
+		@Bean
+		SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+			// @formatter:off
+			http
+				.authorizeExchange((authorize) -> authorize
+					.anyExchange().authenticated()
+				)
+				.oauth2ResourceServer((oauth2) -> oauth2
+					.jwt(Customizer.withDefaults())
+					.protectedResourceMetadata((metadata) ->
+						metadata.protectedResourceMetadataCustomizer(protectedResourceMetadataCustomizer())
+					)
+				);
+			// @formatter:on
+			return http.build();
+		}
+
+		private Consumer<OAuth2ProtectedResourceMetadata.Builder> protectedResourceMetadataCustomizer() {
+			return (protectedResourceMetadata) -> protectedResourceMetadata.authorizationServer(ISSUER_1)
+				.authorizationServer(ISSUER_2)
+				.scope("scope1")
+				.scope("scope2")
+				.resourceName("resourceName");
+		}
+
+	}
+
+}

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -173,6 +173,7 @@
 **** xref:reactive/oauth2/resource-server/opaque-token.adoc[Opaque Token]
 **** xref:reactive/oauth2/resource-server/multitenancy.adoc[Multitenancy]
 **** xref:reactive/oauth2/resource-server/bearer-tokens.adoc[Bearer Tokens]
+**** xref:reactive/oauth2/resource-server/protected-resource-metadata.adoc[Protected Resource Metadata]
 ** xref:reactive/exploits/index.adoc[Protection Against Exploits]
 *** xref:reactive/exploits/csrf.adoc[CSRF]
 *** xref:reactive/exploits/headers.adoc[Headers]

--- a/docs/modules/ROOT/pages/reactive/oauth2/resource-server/protected-resource-metadata.adoc
+++ b/docs/modules/ROOT/pages/reactive/oauth2/resource-server/protected-resource-metadata.adoc
@@ -1,0 +1,28 @@
+[[webflux-oauth2resourceserver-protected-resource-metadata]]
+= OAuth 2.0 Protected Resource Metadata
+
+`ServerHttpSecurity.OAuth2ResourceServerSpec` provides the ability to customize the https://www.rfc-editor.org/rfc/rfc9728.html#section-3[OAuth 2.0 Protected Resource Metadata endpoint].
+It defines an extension point that lets you customize the https://www.rfc-editor.org/rfc/rfc9728.html#section-3.2[OAuth 2.0 Protected Resource Metadata response].
+
+`ServerHttpSecurity.OAuth2ResourceServerSpec` provides the following configuration option:
+
+[source,java]
+----
+@Bean
+public SecurityWebFilterChain filterChain(ServerHttpSecurity http) {
+	http
+		.oauth2ResourceServer((resourceServer) ->
+			resourceServer
+				.protectedResourceMetadata(protectedResourceMetadata ->
+                    protectedResourceMetadata
+                        .protectedResourceMetadataCustomizer(protectedResourceMetadataCustomizer)   <1>
+				)
+		);
+
+	return http.build();
+}
+----
+<1> `protectedResourceMetadataCustomizer()`: The `Consumer` providing access to the `OAuth2ProtectedResourceMetadata.Builder` allowing the ability to customize the claims of the Resource Server's configuration.
+
+`ServerHttpSecurity.OAuth2ResourceServerSpec` configures the `OAuth2ProtectedResourceMetadataWebFilter` and registers it with the Resource Server `SecurityWebFilterChain` `@Bean`.
+`OAuth2ProtectedResourceMetadataWebFilter` is the `WebFilter` that returns the https://www.rfc-editor.org/rfc/rfc9728.html#section-3.2[OAuth2ProtectedResourceMetadata response].

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/server/BearerTokenServerAuthenticationEntryPoint.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/server/BearerTokenServerAuthenticationEntryPoint.java
@@ -18,12 +18,14 @@ package org.springframework.security.oauth2.server.resource.web.server;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Mono;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -32,8 +34,10 @@ import org.springframework.security.oauth2.server.resource.BearerTokenError;
 import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.server.ServerAuthenticationEntryPoint;
+import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * An {@link AuthenticationEntryPoint} implementation used to commence authentication of
@@ -43,6 +47,7 @@ import org.springframework.web.server.ServerWebExchange;
  * and populate {@code WWW-Authenticate} HTTP header.
  *
  * @author Rob Winch
+ * @author Andrey Litvitski
  * @since 5.1
  * @see BearerTokenError
  * @see <a href="https://tools.ietf.org/html/rfc6750#section-3" target="_blank">RFC 6750
@@ -52,6 +57,8 @@ public final class BearerTokenServerAuthenticationEntryPoint implements ServerAu
 
 	private @Nullable String realmName;
 
+	private Function<ServerWebExchange, String> resourceMetadataParameterResolver = BearerTokenServerAuthenticationEntryPoint::getResourceMetadataParameter;
+
 	public void setRealmName(@Nullable String realmName) {
 		this.realmName = realmName;
 	}
@@ -60,7 +67,7 @@ public final class BearerTokenServerAuthenticationEntryPoint implements ServerAu
 	public Mono<Void> commence(ServerWebExchange exchange, AuthenticationException authException) {
 		return Mono.defer(() -> {
 			HttpStatus status = getStatus(authException);
-			Map<String, String> parameters = createParameters(authException);
+			Map<String, String> parameters = createParameters(exchange, authException);
 			String wwwAuthenticate = computeWWWAuthenticateHeaderValue(parameters);
 			ServerHttpResponse response = exchange.getResponse();
 			response.getHeaders().set(HttpHeaders.WWW_AUTHENTICATE, wwwAuthenticate);
@@ -69,7 +76,7 @@ public final class BearerTokenServerAuthenticationEntryPoint implements ServerAu
 		});
 	}
 
-	private Map<String, String> createParameters(AuthenticationException authException) {
+	private Map<String, String> createParameters(ServerWebExchange exchange, AuthenticationException authException) {
 		Map<String, String> parameters = new LinkedHashMap<>();
 		if (this.realmName != null) {
 			parameters.put("realm", this.realmName);
@@ -88,6 +95,7 @@ public final class BearerTokenServerAuthenticationEntryPoint implements ServerAu
 				parameters.put("scope", bearerTokenError.getScope());
 			}
 		}
+		parameters.put("resource_metadata", this.resourceMetadataParameterResolver.apply(exchange));
 		return parameters;
 	}
 
@@ -99,6 +107,33 @@ public final class BearerTokenServerAuthenticationEntryPoint implements ServerAu
 			}
 		}
 		return HttpStatus.UNAUTHORIZED;
+	}
+
+	/**
+	 * Set the resolver to compute the {@code resource_metadata} parameter from the
+	 * request.
+	 * @param resourceMetadataParameterResolver
+	 * @since 7.1
+	 */
+	public void setResourceMetadataParameterResolver(
+			Function<ServerWebExchange, String> resourceMetadataParameterResolver) {
+		Assert.notNull(resourceMetadataParameterResolver, "resourceMetadataParameterResolver cannot be null");
+		this.resourceMetadataParameterResolver = resourceMetadataParameterResolver;
+	}
+
+	private static String getResourceMetadataParameter(ServerWebExchange exchange) {
+		ServerHttpRequest request = exchange.getRequest();
+		String path = request.getPath().contextPath().value()
+				+ OAuth2ProtectedResourceMetadataWebFilter.DEFAULT_OAUTH2_PROTECTED_RESOURCE_METADATA_ENDPOINT_URI;
+
+		// @formatter:off
+		return UriComponentsBuilder.fromUri(request.getURI())
+				.replacePath(path)
+				.replaceQuery(null)
+				.fragment(null)
+				.build()
+				.toUriString();
+		// @formatter:on
 	}
 
 	private static String computeWWWAuthenticateHeaderValue(Map<String, String> parameters) {

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/server/OAuth2ProtectedResourceMetadataWebFilter.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/server/OAuth2ProtectedResourceMetadataWebFilter.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.resource.web.server;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.jspecify.annotations.Nullable;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.HttpMessageWriter;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.security.oauth2.server.resource.OAuth2ProtectedResourceMetadata;
+import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
+import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * A {@link WebFilter} that processes OAuth 2.0 Protected Resource Metadata Requests.
+ *
+ * @author Andrey Litvitski
+ * @since 7.1
+ * @see OAuth2ProtectedResourceMetadata
+ * @see <a target="_blank" href=
+ * "https://www.rfc-editor.org/rfc/rfc9728.html#section-3.1">3.1. Protected Resource
+ * Metadata Request</a>
+ */
+public final class OAuth2ProtectedResourceMetadataWebFilter implements WebFilter {
+
+	private static final ResolvableType STRING_OBJECT_MAP = ResolvableType.forClass(Map.class);
+
+	/**
+	 * The default endpoint {@code URI} for OAuth 2.0 Protected Resource Metadata
+	 * requests.
+	 */
+	static final String DEFAULT_OAUTH2_PROTECTED_RESOURCE_METADATA_ENDPOINT_URI = "/.well-known/oauth-protected-resource";
+
+	private final ServerWebExchangeMatcher requestMatcher = ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET,
+			DEFAULT_OAUTH2_PROTECTED_RESOURCE_METADATA_ENDPOINT_URI.concat("/**"));
+
+	private final @Nullable HttpMessageWriter<Object> jsonMessageWriter = getJsonMessageWriter();
+
+	private Consumer<OAuth2ProtectedResourceMetadata.Builder> protectedResourceMetadataCustomizer = (
+			protectedResourceMetadata) -> {
+	};
+
+	/**
+	 * Sets the {@code Consumer} providing access to the
+	 * {@link OAuth2ProtectedResourceMetadata.Builder} allowing the ability to customize
+	 * the claims of the Resource Server's configuration.
+	 * @param protectedResourceMetadataCustomizer the {@code Consumer} providing access to
+	 * the {@link OAuth2ProtectedResourceMetadata.Builder}
+	 */
+	public void setProtectedResourceMetadataCustomizer(
+			Consumer<OAuth2ProtectedResourceMetadata.Builder> protectedResourceMetadataCustomizer) {
+		Assert.notNull(protectedResourceMetadataCustomizer, "protectedResourceMetadataCustomizer cannot be null");
+		this.protectedResourceMetadataCustomizer = protectedResourceMetadataCustomizer;
+	}
+
+	@Override
+	public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+		return this.requestMatcher.matches(exchange).flatMap((matchResult) -> {
+			if (!matchResult.isMatch()) {
+				return chain.filter(exchange);
+			}
+
+			OAuth2ProtectedResourceMetadata.Builder builder = OAuth2ProtectedResourceMetadata.builder()
+				.resource(resolveResourceIdentifier(exchange))
+				.bearerMethod("header")
+				.tlsClientCertificateBoundAccessTokens(true);
+
+			this.protectedResourceMetadataCustomizer.accept(builder);
+
+			OAuth2ProtectedResourceMetadata protectedResourceMetadata = builder.build();
+			HttpMessageWriter<Object> jsonMessageWriter = this.jsonMessageWriter;
+			Assert.state(jsonMessageWriter != null, "No JSON message writer available");
+			exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+			return jsonMessageWriter.write(Mono.just(protectedResourceMetadata.getClaims()), STRING_OBJECT_MAP,
+					STRING_OBJECT_MAP, MediaType.APPLICATION_JSON, exchange.getRequest(), exchange.getResponse(),
+					Collections.emptyMap());
+		});
+	}
+
+	private static String resolveResourceIdentifier(ServerWebExchange exchange) {
+		// Resolve Resource Identifier dynamically from request
+		String path = exchange.getRequest().getURI().getPath();
+		if (!StringUtils.hasText(path)) {
+			path = "";
+		}
+		else {
+			path = path.replace(DEFAULT_OAUTH2_PROTECTED_RESOURCE_METADATA_ENDPOINT_URI, "");
+		}
+
+		// @formatter:off
+		return UriComponentsBuilder.fromUri(exchange.getRequest().getURI())
+				.replacePath(path)
+				.replaceQuery(null)
+				.fragment(null)
+				.build()
+				.toUriString();
+		// @formatter:on
+	}
+
+	@SuppressWarnings("unchecked")
+	private static @Nullable HttpMessageWriter<Object> getJsonMessageWriter() {
+		return ServerCodecConfigurer.create()
+			.getWriters()
+			.stream()
+			.filter((writer) -> writer.canWrite(STRING_OBJECT_MAP, MediaType.APPLICATION_JSON))
+			.map((writer) -> (HttpMessageWriter<Object>) writer)
+			.findFirst()
+			.orElse(null);
+	}
+
+}

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/BearerTokenServerAuthenticationEntryPointTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/BearerTokenServerAuthenticationEntryPointTests.java
@@ -33,18 +33,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Rob Winch
+ * @author Andrey Litvitski
  * @since 5.1
  */
 public class BearerTokenServerAuthenticationEntryPointTests {
 
 	private BearerTokenServerAuthenticationEntryPoint entryPoint = new BearerTokenServerAuthenticationEntryPoint();
 
-	private MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/"));
+	private MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("http://localhost/"));
 
 	@Test
 	public void commenceWhenNotOAuth2AuthenticationExceptionThenBearer() {
 		this.entryPoint.commence(this.exchange, new BadCredentialsException("")).block();
-		assertThat(getResponse().getHeaders().getFirst(HttpHeaders.WWW_AUTHENTICATE)).isEqualTo("Bearer");
+		assertThat(getResponse().getHeaders().getFirst(HttpHeaders.WWW_AUTHENTICATE))
+			.isEqualTo("Bearer resource_metadata=\"http://localhost/.well-known/oauth-protected-resource\"");
 		assertThat(getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
 	}
 
@@ -52,9 +54,28 @@ public class BearerTokenServerAuthenticationEntryPointTests {
 	public void commenceWhenRealmNameThenHasRealmName() {
 		this.entryPoint.setRealmName("Realm");
 		this.entryPoint.commence(this.exchange, new BadCredentialsException("")).block();
-		assertThat(getResponse().getHeaders().getFirst(HttpHeaders.WWW_AUTHENTICATE))
-			.isEqualTo("Bearer realm=\"Realm\"");
+		assertThat(getResponse().getHeaders().getFirst(HttpHeaders.WWW_AUTHENTICATE)).isEqualTo(
+				"Bearer realm=\"Realm\", resource_metadata=\"http://localhost/.well-known/oauth-protected-resource\"");
 		assertThat(getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+	}
+
+	@Test
+	public void commenceWhenContextPathThenContainsContextPathInResourceMetadata() {
+		this.exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("http://localhost/ctx/").contextPath("/ctx"));
+		this.entryPoint.commence(this.exchange, new BadCredentialsException("")).block();
+		assertThat(getResponse().getHeaders().getFirst(HttpHeaders.WWW_AUTHENTICATE))
+			.isEqualTo("Bearer resource_metadata=\"http://localhost/ctx/.well-known/oauth-protected-resource\"");
+	}
+
+	@Test
+	public void commenceWhenResourceMetadataResolverThenContainsResolvedResourceMetadata() {
+		this.exchange.getAttributes().put("resource_id", "https://example.com/resource-from-request");
+		this.entryPoint
+			.setResourceMetadataParameterResolver((exchange) -> exchange.getAttribute("resource_id").toString());
+		this.entryPoint.commence(this.exchange, new BadCredentialsException("")).block();
+		assertThat(getResponse().getHeaders().getFirst(HttpHeaders.WWW_AUTHENTICATE))
+			.isEqualTo("Bearer resource_metadata=\"https://example.com/resource-from-request\"");
 	}
 
 	@Test
@@ -62,8 +83,8 @@ public class BearerTokenServerAuthenticationEntryPointTests {
 		OAuth2Error oauthError = new OAuth2Error(OAuth2ErrorCodes.INVALID_REQUEST);
 		OAuth2AuthenticationException exception = new OAuth2AuthenticationException(oauthError);
 		this.entryPoint.commence(this.exchange, exception).block();
-		assertThat(getResponse().getHeaders().getFirst(HttpHeaders.WWW_AUTHENTICATE))
-			.isEqualTo("Bearer error=\"invalid_request\"");
+		assertThat(getResponse().getHeaders().getFirst(HttpHeaders.WWW_AUTHENTICATE)).isEqualTo(
+				"Bearer error=\"invalid_request\", resource_metadata=\"http://localhost/.well-known/oauth-protected-resource\"");
 		assertThat(getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
 	}
 
@@ -73,7 +94,8 @@ public class BearerTokenServerAuthenticationEntryPointTests {
 		OAuth2AuthenticationException exception = new OAuth2AuthenticationException(oauthError);
 		this.entryPoint.commence(this.exchange, exception).block();
 		assertThat(getResponse().getHeaders().getFirst(HttpHeaders.WWW_AUTHENTICATE)).isEqualTo(
-				"Bearer error=\"invalid_request\", error_description=\"Oops\", error_uri=\"https://example.com\"");
+				"Bearer error=\"invalid_request\", error_description=\"Oops\", error_uri=\"https://example.com\", "
+						+ "resource_metadata=\"http://localhost/.well-known/oauth-protected-resource\"");
 		assertThat(getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
 	}
 
@@ -84,7 +106,8 @@ public class BearerTokenServerAuthenticationEntryPointTests {
 		OAuth2AuthenticationException exception = new OAuth2AuthenticationException(oauthError);
 		this.entryPoint.commence(this.exchange, exception).block();
 		assertThat(getResponse().getHeaders().getFirst(HttpHeaders.WWW_AUTHENTICATE)).isEqualTo(
-				"Bearer error=\"invalid_request\", error_description=\"Oops\", error_uri=\"https://example.com\"");
+				"Bearer error=\"invalid_request\", error_description=\"Oops\", error_uri=\"https://example.com\", "
+						+ "resource_metadata=\"http://localhost/.well-known/oauth-protected-resource\"");
 		assertThat(getResponse().getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
 	}
 

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/OAuth2ProtectedResourceMetadataWebFilterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/OAuth2ProtectedResourceMetadataWebFilterTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2004-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.oauth2.server.resource.web.server;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import org.springframework.http.MediaType;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpResponse;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilterChain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+/**
+ * Tests for {@link OAuth2ProtectedResourceMetadataWebFilter}.
+ *
+ * @author Andrey Litvitski
+ */
+public class OAuth2ProtectedResourceMetadataWebFilterTests {
+
+	private static final String DEFAULT_OAUTH2_PROTECTED_RESOURCE_METADATA_ENDPOINT_URI = "/.well-known/oauth-protected-resource";
+
+	private final OAuth2ProtectedResourceMetadataWebFilter filter = new OAuth2ProtectedResourceMetadataWebFilter();
+
+	@Test
+	public void setProtectedResourceMetadataCustomizerWhenNullThenThrowIllegalArgumentException() {
+		assertThatExceptionOfType(IllegalArgumentException.class)
+			.isThrownBy(() -> this.filter.setProtectedResourceMetadataCustomizer(null))
+			.withMessage("protectedResourceMetadataCustomizer cannot be null");
+	}
+
+	@Test
+	public void doFilterWhenNotProtectedResourceMetadataRequestThenNotProcessed() {
+		String requestUri = "/path";
+		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get(requestUri));
+		WebFilterChain filterChain = mock(WebFilterChain.class);
+		given(filterChain.filter(exchange)).willReturn(Mono.empty());
+
+		this.filter.filter(exchange, filterChain).block();
+
+		verify(filterChain).filter(any(ServerWebExchange.class));
+	}
+
+	@Test
+	public void doFilterWhenProtectedResourceMetadataRequestPostThenNotProcessed() {
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.post(DEFAULT_OAUTH2_PROTECTED_RESOURCE_METADATA_ENDPOINT_URI));
+		WebFilterChain filterChain = mock(WebFilterChain.class);
+		given(filterChain.filter(exchange)).willReturn(Mono.empty());
+
+		this.filter.filter(exchange, filterChain).block();
+
+		verify(filterChain).filter(any(ServerWebExchange.class));
+	}
+
+	@Test
+	public void doFilterWhenProtectedResourceMetadataRequestThenMetadataResponse() {
+		this.filter.setProtectedResourceMetadataCustomizer(
+				(protectedResourceMetadata) -> protectedResourceMetadata.authorizationServer("https://provider1.com")
+					.authorizationServer("https://provider2.com")
+					.scope("scope1")
+					.scope("scope2")
+					.resourceName("resourceName"));
+
+		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest
+			.get("http://localhost" + DEFAULT_OAUTH2_PROTECTED_RESOURCE_METADATA_ENDPOINT_URI));
+		WebFilterChain filterChain = mock(WebFilterChain.class);
+
+		this.filter.filter(exchange, filterChain).block();
+
+		verifyNoInteractions(filterChain);
+
+		MockServerHttpResponse response = exchange.getResponse();
+		assertThat(response.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
+		String protectedResourceMetadataResponse = response.getBodyAsString().block();
+		assertThat(protectedResourceMetadataResponse).contains("\"resource\":\"http://localhost\"");
+		assertThat(protectedResourceMetadataResponse)
+			.contains("\"authorization_servers\":[\"https://provider1.com\",\"https://provider2.com\"]");
+		assertThat(protectedResourceMetadataResponse).contains("\"scopes_supported\":[\"scope1\",\"scope2\"]");
+		assertThat(protectedResourceMetadataResponse).contains("\"bearer_methods_supported\":[\"header\"]");
+		assertThat(protectedResourceMetadataResponse).contains("\"resource_name\":\"resourceName\"");
+		assertThat(protectedResourceMetadataResponse).contains("\"tls_client_certificate_bound_access_tokens\":true");
+	}
+
+}


### PR DESCRIPTION
We support [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) Protected Resource Metadata discovery for servlet-based applications, but have not done so for reactive resource servers. We should make this behavior consistent across both stacks.

Closes: gh-19446

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
