### PR TITLE
Ignore Content-Type parameters when resolving bearer tokens

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
@@ -24,6 +24,7 @@ import org.jspecify.annotations.Nullable;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.server.resource.BearerTokenError;
@@ -112,8 +113,7 @@ public final class DefaultBearerTokenResolver implements BearerTokenResolver {
 	}
 
 	private @Nullable String resolveAccessTokenFromBody(HttpServletRequest request) {
-		if (!this.allowFormEncodedBodyParameter
-				|| !MediaType.APPLICATION_FORM_URLENCODED_VALUE.equals(request.getContentType())
+		if (!this.allowFormEncodedBodyParameter || !isFormEncoded(request.getContentType())
 				|| HttpMethod.GET.name().equals(request.getMethod())) {
 			return null;
 		}
@@ -124,6 +124,18 @@ public final class DefaultBearerTokenResolver implements BearerTokenResolver {
 		}
 
 		return resolveToken(request.getParameterValues(ACCESS_TOKEN_PARAMETER_NAME));
+	}
+
+	private static boolean isFormEncoded(@Nullable String contentType) {
+		if (!StringUtils.hasText(contentType)) {
+			return false;
+		}
+		try {
+			return MediaType.parseMediaType(contentType).equalsTypeAndSubtype(MediaType.APPLICATION_FORM_URLENCODED);
+		}
+		catch (InvalidMediaTypeException ex) {
+			return false;
+		}
 	}
 
 	/**

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverter.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverter.java
@@ -121,13 +121,17 @@ public class ServerBearerTokenAuthenticationConverter implements ServerAuthentic
 
 	private Flux<String> resolveAccessTokenFromBody(ServerWebExchange exchange) {
 		ServerHttpRequest request = exchange.getRequest();
-		if (!this.allowFormEncodedBodyParameter
-				|| !MediaType.APPLICATION_FORM_URLENCODED.equals(request.getHeaders().getContentType())
+		if (!this.allowFormEncodedBodyParameter || !isFormEncoded(request.getHeaders())
 				|| !HttpMethod.POST.equals(request.getMethod())) {
 			return Flux.empty();
 		}
 
 		return exchange.getFormData().flatMapMany(ServerBearerTokenAuthenticationConverter::resolveTokens);
+	}
+
+	private static boolean isFormEncoded(HttpHeaders headers) {
+		MediaType contentType = headers.getContentType();
+		return contentType != null && contentType.equalsTypeAndSubtype(MediaType.APPLICATION_FORM_URLENCODED);
 	}
 
 	private static Flux<String> resolveTokens(MultiValueMap<String, String> parameters) {

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
@@ -213,6 +213,54 @@ public class DefaultBearerTokenResolverTests {
 	}
 
 	@Test
+	public void resolveWhenContentTypeContainsCharsetAndFormParameterIsPresentAndSupportedThenTokenIsResolved() {
+		this.resolver.setAllowFormEncodedBodyParameter(true);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("POST");
+		request.setContentType("application/x-www-form-urlencoded;charset=UTF-8");
+		request.addParameter("access_token", TEST_TOKEN);
+
+		assertThat(this.resolver.resolve(request)).isEqualTo(TEST_TOKEN);
+	}
+
+	@Test
+	public void resolveWhenContentTypeIsUppercaseAndFormParameterIsPresentAndSupportedThenTokenIsResolved() {
+		this.resolver.setAllowFormEncodedBodyParameter(true);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("POST");
+		request.setContentType("APPLICATION/X-WWW-FORM-URLENCODED");
+		request.addParameter("access_token", TEST_TOKEN);
+
+		assertThat(this.resolver.resolve(request)).isEqualTo(TEST_TOKEN);
+	}
+
+	@Test
+	public void resolveWhenContentTypeIsMalformedAndFormParameterIsPresentAndSupportedThenTokenIsNotResolved() {
+		this.resolver.setAllowFormEncodedBodyParameter(true);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("POST");
+		request.setContentType("application/x-www-form-urlencoded;charset=");
+		request.addParameter("access_token", TEST_TOKEN);
+
+		assertThat(this.resolver.resolve(request)).isNull();
+	}
+
+	@Test
+	public void resolveWhenContentTypeIsWildcardAndFormParameterIsPresentAndSupportedThenTokenIsNotResolved() {
+		this.resolver.setAllowFormEncodedBodyParameter(true);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("POST");
+		request.setContentType("*/*");
+		request.addParameter("access_token", TEST_TOKEN);
+
+		assertThat(this.resolver.resolve(request)).isNull();
+	}
+
+	@Test
 	public void resolveWhenGetAndFormParameterIsPresentAndSupportedThenTokenIsNotResolved() {
 		this.resolver.setAllowFormEncodedBodyParameter(true);
 

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverterTests.java
@@ -317,6 +317,36 @@ public class ServerBearerTokenAuthenticationConverterTests {
 	}
 
 	@Test
+	public void resolveWhenContentTypeContainsCharsetAndBodyParameterIsPresentThenTokenIsResolved() {
+		this.converter.setAllowFormEncodedBodyParameter(true);
+		MockServerHttpRequest request = MockServerHttpRequest.post("/")
+			.header(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded;charset=UTF-8")
+			.body("access_token=" + TEST_TOKEN);
+
+		assertThat(convertToToken(request).getToken()).isEqualTo(TEST_TOKEN);
+	}
+
+	@Test
+	public void resolveWhenContentTypeIsUppercaseAndBodyParameterIsPresentThenTokenIsResolved() {
+		this.converter.setAllowFormEncodedBodyParameter(true);
+		MockServerHttpRequest request = MockServerHttpRequest.post("/")
+			.header(HttpHeaders.CONTENT_TYPE, "APPLICATION/X-WWW-FORM-URLENCODED")
+			.body("access_token=" + TEST_TOKEN);
+
+		assertThat(convertToToken(request).getToken()).isEqualTo(TEST_TOKEN);
+	}
+
+	@Test
+	public void resolveWhenContentTypeIsWildcardAndBodyParameterIsPresentThenTokenIsNotResolved() {
+		this.converter.setAllowFormEncodedBodyParameter(true);
+		MockServerHttpRequest request = MockServerHttpRequest.post("/")
+			.header(HttpHeaders.CONTENT_TYPE, "*/*")
+			.body("access_token=" + TEST_TOKEN);
+
+		assertThat(convertToToken(request)).isNull();
+	}
+
+	@Test
 	public void resolveWhenNoBodyParameterThenTokenIsNotResolved() {
 		this.converter.setAllowFormEncodedBodyParameter(true);
 		MockServerHttpRequest.BaseBuilder<?> request = MockServerHttpRequest.post("/")


### PR DESCRIPTION
Both bearer token resolvers decide whether a request is form-encoded by comparing the `Content-Type` for exact equality:

```java
// DefaultBearerTokenResolver
!MediaType.APPLICATION_FORM_URLENCODED_VALUE.equals(request.getContentType())

// ServerBearerTokenAuthenticationConverter
!MediaType.APPLICATION_FORM_URLENCODED.equals(request.getHeaders().getContentType())
```

A media type parameter defeats both comparisons. `MediaType#equals` includes parameters, so `application/x-www-form-urlencoded;charset=UTF-8` is not equal to `APPLICATION_FORM_URLENCODED`. That header is legal (RFC 9110 §8.3) and is what several HTTP clients send by default for form bodies. The servlet resolver is additionally case-sensitive, though media types are not (RFC 9110 §8.3.1).

The result is a silent failure: with `setAllowFormEncodedBodyParameter(true)`, the `access_token` body parameter is never read, and the request is rejected as unauthenticated with no indication that the token was present.

**Reproduce** (fails on `main` before this change):

```java
DefaultBearerTokenResolver resolver = new DefaultBearerTokenResolver();
resolver.setAllowFormEncodedBodyParameter(true);

MockHttpServletRequest request = new MockHttpServletRequest();
request.setMethod("POST");
request.setContentType("application/x-www-form-urlencoded;charset=UTF-8");
request.addParameter("access_token", "token");

assertThat(resolver.resolve(request)).isEqualTo("token"); // actual: null
```

**Fix**

Both now parse the `Content-Type` and compare with `MimeType#equalsTypeAndSubtype`, which is case-insensitive and ignores parameters. Media types that are not form-encoded are still rejected, including `*/*` — `equalsTypeAndSubtype` is used rather than `isCompatibleWith` precisely so that wildcards do not match. In the servlet resolver, an unparseable `Content-Type` is treated as not form-encoded rather than propagating `InvalidMediaTypeException`; the reactive converter's behaviour on a malformed header is unchanged.

Tests cover the charset parameter, upper-case media types, `*/*`, and a malformed `Content-Type`. The reactive converter already normalizes case via `HttpHeaders#getContentType`, so its upper-case test passes before and after; it is included to pin the behaviour alongside the servlet one.

I did not find an existing issue for this. Happy to open one if you'd prefer the tracking record, and equally happy to target a maintenance branch instead — the servlet resolver has behaved this way since 5.1 and the reactive converter's form-body support since 6.5.

**Related, not included:** `ServerOneTimeTokenAuthenticationConverter#isFormEncodedRequest` compares the raw `Content-Type` header string the same way and has the same blind spot. I left it out to keep this change to one module and one feature, since fixing it there means routing through `HttpHeaders#getContentType`, which throws on a malformed header where the current code does not. Glad to follow up separately if you want it.

**Verification**

```
./gradlew :spring-security-oauth2-resource-server:test :spring-security-oauth2-resource-server:checkFormat
./gradlew :spring-security-config:test --tests "*OAuth2ResourceServer*"
```

Both pass.
