### PR TITLE
GH-19510 Simplify null check in `ProviderManager` using `Assert.noNullElements`

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
@@ -34,7 +34,6 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.CredentialsContainer;
 import org.springframework.security.core.SpringSecurityMessageSource;
 import org.springframework.util.Assert;
-import org.springframework.util.CollectionUtils;
 
 /**
  * Iterates an {@link Authentication} request through a list of
@@ -138,8 +137,7 @@ public class ProviderManager implements AuthenticationManager, MessageSourceAwar
 	private void checkState() {
 		Assert.isTrue(this.parent != null || !this.providers.isEmpty(),
 				"A parent AuthenticationManager or a list of AuthenticationProviders is required");
-		Assert.isTrue(!CollectionUtils.contains(this.providers.iterator(), null),
-				"providers list cannot contain null values");
+		Assert.noNullElements(this.providers, "providers list cannot contain null values");
 	}
 
 	/**


### PR DESCRIPTION
Closes #19510

### Description
Refactored `ProviderManager.checkState()` to use `Assert.noNullElements` instead of `Assert.isTrue(!CollectionUtils.contains(...))`.

### Benefits
- Improves code readability by eliminating double negation logic.
- Eliminates unnecessary `Iterator` object creation.
- Utilizes updated Spring Framework `Assert` API.