### PR TITLE
Fix Bearer token parsing for multiple spaces

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
@@ -34,6 +34,7 @@ import org.springframework.util.StringUtils;
  * The default {@link BearerTokenResolver} implementation based on RFC 6750.
  *
  * @author Vedran Pavic
+ * @author Andrey Litvitski
  * @since 5.1
  * @see <a href="https://tools.ietf.org/html/rfc6750#section-2" target="_blank">RFC 6750
  * Section 2: Authenticated Requests</a>
@@ -42,7 +43,7 @@ public final class DefaultBearerTokenResolver implements BearerTokenResolver {
 
 	private static final String ACCESS_TOKEN_PARAMETER_NAME = "access_token";
 
-	private static final Pattern authorizationPattern = Pattern.compile("^Bearer (?<token>[a-zA-Z0-9-._~+/]+=*)$",
+	private static final Pattern authorizationPattern = Pattern.compile("^Bearer +(?<token>[a-zA-Z0-9-._~+/]+=*)$",
 			Pattern.CASE_INSENSITIVE);
 
 	private boolean allowFormEncodedBodyParameter = false;

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverter.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverter.java
@@ -44,6 +44,7 @@ import org.springframework.web.server.ServerWebExchange;
  * Token</a>s from the {@link ServerWebExchange}.
  *
  * @author Rob Winch
+ * @author Andrey Litvitski
  * @since 5.1
  * @see <a href="https://tools.ietf.org/html/rfc6750#section-2" target="_blank">RFC 6750
  * Section 2: Authenticated Requests</a>
@@ -52,7 +53,7 @@ public class ServerBearerTokenAuthenticationConverter implements ServerAuthentic
 
 	private static final String ACCESS_TOKEN_PARAMETER_NAME = "access_token";
 
-	private static final Pattern authorizationPattern = Pattern.compile("^Bearer (?<token>[a-zA-Z0-9-._~+/]+=*)$",
+	private static final Pattern authorizationPattern = Pattern.compile("^Bearer +(?<token>[a-zA-Z0-9-._~+/]+=*)$",
 			Pattern.CASE_INSENSITIVE);
 
 	private boolean allowFormEncodedBodyParameter = false;

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * Tests for {@link DefaultBearerTokenResolver}.
  *
  * @author Vedran Pavic
+ * @author Andrey Litvitski
  */
 public class DefaultBearerTokenResolverTests {
 
@@ -52,6 +53,14 @@ public class DefaultBearerTokenResolverTests {
 	public void resolveWhenValidHeaderIsPresentThenTokenIsResolved() {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addHeader("Authorization", "Bearer " + TEST_TOKEN);
+		assertThat(this.resolver.resolve(request)).isEqualTo(TEST_TOKEN);
+	}
+
+	// gh-19500
+	@Test
+	public void resolveWhenHeaderHasMultipleSpacesBeforeTokenThenTokenIsResolved() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Bearer  " + TEST_TOKEN);
 		assertThat(this.resolver.resolve(request)).isEqualTo(TEST_TOKEN);
 	}
 

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverterTests.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * @author Rob Winch
+ * @author Andrey Litvitski
  * @since 5.1
  */
 public class ServerBearerTokenAuthenticationConverterTests {
@@ -56,6 +57,16 @@ public class ServerBearerTokenAuthenticationConverterTests {
 		// @formatter:off
 		MockServerHttpRequest.BaseBuilder<?> request = MockServerHttpRequest.get("/")
 				.header(HttpHeaders.AUTHORIZATION, "Bearer " + TEST_TOKEN);
+		// @formatter:on
+		assertThat(convertToToken(request).getToken()).isEqualTo(TEST_TOKEN);
+	}
+
+	// gh-19500
+	@Test
+	public void resolveWhenHeaderHasMultipleSpacesBeforeTokenThenTokenIsResolved() {
+		// @formatter:off
+		MockServerHttpRequest.BaseBuilder<?> request = MockServerHttpRequest.get("/")
+				.header(HttpHeaders.AUTHORIZATION, "Bearer  " + TEST_TOKEN);
 		// @formatter:on
 		assertThat(convertToToken(request).getToken()).isEqualTo(TEST_TOKEN);
 	}


### PR DESCRIPTION
[RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750#section-2.1) allows one or more spaces. This change updates Bearer token parsing accordingly.

Closes: gh-19500

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
