### PR TITLE
Handle missing auth in SwitchUserFilter

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/switchuser/SwitchUserFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/switchuser/SwitchUserFilter.java
@@ -303,7 +303,13 @@ public class SwitchUserFilter extends GenericFilterBean implements ApplicationEv
 		// grant an additional authority that contains the original Authentication object
 		// which will be used to 'exit' from the current switched user.
 		Authentication currentAuthentication = getCurrentAuthentication(request);
-		Assert.notNull(currentAuthentication, "currentAuthentication cannot be null");
+		if (currentAuthentication == null) {
+			// Align with attemptExitUser / SwitchUserWebFilter: switch-user requires an
+			// authenticated source; raise AuthenticationException so doFilter's failure
+			// handler runs instead of an uncaught IllegalArgumentException.
+			throw new AuthenticationCredentialsNotFoundException(this.messages
+				.getMessage("SwitchUserFilter.noCurrentUser", "No current user associated with this request"));
+		}
 		GrantedAuthority switchAuthority = new SwitchUserGrantedAuthority(this.switchAuthorityRole,
 				currentAuthentication);
 		// get the original authorities

--- a/web/src/test/java/org/springframework/security/web/authentication/switchuser/SwitchUserFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/switchuser/SwitchUserFilterTests.java
@@ -30,6 +30,7 @@ import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.AccountExpiredException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.authentication.CredentialsExpiredException;
 import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -330,6 +331,39 @@ public class SwitchUserFilterTests {
 		assertThatExceptionOfType(AuthenticationException.class)
 			.isThrownBy(() -> filter.doFilter(request, response, chain));
 		verify(chain, never()).doFilter(request, response);
+	}
+
+	// gh-19418
+	@Test
+	public void attemptSwitchUserWithNoCurrentUserFails() {
+		SecurityContextHolder.clearContext();
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter(SwitchUserFilter.SPRING_SECURITY_SWITCH_USERNAME_KEY, "jacklord");
+		SwitchUserFilter filter = new SwitchUserFilter();
+		filter.setUserDetailsService(new MockUserDetailsService());
+		assertThatExceptionOfType(AuthenticationCredentialsNotFoundException.class)
+			.isThrownBy(() -> filter.attemptSwitchUser(request))
+			.withMessageContaining("No current user associated with this request");
+	}
+
+	// gh-19418
+	@Test
+	public void switchUserWithNoCurrentUserInvokesFailureHandler() throws Exception {
+		SecurityContextHolder.clearContext();
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/login/impersonate");
+		request.setContextPath("/mywebapp");
+		request.setRequestURI("/mywebapp/login/impersonate");
+		request.addParameter(SwitchUserFilter.SPRING_SECURITY_SWITCH_USERNAME_KEY, "jacklord");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		SwitchUserFilter filter = new SwitchUserFilter();
+		filter.setTargetUrl("/target");
+		filter.setUserDetailsService(new MockUserDetailsService());
+		filter.setSwitchFailureUrl("/switchfailed");
+		filter.afterPropertiesSet();
+		FilterChain chain = mock(FilterChain.class);
+		filter.doFilter(request, response, chain);
+		verify(chain, never()).doFilter(request, response);
+		assertThat(response.getRedirectedUrl()).isEqualTo("/mywebapp/switchfailed");
 	}
 
 	@Test


### PR DESCRIPTION
## Description

`SwitchUserFilter.createSwitchUserToken` required a non-null current authentication via `Assert.notNull`, which throws an uncaught `IllegalArgumentException` when the `SecurityContext` has no authentication (for example an unauthenticated request to the switch-user URL).

That path is now aligned with `attemptExitUser` and `SwitchUserWebFilter`: throw `AuthenticationCredentialsNotFoundException` using the existing `SwitchUserFilter.noCurrentUser` message so `doFilter` can invoke the configured failure handler instead of failing with a raw IAE.

Fixes #19418

## Checklist

- [x] Focused unit tests for null current authentication (`attemptSwitchUser` + failure-handler redirect)
- [x] `SwitchUserFilterTests` **36/36** (Temurin 21/25 toolchain)
- [x] DCO Signed-off-by