### PR TITLE
Document global servlet path matcher configuration

### DIFF
--- a/docs/modules/ROOT/pages/migration-7/web.adoc
+++ b/docs/modules/ROOT/pages/migration-7/web.adoc
@@ -420,6 +420,20 @@ http
         .requestMatchers(servlet.matcher("/orders/**")).authenticated()
     )
 ----
+Alternatively, if most of your authorization rules use the same servlet path, you can configure a global `PathPatternRequestMatcher.Builder` bean:
+
+[method,java]
+----
+@Bean
+PathPatternRequestMatcher.Builder requestMatcherBuilder(
+        PathPatternParser mvcPatternParser, DispatcherServletPath servletPath) {
+    PathPatternRequestMatcher.Builder builder = PathPatternRequestMatcher.withPathPatternParser(mvcPatternParser);
+    String path = servletPath.getPath();
+    return "/".equals(path) ? builder : builder.basePath(path);
+}
+----
+
+With this configuration, Spring Security uses the servlet path when creating `RequestMatcher`s from the string-based `requestMatchers` methods.
 
 
 For paths that belong to the default servlet, use `PathPatternRequestMatcher.withDefaults()` instead:


### PR DESCRIPTION
Fixes #17811

This updates the Spring Security 7 migration guide to explain an alternative way to handle servlet path prefixes in authorization rules.

In addition to the existing explicit `basePath("/mvc")` example, the guide now shows how to configure a global `PathPatternRequestMatcher.Builder` bean for applications that use the same servlet path across most authorization rules.

The example uses `PathPatternRequestMatcher.withPathPatternParser(...)` together with `DispatcherServletPath` so the configured servlet path is applied consistently when Spring Security builds request matchers from string-based authorization methods.

### Validation
- `git diff --check`
- Reviewed the generated patch locally

Note: the local `:spring-security-docs:antora` build was blocked by an unrelated Windows `esbuild`/Gradle environment issue in the JavaScript task, not by this documentation change.