### PR TITLE
Avoid final-field mutation in security tests

### DIFF
--- a/test/src/main/java/org/springframework/security/test/web/support/WebTestUtils.java
+++ b/test/src/main/java/org/springframework/security/test/web/support/WebTestUtils.java
@@ -98,7 +98,7 @@ public abstract class WebTestUtils {
 		}
 		SecurityContextHolderFilter holderFilter = findFilter(request, SecurityContextHolderFilter.class);
 		if (holderFilter != null) {
-			ReflectionTestUtils.setField(holderFilter, "securityContextRepository", securityContextRepository);
+			holderFilter.setSecurityContextRepository(securityContextRepository);
 		}
 	}
 

--- a/web/src/main/java/org/springframework/security/web/context/SecurityContextHolderFilter.java
+++ b/web/src/main/java/org/springframework/security/web/context/SecurityContextHolderFilter.java
@@ -49,7 +49,7 @@ public class SecurityContextHolderFilter extends GenericFilterBean {
 
 	private static final String FILTER_APPLIED = SecurityContextHolderFilter.class.getName() + ".APPLIED";
 
-	private final SecurityContextRepository securityContextRepository;
+	private SecurityContextRepository securityContextRepository;
 
 	private SecurityContextHolderStrategy securityContextHolderStrategy = SecurityContextHolder
 		.getContextHolderStrategy();
@@ -59,6 +59,16 @@ public class SecurityContextHolderFilter extends GenericFilterBean {
 	 * @param securityContextRepository the repository to use. Cannot be null.
 	 */
 	public SecurityContextHolderFilter(SecurityContextRepository securityContextRepository) {
+		Assert.notNull(securityContextRepository, "securityContextRepository cannot be null");
+		this.securityContextRepository = securityContextRepository;
+	}
+
+	/**
+	 * Sets the {@link SecurityContextRepository} to use.
+	 * @param securityContextRepository the repository to use. Cannot be null.
+	 * @since 7.1
+	 */
+	public void setSecurityContextRepository(SecurityContextRepository securityContextRepository) {
 		Assert.notNull(securityContextRepository, "securityContextRepository cannot be null");
 		this.securityContextRepository = securityContextRepository;
 	}

--- a/web/src/test/java/org/springframework/security/web/context/SecurityContextHolderFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/context/SecurityContextHolderFilterTests.java
@@ -43,6 +43,7 @@ import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.core.context.SecurityContextImpl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
@@ -75,6 +76,11 @@ class SecurityContextHolderFilterTests {
 	@BeforeEach
 	void setup() {
 		this.filter = new SecurityContextHolderFilter(this.repository);
+	}
+
+	@Test
+	void setSecurityContextRepositoryWhenNullThenThrowsIllegalArgumentException() {
+		assertThatIllegalArgumentException().isThrownBy(() -> this.filter.setSecurityContextRepository(null));
 	}
 
 	@AfterEach


### PR DESCRIPTION
Closes gh-19520

`WebTestUtils` currently replaces `SecurityContextHolderFilter.securityContextRepository` reflectively even though it is final. Current JDKs warn about this operation and state it will be blocked in a future release.

This adds a null-checked repository setter and uses it from test support. Reflective reads remain unchanged, so the new setter is the only additional production API.

Verification (JDK 25):

```
./gradlew :spring-security-web:test \
  --tests org.springframework.security.web.context.SecurityContextHolderFilterTests \
  :spring-security-test:test \
  --tests org.springframework.security.test.web.support.WebTestUtilsTests
./gradlew format
```