### PR TITLE
Prevent concurrent OAuth2 client authorization requests

### DIFF
--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/AuthorizedClientServiceOAuth2AuthorizedClientManager.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/AuthorizedClientServiceOAuth2AuthorizedClientManager.java
@@ -19,6 +19,9 @@ package org.springframework.security.oauth2.client;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import org.jspecify.annotations.Nullable;
@@ -84,6 +87,20 @@ public final class AuthorizedClientServiceOAuth2AuthorizedClientManager implemen
 
 	private final OAuth2AuthorizedClientService authorizedClientService;
 
+	/**
+	 * Tracks authorization requests currently in progress.
+	 *
+	 * <p>
+	 * The key is composed of the client registration id and principal name. The value
+	 * represents the authorization operation currently in progress.
+	 *
+	 * <p>
+	 * A concurrent authorization request for the same client registration and principal
+	 * waits for the existing authorization operation to complete rather than invoking the
+	 * provider again.
+	 */
+	private final Map<OAuth2AuthorizedClientId, CompletableFuture<OAuth2AuthorizedClient>> authorizationRequests = new ConcurrentHashMap<>();
+
 	private OAuth2AuthorizedClientProvider authorizedClientProvider;
 
 	private Function<OAuth2AuthorizeRequest, Map<String, Object>> contextAttributesMapper;
@@ -114,32 +131,115 @@ public final class AuthorizedClientServiceOAuth2AuthorizedClientManager implemen
 					.removeAuthorizedClient(clientRegistrationId, principal.getName()));
 	}
 
+	private OAuth2AuthorizedClientId getAuthorizationRequestId(String clientRegistrationId, Authentication principal) {
+		return new OAuth2AuthorizedClientId(clientRegistrationId, principal.getName());
+	}
+
 	@Override
 	public @Nullable OAuth2AuthorizedClient authorize(OAuth2AuthorizeRequest authorizeRequest) {
 		Assert.notNull(authorizeRequest, "authorizeRequest cannot be null");
+
 		String clientRegistrationId = authorizeRequest.getClientRegistrationId();
 		OAuth2AuthorizedClient authorizedClient = authorizeRequest.getAuthorizedClient();
 		Authentication principal = authorizeRequest.getPrincipal();
-		OAuth2AuthorizationContext.Builder contextBuilder;
+
 		if (authorizedClient != null) {
-			contextBuilder = OAuth2AuthorizationContext.withAuthorizedClient(authorizedClient);
+			OAuth2AuthorizationContext.Builder contextBuilder = OAuth2AuthorizationContext
+				.withAuthorizedClient(authorizedClient);
+			return authorize(authorizeRequest, principal, contextBuilder);
 		}
-		else {
-			ClientRegistration clientRegistration = this.clientRegistrationRepository
-				.findByRegistrationId(clientRegistrationId);
-			Assert.notNull(clientRegistration,
-					"Could not find ClientRegistration with id '" + clientRegistrationId + "'");
+
+		OAuth2AuthorizedClientId authorizationKey = getAuthorizationRequestId(clientRegistrationId, principal);
+
+		CompletableFuture<OAuth2AuthorizedClient> authorizationRequest = new CompletableFuture<>();
+
+		/*
+		 * Atomically register this authorization request.
+		 *
+		 * If another thread has already registered an authorization request for the same
+		 * client registration and principal, that request becomes the owner and this
+		 * thread waits for its result.
+		 */
+		CompletableFuture<OAuth2AuthorizedClient> existingAuthorizationRequest = this.authorizationRequests
+			.putIfAbsent(authorizationKey, authorizationRequest);
+
+		if (existingAuthorizationRequest != null) {
+			return waitForAuthorization(existingAuthorizationRequest);
+		}
+
+		try {
 			authorizedClient = this.authorizedClientService.loadAuthorizedClient(clientRegistrationId,
 					principal.getName());
+
 			if (authorizedClient != null) {
-				contextBuilder = OAuth2AuthorizationContext.withAuthorizedClient(authorizedClient);
+				OAuth2AuthorizationContext.Builder contextBuilder = OAuth2AuthorizationContext
+					.withAuthorizedClient(authorizedClient);
+
+				OAuth2AuthorizedClient result = authorize(authorizeRequest, principal, contextBuilder);
+				authorizationRequest.complete(result);
+				return result;
 			}
-			else {
-				contextBuilder = OAuth2AuthorizationContext.withClientRegistration(clientRegistration);
-			}
+
+			ClientRegistration clientRegistration = this.clientRegistrationRepository
+				.findByRegistrationId(clientRegistrationId);
+
+			Assert.notNull(clientRegistration,
+					"Could not find ClientRegistration with id '" + clientRegistrationId + "'");
+
+			OAuth2AuthorizationContext.Builder contextBuilder = OAuth2AuthorizationContext
+				.withClientRegistration(clientRegistration);
+
+			OAuth2AuthorizedClient result = authorize(authorizeRequest, principal, contextBuilder);
+			authorizationRequest.complete(result);
+			return result;
 		}
+		catch (RuntimeException ex) {
+			authorizationRequest.completeExceptionally(ex);
+			throw ex;
+		}
+		catch (Error ex) {
+			authorizationRequest.completeExceptionally(ex);
+			throw ex;
+		}
+		finally {
+			/*
+			 * Only remove the future that this thread inserted.
+			 *
+			 * The conditional remove prevents a completed authorization request from
+			 * accidentally removing a newer request for the same key.
+			 */
+			this.authorizationRequests.remove(authorizationKey, authorizationRequest);
+		}
+	}
+
+	@Nullable private OAuth2AuthorizedClient waitForAuthorization(
+			CompletableFuture<OAuth2AuthorizedClient> authorizationRequest) {
+
+		try {
+			return authorizationRequest.join();
+		}
+		catch (CompletionException ex) {
+			Throwable cause = ex.getCause();
+
+			if (cause instanceof RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+
+			if (cause instanceof Error error) {
+				throw error;
+			}
+
+			throw ex;
+		}
+	}
+
+	@Nullable private OAuth2AuthorizedClient authorize(OAuth2AuthorizeRequest authorizeRequest, Authentication principal,
+			OAuth2AuthorizationContext.Builder contextBuilder) {
+
 		OAuth2AuthorizationContext authorizationContext = buildAuthorizationContext(authorizeRequest, principal,
 				contextBuilder);
+
+		OAuth2AuthorizedClient authorizedClient;
 		try {
 			authorizedClient = this.authorizedClientProvider.authorize(authorizationContext);
 		}
@@ -147,6 +247,7 @@ public final class AuthorizedClientServiceOAuth2AuthorizedClientManager implemen
 			this.authorizationFailureHandler.onAuthorizationFailure(ex, principal, Collections.emptyMap());
 			throw ex;
 		}
+
 		if (authorizedClient != null) {
 			this.authorizationSuccessHandler.onAuthorizationSuccess(authorizedClient, principal,
 					Collections.emptyMap());
@@ -160,6 +261,7 @@ public final class AuthorizedClientServiceOAuth2AuthorizedClientManager implemen
 				return authorizationContext.getAuthorizedClient();
 			}
 		}
+
 		return authorizedClient;
 	}
 

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/AuthorizedClientServiceOAuth2AuthorizedClientManagerTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/AuthorizedClientServiceOAuth2AuthorizedClientManagerTests.java
@@ -17,6 +17,12 @@
 package org.springframework.security.oauth2.client;
 
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -40,9 +46,11 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -227,6 +235,60 @@ public class AuthorizedClientServiceOAuth2AuthorizedClientManagerTests {
 		verify(this.authorizationSuccessHandler).onAuthorizationSuccess(eq(this.authorizedClient), eq(this.principal),
 				any());
 		verify(this.authorizedClientService).saveAuthorizedClient(eq(this.authorizedClient), eq(this.principal));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void authorizeWhenCalledConcurrentlyThenOnlyOneAuthorizationRequest() throws Exception {
+		given(this.clientRegistrationRepository.findByRegistrationId(eq(this.clientRegistration.getRegistrationId())))
+			.willReturn(this.clientRegistration);
+
+		AtomicReference<OAuth2AuthorizedClient> storedAuthorizedClient = new AtomicReference<>();
+
+		CountDownLatch authorizationStarted = new CountDownLatch(1);
+		CountDownLatch continueAuthorization = new CountDownLatch(1);
+
+		given(this.authorizedClientService.loadAuthorizedClient(eq(this.clientRegistration.getRegistrationId()),
+				eq(this.principal.getName())))
+			.willAnswer((invocation) -> storedAuthorizedClient.get());
+
+		given(this.authorizedClientProvider.authorize(any(OAuth2AuthorizationContext.class)))
+			.willAnswer((invocation) -> {
+				authorizationStarted.countDown();
+				continueAuthorization.await(5, TimeUnit.SECONDS);
+				return this.authorizedClient;
+			});
+
+		willAnswer((invocation) -> {
+			storedAuthorizedClient.set(this.authorizedClient);
+			return null;
+		}).given(this.authorizedClientService).saveAuthorizedClient(eq(this.authorizedClient), eq(this.principal));
+
+		OAuth2AuthorizeRequest authorizeRequest = OAuth2AuthorizeRequest
+			.withClientRegistrationId(this.clientRegistration.getRegistrationId())
+			.principal(this.principal)
+			.build();
+
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		try {
+			Future<OAuth2AuthorizedClient> first = executor
+				.submit(() -> this.authorizedClientManager.authorize(authorizeRequest));
+
+			assertThat(authorizationStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+			Future<OAuth2AuthorizedClient> second = executor
+				.submit(() -> this.authorizedClientManager.authorize(authorizeRequest));
+
+			continueAuthorization.countDown();
+
+			assertThat(first.get(5, TimeUnit.SECONDS)).isSameAs(this.authorizedClient);
+			assertThat(second.get(5, TimeUnit.SECONDS)).isSameAs(this.authorizedClient);
+		}
+		finally {
+			executor.shutdownNow();
+		}
+
+		verify(this.authorizedClientProvider, times(1)).authorize(any(OAuth2AuthorizationContext.class));
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

Prevent duplicate OAuth2 client authorization requests when multiple threads concurrently authorize the same client registration and principal.

## Changes

- Coordinate in-flight authorization requests using `OAuth2AuthorizedClientId` and `CompletableFuture`.
- Ensure only one concurrent request invokes the `OAuth2AuthorizedClientProvider` for a given client registration and principal.
- Have concurrent callers wait for and reuse the in-flight authorization result.
- Propagate authorization failures to waiting callers and remove completed in-flight requests safely.
- Add a regression test covering concurrent authorization.

## Validation

- `./gradlew :spring-security-oauth2-client:check`
- `./gradlew :spring-security-oauth2-client:test`
- `./gradlew :spring-security-oauth2-client:checkstyleMain :spring-security-oauth2-client:checkstyleTest`

The branch was rebased onto the latest `upstream/main` before publishing.