### PR TITLE
Document DaoAuthenticationProvider timing-attack mitigation

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -110,6 +110,7 @@
 *** xref:servlet/exploits/headers.adoc[]
 *** xref:servlet/exploits/http.adoc[]
 *** xref:servlet/exploits/firewall.adoc[]
+*** xref:servlet/exploits/timing.adoc[Timing Attacks]
 ** xref:servlet/integrations/index.adoc[Integrations]
 *** xref:servlet/integrations/concurrency.adoc[Concurrency]
 *** xref:servlet/integrations/localization.adoc[Localization]

--- a/docs/modules/ROOT/pages/servlet/authentication/passwords/dao-authentication-provider.adoc
+++ b/docs/modules/ROOT/pages/servlet/authentication/passwords/dao-authentication-provider.adoc
@@ -21,3 +21,14 @@ image:{icondir}/number_4.png[] `DaoAuthenticationProvider` uses the xref:servlet
 
 image:{icondir}/number_5.png[] When authentication is successful, the xref:servlet/authentication/architecture.adoc#servlet-authentication-authentication[`Authentication`] that is returned is of type `UsernamePasswordAuthenticationToken` and has a principal that is the `UserDetails` returned by the configured `UserDetailsService` and a set of authorities containing at least `FACTOR_PASSWORD`.
 Ultimately, the returned `UsernamePasswordAuthenticationToken` is set on the xref:servlet/authentication/architecture.adoc#servlet-authentication-securitycontextholder[`SecurityContextHolder`] by the authentication `Filter`.
+
+[[servlet-authentication-daoauthenticationprovider-timing]]
+== Timing Attack Mitigation
+
+When a username is not found, `DaoAuthenticationProvider` still performs password validation work against an internally generated password by using the configured `PasswordEncoder`.
+This keeps the not-found path closer in duration to the path taken when a user exists, which mitigates username enumeration through timing differences.
+
+Because the same `PasswordEncoder` is used for both paths, the not-found and found paths typically take the same order of magnitude of time when passwords share one encoding algorithm.
+If the credential store contains multiple password hash algorithms, those found paths can differ substantially in cost, so a single not-found duration cannot match every found case.
+Upgrading stored passwords to a modern algorithm reduces that gap.
+See xref:servlet/exploits/timing.adoc#servlet-exploits-timing[Timing Attacks] for more detail.

--- a/docs/modules/ROOT/pages/servlet/exploits/index.adoc
+++ b/docs/modules/ROOT/pages/servlet/exploits/index.adoc
@@ -3,3 +3,4 @@
 :page-section-summary-toc: 1
 
 This section discusses Servlet specific support for xref:features/exploits/index.adoc#exploits[Spring Security's protection against common exploits].
+It also covers xref:servlet/exploits/timing.adoc#servlet-exploits-timing[timing attack] mitigation for username and password authentication.

--- a/docs/modules/ROOT/pages/servlet/exploits/timing.adoc
+++ b/docs/modules/ROOT/pages/servlet/exploits/timing.adoc
@@ -1,0 +1,18 @@
+[[servlet-exploits-timing]]
+= Timing Attacks
+
+A timing attack observes how long an operation takes in order to learn something about secret state.
+For username and password authentication, a common concern is username enumeration: if authenticating with an unknown username is much faster than authenticating with a known username (because password checking is skipped), an attacker can measure response times to discover which usernames exist.
+
+[[servlet-exploits-timing-dao]]
+== DaoAuthenticationProvider
+
+xref:servlet/authentication/passwords/dao-authentication-provider.adoc#servlet-authentication-daoauthenticationprovider[`DaoAuthenticationProvider`] mitigates this by still invoking the configured xref:servlet/authentication/passwords/password-encoder.adoc#servlet-authentication-password-storage[`PasswordEncoder`] when the username is not found.
+It encodes an internally generated password once and, on the not-found path, calls `PasswordEncoder.matches` with the presented password against that value.
+The encoder is the same one used for real users, so the not-found path and a found path that uses that encoder typically take the same order of magnitude of time.
+
+There are limits to when the same timing is plausible.
+If a credential store contains more than one kind of password hash, found users can take orders of magnitude different amounts of time depending on which algorithm their stored password uses.
+Spring Security cannot anticipate a single not-found duration that matches every found scenario in that case.
+The best defense is to upgrade user passwords to a modern password algorithm so that validation cost is consistent.
+See xref:features/authentication/password-storage.adoc#authentication-password-storage-dpe[`DelegatingPasswordEncoder`] for migrating encodings over time.


### PR DESCRIPTION
Document that `DaoAuthenticationProvider` mitigates username-enumeration timing attacks on the user-not-found path by performing equivalent password-encoding work, and note the limitation when mixed `PasswordEncoder` / hash algorithms are in use.

Changes are aligned with the current `retrieveUser` / `mitigateAgainstTimingAttack` implementation.

Closes #19082