### PR TITLE
Prevent circular ACL parent relationships

### DIFF
--- a/acl/src/main/java/org/springframework/security/acls/domain/AclImpl.java
+++ b/acl/src/main/java/org/springframework/security/acls/domain/AclImpl.java
@@ -247,7 +247,11 @@ public class AclImpl implements Acl, MutableAcl, AuditableAcl, OwnershipAcl {
 	@Override
 	public void setParent(@Nullable Acl newParent) {
 		this.aclAuthorizationStrategy.securityCheck(this, AclAuthorizationStrategy.CHANGE_GENERAL);
-		Assert.isTrue(newParent == null || !newParent.equals(this), "Cannot be the parent of yourself");
+		Acl parent = newParent;
+		while (parent != null) {
+			Assert.isTrue(parent != this, "Cannot create a circular parent relationship");
+			parent = parent.getParentAcl();
+		}
 		this.parentAcl = newParent;
 	}
 

--- a/acl/src/test/java/org/springframework/security/acls/domain/AclImplTests.java
+++ b/acl/src/test/java/org/springframework/security/acls/domain/AclImplTests.java
@@ -392,6 +392,33 @@ public class AclImplTests {
 	}
 
 	@Test
+	public void setParentRejectsAncestor() {
+		MutableAcl parentAcl = new AclImpl(new ObjectIdentityImpl(TARGET_CLASS, 101), 101,
+				this.authzStrategy, this.pgs, null, null, true, new PrincipalSid("joe"));
+		MutableAcl childAcl = new AclImpl(new ObjectIdentityImpl(TARGET_CLASS, 102), 102,
+				this.authzStrategy, this.pgs, null, null, true, new PrincipalSid("joe"));
+
+		childAcl.setParent(parentAcl);
+
+		assertThatIllegalArgumentException().isThrownBy(() -> parentAcl.setParent(childAcl));
+	}
+
+	@Test
+	public void setParentRejectsIndirectAncestor() {
+		MutableAcl grandParentAcl = new AclImpl(new ObjectIdentityImpl(TARGET_CLASS, 101), 101,
+				this.authzStrategy, this.pgs, null, null, true, new PrincipalSid("joe"));
+		MutableAcl parentAcl = new AclImpl(new ObjectIdentityImpl(TARGET_CLASS, 102), 102,
+				this.authzStrategy, this.pgs, null, null, true, new PrincipalSid("joe"));
+		MutableAcl childAcl = new AclImpl(new ObjectIdentityImpl(TARGET_CLASS, 103), 103,
+				this.authzStrategy, this.pgs, null, null, true, new PrincipalSid("joe"));
+
+		parentAcl.setParent(grandParentAcl);
+		childAcl.setParent(parentAcl);
+
+		assertThatIllegalArgumentException().isThrownBy(() -> grandParentAcl.setParent(childAcl));
+	}
+
+	@Test
 	public void isSidLoadedBehavesAsExpected() {
 		List<Sid> loadedSids = Arrays.asList(new PrincipalSid("ben"), new GrantedAuthoritySid("ROLE_IGNORED"));
 		MutableAcl acl = new AclImpl(this.objectIdentity, 1, this.authzStrategy, this.pgs, null, loadedSids, true,


### PR DESCRIPTION
Closes #19513

This change prevents circular parent relationships from being created
when configuring ACL hierarchies.

Previously, `AclImpl#setParent` only prevented an ACL from being
assigned itself as its parent. This allowed indirect circular
relationships to be created.

The implementation now walks the existing parent hierarchy and rejects
a relationship when the current ACL instance is encountered.

Tests were added for both direct and indirect circular parent
relationships.

Existing parent-changing behavior is also covered by the existing test
suite.

Tests:
- `./gradlew :spring-security-acl:test`