### PR TITLE
Fix SecurityObservationSettings sample in docs

### DIFF
--- a/docs/modules/ROOT/pages/servlet/integrations/observability.adoc
+++ b/docs/modules/ROOT/pages/servlet/integrations/observability.adoc
@@ -261,7 +261,7 @@ Java::
 @Bean
 SecurityObservationSettings allSpringSecurityObservations() {
 	return SecurityObservationSettings.withDefaults()
-            .shouldObserveFilterChains(true).build();
+            .shouldObserveRequests(true).build();
 }
 ----
 
@@ -271,8 +271,8 @@ Kotlin::
 ----
 @Bean
 fun allSpringSecurityObservations(): SecurityObservationSettings {
-    return SecurityObservationSettings.builder()
-            .shouldObserveFilterChains(true).build()
+    return SecurityObservationSettings.withDefaults()
+            .shouldObserveRequests(true).build()
 }
 ----
 ======


### PR DESCRIPTION
The "turn on and off observations individually" sample in the Observability
section does not compile against any released version of Spring Security.

Two problems in the same snippet:

- The Java sample calls `.shouldObserveFilterChains(true)`.
  `SecurityObservationSettings.Builder` exposes `shouldObserveRequests`,
  `shouldObserveAuthentications`, `shouldObserveAuthorizations` and `build` —
  there is no `shouldObserveFilterChains`.
- The Kotlin sample additionally calls `SecurityObservationSettings.builder()`.
  The class only offers the static factories `noObservations()` and
  `withDefaults()`; there is no `builder()`.

Since the surrounding prose is about re-enabling the filter chain observations
that `withDefaults()` turns off, `shouldObserveRequests(true)` is the intended
call — `observeRequests` is the field that gates
`spring.security.http.secured.requests`.

This changes documentation only; no runtime behaviour is affected.

I ran into this while checking a training module against the reference docs: the
lab used `shouldObserveRequests(true)` and I initially "corrected" it to match
the documentation, which then failed to compile.

Happy to fold in the Kotlin `builder()` fix separately if you would rather keep
the two changes apart.
