### PR TITLE
Add RuntimeHints for FactorGrantedAuthority

### DIFF
--- a/core/src/main/java/org/springframework/security/aot/hint/CoreSecurityRuntimeHints.java
+++ b/core/src/main/java/org/springframework/security/aot/hint/CoreSecurityRuntimeHints.java
@@ -16,6 +16,7 @@
 
 package org.springframework.security.aot.hint;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -46,6 +47,7 @@ import org.springframework.security.authentication.event.AuthenticationFailurePr
 import org.springframework.security.authentication.event.AuthenticationFailureProxyUntrustedEvent;
 import org.springframework.security.authentication.event.AuthenticationFailureServiceExceptionEvent;
 import org.springframework.security.authentication.ott.OneTimeTokenAuthentication;
+import org.springframework.security.core.authority.FactorGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.core.userdetails.jdbc.JdbcDaoImpl;
@@ -67,6 +69,7 @@ class CoreSecurityRuntimeHints implements RuntimeHintsRegistrar {
 		hints.resources().registerResourceBundle("org.springframework.security.messages");
 		registerDefaultJdbcSchemaFileHint(hints);
 		registerSecurityContextHints(hints);
+		registerFactorGrantedAuthorityHints(hints);
 	}
 
 	private void registerMethodSecurityHints(RuntimeHints hints) {
@@ -116,6 +119,17 @@ class CoreSecurityRuntimeHints implements RuntimeHintsRegistrar {
 		hints.reflection()
 			.registerType(SecurityContextImpl.class,
 					(builder) -> builder.withMembers(MemberCategory.INVOKE_PUBLIC_METHODS));
+	}
+
+	private void registerFactorGrantedAuthorityHints(RuntimeHints hints) {
+		// FactorGrantedAuthority is java.io.Serializable and carries an Instant, so it
+		// needs both reflection and Java serialization hints to be cached with, for
+		// example, Spring Session's JdkSerializationRedisSerializer under a native
+		// image. Instant's own serialized form delegates to the JDK-internal
+		// java.time.Ser proxy, which needs the same treatment.
+		hints.reflection()
+			.registerTypes(List.of(TypeReference.of(FactorGrantedAuthority.class), TypeReference.of(Instant.class),
+					TypeReference.of("java.time.Ser")), (builder) -> builder.withJavaSerialization(true));
 	}
 
 	private void registerAdditionalAuthenticationTypes(RuntimeHints hints) {

--- a/core/src/test/java/org/springframework/security/aot/hint/CoreSecurityRuntimeHintsTests.java
+++ b/core/src/test/java/org/springframework/security/aot/hint/CoreSecurityRuntimeHintsTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.security.aot.hint;
 
+import java.time.Instant;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +50,7 @@ import org.springframework.security.authentication.event.AuthenticationFailurePr
 import org.springframework.security.authentication.event.AuthenticationFailureProxyUntrustedEvent;
 import org.springframework.security.authentication.event.AuthenticationFailureServiceExceptionEvent;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.FactorGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.util.ClassUtils;
@@ -149,6 +151,38 @@ class CoreSecurityRuntimeHintsTests {
 		assertThat(RuntimeHintsPredicates.reflection()
 			.onType(SecurityContextImpl.class)
 			.withMemberCategories(MemberCategory.INVOKE_PUBLIC_METHODS)).accepts(this.hints);
+	}
+
+	@Test
+	void factorGrantedAuthorityHasReflectionHints() {
+		assertThat(RuntimeHintsPredicates.reflection().onType(FactorGrantedAuthority.class)).accepts(this.hints);
+	}
+
+	@Test
+	void factorGrantedAuthorityHasJavaSerializationHints() {
+		assertThat(RuntimeHintsPredicates.reflection().onJavaSerialization(FactorGrantedAuthority.class, true))
+			.accepts(this.hints);
+	}
+
+	@Test
+	void instantHasReflectionHints() {
+		assertThat(RuntimeHintsPredicates.reflection().onType(Instant.class)).accepts(this.hints);
+	}
+
+	@Test
+	void instantHasJavaSerializationHints() {
+		assertThat(RuntimeHintsPredicates.reflection().onJavaSerialization(Instant.class, true)).accepts(this.hints);
+	}
+
+	@Test
+	void javaTimeSerHasReflectionHints() {
+		assertThat(RuntimeHintsPredicates.reflection().onType(TypeReference.of("java.time.Ser"))).accepts(this.hints);
+	}
+
+	@Test
+	void javaTimeSerHasJavaSerializationHints() {
+		assertThat(RuntimeHintsPredicates.reflection().onJavaSerialization(TypeReference.of("java.time.Ser"), true))
+			.accepts(this.hints);
 	}
 
 }


### PR DESCRIPTION
## Summary

`FactorGrantedAuthority` shipped without any `RuntimeHints` registration, so under a GraalVM native image it has no reflection or Java-serialization support. This breaks any caller that serializes it via plain Java serialization — for example Spring Session Data Redis's `JdkSerializationRedisSerializer` — which fails with:

```
com.oracle.svm.core.jdk.UnsupportedFeatureError: SerializationConstructorAccessor class not found for declaringClass: org.springframework.security.core.authority.FactorGrantedAuthority (targetConstructorClass: java.lang.Object)
```

`FactorGrantedAuthority` carries a `java.time.Instant`, whose own serialized form delegates to the JDK-internal `java.time.Ser` proxy class, so that type needs the same treatment (referenced via `TypeReference.of("java.time.Ser")` since it isn't public API).

This registers reflection and Java-serialization hints for `FactorGrantedAuthority`, `Instant`, and `java.time.Ser` in the existing `CoreSecurityRuntimeHints`, using `TypeHint.Builder#withJavaSerialization`, alongside the other `Authentication`-related types it already covers for the same class of problem.

Credit to @k6leung, who diagnosed the root cause and validated this exact set of hints as a workaround in #18739.

## Test plan

- [x] Added `RuntimeHintsPredicates`-based tests to `CoreSecurityRuntimeHintsTests` asserting reflection and Java-serialization hints are registered for `FactorGrantedAuthority`, `Instant`, and `java.time.Ser`.
- [x] `./gradlew :spring-security-core:test` — full module suite passes.

Closes gh-18739