### PR TITLE
Add regression test for FactorGrantedAuthority Jackson support

### DIFF
--- a/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/jackson/OAuth2AuthorizationServerJacksonModuleTests.java
+++ b/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/jackson/OAuth2AuthorizationServerJacksonModuleTests.java
@@ -27,6 +27,8 @@ import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.FactorGrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.jackson.SecurityJacksonModules;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.JwtClaimNames;
@@ -63,6 +65,19 @@ public class OAuth2AuthorizationServerJacksonModuleTests {
 	@Test
 	public void readValueWhenOAuth2AuthorizationAttributesThenSuccess() {
 		Authentication principal = new UsernamePasswordAuthenticationToken("principal", "credentials");
+		OAuth2Authorization authorization = TestOAuth2Authorizations.authorization()
+			.attributes((attrs) -> attrs.put(Principal.class.getName(), principal))
+			.build();
+		Map<String, Object> attributes = authorization.getAttributes();
+		String json = this.mapper.writeValueAsString(attributes);
+		assertThat(this.mapper.readValue(json, STRING_OBJECT_MAP)).isEqualTo(attributes);
+	}
+
+	@Test
+	public void readValueWhenOAuth2AuthorizationAttributesWithFactorGrantedAuthorityThenSuccess() {
+		Authentication principal = UsernamePasswordAuthenticationToken.authenticated("principal", "credentials",
+				List.of(new SimpleGrantedAuthority("ROLE_USER"),
+						FactorGrantedAuthority.fromAuthority(FactorGrantedAuthority.PASSWORD_AUTHORITY)));
 		OAuth2Authorization authorization = TestOAuth2Authorizations.authorization()
 			.attributes((attrs) -> attrs.put(Principal.class.getName(), principal))
 			.build();

--- a/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/jackson2/OAuth2AuthorizationServerJackson2ModuleTests.java
+++ b/oauth2/oauth2-authorization-server/src/test/java/org/springframework/security/oauth2/server/authorization/jackson2/OAuth2AuthorizationServerJackson2ModuleTests.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.FactorGrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.jackson2.SecurityJackson2Modules;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.JwtClaimNames;
@@ -66,6 +68,19 @@ public class OAuth2AuthorizationServerJackson2ModuleTests {
 	@Test
 	public void readValueWhenOAuth2AuthorizationAttributesThenSuccess() throws Exception {
 		Authentication principal = new UsernamePasswordAuthenticationToken("principal", "credentials");
+		OAuth2Authorization authorization = TestOAuth2Authorizations.authorization()
+			.attributes((attrs) -> attrs.put(Principal.class.getName(), principal))
+			.build();
+		Map<String, Object> attributes = authorization.getAttributes();
+		String json = this.objectMapper.writeValueAsString(attributes);
+		assertThat(this.objectMapper.readValue(json, STRING_OBJECT_MAP)).isEqualTo(attributes);
+	}
+
+	@Test
+	public void readValueWhenOAuth2AuthorizationAttributesWithFactorGrantedAuthorityThenSuccess() throws Exception {
+		Authentication principal = UsernamePasswordAuthenticationToken.authenticated("principal", "credentials",
+				List.of(new SimpleGrantedAuthority("ROLE_USER"),
+						FactorGrantedAuthority.fromAuthority(FactorGrantedAuthority.PASSWORD_AUTHORITY)));
 		OAuth2Authorization authorization = TestOAuth2Authorizations.authorization()
 			.attributes((attrs) -> attrs.put(Principal.class.getName(), principal))
 			.build();


### PR DESCRIPTION
## Summary

#18771 reports that `JdbcOAuth2AuthorizationService` fails to deserialize `FactorGrantedAuthority` because of a missing Jackson mixin, and @k6leung validated a `FactorGrantedAuthorityMixin` + module as a workaround.

Investigating on current `main`, `FactorGrantedAuthorityMixin` already exists and is already registered in both `CoreJackson2Module` and `CoreJacksonModule` — it was added together with `FactorGrantedAuthority` itself, before this issue was filed. A from-scratch reproduction (round-tripping a `UsernamePasswordAuthenticationToken` whose authorities include a `FactorGrantedAuthority`, through the exact `ObjectMapper`/`JsonMapper` setup `JdbcOAuth2AuthorizationService` builds internally) already passes on `main`, so adding another mixin would just duplicate existing plumbing.

Rather than duplicate that fix, this PR adds a regression test — to `OAuth2AuthorizationServerJackson2ModuleTests` and its Jackson 3 counterpart `OAuth2AuthorizationServerJacksonModuleTests` — that locks in the already-working round trip so a future regression here is caught before release. I verified the test is non-tautological by temporarily reverting the mixin registration locally and confirming both new tests fail without it.

I'll comment on #18771 to let @k6leung know the underlying mixin is already fixed on `main`.

## Test plan

- [x] Added `readValueWhenOAuth2AuthorizationAttributesWithFactorGrantedAuthorityThenSuccess` to both `OAuth2AuthorizationServerJackson2ModuleTests` and `OAuth2AuthorizationServerJacksonModuleTests`.
- [x] Verified the new tests fail if the `FactorGrantedAuthorityMixin` registration is reverted, confirming they're not tautological.
- [x] `./gradlew :spring-security-oauth2-authorization-server:test` — full module suite passes.

Closes gh-18771