### PR TITLE
Fix DefaultBearerTokenResolver rejecting RFC-legal multi-space Authorization header

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
@@ -42,7 +42,7 @@ public final class DefaultBearerTokenResolver implements BearerTokenResolver {
 
 	private static final String ACCESS_TOKEN_PARAMETER_NAME = "access_token";
 
-	private static final Pattern authorizationPattern = Pattern.compile("^Bearer (?<token>[a-zA-Z0-9-._~+/]+=*)$",
+	private static final Pattern authorizationPattern = Pattern.compile("^Bearer +(?<token>[a-zA-Z0-9-._~+/]+=*)$",
 			Pattern.CASE_INSENSITIVE);
 
 	private boolean allowFormEncodedBodyParameter = false;

--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverter.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverter.java
@@ -52,7 +52,7 @@ public class ServerBearerTokenAuthenticationConverter implements ServerAuthentic
 
 	private static final String ACCESS_TOKEN_PARAMETER_NAME = "access_token";
 
-	private static final Pattern authorizationPattern = Pattern.compile("^Bearer (?<token>[a-zA-Z0-9-._~+/]+=*)$",
+	private static final Pattern authorizationPattern = Pattern.compile("^Bearer +(?<token>[a-zA-Z0-9-._~+/]+=*)$",
 			Pattern.CASE_INSENSITIVE);
 
 	private boolean allowFormEncodedBodyParameter = false;

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
@@ -55,6 +55,39 @@ public class DefaultBearerTokenResolverTests {
 		assertThat(this.resolver.resolve(request)).isEqualTo(TEST_TOKEN);
 	}
 
+	// gh-19500
+	@Test
+	public void resolveWhenValidHeaderWithOneSpaceIsPresentThenTokenIsResolved() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Bearer " + TEST_TOKEN);
+		assertThat(this.resolver.resolve(request)).isEqualTo(TEST_TOKEN);
+	}
+
+	// gh-19500
+	@Test
+	public void resolveWhenValidHeaderWithTwoSpacesIsPresentThenTokenIsResolved() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Bearer  " + TEST_TOKEN);
+		assertThat(this.resolver.resolve(request)).isEqualTo(TEST_TOKEN);
+	}
+
+	// gh-19500
+	@Test
+	public void resolveWhenValidHeaderWithThreeSpacesIsPresentThenTokenIsResolved() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Bearer   " + TEST_TOKEN);
+		assertThat(this.resolver.resolve(request)).isEqualTo(TEST_TOKEN);
+	}
+
+	// gh-19500
+	@Test
+	public void resolveWhenHeaderWithZeroSpacesIsPresentThenTokenIsNotResolved() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Bearer" + TEST_TOKEN);
+		assertThatExceptionOfType(OAuth2AuthenticationException.class).isThrownBy(() -> this.resolver.resolve(request))
+			.withMessageContaining(("Bearer token is malformed"));
+	}
+
 	// gh-8502
 	@Test
 	public void resolveWhenHeaderEndsWithPaddingIndicatorThenTokenIsResolved() {

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverterTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/server/authentication/ServerBearerTokenAuthenticationConverterTests.java
@@ -60,6 +60,40 @@ public class ServerBearerTokenAuthenticationConverterTests {
 		assertThat(convertToToken(request).getToken()).isEqualTo(TEST_TOKEN);
 	}
 
+	// gh-19500
+	@Test
+	public void resolveWhenValidHeaderWithOneSpaceIsPresentThenTokenIsResolved() {
+		MockServerHttpRequest.BaseBuilder<?> request = MockServerHttpRequest.get("/")
+				.header(HttpHeaders.AUTHORIZATION, "Bearer " + TEST_TOKEN);
+		assertThat(convertToToken(request).getToken()).isEqualTo(TEST_TOKEN);
+	}
+
+	// gh-19500
+	@Test
+	public void resolveWhenValidHeaderWithTwoSpacesIsPresentThenTokenIsResolved() {
+		MockServerHttpRequest.BaseBuilder<?> request = MockServerHttpRequest.get("/")
+				.header(HttpHeaders.AUTHORIZATION, "Bearer  " + TEST_TOKEN);
+		assertThat(convertToToken(request).getToken()).isEqualTo(TEST_TOKEN);
+	}
+
+	// gh-19500
+	@Test
+	public void resolveWhenValidHeaderWithThreeSpacesIsPresentThenTokenIsResolved() {
+		MockServerHttpRequest.BaseBuilder<?> request = MockServerHttpRequest.get("/")
+				.header(HttpHeaders.AUTHORIZATION, "Bearer   " + TEST_TOKEN);
+		assertThat(convertToToken(request).getToken()).isEqualTo(TEST_TOKEN);
+	}
+
+	// gh-19500
+	@Test
+	public void resolveWhenHeaderWithZeroSpacesIsPresentThenTokenIsNotResolved() {
+		MockServerHttpRequest.BaseBuilder<?> request = MockServerHttpRequest.get("/")
+				.header(HttpHeaders.AUTHORIZATION, "Bearer" + TEST_TOKEN);
+		assertThatExceptionOfType(OAuth2AuthenticationException.class)
+				.isThrownBy(() -> convertToToken(request))
+				.withMessageContaining("Bearer token is malformed");
+	}
+
 	// gh-8502
 	@Test
 	public void resolveWhenHeaderEndsWithPaddingIndicatorThenTokenIsResolved() {


### PR DESCRIPTION
Closes gh-19500

RFC 6750 allows one or more spaces between `Bearer` and the token. This change updates the regex patterns in `DefaultBearerTokenResolver` and `ServerBearerTokenAuthenticationConverter` to accept `Bearer +` instead of `Bearer `.

Tests have been added to verify that 1, 2, and 3 spaces are accepted, while 0 spaces are rejected.