### PR TITLE
Add OAuth2 Jackson runtime hints

### DIFF
--- a/core/src/main/java/org/springframework/security/aot/hint/CoreSecurityRuntimeHints.java
+++ b/core/src/main/java/org/springframework/security/aot/hint/CoreSecurityRuntimeHints.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.aot.hint.BindingReflectionHintsRegistrar;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
@@ -49,6 +50,7 @@ import org.springframework.security.authentication.ott.OneTimeTokenAuthenticatio
 import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.core.userdetails.jdbc.JdbcDaoImpl;
+import org.springframework.util.ClassUtils;
 
 /**
  * {@link RuntimeHintsRegistrar} for core classes
@@ -57,6 +59,8 @@ import org.springframework.security.core.userdetails.jdbc.JdbcDaoImpl;
  * @since 6.0
  */
 class CoreSecurityRuntimeHints implements RuntimeHintsRegistrar {
+
+	private final BindingReflectionHintsRegistrar bindingReflectionHintsRegistrar = new BindingReflectionHintsRegistrar();
 
 	@Override
 	public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
@@ -67,6 +71,64 @@ class CoreSecurityRuntimeHints implements RuntimeHintsRegistrar {
 		hints.resources().registerResourceBundle("org.springframework.security.messages");
 		registerDefaultJdbcSchemaFileHint(hints);
 		registerSecurityContextHints(hints);
+		registerJacksonHints(hints, classLoader);
+	}
+
+	private void registerJacksonHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
+		ClassLoader loader = (classLoader != null) ? classLoader : ClassUtils.getDefaultClassLoader();
+		boolean jackson2Present = ClassUtils.isPresent("com.fasterxml.jackson.databind.ObjectMapper", loader)
+				&& ClassUtils.isPresent("com.fasterxml.jackson.core.JsonGenerator", loader);
+		boolean jackson3Present = ClassUtils.isPresent("tools.jackson.databind.json.JsonMapper", loader);
+		if (!jackson2Present && !jackson3Present) {
+			return;
+		}
+		hints.reflection()
+			.registerTypes(getJacksonBindingTypes(),
+					(builder) -> builder.withMembers(MemberCategory.ACCESS_DECLARED_FIELDS,
+							MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.INVOKE_DECLARED_METHODS));
+		if (jackson2Present) {
+			registerJacksonModule(hints, "org.springframework.security.jackson2.CoreJackson2Module");
+			registerJacksonMixins(hints, loader, "org.springframework.security.jackson2",
+					"AnonymousAuthenticationTokenMixin", "BadCredentialsExceptionMixin", "FactorGrantedAuthorityMixin",
+					"OneTimeTokenAuthenticationTokenMixin", "RememberMeAuthenticationTokenMixin",
+					"SimpleGrantedAuthorityMixin", "UnmodifiableListMixin", "UnmodifiableMapMixin",
+					"UnmodifiableSetMixin", "UserMixin", "UsernamePasswordAuthenticationTokenMixin");
+		}
+		if (jackson3Present) {
+			registerJacksonModule(hints, "org.springframework.security.jackson.CoreJacksonModule");
+			registerJacksonMixins(hints, loader, "org.springframework.security.jackson",
+					"AnonymousAuthenticationTokenMixin", "BadCredentialsExceptionMixin", "FactorGrantedAuthorityMixin",
+					"OneTimeTokenAuthenticationMixin", "RememberMeAuthenticationTokenMixin",
+					"SimpleGrantedAuthorityMixin", "TestingAuthenticationTokenMixin", "UserMixin",
+					"UsernamePasswordAuthenticationTokenMixin");
+		}
+	}
+
+	private List<TypeReference> getJacksonBindingTypes() {
+		return List.of(TypeReference.of("org.springframework.security.authentication.AbstractAuthenticationToken"),
+				TypeReference.of("org.springframework.security.authentication.AnonymousAuthenticationToken"),
+				TypeReference.of("org.springframework.security.authentication.BadCredentialsException"),
+				TypeReference.of("org.springframework.security.authentication.RememberMeAuthenticationToken"),
+				TypeReference.of("org.springframework.security.authentication.TestingAuthenticationToken"),
+				TypeReference.of("org.springframework.security.authentication.UsernamePasswordAuthenticationToken"),
+				TypeReference.of("org.springframework.security.authentication.ott.OneTimeTokenAuthentication"),
+				TypeReference.of("org.springframework.security.authentication.ott.OneTimeTokenAuthenticationToken"),
+				TypeReference.of("org.springframework.security.core.authority.FactorGrantedAuthority"),
+				TypeReference.of("org.springframework.security.core.authority.SimpleGrantedAuthority"),
+				TypeReference.of("org.springframework.security.core.context.SecurityContextImpl"),
+				TypeReference.of("org.springframework.security.core.userdetails.User"));
+	}
+
+	private void registerJacksonModule(RuntimeHints hints, String moduleClassName) {
+		hints.reflection().registerType(TypeReference.of(moduleClassName), MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
+	}
+
+	private void registerJacksonMixins(RuntimeHints hints, @Nullable ClassLoader classLoader, String packageName,
+			String... mixinClassNames) {
+		for (String mixinClassName : mixinClassNames) {
+			Class<?> mixinClass = ClassUtils.resolveClassName(packageName + "." + mixinClassName, classLoader);
+			this.bindingReflectionHintsRegistrar.registerReflectionHints(hints.reflection(), mixinClass);
+		}
 	}
 
 	private void registerMethodSecurityHints(RuntimeHints hints) {

--- a/core/src/test/java/org/springframework/security/aot/hint/CoreSecurityRuntimeHintsTests.java
+++ b/core/src/test/java/org/springframework/security/aot/hint/CoreSecurityRuntimeHintsTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.security.aot.hint;
 
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -148,7 +149,84 @@ class CoreSecurityRuntimeHintsTests {
 	void securityContextHasHints() {
 		assertThat(RuntimeHintsPredicates.reflection()
 			.onType(SecurityContextImpl.class)
-			.withMemberCategories(MemberCategory.INVOKE_PUBLIC_METHODS)).accepts(this.hints);
+			.withMemberCategories(MemberCategory.INVOKE_PUBLIC_METHODS, MemberCategory.ACCESS_DECLARED_FIELDS,
+					MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.INVOKE_DECLARED_METHODS))
+			.accepts(this.hints);
+	}
+
+	@Test
+	void factorGrantedAuthorityHasJacksonBindingHints() {
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(TypeReference.of("org.springframework.security.core.authority.FactorGrantedAuthority"))
+			.withMemberCategories(MemberCategory.ACCESS_DECLARED_FIELDS, MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+					MemberCategory.INVOKE_DECLARED_METHODS))
+			.accepts(this.hints);
+	}
+
+	@ParameterizedTest
+	@MethodSource("getJacksonModuleTypes")
+	void jacksonModulesHaveHints(TypeReference moduleType) {
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(moduleType)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS)).accepts(this.hints);
+	}
+
+	private static Stream<TypeReference> getJacksonModuleTypes() {
+		return Stream.of(TypeReference.of("org.springframework.security.jackson2.CoreJackson2Module"),
+				TypeReference.of("org.springframework.security.jackson.CoreJacksonModule"));
+	}
+
+	@Test
+	void jacksonHintsUseProvidedClassLoader() {
+		assertJacksonModuleVisibility(hideClasses("tools.jackson.databind.json.JsonMapper"), true, false);
+		assertJacksonModuleVisibility(
+				hideClasses("com.fasterxml.jackson.databind.ObjectMapper", "com.fasterxml.jackson.core.JsonGenerator"),
+				false, true);
+		assertJacksonModuleVisibility(hideClasses("com.fasterxml.jackson.databind.ObjectMapper",
+				"com.fasterxml.jackson.core.JsonGenerator", "tools.jackson.databind.json.JsonMapper"), false, false);
+	}
+
+	private void assertJacksonModuleVisibility(ClassLoader classLoader, boolean jackson2, boolean jackson3) {
+		RuntimeHints hints = new RuntimeHints();
+		new CoreSecurityRuntimeHints().registerHints(hints, classLoader);
+		assertThat(hints.reflection()
+			.getTypeHint(TypeReference.of("org.springframework.security.jackson2.CoreJackson2Module")) != null)
+			.isEqualTo(jackson2);
+		assertThat(hints.reflection()
+			.getTypeHint(TypeReference.of("org.springframework.security.jackson.CoreJacksonModule")) != null)
+			.isEqualTo(jackson3);
+	}
+
+	private static ClassLoader hideClasses(String... classNames) {
+		Set<String> hiddenClasses = Set.of(classNames);
+		return new ClassLoader(ClassUtils.getDefaultClassLoader()) {
+			@Override
+			protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+				if (hiddenClasses.contains(name)) {
+					throw new ClassNotFoundException(name);
+				}
+				return super.loadClass(name, resolve);
+			}
+		};
+	}
+
+	@ParameterizedTest
+	@MethodSource("getJacksonDeserializerTypes")
+	void jacksonDeserializersHaveHints(TypeReference deserializerType) {
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(deserializerType)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS)).accepts(this.hints);
+	}
+
+	private static Stream<TypeReference> getJacksonDeserializerTypes() {
+		return Stream.of(TypeReference.of("org.springframework.security.jackson2.UnmodifiableListDeserializer"),
+				TypeReference.of("org.springframework.security.jackson2.UnmodifiableMapDeserializer"),
+				TypeReference.of("org.springframework.security.jackson2.UnmodifiableSetDeserializer"),
+				TypeReference.of("org.springframework.security.jackson2.UserDeserializer"),
+				TypeReference
+					.of("org.springframework.security.jackson2.UsernamePasswordAuthenticationTokenDeserializer"),
+				TypeReference.of("org.springframework.security.jackson.UserDeserializer"), TypeReference
+					.of("org.springframework.security.jackson.UsernamePasswordAuthenticationTokenDeserializer"));
 	}
 
 }

--- a/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/aot/hint/OAuth2ClientRuntimeHints.java
+++ b/oauth2/oauth2-client/src/main/java/org/springframework/security/oauth2/client/aot/hint/OAuth2ClientRuntimeHints.java
@@ -16,8 +16,11 @@
 
 package org.springframework.security.oauth2.client.aot.hint;
 
+import java.util.List;
+
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.aot.hint.BindingReflectionHintsRegistrar;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
@@ -40,11 +43,71 @@ class OAuth2ClientRuntimeHints implements RuntimeHintsRegistrar {
 				&& ClassUtils.isPresent("org.springframework.r2dbc.core.DatabaseClient", classLoader);
 	}
 
+	private final BindingReflectionHintsRegistrar bindingReflectionHintsRegistrar = new BindingReflectionHintsRegistrar();
+
 	@Override
 	public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
 		registerOAuth2ClientSchemaFilesHints(hints);
+		registerJacksonHints(hints, classLoader);
 		if (r2dbcPresent) {
 			registerR2dbcHints(hints);
+		}
+	}
+
+	private void registerJacksonHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
+		ClassLoader loader = (classLoader != null) ? classLoader : ClassUtils.getDefaultClassLoader();
+		boolean jackson2Present = ClassUtils.isPresent("com.fasterxml.jackson.databind.ObjectMapper", loader)
+				&& ClassUtils.isPresent("com.fasterxml.jackson.core.JsonGenerator", loader);
+		boolean jackson3Present = ClassUtils.isPresent("tools.jackson.databind.json.JsonMapper", loader);
+		if (!jackson2Present && !jackson3Present) {
+			return;
+		}
+		hints.reflection()
+			.registerTypes(getOAuth2ClientTypes(),
+					(builder) -> builder.withMembers(MemberCategory.ACCESS_DECLARED_FIELDS,
+							MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.INVOKE_DECLARED_METHODS));
+		if (jackson2Present) {
+			registerJacksonModule(hints,
+					"org.springframework.security.oauth2.client.jackson2.OAuth2ClientJackson2Module");
+			registerJacksonMixins(hints, loader, "org.springframework.security.oauth2.client.jackson2");
+		}
+		if (jackson3Present) {
+			registerJacksonModule(hints,
+					"org.springframework.security.oauth2.client.jackson.OAuth2ClientJacksonModule");
+			registerJacksonMixins(hints, loader, "org.springframework.security.oauth2.client.jackson");
+		}
+	}
+
+	private List<TypeReference> getOAuth2ClientTypes() {
+		return List.of(TypeReference.of("org.springframework.security.oauth2.client.OAuth2AuthorizedClient"),
+				TypeReference.of("org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken"),
+				TypeReference.of("org.springframework.security.oauth2.client.registration.ClientRegistration"),
+				TypeReference.of("org.springframework.security.oauth2.core.OAuth2AccessToken"),
+				TypeReference.of("org.springframework.security.oauth2.core.OAuth2AuthenticationException"),
+				TypeReference.of("org.springframework.security.oauth2.core.OAuth2Error"),
+				TypeReference.of("org.springframework.security.oauth2.core.OAuth2RefreshToken"),
+				TypeReference.of("org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest"),
+				TypeReference.of("org.springframework.security.oauth2.core.oidc.OidcIdToken"),
+				TypeReference.of("org.springframework.security.oauth2.core.oidc.OidcUserInfo"),
+				TypeReference.of("org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser"),
+				TypeReference.of("org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority"),
+				TypeReference.of("org.springframework.security.oauth2.core.user.DefaultOAuth2User"),
+				TypeReference.of("org.springframework.security.oauth2.core.user.OAuth2UserAuthority"));
+	}
+
+	private void registerJacksonModule(RuntimeHints hints, String moduleClassName) {
+		hints.reflection().registerType(TypeReference.of(moduleClassName), MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
+	}
+
+	private void registerJacksonMixins(RuntimeHints hints, @Nullable ClassLoader classLoader, String packageName) {
+		String[] mixinClassNames = { "ClientRegistrationMixin", "DefaultOAuth2UserMixin", "DefaultOidcUserMixin",
+				"OAuth2AccessTokenMixin", "OAuth2AuthenticationExceptionMixin", "OAuth2AuthenticationTokenMixin",
+				"OAuth2AuthorizationRequestMixin", "OAuth2AuthorizedClientMixin", "OAuth2ErrorMixin",
+				"OAuth2RefreshTokenMixin", "OAuth2UserAuthorityMixin", "OidcIdTokenMixin", "OidcUserAuthorityMixin",
+				"OidcUserInfoMixin" };
+		for (String mixinClassName : mixinClassNames) {
+			Class<?> mixinClass = ClassUtils.resolveClassName(packageName + "." + mixinClassName, classLoader);
+			this.bindingReflectionHintsRegistrar.registerReflectionHints(hints.reflection(), mixinClass);
 		}
 	}
 

--- a/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/aot/hint/OAuth2ClientRuntimeHintsTests.java
+++ b/oauth2/oauth2-client/src/test/java/org/springframework/security/oauth2/client/aot/hint/OAuth2ClientRuntimeHintsTests.java
@@ -16,14 +16,18 @@
 
 package org.springframework.security.oauth2.client.aot.hint;
 
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
 import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
 import org.springframework.core.io.support.SpringFactoriesLoader;
 import org.springframework.util.ClassUtils;
@@ -53,6 +57,83 @@ class OAuth2ClientRuntimeHintsTests {
 	private static Stream<String> getOAuth2ClientSchemaFiles() {
 		return Stream.of("org/springframework/security/oauth2/client/oauth2-client-schema.sql",
 				"org/springframework/security/oauth2/client/oauth2-client-schema-postgres.sql");
+	}
+
+	@ParameterizedTest
+	@MethodSource("getJacksonModuleTypes")
+	void jacksonModulesHaveHints(TypeReference moduleType) {
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(moduleType)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS)).accepts(this.hints);
+	}
+
+	private static Stream<TypeReference> getJacksonModuleTypes() {
+		return Stream.of(
+				TypeReference.of("org.springframework.security.oauth2.client.jackson2.OAuth2ClientJackson2Module"),
+				TypeReference.of("org.springframework.security.oauth2.client.jackson.OAuth2ClientJacksonModule"));
+	}
+
+	@Test
+	void jacksonHintsUseProvidedClassLoader() {
+		assertJacksonModuleVisibility(hideClasses("tools.jackson.databind.json.JsonMapper"), true, false);
+		assertJacksonModuleVisibility(
+				hideClasses("com.fasterxml.jackson.databind.ObjectMapper", "com.fasterxml.jackson.core.JsonGenerator"),
+				false, true);
+		assertJacksonModuleVisibility(hideClasses("com.fasterxml.jackson.databind.ObjectMapper",
+				"com.fasterxml.jackson.core.JsonGenerator", "tools.jackson.databind.json.JsonMapper"), false, false);
+	}
+
+	private void assertJacksonModuleVisibility(ClassLoader classLoader, boolean jackson2, boolean jackson3) {
+		RuntimeHints hints = new RuntimeHints();
+		new OAuth2ClientRuntimeHints().registerHints(hints, classLoader);
+		assertThat(hints.reflection()
+			.getTypeHint(TypeReference
+				.of("org.springframework.security.oauth2.client.jackson2.OAuth2ClientJackson2Module")) != null)
+			.isEqualTo(jackson2);
+		assertThat(hints.reflection()
+			.getTypeHint(TypeReference
+				.of("org.springframework.security.oauth2.client.jackson.OAuth2ClientJacksonModule")) != null)
+			.isEqualTo(jackson3);
+	}
+
+	private static ClassLoader hideClasses(String... classNames) {
+		Set<String> hiddenClasses = Set.of(classNames);
+		return new ClassLoader(ClassUtils.getDefaultClassLoader()) {
+			@Override
+			protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+				if (hiddenClasses.contains(name)) {
+					throw new ClassNotFoundException(name);
+				}
+				return super.loadClass(name, resolve);
+			}
+		};
+	}
+
+	@Test
+	void authorizationRequestHasBindingHints() {
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(TypeReference.of("org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest"))
+			.withMemberCategories(MemberCategory.ACCESS_DECLARED_FIELDS, MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+					MemberCategory.INVOKE_DECLARED_METHODS))
+			.accepts(this.hints);
+	}
+
+	@ParameterizedTest
+	@MethodSource("getJacksonDeserializerTypes")
+	void jacksonDeserializersHaveHints(TypeReference deserializerType) {
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(deserializerType)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS)).accepts(this.hints);
+	}
+
+	private static Stream<TypeReference> getJacksonDeserializerTypes() {
+		return Stream.of(
+				TypeReference.of("org.springframework.security.oauth2.client.jackson2.ClientRegistrationDeserializer"),
+				TypeReference
+					.of("org.springframework.security.oauth2.client.jackson2.OAuth2AuthorizationRequestDeserializer"),
+				TypeReference.of("org.springframework.security.oauth2.client.jackson.ClientRegistrationDeserializer"),
+				TypeReference
+					.of("org.springframework.security.oauth2.client.jackson.OAuth2AuthorizationRequestDeserializer"));
 	}
 
 }

--- a/web/src/main/java/org/springframework/security/web/aot/hint/WebMvcSecurityRuntimeHints.java
+++ b/web/src/main/java/org/springframework/security/web/aot/hint/WebMvcSecurityRuntimeHints.java
@@ -16,8 +16,12 @@
 
 package org.springframework.security.web.aot.hint;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.aot.hint.BindingReflectionHintsRegistrar;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
@@ -25,15 +29,18 @@ import org.springframework.aot.hint.TypeReference;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.web.access.expression.WebSecurityExpressionRoot;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.util.ClassUtils;
 
 /**
- * {@link RuntimeHintsRegistrar} for WebMVC classes
+ * {@link RuntimeHintsRegistrar} for web classes
  *
  * @author Marcus Da Coregio
  * @author Daniel Garnier-Moiroux
  * @since 6.0
  */
 class WebMvcSecurityRuntimeHints implements RuntimeHintsRegistrar {
+
+	private final BindingReflectionHintsRegistrar bindingReflectionHintsRegistrar = new BindingReflectionHintsRegistrar();
 
 	@Override
 	public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
@@ -49,6 +56,7 @@ class WebMvcSecurityRuntimeHints implements RuntimeHintsRegistrar {
 			.registerType(PreAuthenticatedAuthenticationToken.class,
 					(builder) -> builder.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
 							MemberCategory.INVOKE_DECLARED_METHODS, MemberCategory.ACCESS_DECLARED_FIELDS));
+		registerJacksonHints(hints, classLoader);
 
 		ClassPathResource css = new ClassPathResource("org/springframework/security/default-ui.css");
 		if (css.exists()) {
@@ -61,6 +69,77 @@ class WebMvcSecurityRuntimeHints implements RuntimeHintsRegistrar {
 			hints.resources().registerResource(webauthnJavascript);
 		}
 
+	}
+
+	private void registerJacksonHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
+		ClassLoader loader = (classLoader != null) ? classLoader : ClassUtils.getDefaultClassLoader();
+		boolean jackson2Present = ClassUtils.isPresent("com.fasterxml.jackson.databind.ObjectMapper", loader)
+				&& ClassUtils.isPresent("com.fasterxml.jackson.core.JsonGenerator", loader);
+		boolean jackson3Present = ClassUtils.isPresent("tools.jackson.databind.json.JsonMapper", loader);
+		if (!jackson2Present && !jackson3Present) {
+			return;
+		}
+		boolean servletPresent = ClassUtils.isPresent("jakarta.servlet.http.Cookie", loader);
+		hints.reflection()
+			.registerTypes(getWebTypes(servletPresent),
+					(builder) -> builder.withMembers(MemberCategory.ACCESS_DECLARED_FIELDS,
+							MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.INVOKE_DECLARED_METHODS));
+		if (jackson2Present) {
+			registerJacksonModule(hints, "org.springframework.security.web.jackson2.WebJackson2Module");
+			registerJacksonModule(hints, "org.springframework.security.web.server.jackson2.WebServerJackson2Module");
+			registerJacksonMixins(hints, loader, "org.springframework.security.web.jackson2", "DefaultCsrfTokenMixin",
+					"PreAuthenticatedAuthenticationTokenMixin", "SwitchUserGrantedAuthorityMixIn");
+			registerJacksonMixins(hints, loader, "org.springframework.security.web.server.jackson2",
+					"DefaultCsrfServerTokenMixin");
+			if (servletPresent) {
+				registerJacksonModule(hints, "org.springframework.security.web.jackson2.WebServletJackson2Module");
+				registerJacksonMixins(hints, loader, "org.springframework.security.web.jackson2", "CookieMixin",
+						"DefaultSavedRequestMixin", "SavedCookieMixin", "WebAuthenticationDetailsMixin");
+			}
+		}
+		if (jackson3Present) {
+			registerJacksonModule(hints, "org.springframework.security.web.jackson.WebJacksonModule");
+			registerJacksonModule(hints, "org.springframework.security.web.server.jackson.WebServerJacksonModule");
+			registerJacksonMixins(hints, loader, "org.springframework.security.web.jackson", "DefaultCsrfTokenMixin",
+					"PreAuthenticatedAuthenticationTokenMixin", "SwitchUserGrantedAuthorityMixIn");
+			registerJacksonMixins(hints, loader, "org.springframework.security.web.server.jackson",
+					"DefaultCsrfServerTokenMixin");
+			if (servletPresent) {
+				registerJacksonModule(hints, "org.springframework.security.web.jackson.WebServletJacksonModule");
+				registerJacksonMixins(hints, loader, "org.springframework.security.web.jackson", "CookieMixin",
+						"DefaultSavedRequestMixin", "SavedCookieMixin", "WebAuthenticationDetailsMixin");
+			}
+		}
+	}
+
+	private List<TypeReference> getWebTypes(boolean servletPresent) {
+		List<TypeReference> types = new ArrayList<>(List.of(
+				TypeReference
+					.of("org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken"),
+				TypeReference
+					.of("org.springframework.security.web.authentication.switchuser.SwitchUserGrantedAuthority"),
+				TypeReference.of("org.springframework.security.web.csrf.DefaultCsrfToken"),
+				TypeReference.of("org.springframework.security.web.server.csrf.DefaultCsrfToken")));
+		if (servletPresent) {
+			types.addAll(List.of(TypeReference.of("jakarta.servlet.http.Cookie"),
+					TypeReference.of("org.springframework.security.web.authentication.WebAuthenticationDetails"),
+					TypeReference.of("org.springframework.security.web.savedrequest.DefaultSavedRequest"),
+					TypeReference.of("org.springframework.security.web.savedrequest.DefaultSavedRequest$Builder"),
+					TypeReference.of("org.springframework.security.web.savedrequest.SavedCookie")));
+		}
+		return types;
+	}
+
+	private void registerJacksonModule(RuntimeHints hints, String moduleClassName) {
+		hints.reflection().registerType(TypeReference.of(moduleClassName), MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
+	}
+
+	private void registerJacksonMixins(RuntimeHints hints, @Nullable ClassLoader classLoader, String packageName,
+			String... mixinClassNames) {
+		for (String mixinClassName : mixinClassNames) {
+			Class<?> mixinClass = ClassUtils.resolveClassName(packageName + "." + mixinClassName, classLoader);
+			this.bindingReflectionHintsRegistrar.registerReflectionHints(hints.reflection(), mixinClass);
+		}
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/aot/hint/WebMvcSecurityRuntimeHintsTests.java
+++ b/web/src/test/java/org/springframework/security/web/aot/hint/WebMvcSecurityRuntimeHintsTests.java
@@ -16,8 +16,13 @@
 
 package org.springframework.security.web.aot.hint;
 
+import java.util.Set;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
@@ -72,6 +77,108 @@ class WebMvcSecurityRuntimeHintsTests {
 	void webauthnJavascriptHasHints() {
 		assertThat(RuntimeHintsPredicates.resource()
 			.forResource("org/springframework/security/spring-security-webauthn.js")).accepts(this.hints);
+	}
+
+	@ParameterizedTest
+	@MethodSource("getJacksonModuleTypes")
+	void jacksonModulesHaveHints(TypeReference moduleType) {
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(moduleType)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS)).accepts(this.hints);
+	}
+
+	private static Stream<TypeReference> getJacksonModuleTypes() {
+		return Stream.of(TypeReference.of("org.springframework.security.web.jackson2.WebJackson2Module"),
+				TypeReference.of("org.springframework.security.web.jackson2.WebServletJackson2Module"),
+				TypeReference.of("org.springframework.security.web.server.jackson2.WebServerJackson2Module"),
+				TypeReference.of("org.springframework.security.web.jackson.WebJacksonModule"),
+				TypeReference.of("org.springframework.security.web.jackson.WebServletJacksonModule"),
+				TypeReference.of("org.springframework.security.web.server.jackson.WebServerJacksonModule"));
+	}
+
+	@Test
+	void jacksonHintsUseProvidedClassLoader() {
+		assertJacksonModuleVisibility(hideClasses("tools.jackson.databind.json.JsonMapper"), true, false);
+		assertJacksonModuleVisibility(
+				hideClasses("com.fasterxml.jackson.databind.ObjectMapper", "com.fasterxml.jackson.core.JsonGenerator"),
+				false, true);
+		assertJacksonModuleVisibility(hideClasses("com.fasterxml.jackson.databind.ObjectMapper",
+				"com.fasterxml.jackson.core.JsonGenerator", "tools.jackson.databind.json.JsonMapper"), false, false);
+	}
+
+	private void assertJacksonModuleVisibility(ClassLoader classLoader, boolean jackson2, boolean jackson3) {
+		RuntimeHints hints = new RuntimeHints();
+		new WebMvcSecurityRuntimeHints().registerHints(hints, classLoader);
+		assertThat(hints.reflection()
+			.getTypeHint(TypeReference.of("org.springframework.security.web.jackson2.WebJackson2Module")) != null)
+			.isEqualTo(jackson2);
+		assertThat(hints.reflection()
+			.getTypeHint(TypeReference.of("org.springframework.security.web.jackson.WebJacksonModule")) != null)
+			.isEqualTo(jackson3);
+	}
+
+	@Test
+	void servletJacksonHintsUseProvidedClassLoader() {
+		RuntimeHints hints = new RuntimeHints();
+		new WebMvcSecurityRuntimeHints().registerHints(hints, hideClasses("jakarta.servlet.http.Cookie"));
+		assertThat(hints.reflection()
+			.getTypeHint(TypeReference.of("org.springframework.security.web.jackson2.WebServletJackson2Module")))
+			.isNull();
+		assertThat(hints.reflection()
+			.getTypeHint(TypeReference.of("org.springframework.security.web.jackson.WebServletJacksonModule")))
+			.isNull();
+	}
+
+	private static ClassLoader hideClasses(String... classNames) {
+		Set<String> hiddenClasses = Set.of(classNames);
+		return new ClassLoader(ClassUtils.getDefaultClassLoader()) {
+			@Override
+			protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+				if (hiddenClasses.contains(name)) {
+					throw new ClassNotFoundException(name);
+				}
+				return super.loadClass(name, resolve);
+			}
+		};
+	}
+
+	@ParameterizedTest
+	@MethodSource("getReactiveCsrfMixinTypes")
+	void reactiveCsrfMixinsHaveBindingHints(TypeReference mixinType) {
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(mixinType)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS)).accepts(this.hints);
+	}
+
+	private static Stream<TypeReference> getReactiveCsrfMixinTypes() {
+		return Stream.of(
+				TypeReference.of("org.springframework.security.web.server.jackson2.DefaultCsrfServerTokenMixin"),
+				TypeReference.of("org.springframework.security.web.server.jackson.DefaultCsrfServerTokenMixin"));
+	}
+
+	@Test
+	void reactiveCsrfTokenHasBindingHints() {
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(TypeReference.of("org.springframework.security.web.server.csrf.DefaultCsrfToken"))
+			.withMemberCategories(MemberCategory.ACCESS_DECLARED_FIELDS, MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+					MemberCategory.INVOKE_DECLARED_METHODS))
+			.accepts(this.hints);
+	}
+
+	@ParameterizedTest
+	@MethodSource("getJacksonDeserializerTypes")
+	void jacksonDeserializersHaveHints(TypeReference deserializerType) {
+		assertThat(RuntimeHintsPredicates.reflection()
+			.onType(deserializerType)
+			.withMemberCategory(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS)).accepts(this.hints);
+	}
+
+	private static Stream<TypeReference> getJacksonDeserializerTypes() {
+		return Stream.of(TypeReference.of("org.springframework.security.web.jackson2.CookieDeserializer"),
+				TypeReference
+					.of("org.springframework.security.web.jackson2.PreAuthenticatedAuthenticationTokenDeserializer"),
+				TypeReference.of("org.springframework.security.web.jackson.CookieDeserializer"), TypeReference
+					.of("org.springframework.security.web.jackson.PreAuthenticatedAuthenticationTokenDeserializer"));
 	}
 
 }


### PR DESCRIPTION
## Summary

Register the Jackson runtime hints needed when OAuth2 login or client state is stored in a session in a native image.

The hints cover:

- reflective construction of Spring Security's Core, Web, WebFlux, servlet, and OAuth2 Client Jackson modules
- binding metadata for their mixins and custom deserializers
- OAuth2 client, authentication, saved-request, reactive CSRF, and factor authority types stored in sessions
- both Jackson 2 and Jackson 3, while preserving optional classpath boundaries

This follows the working reproducer from the issue and includes the reactive `WebServerJackson2Module` and `DefaultCsrfServerTokenMixin` path confirmed by the reporter.

JDK serialization hints remain tracked by spring-projects/spring-session#3103 and its active PR #3411; this change does not duplicate that work. Spring Security PR #19593 separately adds Java-serialization metadata for `FactorGrantedAuthority`; this change adds only the Jackson binding categories needed because OAuth2 login stores that authority in the authenticated session.

## Testing

- `./gradlew :spring-security-core:test :spring-security-web:test :spring-security-oauth2-client:test --continue`
- `./gradlew check`
- focused runtime-hint tests rerun with `--rerun-tasks --no-build-cache`

Closes gh-18145