### PR TITLE
Use HtmlUnit 5 cookie package

### DIFF
--- a/config/src/test/java/org/springframework/security/htmlunit/server/HtmlUnitWebTestClient.java
+++ b/config/src/test/java/org/springframework/security/htmlunit/server/HtmlUnitWebTestClient.java
@@ -27,7 +27,7 @@ import java.util.StringTokenizer;
 import org.htmlunit.FormEncodingType;
 import org.htmlunit.WebClient;
 import org.htmlunit.WebRequest;
-import org.htmlunit.util.Cookie;
+import org.htmlunit.http.Cookie;
 import org.htmlunit.util.NameValuePair;
 import reactor.core.publisher.Mono;
 


### PR DESCRIPTION
Companion compatibility fix for #19551.

## Why

Selenium 4.47.0 and `htmlunit3-driver` 4.47.0 resolve HtmlUnit 5.4.0. HtmlUnit 5 relocates `Cookie` from `org.htmlunit.util` to `org.htmlunit.http`, so the Dependabot head fails `:spring-security-config:compileTestJava` with three missing-type errors.

This changes only that test-fixture import. `WebClient#getCookies(URL)` still returns the relocated type with the same `getName()` and `getValue()` calls; no cookie-flow logic changes.

## Verification

- Exact pre-upgrade parent `82241b6cb887f1e93d6bc12125326416b9be3e13`, JDK 17: `./gradlew :spring-security-config:test --tests org.springframework.security.htmlunit.server.WebTestClientHtmlUnitDriverBuilderTests --no-daemon --stacktrace` passed both tests, including `cookies()`.
- Exact Dependabot head `8cab91b485ecefa1b37dbe83a4b4839f94977db8`, JDK 17: `./gradlew :spring-security-config:compileTestJava --no-daemon --stacktrace` reproduced the three CI compiler errors.
- Candidate, JDK 17: the identical focused test command passed 2 tests with 0 failures and 0 errors.
- Candidate, JDK 25 CI parity: `./gradlew clean build -PskipCheckExpectedBranchVersion --continue --no-daemon` passed all 572 tasks in 12m54s.
- `./gradlew format --no-daemon` and `git diff --check` passed.

Note: repository-wide `check` on JDK 17 reports formatting violations in two unrelated authorization-server sources on the exact parent as well. The same formatter task and the full clean build pass with the repository PR workflow toolchain, JDK 25.