### PR TITLE
Fix Authorization Granted Events sample

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authorization/events.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/events.adoc
@@ -74,8 +74,8 @@ Because ``AuthorizationGrantedEvent``s have the potential to be quite noisy, the
 
 In fact, publishing these events will likely require some business logic on your part to ensure that your application is not inundated with noisy authorization events.
 
-You can provide your own predicate that filters success events.
-For example, the following publisher only publishes authorization grants where `ROLE_ADMIN` was required:
+`SpringAuthorizationEventPublisher` publishes only ``AuthorizationDeniedEvent``s, so the predicate you give it decides which denials are published rather than adding grants.
+For example, the following publisher skips denials that did not require `ROLE_ADMIN`:
 
 [tabs]
 ======
@@ -84,11 +84,11 @@ Java::
 [source,java,role="primary"]
 ----
 @Bean
-AuthorizationEventPublisher authorizationEventPublisher() {
-    SpringAuthorizationEventPublisher eventPublisher = new SpringAuthorizationEventPublisher();
-    eventPublisher.setShouldPublishEvent((result) -> {
-        if (!result.isGranted()) {
-            return true;
+AuthorizationEventPublisher authorizationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+    SpringAuthorizationEventPublisher eventPublisher = new SpringAuthorizationEventPublisher(applicationEventPublisher);
+    eventPublisher.setShouldPublishResult((result) -> {
+        if (result.isGranted()) {
+            return false;
         }
         if (result instanceof AuthorityAuthorizationDecision decision) {
             Collection<GrantedAuthority> authorities = decision.getAuthorities();
@@ -105,17 +105,17 @@ Kotlin::
 [source,kotlin,role="secondary"]
 ----
 @Bean
-fun authorizationEventPublisher(): AuthorizationEventPublisher {
-    val eventPublisher = SpringAuthorizationEventPublisher()
-    eventPublisher.setShouldPublishEvent { (result) ->
-        if (!result.isGranted()) {
-            return true
+fun authorizationEventPublisher(applicationEventPublisher: ApplicationEventPublisher): AuthorizationEventPublisher {
+    val eventPublisher = SpringAuthorizationEventPublisher(applicationEventPublisher)
+    eventPublisher.setShouldPublishResult { result ->
+        if (result.isGranted) {
+            return@setShouldPublishResult false
         }
-        if (decision is AuthorityAuthorizationDecision) {
-            val authorities = decision.getAuthorities()
-            return AuthorityUtils.authorityListToSet(authorities).contains("ROLE_ADMIN")
+        if (result is AuthorityAuthorizationDecision) {
+            val authorities = result.authorities
+            return@setShouldPublishResult AuthorityUtils.authorityListToSet(authorities).contains("ROLE_ADMIN")
         }
-        return false
+        false
     }
     return eventPublisher
 }


### PR DESCRIPTION
The sample under [Authorization Granted Events](https://docs.spring.io/spring-security/reference/servlet/authorization/events.html#authorization-granted-events) does not compile, and the prose around it describes behaviour `SpringAuthorizationEventPublisher` does not have.

**The sample.** It calls a no-arg constructor, but the only one is `SpringAuthorizationEventPublisher(ApplicationEventPublisher)`, and it calls `setShouldPublishEvent`, which is `setShouldPublishResult(Predicate<AuthorizationResult>)`. The Kotlin version additionally destructures the lambda parameter as `(result)`, refers to an undefined `decision` instead of the parameter, and uses bare `return` inside a lambda, none of which compile.

**The prose.** It says the publisher "only publishes authorization grants where `ROLE_ADMIN` was required", but the class javadoc states the opposite:

> Because `AuthorizationGrantedEvent`s typically require additional business logic to decide whether to publish, this implementation only publishes `AuthorizationDeniedEvent`s.

and `publishAuthorizationEvent` bears that out — it only ever constructs an `AuthorizationDeniedEvent`; `AuthorizationGrantedEvent` is imported solely for that javadoc reference. So a predicate returning `true` for a granted result publishes an `AuthorizationDeniedEvent` carrying a granted `AuthorizationResult`, which is not what a reader following this section would expect.

I have taken the implementation as correct and fixed the documentation to match it, describing the predicate as selecting which denials are published. The default is `(result) -> !result.isGranted()`, so that reading seems consistent with the intended design.

If the team would rather `SpringAuthorizationEventPublisher` gain the ability to publish granted events, then this section is describing a feature request instead and the fix belongs in the class rather than the docs — happy to redo it that way.

Closes gh-19584
