### PR TITLE
Read relayState from authenticationRequest

### DIFF
--- a/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/CacheSaml2AuthenticationRequestRepository.java
+++ b/saml2/saml2-service-provider/src/main/java/org/springframework/security/saml2/provider/service/web/CacheSaml2AuthenticationRequestRepository.java
@@ -54,7 +54,7 @@ public final class CacheSaml2AuthenticationRequestRepository
 	public void saveAuthenticationRequest(AbstractSaml2AuthenticationRequest authenticationRequest,
 			HttpServletRequest request, HttpServletResponse response) {
 		Assert.notNull(authenticationRequest, "authenticationRequest must not be null");
-		String relayState = request.getParameter(Saml2ParameterNames.RELAY_STATE);
+		String relayState = authenticationRequest.getRelayState();
 		Assert.notNull(relayState, "relayState must not be null");
 		this.cache.put(relayState, authenticationRequest);
 	}

--- a/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/web/CacheSaml2AuthenticationRequestRepositoryTests.java
+++ b/saml2/saml2-service-provider/src/test/java/org/springframework/security/saml2/provider/service/web/CacheSaml2AuthenticationRequestRepositoryTests.java
@@ -42,13 +42,23 @@ class CacheSaml2AuthenticationRequestRepositoryTests {
 
 	@Test
 	void loadAuthenticationRequestWhenCachedThenReturns() {
-		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.setParameter(Saml2ParameterNames.RELAY_STATE, "test");
 		Saml2PostAuthenticationRequest authenticationRequest = TestSaml2PostAuthenticationRequests.create();
+		String relayState = authenticationRequest.getRelayState();
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setParameter(Saml2ParameterNames.RELAY_STATE, relayState);
 		this.repository.saveAuthenticationRequest(authenticationRequest, request, null);
 		assertThat(this.repository.loadAuthenticationRequest(request)).isEqualTo(authenticationRequest);
 		this.repository.removeAuthenticationRequest(request, null);
 		assertThat(this.repository.loadAuthenticationRequest(request)).isNull();
+	}
+
+	@Test
+	void saveAuthenticationRequestWhenRelayStateOnlyInAuthenticationRequestThenSaves() {
+		Saml2PostAuthenticationRequest authenticationRequest = TestSaml2PostAuthenticationRequests.create();
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		this.repository.saveAuthenticationRequest(authenticationRequest, request, null);
+		request.setParameter(Saml2ParameterNames.RELAY_STATE, authenticationRequest.getRelayState());
+		assertThat(this.repository.loadAuthenticationRequest(request)).isEqualTo(authenticationRequest);
 	}
 
 	@Test
@@ -77,15 +87,16 @@ class CacheSaml2AuthenticationRequestRepositoryTests {
 		CacheSaml2AuthenticationRequestRepository repository = new CacheSaml2AuthenticationRequestRepository();
 		Cache cache = spy(new ConcurrentMapCache("requests"));
 		repository.setCache(cache);
-		MockHttpServletRequest request = new MockHttpServletRequest();
-		request.setParameter(Saml2ParameterNames.RELAY_STATE, "test");
 		Saml2PostAuthenticationRequest authenticationRequest = TestSaml2PostAuthenticationRequests.create();
+		String relayState = authenticationRequest.getRelayState();
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setParameter(Saml2ParameterNames.RELAY_STATE, relayState);
 		repository.saveAuthenticationRequest(authenticationRequest, request, null);
-		verify(cache).put(eq("test"), any());
+		verify(cache).put(eq(relayState), any());
 		repository.loadAuthenticationRequest(request);
-		verify(cache).get("test", AbstractSaml2AuthenticationRequest.class);
+		verify(cache).get(relayState, AbstractSaml2AuthenticationRequest.class);
 		repository.removeAuthenticationRequest(request, null);
-		verify(cache).evict("test");
+		verify(cache).evict(relayState);
 	}
 
 }


### PR DESCRIPTION
Summary

Closes #19627

Restores the behavior previously introduced for #18243 in CacheSaml2AuthenticationRequestRepository.

saveAuthenticationRequest now reads the relay state from the AbstractSaml2AuthenticationRequest instead of the HttpServletRequest. This allows the authentication request to be cached when the relay state is not present as a parameter on the current HTTP request.

A regression test has been added to cover this scenario.

Test plan

* CacheSaml2AuthenticationRequestRepositoryTests
* spring-security-saml2-service-provider test suite
* opensaml5Test
* bouncyCastleTest
* checkstyleMain
* checkstyleTest