### PR TITLE
Allow multiple spaces in bearer authorization header

### DIFF
--- a/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
+++ b/oauth2/oauth2-resource-server/src/main/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolver.java
@@ -42,7 +42,7 @@ public final class DefaultBearerTokenResolver implements BearerTokenResolver {
 
 	private static final String ACCESS_TOKEN_PARAMETER_NAME = "access_token";
 
-	private static final Pattern authorizationPattern = Pattern.compile("^Bearer (?<token>[a-zA-Z0-9-._~+/]+=*)$",
+	private static final Pattern authorizationPattern = Pattern.compile("^Bearer +(?<token>[a-zA-Z0-9-._~+/]+=*)$",
 			Pattern.CASE_INSENSITIVE);
 
 	private boolean allowFormEncodedBodyParameter = false;

--- a/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
+++ b/oauth2/oauth2-resource-server/src/test/java/org/springframework/security/oauth2/server/resource/web/DefaultBearerTokenResolverTests.java
@@ -327,5 +327,11 @@ public class DefaultBearerTokenResolverTests {
 				assertThat(error.getHttpStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
 			});
 	}
+@Test
+void resolveWhenHeaderHasMultipleSpacesBeforeTokenThenTokenIsResolved() {
+	MockHttpServletRequest request = new MockHttpServletRequest();
+	request.addHeader("Authorization", "Bearer  " + TEST_TOKEN);
 
+	assertThat(this.resolver.resolve(request)).isEqualTo(TEST_TOKEN);
+}
 }


### PR DESCRIPTION
### Summary

Allow `DefaultBearerTokenResolver` to accept one or more spaces between
the `Bearer` authentication scheme and the token.

RFC 6750 permits one or more `SP` characters between `Bearer` and the
credentials, while the current pattern only accepts exactly one space.

### Changes

- Update the bearer token pattern to accept one or more spaces.
- Add regression coverage for an Authorization header containing multiple
  spaces before the token.
- Preserve the existing behavior for valid single-space bearer headers.

### Testing

- Added a focused regression test for multiple spaces.
- Existing `DefaultBearerTokenResolverTests` pass.
- `git diff --check` is clean.

Closes gh-19500
