### PR TITLE
Avoid reflective SecurityContextRepository mutation

### DIFF
--- a/test/src/main/java/org/springframework/security/test/web/support/WebTestUtils.java
+++ b/test/src/main/java/org/springframework/security/test/web/support/WebTestUtils.java
@@ -98,7 +98,7 @@ public abstract class WebTestUtils {
 		}
 		SecurityContextHolderFilter holderFilter = findFilter(request, SecurityContextHolderFilter.class);
 		if (holderFilter != null) {
-			ReflectionTestUtils.setField(holderFilter, "securityContextRepository", securityContextRepository);
+			holderFilter.setSecurityContextRepository(securityContextRepository);
 		}
 	}
 

--- a/web/src/main/java/org/springframework/security/web/context/SecurityContextHolderFilter.java
+++ b/web/src/main/java/org/springframework/security/web/context/SecurityContextHolderFilter.java
@@ -49,7 +49,7 @@ public class SecurityContextHolderFilter extends GenericFilterBean {
 
 	private static final String FILTER_APPLIED = SecurityContextHolderFilter.class.getName() + ".APPLIED";
 
-	private final SecurityContextRepository securityContextRepository;
+	private SecurityContextRepository securityContextRepository;
 
 	private SecurityContextHolderStrategy securityContextHolderStrategy = SecurityContextHolder
 		.getContextHolderStrategy();
@@ -69,6 +69,10 @@ public class SecurityContextHolderFilter extends GenericFilterBean {
 		doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
 	}
 
+	public void setSecurityContextRepository(SecurityContextRepository securityContextRepository) {
+		Assert.notNull(securityContextRepository, "securityContextRepository cannot be null");
+		this.securityContextRepository = securityContextRepository;
+	}
 	private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
 			throws ServletException, IOException {
 		if (request.getAttribute(FILTER_APPLIED) != null) {

--- a/web/src/test/java/org/springframework/security/web/context/SecurityContextHolderFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/context/SecurityContextHolderFilterTests.java
@@ -43,6 +43,7 @@ import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.core.context.SecurityContextImpl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
@@ -81,7 +82,12 @@ class SecurityContextHolderFilterTests {
 	void cleanup() {
 		SecurityContextHolder.clearContext();
 	}
-
+	@Test
+	void setSecurityContextRepositoryWhenNullThenThrowsIllegalArgumentException() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> this.filter.setSecurityContextRepository(null))
+			.withMessage("securityContextRepository cannot be null");
+	}
 	@Test
 	void doFilterThenSetsAndClearsSecurityContextHolder() throws Exception {
 		Authentication authentication = TestAuthentication.authenticatedUser();


### PR DESCRIPTION
Add a setter for the SecurityContextRepository used by SecurityContextHolderFilter and use it from WebTestUtils instead of reflectively modifying the field.

Add coverage verifying that a null repository is rejected.

Closes gh-19520

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
