### PR TITLE
Include smart card in AuthenticatorTransport values

### DIFF
--- a/webauthn/src/main/java/org/springframework/security/web/webauthn/api/AuthenticatorTransport.java
+++ b/webauthn/src/main/java/org/springframework/security/web/webauthn/api/AuthenticatorTransport.java
@@ -119,7 +119,7 @@ public final class AuthenticatorTransport implements Serializable {
 	}
 
 	public static AuthenticatorTransport[] values() {
-		return new AuthenticatorTransport[] { USB, NFC, BLE, HYBRID, INTERNAL };
+		return new AuthenticatorTransport[] { USB, NFC, BLE, SMART_CARD, HYBRID, INTERNAL };
 	}
 
 	@Override

--- a/webauthn/src/test/java/org/springframework/security/web/webauthn/api/AuthenticatorTransportTests.java
+++ b/webauthn/src/test/java/org/springframework/security/web/webauthn/api/AuthenticatorTransportTests.java
@@ -73,4 +73,11 @@ class AuthenticatorTransportTests {
 		assertThat(AuthenticatorTransport.USB).isNotEqualTo(AuthenticatorTransport.NFC);
 	}
 
+	@Test
+	void valuesThenContainsAllAuthenticatorTransports() {
+		assertThat(AuthenticatorTransport.values()).containsExactly(AuthenticatorTransport.USB,
+				AuthenticatorTransport.NFC, AuthenticatorTransport.BLE, AuthenticatorTransport.SMART_CARD,
+				AuthenticatorTransport.HYBRID, AuthenticatorTransport.INTERNAL);
+	}
+
 }


### PR DESCRIPTION
### Summary

Include `SMART_CARD` in `AuthenticatorTransport.values()`.

`SMART_CARD` is a defined authenticator transport and is already
supported by `AuthenticatorTransport.valueOf(String)`, but it is
currently omitted from `values()`.

### Changes

- Include `SMART_CARD` in `AuthenticatorTransport.values()`.
- Add regression coverage verifying that all defined authenticator
  transports are returned.

### Testing

- `AuthenticatorTransportTests` passes.
- `:spring-security-webauthn:test` passes.
- `:spring-security-webauthn:checkFormat` passes.
- `git diff --check` is clean.

Closes gh-19232