### PR TITLE
Simplify ProviderManager null provider check

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
+++ b/core/src/main/java/org/springframework/security/authentication/ProviderManager.java
@@ -34,7 +34,6 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.CredentialsContainer;
 import org.springframework.security.core.SpringSecurityMessageSource;
 import org.springframework.util.Assert;
-import org.springframework.util.CollectionUtils;
 
 /**
  * Iterates an {@link Authentication} request through a list of
@@ -138,8 +137,7 @@ public class ProviderManager implements AuthenticationManager, MessageSourceAwar
 	private void checkState() {
 		Assert.isTrue(this.parent != null || !this.providers.isEmpty(),
 				"A parent AuthenticationManager or a list of AuthenticationProviders is required");
-		Assert.isTrue(!CollectionUtils.contains(this.providers.iterator(), null),
-				"providers list cannot contain null values");
+		Assert.noNullElements(this.providers, "providers list cannot contain null values");
 	}
 
 	/**


### PR DESCRIPTION
### Summary

Simplify null-provider validation in `ProviderManager.checkState()`.

The existing implementation uses `CollectionUtils.contains` with an
iterator to detect null entries. This can be expressed more directly
using `Assert.noNullElements`.

### Changes

- Replace the iterator-based `CollectionUtils.contains` null check with
  `Assert.noNullElements`.
- Remove the now-unused `CollectionUtils` import.
- Preserve the existing validation behavior and exception message.

### Testing

- `ProviderManagerTests` passes.
- `:spring-security-core:test` passes.
- `:spring-security-core:checkFormat` passes.
- `git diff --check` is clean.

Closes gh-19510
