### PR TITLE
Use correct logger for user details configuration warning

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeUserDetailsBeanManagerConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configuration/InitializeUserDetailsBeanManagerConfigurer.java
@@ -62,7 +62,7 @@ class InitializeUserDetailsBeanManagerConfigurer extends GlobalAuthenticationCon
 
 	class InitializeUserDetailsManagerConfigurer extends GlobalAuthenticationConfigurerAdapter {
 
-		private final Log logger = LogFactory.getLog(getClass());
+		private final Log logger = LogFactory.getLog(InitializeUserDetailsBeanManagerConfigurer.class);
 
 		@Override
 		public void configure(AuthenticationManagerBuilder auth) {

--- a/config/src/test/java/org/springframework/security/config/annotation/authentication/configuration/AuthenticationConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/authentication/configuration/AuthenticationConfigurationTests.java
@@ -16,6 +16,11 @@
 
 package org.springframework.security.config.annotation.authentication.configuration;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -264,6 +269,31 @@ public class AuthenticationConfigurationTests {
 		given(ap.supports(any())).willReturn(true);
 		given(ap.authenticate(any())).willReturn(TestAuthentication.authenticatedUser());
 		am.authenticate(UsernamePasswordAuthenticationToken.unauthenticated("user", "password"));
+	}
+
+	@Test
+	public void getAuthenticationWhenAuthenticationProviderAndUserDetailsBeanThenWarningUsesConfigurerLogger()
+			throws Exception {
+		Logger rootLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+		ListAppender<ILoggingEvent> appender = new ListAppender<>();
+		appender.start();
+		rootLogger.addAppender(appender);
+
+		try {
+			this.spring.register(AuthenticationProviderBeanAndUserDetailsServiceConfig.class).autowire();
+
+			this.spring.getContext().getBean(AuthenticationConfiguration.class).getAuthenticationManager();
+
+			assertThat(appender.list)
+				.filteredOn(
+						(event) -> event.getFormattedMessage().contains("UserDetailsService beans will not be used"))
+				.extracting(ILoggingEvent::getLoggerName)
+				.containsExactly(InitializeUserDetailsBeanManagerConfigurer.class.getName());
+		}
+		finally {
+			rootLogger.detachAppender(appender);
+			appender.stop();
+		}
 	}
 
 	// gh-3091


### PR DESCRIPTION
### Summary

Use the `InitializeUserDetailsBeanManagerConfigurer` logger category for
the user details configuration warning.

The warning tells users to configure the logging level for
`InitializeUserDetailsBeanManagerConfigurer`, but the logger is currently
created from the inner `InitializeUserDetailsManagerConfigurer` class.

As a result, the logger that emits the warning does not match the logger
category referenced by the warning message.

### Changes

- Use `InitializeUserDetailsBeanManagerConfigurer.class` when creating
  the logger.
- Add regression coverage verifying that the warning is emitted using
  the documented logger category.

### Testing

- Added a regression test that failed before the change because the
  warning was emitted from the inner configurer logger.
- The regression test passes after the fix.
- `AuthenticationConfigurationTests` passes.
- `:spring-security-config:checkFormat` passes.
- `git diff --check` is clean.

Closes gh-19595