### PR TITLE
Handle null UserDetails in TokenBasedRememberMeServices

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/rememberme/TokenBasedRememberMeServices.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/rememberme/TokenBasedRememberMeServices.java
@@ -225,6 +225,10 @@ public class TokenBasedRememberMeServices extends AbstractRememberMeServices {
 		}
 		if (!StringUtils.hasLength(password)) {
 			UserDetails user = getUserDetailsService().loadUserByUsername(username);
+			if (user == null) {
+				this.logger.debug("Unable to obtain user details for user: " + username);
+				return;
+			}
 			password = user.getPassword();
 			if (!StringUtils.hasLength(password)) {
 				this.logger.debug("Unable to obtain password for user: " + username);

--- a/web/src/test/java/org/springframework/security/web/authentication/rememberme/TokenBasedRememberMeServicesTests.java
+++ b/web/src/test/java/org/springframework/security/web/authentication/rememberme/TokenBasedRememberMeServicesTests.java
@@ -396,6 +396,18 @@ public class TokenBasedRememberMeServicesTests {
 	}
 
 	@Test
+	public void loginSuccessWhenUserDetailsServiceReturnsNullThenNoCookieIsSet() {
+		// gh-19535
+		udsWillReturnNull();
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter(AbstractRememberMeServices.DEFAULT_PARAMETER, "true");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		this.services.loginSuccess(request, response, new TestingAuthenticationToken("someone", null, "ROLE_ABC"));
+		Cookie cookie = response.getCookie(AbstractRememberMeServices.SPRING_SECURITY_REMEMBER_ME_COOKIE_KEY);
+		assertThat(cookie).isNull();
+	}
+
+	@Test
 	public void loginSuccessWhenDefaultEncodingAlgorithmThenContainsAlgorithmName() {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.addParameter(AbstractRememberMeServices.DEFAULT_PARAMETER, "true");


### PR DESCRIPTION
`TokenBasedRememberMeServices#onLoginSuccess` falls back to `UserDetailsService#loadUserByUsername` when the `Authentication` carries no password, and then reads `getPassword()` on the result without checking it. A `UserDetailsService` that returns `null` for a user (the reporter's case: only some users support remember-me) therefore throws a `NullPointerException` on login.

The method already returns without setting a cookie when the password cannot be obtained, so a `null` `UserDetails` now takes the same path, with its own debug message.

Adds `loginSuccessWhenUserDetailsServiceReturnsNullThenNoCookieIsSet`, built on the existing `udsWillReturnNull()` setup; it throws on `main` and passes here.

Closes gh-19535
