### PR TITLE
Modernize the default RequestCache background-request ignore list

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurer.java
@@ -185,7 +185,10 @@ public final class RequestCacheConfigurer<H extends HttpSecurityBuilder<H>>
 			"/apple-touch-icon*.png",
 			// Chromium browsers fetch the web app manifest in the background to
 			// evaluate PWA installability
-			"/manifest.json", "/manifest.webmanifest" };
+			"/manifest.json", "/manifest.webmanifest",
+			// Legacy IE11/Edge fetch browserconfig.xml in the background to
+			// configure pinned-site tiles
+			"/browserconfig.xml" };
 
 	private RequestMatcher getIgnoredBackgroundRequestMatcher() {
 		List<RequestMatcher> matchers = new ArrayList<>();

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurer.java
@@ -188,7 +188,10 @@ public final class RequestCacheConfigurer<H extends HttpSecurityBuilder<H>>
 			"/manifest.json", "/manifest.webmanifest",
 			// Legacy IE11/Edge fetch browserconfig.xml in the background to
 			// configure pinned-site tiles
-			"/browserconfig.xml" };
+			"/browserconfig.xml",
+			// Chrome DevTools itself (not the page, not the user) requests this to
+			// discover an Automatic Workspace Folder mapping for local source editing
+			"/.well-known/appspecific/com.chrome.devtools.json" };
 
 	private RequestMatcher getIgnoredBackgroundRequestMatcher() {
 		List<RequestMatcher> matchers = new ArrayList<>();

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurer.java
@@ -182,7 +182,10 @@ public final class RequestCacheConfigurer<H extends HttpSecurityBuilder<H>>
 			// apple-touch-icon-precomposed.png,
 			// and sized variants (e.g. apple-touch-icon-152x152.png) even without a
 			// matching <link> tag in the page
-			"/apple-touch-icon*.png" };
+			"/apple-touch-icon*.png",
+			// Chromium browsers fetch the web app manifest in the background to
+			// evaluate PWA installability
+			"/manifest.json", "/manifest.webmanifest" };
 
 	private RequestMatcher getIgnoredBackgroundRequestMatcher() {
 		List<RequestMatcher> matchers = new ArrayList<>();

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurer.java
@@ -32,6 +32,7 @@ import org.springframework.security.web.savedrequest.RequestCacheAwareFilter;
 import org.springframework.security.web.util.matcher.AndRequestMatcher;
 import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
 import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestHeaderRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.accept.ContentNegotiationStrategy;
@@ -140,7 +141,7 @@ public final class RequestCacheConfigurer<H extends HttpSecurityBuilder<H>>
 
 	@SuppressWarnings("unchecked")
 	private RequestMatcher createDefaultSavedRequestMatcher(H http) {
-		RequestMatcher notFavIcon = new NegatedRequestMatcher(getFaviconRequestMatcher());
+		RequestMatcher notIgnoredBackgroundRequest = new NegatedRequestMatcher(getIgnoredBackgroundRequestMatcher());
 		RequestMatcher notXRequestedWith = new NegatedRequestMatcher(
 				new RequestHeaderRequestMatcher("X-Requested-With", "XMLHttpRequest"));
 		RequestMatcher notWebSocket = new NegatedRequestMatcher(
@@ -152,7 +153,7 @@ public final class RequestCacheConfigurer<H extends HttpSecurityBuilder<H>>
 			RequestMatcher getRequests = getRequestMatcherBuilder().matcher(HttpMethod.GET, "/**");
 			matchers.add(0, getRequests);
 		}
-		matchers.add(notFavIcon);
+		matchers.add(notIgnoredBackgroundRequest);
 		matchers.add(notMatchingMediaType(http, MediaType.APPLICATION_JSON));
 		matchers.add(notXRequestedWith);
 		matchers.add(notMatchingMediaType(http, MediaType.MULTIPART_FORM_DATA));
@@ -171,8 +172,24 @@ public final class RequestCacheConfigurer<H extends HttpSecurityBuilder<H>>
 		return new NegatedRequestMatcher(mediaRequest);
 	}
 
-	private RequestMatcher getFaviconRequestMatcher() {
-		return getRequestMatcherBuilder().matcher("/favicon.*");
+	/**
+	 * Path patterns for requests that browsers request automatically in the background
+	 * (e.g. to display an icon), and that should therefore never be saved as the URL to
+	 * redirect to after authentication succeeds.
+	 */
+	private static final String[] IGNORED_BACKGROUND_REQUEST_PATTERNS = { "/favicon.*",
+			// Safari/WebKit request apple-touch-icon.png,
+			// apple-touch-icon-precomposed.png,
+			// and sized variants (e.g. apple-touch-icon-152x152.png) even without a
+			// matching <link> tag in the page
+			"/apple-touch-icon*.png" };
+
+	private RequestMatcher getIgnoredBackgroundRequestMatcher() {
+		List<RequestMatcher> matchers = new ArrayList<>();
+		for (String pattern : IGNORED_BACKGROUND_REQUEST_PATTERNS) {
+			matchers.add(getRequestMatcherBuilder().matcher(pattern));
+		}
+		return new OrRequestMatcher(matchers);
 	}
 
 }

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurerTests.java
@@ -186,6 +186,20 @@ public class RequestCacheConfigurerTests {
 		this.mvc.perform(formLogin(session)).andExpect(redirectedUrl("/"));
 	}
 
+	@Test
+	public void getWhenBookmarkedUrlIsBrowserConfigXmlThenPostAuthenticationRedirectsToRoot() throws Exception {
+		this.spring.register(RequestCacheDefaultsConfig.class, DefaultSecurityConfig.class).autowire();
+		// @formatter:off
+		MockHttpSession session = (MockHttpSession) this.mvc.perform(get("/browserconfig.xml"))
+				.andExpect(redirectedUrl("/login"))
+				.andReturn()
+				.getRequest()
+				.getSession();
+		// @formatter:on
+		// ignores browserconfig.xml
+		this.mvc.perform(formLogin(session)).andExpect(redirectedUrl("/"));
+	}
+
 	// SEC-2321
 	@Test
 	public void getWhenBookmarkedRequestIsApplicationJsonThenPostAuthenticationRedirectsToRoot() throws Exception {

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurerTests.java
@@ -114,6 +114,50 @@ public class RequestCacheConfigurerTests {
 		this.mvc.perform(formLogin(session)).andExpect(redirectedUrl("/"));
 	}
 
+	@Test
+	public void getWhenBookmarkedUrlIsAppleTouchIconThenPostAuthenticationRedirectsToRoot() throws Exception {
+		this.spring.register(RequestCacheDefaultsConfig.class, DefaultSecurityConfig.class).autowire();
+		// @formatter:off
+		MockHttpSession session = (MockHttpSession) this.mvc.perform(get("/apple-touch-icon.png"))
+				.andExpect(redirectedUrl("/login"))
+				.andReturn()
+				.getRequest()
+				.getSession();
+		// @formatter:on
+		// ignores apple-touch-icon.png
+		this.mvc.perform(formLogin(session)).andExpect(redirectedUrl("/"));
+	}
+
+	@Test
+	public void getWhenBookmarkedUrlIsAppleTouchIconPrecomposedThenPostAuthenticationRedirectsToRoot()
+			throws Exception {
+		this.spring.register(RequestCacheDefaultsConfig.class, DefaultSecurityConfig.class).autowire();
+		// @formatter:off
+		MockHttpSession session = (MockHttpSession) this.mvc.perform(get("/apple-touch-icon-precomposed.png"))
+				.andExpect(redirectedUrl("/login"))
+				.andReturn()
+				.getRequest()
+				.getSession();
+		// @formatter:on
+		// ignores apple-touch-icon-precomposed.png
+		this.mvc.perform(formLogin(session)).andExpect(redirectedUrl("/"));
+	}
+
+	@Test
+	public void getWhenBookmarkedUrlIsAppleTouchIconSizedPrecomposedThenPostAuthenticationRedirectsToRoot()
+			throws Exception {
+		this.spring.register(RequestCacheDefaultsConfig.class, DefaultSecurityConfig.class).autowire();
+		// @formatter:off
+		MockHttpSession session = (MockHttpSession) this.mvc.perform(get("/apple-touch-icon-152x152-precomposed.png"))
+				.andExpect(redirectedUrl("/login"))
+				.andReturn()
+				.getRequest()
+				.getSession();
+		// @formatter:on
+		// ignores apple-touch-icon-152x152-precomposed.png
+		this.mvc.perform(formLogin(session)).andExpect(redirectedUrl("/"));
+	}
+
 	// SEC-2321
 	@Test
 	public void getWhenBookmarkedRequestIsApplicationJsonThenPostAuthenticationRedirectsToRoot() throws Exception {

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurerTests.java
@@ -200,6 +200,20 @@ public class RequestCacheConfigurerTests {
 		this.mvc.perform(formLogin(session)).andExpect(redirectedUrl("/"));
 	}
 
+	@Test
+	public void getWhenBookmarkedUrlIsChromeDevtoolsJsonThenPostAuthenticationRedirectsToRoot() throws Exception {
+		this.spring.register(RequestCacheDefaultsConfig.class, DefaultSecurityConfig.class).autowire();
+		// @formatter:off
+		MockHttpSession session = (MockHttpSession) this.mvc.perform(get("/.well-known/appspecific/com.chrome.devtools.json"))
+				.andExpect(redirectedUrl("/login"))
+				.andReturn()
+				.getRequest()
+				.getSession();
+		// @formatter:on
+		// ignores /.well-known/appspecific/com.chrome.devtools.json
+		this.mvc.perform(formLogin(session)).andExpect(redirectedUrl("/"));
+	}
+
 	// SEC-2321
 	@Test
 	public void getWhenBookmarkedRequestIsApplicationJsonThenPostAuthenticationRedirectsToRoot() throws Exception {

--- a/config/src/test/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/configurers/RequestCacheConfigurerTests.java
@@ -158,6 +158,34 @@ public class RequestCacheConfigurerTests {
 		this.mvc.perform(formLogin(session)).andExpect(redirectedUrl("/"));
 	}
 
+	@Test
+	public void getWhenBookmarkedUrlIsManifestJsonThenPostAuthenticationRedirectsToRoot() throws Exception {
+		this.spring.register(RequestCacheDefaultsConfig.class, DefaultSecurityConfig.class).autowire();
+		// @formatter:off
+		MockHttpSession session = (MockHttpSession) this.mvc.perform(get("/manifest.json"))
+				.andExpect(redirectedUrl("/login"))
+				.andReturn()
+				.getRequest()
+				.getSession();
+		// @formatter:on
+		// ignores manifest.json
+		this.mvc.perform(formLogin(session)).andExpect(redirectedUrl("/"));
+	}
+
+	@Test
+	public void getWhenBookmarkedUrlIsManifestWebmanifestThenPostAuthenticationRedirectsToRoot() throws Exception {
+		this.spring.register(RequestCacheDefaultsConfig.class, DefaultSecurityConfig.class).autowire();
+		// @formatter:off
+		MockHttpSession session = (MockHttpSession) this.mvc.perform(get("/manifest.webmanifest"))
+				.andExpect(redirectedUrl("/login"))
+				.andReturn()
+				.getRequest()
+				.getSession();
+		// @formatter:on
+		// ignores manifest.webmanifest
+		this.mvc.perform(formLogin(session)).andExpect(redirectedUrl("/"));
+	}
+
 	// SEC-2321
 	@Test
 	public void getWhenBookmarkedRequestIsApplicationJsonThenPostAuthenticationRedirectsToRoot() throws Exception {

--- a/web/src/main/java/org/springframework/security/web/server/savedrequest/CookieServerRequestCache.java
+++ b/web/src/main/java/org/springframework/security/web/server/savedrequest/CookieServerRequestCache.java
@@ -171,7 +171,10 @@ public class CookieServerRequestCache implements ServerRequestCache {
 			"/apple-touch-icon*.png",
 			// Chromium browsers fetch the web app manifest in the background to
 			// evaluate PWA installability
-			"/manifest.json", "/manifest.webmanifest" };
+			"/manifest.json", "/manifest.webmanifest",
+			// Legacy IE11/Edge fetch browserconfig.xml in the background to
+			// configure pinned-site tiles
+			"/browserconfig.xml" };
 
 	private static ServerWebExchangeMatcher createDefaultRequestMatcher() {
 		ServerWebExchangeMatcher get = ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, "/**");

--- a/web/src/main/java/org/springframework/security/web/server/savedrequest/CookieServerRequestCache.java
+++ b/web/src/main/java/org/springframework/security/web/server/savedrequest/CookieServerRequestCache.java
@@ -174,7 +174,10 @@ public class CookieServerRequestCache implements ServerRequestCache {
 			"/manifest.json", "/manifest.webmanifest",
 			// Legacy IE11/Edge fetch browserconfig.xml in the background to
 			// configure pinned-site tiles
-			"/browserconfig.xml" };
+			"/browserconfig.xml",
+			// Chrome DevTools itself (not the page, not the user) requests this to
+			// discover an Automatic Workspace Folder mapping for local source editing
+			"/.well-known/appspecific/com.chrome.devtools.json" };
 
 	private static ServerWebExchangeMatcher createDefaultRequestMatcher() {
 		ServerWebExchangeMatcher get = ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, "/**");

--- a/web/src/main/java/org/springframework/security/web/server/savedrequest/CookieServerRequestCache.java
+++ b/web/src/main/java/org/springframework/security/web/server/savedrequest/CookieServerRequestCache.java
@@ -158,13 +158,25 @@ public class CookieServerRequestCache implements ServerRequestCache {
 				StandardCharsets.UTF_8);
 	}
 
+	/**
+	 * Path patterns for requests that browsers request automatically in the background
+	 * (e.g. to display an icon), and that should therefore never be saved as the URL to
+	 * redirect to after authentication succeeds.
+	 */
+	private static final String[] IGNORED_BACKGROUND_REQUEST_PATTERNS = { "/favicon.*",
+			// Safari/WebKit request apple-touch-icon.png,
+			// apple-touch-icon-precomposed.png,
+			// and sized variants (e.g. apple-touch-icon-152x152.png) even without a
+			// matching <link> tag in the page
+			"/apple-touch-icon*.png" };
+
 	private static ServerWebExchangeMatcher createDefaultRequestMatcher() {
 		ServerWebExchangeMatcher get = ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, "/**");
-		ServerWebExchangeMatcher notFavicon = new NegatedServerWebExchangeMatcher(
-				ServerWebExchangeMatchers.pathMatchers("/favicon.*"));
+		ServerWebExchangeMatcher notIgnoredBackgroundRequest = new NegatedServerWebExchangeMatcher(
+				ServerWebExchangeMatchers.pathMatchers(IGNORED_BACKGROUND_REQUEST_PATTERNS));
 		MediaTypeServerWebExchangeMatcher html = new MediaTypeServerWebExchangeMatcher(MediaType.TEXT_HTML);
 		html.setIgnoredMediaTypes(Collections.singleton(MediaType.ALL));
-		return new AndServerWebExchangeMatcher(get, notFavicon, html);
+		return new AndServerWebExchangeMatcher(get, notIgnoredBackgroundRequest, html);
 	}
 
 }

--- a/web/src/main/java/org/springframework/security/web/server/savedrequest/CookieServerRequestCache.java
+++ b/web/src/main/java/org/springframework/security/web/server/savedrequest/CookieServerRequestCache.java
@@ -168,7 +168,10 @@ public class CookieServerRequestCache implements ServerRequestCache {
 			// apple-touch-icon-precomposed.png,
 			// and sized variants (e.g. apple-touch-icon-152x152.png) even without a
 			// matching <link> tag in the page
-			"/apple-touch-icon*.png" };
+			"/apple-touch-icon*.png",
+			// Chromium browsers fetch the web app manifest in the background to
+			// evaluate PWA installability
+			"/manifest.json", "/manifest.webmanifest" };
 
 	private static ServerWebExchangeMatcher createDefaultRequestMatcher() {
 		ServerWebExchangeMatcher get = ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, "/**");

--- a/web/src/main/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCache.java
+++ b/web/src/main/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCache.java
@@ -168,7 +168,10 @@ public class WebSessionServerRequestCache implements ServerRequestCache {
 			// apple-touch-icon-precomposed.png,
 			// and sized variants (e.g. apple-touch-icon-152x152.png) even without a
 			// matching <link> tag in the page
-			"/apple-touch-icon*.png" };
+			"/apple-touch-icon*.png",
+			// Chromium browsers fetch the web app manifest in the background to
+			// evaluate PWA installability
+			"/manifest.json", "/manifest.webmanifest" };
 
 	private static ServerWebExchangeMatcher createDefaultRequestMatcher() {
 		ServerWebExchangeMatcher get = ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, "/**");

--- a/web/src/main/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCache.java
+++ b/web/src/main/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCache.java
@@ -171,7 +171,10 @@ public class WebSessionServerRequestCache implements ServerRequestCache {
 			"/apple-touch-icon*.png",
 			// Chromium browsers fetch the web app manifest in the background to
 			// evaluate PWA installability
-			"/manifest.json", "/manifest.webmanifest" };
+			"/manifest.json", "/manifest.webmanifest",
+			// Legacy IE11/Edge fetch browserconfig.xml in the background to
+			// configure pinned-site tiles
+			"/browserconfig.xml" };
 
 	private static ServerWebExchangeMatcher createDefaultRequestMatcher() {
 		ServerWebExchangeMatcher get = ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, "/**");

--- a/web/src/main/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCache.java
+++ b/web/src/main/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCache.java
@@ -174,7 +174,10 @@ public class WebSessionServerRequestCache implements ServerRequestCache {
 			"/manifest.json", "/manifest.webmanifest",
 			// Legacy IE11/Edge fetch browserconfig.xml in the background to
 			// configure pinned-site tiles
-			"/browserconfig.xml" };
+			"/browserconfig.xml",
+			// Chrome DevTools itself (not the page, not the user) requests this to
+			// discover an Automatic Workspace Folder mapping for local source editing
+			"/.well-known/appspecific/com.chrome.devtools.json" };
 
 	private static ServerWebExchangeMatcher createDefaultRequestMatcher() {
 		ServerWebExchangeMatcher get = ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, "/**");

--- a/web/src/main/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCache.java
+++ b/web/src/main/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCache.java
@@ -158,13 +158,25 @@ public class WebSessionServerRequestCache implements ServerRequestCache {
 		// @formatter:on
 	}
 
+	/**
+	 * Path patterns for requests that browsers request automatically in the background
+	 * (e.g. to display an icon), and that should therefore never be saved as the URL to
+	 * redirect to after authentication succeeds.
+	 */
+	private static final String[] IGNORED_BACKGROUND_REQUEST_PATTERNS = { "/favicon.*",
+			// Safari/WebKit request apple-touch-icon.png,
+			// apple-touch-icon-precomposed.png,
+			// and sized variants (e.g. apple-touch-icon-152x152.png) even without a
+			// matching <link> tag in the page
+			"/apple-touch-icon*.png" };
+
 	private static ServerWebExchangeMatcher createDefaultRequestMatcher() {
 		ServerWebExchangeMatcher get = ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, "/**");
-		ServerWebExchangeMatcher notFavicon = new NegatedServerWebExchangeMatcher(
-				ServerWebExchangeMatchers.pathMatchers("/favicon.*"));
+		ServerWebExchangeMatcher notIgnoredBackgroundRequest = new NegatedServerWebExchangeMatcher(
+				ServerWebExchangeMatchers.pathMatchers(IGNORED_BACKGROUND_REQUEST_PATTERNS));
 		MediaTypeServerWebExchangeMatcher html = new MediaTypeServerWebExchangeMatcher(MediaType.TEXT_HTML);
 		html.setIgnoredMediaTypes(Collections.singleton(MediaType.ALL));
-		return new AndServerWebExchangeMatcher(get, notFavicon, html);
+		return new AndServerWebExchangeMatcher(get, notIgnoredBackgroundRequest, html);
 	}
 
 }

--- a/web/src/test/java/org/springframework/security/web/server/savedrequest/CookieServerRequestCacheTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/savedrequest/CookieServerRequestCacheTests.java
@@ -123,6 +123,15 @@ public class CookieServerRequestCacheTests {
 	}
 
 	@Test
+	public void saveRequestWhenGetRequestBrowserConfigXmlThenNoCookie() {
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("/browserconfig.xml").accept(MediaType.TEXT_HTML));
+		this.cache.saveRequest(exchange).block();
+		MultiValueMap<String, ResponseCookie> cookies = exchange.getResponse().getCookies();
+		assertThat(cookies).isEmpty();
+	}
+
+	@Test
 	public void saveRequestWhenPostRequestThenNoCookie() {
 		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.post("/secured/"));
 		this.cache.saveRequest(exchange).block();

--- a/web/src/test/java/org/springframework/security/web/server/savedrequest/CookieServerRequestCacheTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/savedrequest/CookieServerRequestCacheTests.java
@@ -78,6 +78,33 @@ public class CookieServerRequestCacheTests {
 	}
 
 	@Test
+	public void saveRequestWhenGetRequestAppleTouchIconThenNoCookie() {
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("/apple-touch-icon.png").accept(MediaType.TEXT_HTML));
+		this.cache.saveRequest(exchange).block();
+		MultiValueMap<String, ResponseCookie> cookies = exchange.getResponse().getCookies();
+		assertThat(cookies).isEmpty();
+	}
+
+	@Test
+	public void saveRequestWhenGetRequestAppleTouchIconPrecomposedThenNoCookie() {
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("/apple-touch-icon-precomposed.png").accept(MediaType.TEXT_HTML));
+		this.cache.saveRequest(exchange).block();
+		MultiValueMap<String, ResponseCookie> cookies = exchange.getResponse().getCookies();
+		assertThat(cookies).isEmpty();
+	}
+
+	@Test
+	public void saveRequestWhenGetRequestAppleTouchIconSizedPrecomposedThenNoCookie() {
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("/apple-touch-icon-152x152-precomposed.png").accept(MediaType.TEXT_HTML));
+		this.cache.saveRequest(exchange).block();
+		MultiValueMap<String, ResponseCookie> cookies = exchange.getResponse().getCookies();
+		assertThat(cookies).isEmpty();
+	}
+
+	@Test
 	public void saveRequestWhenPostRequestThenNoCookie() {
 		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.post("/secured/"));
 		this.cache.saveRequest(exchange).block();

--- a/web/src/test/java/org/springframework/security/web/server/savedrequest/CookieServerRequestCacheTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/savedrequest/CookieServerRequestCacheTests.java
@@ -132,6 +132,16 @@ public class CookieServerRequestCacheTests {
 	}
 
 	@Test
+	public void saveRequestWhenGetRequestChromeDevtoolsJsonThenNoCookie() {
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("/.well-known/appspecific/com.chrome.devtools.json")
+				.accept(MediaType.TEXT_HTML));
+		this.cache.saveRequest(exchange).block();
+		MultiValueMap<String, ResponseCookie> cookies = exchange.getResponse().getCookies();
+		assertThat(cookies).isEmpty();
+	}
+
+	@Test
 	public void saveRequestWhenPostRequestThenNoCookie() {
 		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.post("/secured/"));
 		this.cache.saveRequest(exchange).block();

--- a/web/src/test/java/org/springframework/security/web/server/savedrequest/CookieServerRequestCacheTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/savedrequest/CookieServerRequestCacheTests.java
@@ -105,6 +105,24 @@ public class CookieServerRequestCacheTests {
 	}
 
 	@Test
+	public void saveRequestWhenGetRequestManifestJsonThenNoCookie() {
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("/manifest.json").accept(MediaType.TEXT_HTML));
+		this.cache.saveRequest(exchange).block();
+		MultiValueMap<String, ResponseCookie> cookies = exchange.getResponse().getCookies();
+		assertThat(cookies).isEmpty();
+	}
+
+	@Test
+	public void saveRequestWhenGetRequestManifestWebmanifestThenNoCookie() {
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("/manifest.webmanifest").accept(MediaType.TEXT_HTML));
+		this.cache.saveRequest(exchange).block();
+		MultiValueMap<String, ResponseCookie> cookies = exchange.getResponse().getCookies();
+		assertThat(cookies).isEmpty();
+	}
+
+	@Test
 	public void saveRequestWhenPostRequestThenNoCookie() {
 		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.post("/secured/"));
 		this.cache.saveRequest(exchange).block();

--- a/web/src/test/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCacheTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCacheTests.java
@@ -96,6 +96,24 @@ public class WebSessionServerRequestCacheTests {
 	}
 
 	@Test
+	public void saveRequestGetRequestWhenManifestJsonThenNotFound() {
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("/manifest.json").accept(MediaType.TEXT_HTML));
+		this.cache.saveRequest(exchange).block();
+		URI saved = this.cache.getRedirectUri(exchange).block();
+		assertThat(saved).isNull();
+	}
+
+	@Test
+	public void saveRequestGetRequestWhenManifestWebmanifestThenNotFound() {
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("/manifest.webmanifest").accept(MediaType.TEXT_HTML));
+		this.cache.saveRequest(exchange).block();
+		URI saved = this.cache.getRedirectUri(exchange).block();
+		assertThat(saved).isNull();
+	}
+
+	@Test
 	public void saveRequestGetRequestWhenPostThenNotFound() {
 		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.post("/secured/"));
 		this.cache.saveRequest(exchange).block();

--- a/web/src/test/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCacheTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCacheTests.java
@@ -114,6 +114,15 @@ public class WebSessionServerRequestCacheTests {
 	}
 
 	@Test
+	public void saveRequestGetRequestWhenBrowserConfigXmlThenNotFound() {
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("/browserconfig.xml").accept(MediaType.TEXT_HTML));
+		this.cache.saveRequest(exchange).block();
+		URI saved = this.cache.getRedirectUri(exchange).block();
+		assertThat(saved).isNull();
+	}
+
+	@Test
 	public void saveRequestGetRequestWhenPostThenNotFound() {
 		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.post("/secured/"));
 		this.cache.saveRequest(exchange).block();

--- a/web/src/test/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCacheTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCacheTests.java
@@ -69,6 +69,33 @@ public class WebSessionServerRequestCacheTests {
 	}
 
 	@Test
+	public void saveRequestGetRequestWhenAppleTouchIconThenNotFound() {
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("/apple-touch-icon.png").accept(MediaType.TEXT_HTML));
+		this.cache.saveRequest(exchange).block();
+		URI saved = this.cache.getRedirectUri(exchange).block();
+		assertThat(saved).isNull();
+	}
+
+	@Test
+	public void saveRequestGetRequestWhenAppleTouchIconPrecomposedThenNotFound() {
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("/apple-touch-icon-precomposed.png").accept(MediaType.TEXT_HTML));
+		this.cache.saveRequest(exchange).block();
+		URI saved = this.cache.getRedirectUri(exchange).block();
+		assertThat(saved).isNull();
+	}
+
+	@Test
+	public void saveRequestGetRequestWhenAppleTouchIconSizedPrecomposedThenNotFound() {
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("/apple-touch-icon-152x152-precomposed.png").accept(MediaType.TEXT_HTML));
+		this.cache.saveRequest(exchange).block();
+		URI saved = this.cache.getRedirectUri(exchange).block();
+		assertThat(saved).isNull();
+	}
+
+	@Test
 	public void saveRequestGetRequestWhenPostThenNotFound() {
 		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.post("/secured/"));
 		this.cache.saveRequest(exchange).block();

--- a/web/src/test/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCacheTests.java
+++ b/web/src/test/java/org/springframework/security/web/server/savedrequest/WebSessionServerRequestCacheTests.java
@@ -123,6 +123,16 @@ public class WebSessionServerRequestCacheTests {
 	}
 
 	@Test
+	public void saveRequestGetRequestWhenChromeDevtoolsJsonThenNotFound() {
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("/.well-known/appspecific/com.chrome.devtools.json")
+				.accept(MediaType.TEXT_HTML));
+		this.cache.saveRequest(exchange).block();
+		URI saved = this.cache.getRedirectUri(exchange).block();
+		assertThat(saved).isNull();
+	}
+
+	@Test
 	public void saveRequestGetRequestWhenPostThenNotFound() {
 		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.post("/secured/"));
 		this.cache.saveRequest(exchange).block();


### PR DESCRIPTION
Broadens the default RequestCache's ignored-background-request patterns beyond `/favicon.*` to cover other well-known paths browsers (and their devtools) request automatically in the background, so they can never become the URL a user is redirected to after authenticating

Closes gh-19691
